### PR TITLE
fix: make sh script compatible with Mac OSX sed

### DIFF
--- a/scripts/gen_openapi_server.sh
+++ b/scripts/gen_openapi_server.sh
@@ -11,8 +11,14 @@ openapi-generator-cli generate \
 		--ignore-file-override $ROOT_FOLDER/.openapi-generator-ignore --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true \
 		--template-dir $ROOT_FOLDER/templates/go-server
 
-sed -i 's/, orderByParam/, model.OrderByField(orderByParam)/g' $ROOT_FOLDER/internal/server/openapi/api_model_registry_service.go
-sed -i 's/, sortOrderParam/, model.SortOrder(sortOrderParam)/g' $ROOT_FOLDER/internal/server/openapi/api_model_registry_service.go
+if [[ $(uname) == "Darwin" ]]; then
+  # introduce -i parameter for Mac OSX sed compatibility
+  sed -i '' 's/, orderByParam/, model.OrderByField(orderByParam)/g' $ROOT_FOLDER/internal/server/openapi/api_model_registry_service.go
+  sed -i '' 's/, sortOrderParam/, model.SortOrder(sortOrderParam)/g' $ROOT_FOLDER/internal/server/openapi/api_model_registry_service.go
+else
+  sed -i 's/, orderByParam/, model.OrderByField(orderByParam)/g' $ROOT_FOLDER/internal/server/openapi/api_model_registry_service.go
+  sed -i 's/, sortOrderParam/, model.SortOrder(sortOrderParam)/g' $ROOT_FOLDER/internal/server/openapi/api_model_registry_service.go
+fi
 
 echo "Assembling type_assert Go file"
 ./scripts/gen_type_asserts.sh


### PR DESCRIPTION
@lampajr mind trying this on your end on a bare metal linux box, please?

## Description
changes script to execute `sed` differently depending on `uname`.

## How Has This Been Tested?
Run locally with:
```sh
gmake FORCE_SERVER_GENERATION=true clean build
```

Does no longer result in error:

```
sed: 1: "./internal/server/opena ...": invalid command code .
```

on Mac OSX.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
