### PR TITLE
OAS: Fix discriminator field definition for Artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ metadata.sqlite.db
 
 # Ignore go vendor and code coverage files
 vendor
-coverage.txt
+coverage.*
 
 # Robot Framework files
 log.html

--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -971,24 +971,26 @@ components:
     ModelArtifact:
       description: An ML model artifact.
       type: object
+      required:
+        - artifactType
+      properties:
+        artifactType:
+          type: string
+          default: "model-artifact"
       allOf:
         - $ref: "#/components/schemas/BaseArtifact"
         - $ref: "#/components/schemas/ModelArtifactCreate"
-        - type: object
-          properties:
-            artifactType:
-              type: string
-              default: "model-artifact"
     DocArtifact:
       description: A document.
       type: object
+      required:
+        - artifactType
+      properties:
+        artifactType:
+          type: string
+          default: "doc-artifact"
       allOf:
         - $ref: "#/components/schemas/BaseArtifact"
-        - type: object
-          properties:
-            artifactType:
-              type: string
-              default: "doc-artifact"
     RegisteredModel:
       description: A registered model in model registry. A registered model has ModelVersion children.
       allOf:
@@ -1105,12 +1107,12 @@ components:
       discriminator:
         propertyName: metadataType
         mapping:
-            MetadataBoolValue: '#/components/schemas/MetadataBoolValue'
-            MetadataDoubleValue: '#/components/schemas/MetadataDoubleValue'
-            MetadataIntValue: '#/components/schemas/MetadataIntValue'
-            MetadataProtoValue: '#/components/schemas/MetadataProtoValue'
-            MetadataStringValue: '#/components/schemas/MetadataStringValue'
-            MetadataStructValue: '#/components/schemas/MetadataStructValue'
+          MetadataBoolValue: "#/components/schemas/MetadataBoolValue"
+          MetadataDoubleValue: "#/components/schemas/MetadataDoubleValue"
+          MetadataIntValue: "#/components/schemas/MetadataIntValue"
+          MetadataProtoValue: "#/components/schemas/MetadataProtoValue"
+          MetadataStringValue: "#/components/schemas/MetadataStringValue"
+          MetadataStructValue: "#/components/schemas/MetadataStructValue"
       description: A value in properties.
     MetadataIntValue:
       description: An integer (int64) property value.
@@ -1345,12 +1347,6 @@ components:
       allOf:
         - $ref: "#/components/schemas/BaseArtifactCreate"
         - $ref: "#/components/schemas/BaseResource"
-        - required:
-            - artifactType
-          type: object
-          properties:
-            artifactType:
-              type: string
     ServingEnvironmentList:
       description: List of ServingEnvironments.
       type: object

--- a/internal/converter/generated/mlmd_openapi_converter.gen.go
+++ b/internal/converter/generated/mlmd_openapi_converter.gen.go
@@ -15,6 +15,11 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertDocArtifact(source *proto.Artifact) 
 	var pOpenapiDocArtifact *openapi.DocArtifact
 	if source != nil {
 		var openapiDocArtifact openapi.DocArtifact
+		xstring, err := converter.MapArtifactType(source)
+		if err != nil {
+			return nil, fmt.Errorf("error setting field ArtifactType: %w", err)
+		}
+		openapiDocArtifact.ArtifactType = xstring
 		mapStringOpenapiMetadataValue, err := converter.MapMLMDCustomProperties((*source).CustomProperties)
 		if err != nil {
 			return nil, err
@@ -23,14 +28,14 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertDocArtifact(source *proto.Artifact) 
 		openapiDocArtifact.Description = converter.MapDescription((*source).Properties)
 		var pString *string
 		if (*source).ExternalId != nil {
-			xstring := *(*source).ExternalId
-			pString = &xstring
+			xstring2 := *(*source).ExternalId
+			pString = &xstring2
 		}
 		openapiDocArtifact.ExternalID = pString
 		var pString2 *string
 		if (*source).Uri != nil {
-			xstring2 := *(*source).Uri
-			pString2 = &xstring2
+			xstring3 := *(*source).Uri
+			pString2 = &xstring3
 		}
 		openapiDocArtifact.Uri = pString2
 		openapiDocArtifact.State = converter.MapMLMDArtifactState((*source).State)
@@ -38,11 +43,6 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertDocArtifact(source *proto.Artifact) 
 		openapiDocArtifact.Id = converter.Int64ToString((*source).Id)
 		openapiDocArtifact.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
 		openapiDocArtifact.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)
-		xstring3, err := converter.MapArtifactType(source)
-		if err != nil {
-			return nil, fmt.Errorf("error setting field ArtifactType: %w", err)
-		}
-		openapiDocArtifact.ArtifactType = xstring3
 		pOpenapiDocArtifact = &openapiDocArtifact
 	}
 	return pOpenapiDocArtifact, nil
@@ -80,6 +80,11 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertModelArtifact(source *proto.Artifact
 	var pOpenapiModelArtifact *openapi.ModelArtifact
 	if source != nil {
 		var openapiModelArtifact openapi.ModelArtifact
+		xstring, err := converter.MapArtifactType(source)
+		if err != nil {
+			return nil, fmt.Errorf("error setting field ArtifactType: %w", err)
+		}
+		openapiModelArtifact.ArtifactType = xstring
 		mapStringOpenapiMetadataValue, err := converter.MapMLMDCustomProperties((*source).CustomProperties)
 		if err != nil {
 			return nil, err
@@ -88,14 +93,14 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertModelArtifact(source *proto.Artifact
 		openapiModelArtifact.Description = converter.MapDescription((*source).Properties)
 		var pString *string
 		if (*source).ExternalId != nil {
-			xstring := *(*source).ExternalId
-			pString = &xstring
+			xstring2 := *(*source).ExternalId
+			pString = &xstring2
 		}
 		openapiModelArtifact.ExternalID = pString
 		var pString2 *string
 		if (*source).Uri != nil {
-			xstring2 := *(*source).Uri
-			pString2 = &xstring2
+			xstring3 := *(*source).Uri
+			pString2 = &xstring3
 		}
 		openapiModelArtifact.Uri = pString2
 		openapiModelArtifact.State = converter.MapMLMDArtifactState((*source).State)
@@ -103,11 +108,6 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertModelArtifact(source *proto.Artifact
 		openapiModelArtifact.Id = converter.Int64ToString((*source).Id)
 		openapiModelArtifact.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
 		openapiModelArtifact.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)
-		xstring3, err := converter.MapArtifactType(source)
-		if err != nil {
-			return nil, fmt.Errorf("error setting field ArtifactType: %w", err)
-		}
-		openapiModelArtifact.ArtifactType = xstring3
 		openapiModelArtifact.ModelFormatName = converter.MapModelArtifactFormatName((*source).Properties)
 		openapiModelArtifact.StorageKey = converter.MapModelArtifactStorageKey((*source).Properties)
 		openapiModelArtifact.StoragePath = converter.MapModelArtifactStoragePath((*source).Properties)

--- a/internal/converter/generated/openapi_converter.gen.go
+++ b/internal/converter/generated/openapi_converter.gen.go
@@ -605,23 +605,23 @@ func (c *OpenAPIConverterImpl) OverrideNotEditableForModelArtifact(source conver
 	openapiModelArtifact := converter.InitModelArtifactWithUpdate(source)
 	var pString *string
 	if source.Existing != nil {
-		pString = source.Existing.Name
+		pString = &source.Existing.ArtifactType
 	}
-	var pString2 *string
+	var xstring string
 	if pString != nil {
-		xstring := *pString
-		pString2 = &xstring
+		xstring = *pString
 	}
-	openapiModelArtifact.Name = pString2
-	var pString3 *string
+	openapiModelArtifact.ArtifactType = xstring
+	var pString2 *string
 	if source.Existing != nil {
-		pString3 = &source.Existing.ArtifactType
+		pString2 = source.Existing.Name
 	}
-	var xstring2 string
-	if pString3 != nil {
-		xstring2 = *pString3
+	var pString3 *string
+	if pString2 != nil {
+		xstring2 := *pString2
+		pString3 = &xstring2
 	}
-	openapiModelArtifact.ArtifactType = xstring2
+	openapiModelArtifact.Name = pString3
 	return openapiModelArtifact, nil
 }
 func (c *OpenAPIConverterImpl) OverrideNotEditableForModelVersion(source converter.OpenapiUpdateWrapper[openapi.ModelVersion]) (openapi.ModelVersion, error) {

--- a/internal/server/openapi/type_asserts.go
+++ b/internal/server/openapi/type_asserts.go
@@ -18,15 +18,6 @@ import (
 
 // AssertArtifactRequired checks if the required fields are not zero-ed
 func AssertArtifactRequired(obj model.Artifact) error {
-	// FIXME(manual): Artifact.ArtifactType is not present on client models
-	// elements := map[string]interface{}{
-	// 	"artifactType": obj.ArtifactType,
-	// }
-	// for name, el := range elements {
-	// 	if isZero := IsZeroValue(el); isZero {
-	// 		return &RequiredError{Field: name}
-	// 	}
-	// }
 	return nil
 }
 
@@ -83,15 +74,6 @@ func AssertBaseArtifactCreateConstraints(obj model.BaseArtifactCreate) error {
 
 // AssertBaseArtifactRequired checks if the required fields are not zero-ed
 func AssertBaseArtifactRequired(obj model.BaseArtifact) error {
-	elements := map[string]interface{}{
-		"artifactType": obj.ArtifactType,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
 	return nil
 }
 

--- a/patches/type_asserts.patch
+++ b/patches/type_asserts.patch
@@ -2,31 +2,6 @@ diff --git a/internal/server/openapi/type_asserts.go b/internal/server/openapi/t
 index b001018..9907fbc 100644
 --- a/internal/server/openapi/type_asserts.go
 +++ b/internal/server/openapi/type_asserts.go
-@@ -18,15 +18,15 @@ import (
- 
- // AssertArtifactRequired checks if the required fields are not zero-ed
- func AssertArtifactRequired(obj model.Artifact) error {
--	elements := map[string]interface{}{
--		"artifactType": obj.ArtifactType,
--	}
--	for name, el := range elements {
--		if isZero := IsZeroValue(el); isZero {
--			return &RequiredError{Field: name}
--		}
--	}
--
-+	// FIXME(manual): Artifact.ArtifactType is not present on client models
-+	// elements := map[string]interface{}{
-+	// 	"artifactType": obj.ArtifactType,
-+	// }
-+	// for name, el := range elements {
-+	// 	if isZero := IsZeroValue(el); isZero {
-+	// 		return &RequiredError{Field: name}
-+	// 	}
-+	// }
- 	return nil
- }
- 
 @@ -449,21 +449,22 @@ func AssertMetadataStructValueConstraints(obj model.MetadataStructValue) error {
  
  // AssertMetadataValueRequired checks if the required fields are not zero-ed

--- a/pkg/openapi/model_base_artifact.go
+++ b/pkg/openapi/model_base_artifact.go
@@ -36,18 +36,16 @@ type BaseArtifact struct {
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`
 	// Output only. Last update time of the resource since epoch in millisecond since epoch.
 	LastUpdateTimeSinceEpoch *string `json:"lastUpdateTimeSinceEpoch,omitempty"`
-	ArtifactType             string  `json:"artifactType"`
 }
 
 // NewBaseArtifact instantiates a new BaseArtifact object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBaseArtifact(artifactType string) *BaseArtifact {
+func NewBaseArtifact() *BaseArtifact {
 	this := BaseArtifact{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
-	this.ArtifactType = artifactType
 	return &this
 }
 
@@ -349,30 +347,6 @@ func (o *BaseArtifact) SetLastUpdateTimeSinceEpoch(v string) {
 	o.LastUpdateTimeSinceEpoch = &v
 }
 
-// GetArtifactType returns the ArtifactType field value
-func (o *BaseArtifact) GetArtifactType() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.ArtifactType
-}
-
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
-// and a boolean to check if the value has been set.
-func (o *BaseArtifact) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.ArtifactType, true
-}
-
-// SetArtifactType sets field value
-func (o *BaseArtifact) SetArtifactType(v string) {
-	o.ArtifactType = v
-}
-
 func (o BaseArtifact) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -410,7 +384,6 @@ func (o BaseArtifact) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LastUpdateTimeSinceEpoch) {
 		toSerialize["lastUpdateTimeSinceEpoch"] = o.LastUpdateTimeSinceEpoch
 	}
-	toSerialize["artifactType"] = o.ArtifactType
 	return toSerialize, nil
 }
 

--- a/pkg/openapi/model_doc_artifact.go
+++ b/pkg/openapi/model_doc_artifact.go
@@ -19,6 +19,7 @@ var _ MappedNullable = &DocArtifact{}
 
 // DocArtifact A document.
 type DocArtifact struct {
+	ArtifactType string `json:"artifactType"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -36,7 +37,6 @@ type DocArtifact struct {
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`
 	// Output only. Last update time of the resource since epoch in millisecond since epoch.
 	LastUpdateTimeSinceEpoch *string `json:"lastUpdateTimeSinceEpoch,omitempty"`
-	ArtifactType             string  `json:"artifactType"`
 }
 
 // NewDocArtifact instantiates a new DocArtifact object
@@ -47,7 +47,6 @@ func NewDocArtifact(artifactType string) *DocArtifact {
 	this := DocArtifact{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
-	this.ArtifactType = artifactType
 	return &this
 }
 
@@ -56,11 +55,35 @@ func NewDocArtifact(artifactType string) *DocArtifact {
 // but it doesn't guarantee that properties required by API are set
 func NewDocArtifactWithDefaults() *DocArtifact {
 	this := DocArtifact{}
-	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
-	this.State = &state
 	var artifactType string = "doc-artifact"
 	this.ArtifactType = artifactType
+	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
+	this.State = &state
 	return &this
+}
+
+// GetArtifactType returns the ArtifactType field value
+func (o *DocArtifact) GetArtifactType() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.ArtifactType
+}
+
+// GetArtifactTypeOk returns a tuple with the ArtifactType field value
+// and a boolean to check if the value has been set.
+func (o *DocArtifact) GetArtifactTypeOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.ArtifactType, true
+}
+
+// SetArtifactType sets field value
+func (o *DocArtifact) SetArtifactType(v string) {
+	o.ArtifactType = v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -351,30 +374,6 @@ func (o *DocArtifact) SetLastUpdateTimeSinceEpoch(v string) {
 	o.LastUpdateTimeSinceEpoch = &v
 }
 
-// GetArtifactType returns the ArtifactType field value
-func (o *DocArtifact) GetArtifactType() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.ArtifactType
-}
-
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
-// and a boolean to check if the value has been set.
-func (o *DocArtifact) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.ArtifactType, true
-}
-
-// SetArtifactType sets field value
-func (o *DocArtifact) SetArtifactType(v string) {
-	o.ArtifactType = v
-}
-
 func (o DocArtifact) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -385,6 +384,7 @@ func (o DocArtifact) MarshalJSON() ([]byte, error) {
 
 func (o DocArtifact) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	toSerialize["artifactType"] = o.ArtifactType
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -412,7 +412,6 @@ func (o DocArtifact) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LastUpdateTimeSinceEpoch) {
 		toSerialize["lastUpdateTimeSinceEpoch"] = o.LastUpdateTimeSinceEpoch
 	}
-	toSerialize["artifactType"] = o.ArtifactType
 	return toSerialize, nil
 }
 

--- a/pkg/openapi/model_model_artifact.go
+++ b/pkg/openapi/model_model_artifact.go
@@ -19,6 +19,7 @@ var _ MappedNullable = &ModelArtifact{}
 
 // ModelArtifact An ML model artifact.
 type ModelArtifact struct {
+	ArtifactType string `json:"artifactType"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -36,7 +37,6 @@ type ModelArtifact struct {
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`
 	// Output only. Last update time of the resource since epoch in millisecond since epoch.
 	LastUpdateTimeSinceEpoch *string `json:"lastUpdateTimeSinceEpoch,omitempty"`
-	ArtifactType             string  `json:"artifactType"`
 	// Name of the model format.
 	ModelFormatName *string `json:"modelFormatName,omitempty"`
 	// Storage secret name.
@@ -57,7 +57,6 @@ func NewModelArtifact(artifactType string) *ModelArtifact {
 	this := ModelArtifact{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
-	this.ArtifactType = artifactType
 	return &this
 }
 
@@ -66,11 +65,35 @@ func NewModelArtifact(artifactType string) *ModelArtifact {
 // but it doesn't guarantee that properties required by API are set
 func NewModelArtifactWithDefaults() *ModelArtifact {
 	this := ModelArtifact{}
-	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
-	this.State = &state
 	var artifactType string = "model-artifact"
 	this.ArtifactType = artifactType
+	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
+	this.State = &state
 	return &this
+}
+
+// GetArtifactType returns the ArtifactType field value
+func (o *ModelArtifact) GetArtifactType() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.ArtifactType
+}
+
+// GetArtifactTypeOk returns a tuple with the ArtifactType field value
+// and a boolean to check if the value has been set.
+func (o *ModelArtifact) GetArtifactTypeOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.ArtifactType, true
+}
+
+// SetArtifactType sets field value
+func (o *ModelArtifact) SetArtifactType(v string) {
+	o.ArtifactType = v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -361,30 +384,6 @@ func (o *ModelArtifact) SetLastUpdateTimeSinceEpoch(v string) {
 	o.LastUpdateTimeSinceEpoch = &v
 }
 
-// GetArtifactType returns the ArtifactType field value
-func (o *ModelArtifact) GetArtifactType() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.ArtifactType
-}
-
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
-// and a boolean to check if the value has been set.
-func (o *ModelArtifact) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.ArtifactType, true
-}
-
-// SetArtifactType sets field value
-func (o *ModelArtifact) SetArtifactType(v string) {
-	o.ArtifactType = v
-}
-
 // GetModelFormatName returns the ModelFormatName field value if set, zero value otherwise.
 func (o *ModelArtifact) GetModelFormatName() string {
 	if o == nil || IsNil(o.ModelFormatName) {
@@ -555,6 +554,7 @@ func (o ModelArtifact) MarshalJSON() ([]byte, error) {
 
 func (o ModelArtifact) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	toSerialize["artifactType"] = o.ArtifactType
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -582,7 +582,6 @@ func (o ModelArtifact) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LastUpdateTimeSinceEpoch) {
 		toSerialize["lastUpdateTimeSinceEpoch"] = o.LastUpdateTimeSinceEpoch
 	}
-	toSerialize["artifactType"] = o.ArtifactType
 	if !IsNil(o.ModelFormatName) {
 		toSerialize["modelFormatName"] = o.ModelFormatName
 	}


### PR DESCRIPTION
This fixes an improper polymorphic type definition by moving its discriminator to the composing types.

There's also a small fix for ignoring `coverage.html`, that is generated when running `make test-cover`.

## Description

This problem was spotted while using the Kiota generator, and can be traced back to [the following pattern](https://github.com/microsoft/kiota/issues/2304),
which is incompatible with JSONSchema.

## How Has This Been Tested?

Following the same steps laid out on the last PR referencing OAS #17:

```
make FORCE_SERVER_GENERATION=true clean build
make test
```

then,

1. start an MLMD server
2. run `make proxy`
3. run `robot test/robot/ && TEST_MODE=python robot test/robot/MRandLogicalModel.robot`

## Merge criteria:
* [ ]  The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
* [x]  Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
* [x]  The developer has manually tested the changes and verified that the changes work