### PR TITLE
kubeflow: disable codecov reporting GHA step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,3 @@ jobs:
           fi
       - name: Unit tests
         run: make test-cover
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: coverage.txt
-          fail_ci_if_error: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -59,14 +59,6 @@ jobs:
           else
             nox --python=${{ matrix.python }}
           fi
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v4.0.1
-        if: always() && matrix.session == 'tests'
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: coverage.xml
-          fail_ci_if_error: true
       - name: Upload documentation
         if: matrix.session == 'docs-build'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
this take immediate action to avoid failed builds due to this specific GHA step.

## Description
Currently builds are [failing on main](https://github.com/kubeflow/model-registry/commits/main/) as trying to report coverage data to Codecov which is not generally enabled in Kubeflow org.

## How Has This Been Tested?
n/a

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [n/a] The developer has manually tested the changes and verified that the changes work
