### PR TITLE
New(robot): Environment variable TEST_PORT for setting test port

### DIFF
--- a/test/robot/MRkeywords.resource
+++ b/test/robot/MRkeywords.resource
@@ -6,6 +6,7 @@ Library    ModelRegistry.py
 
 *** Variables ***
 ${MR_HOST}     %{TEST_MR_HOST=localhost}
+${MR_PORT}     %{TEST_MR_PORT=8080}
 ${MODE}        %{TEST_MODE=REST}
 
 *** Keywords ***
@@ -13,7 +14,7 @@ I create a RegisteredModel having
     [Arguments]  ${name}
     IF  $MODE == "REST"
         ${data}    Create Dictionary    name=${name}
-        ${resp}    POST    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/registered_models    json=${data}    expected_status=201
+        ${resp}    POST    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/registered_models    json=${data}    expected_status=201
         Log to console    ${resp.json()}
         ${result}    Set Variable    ${resp.json()['id']}
     ELSE
@@ -27,7 +28,7 @@ I create a RegisteredModel having
 I create a RegisteredModel
     [Arguments]  ${payload}
     IF  $MODE == "REST"
-        ${resp}    POST    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/registered_models    json=&{payload}    expected_status=201
+        ${resp}    POST    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/registered_models    json=&{payload}    expected_status=201
         Log to console    ${resp.json()}
         ${result}    Set Variable    ${resp.json()['id']}
     ELSE
@@ -41,7 +42,7 @@ I create a child ModelVersion having
     [Arguments]  ${registeredModelID}  ${name}
     IF  $MODE == "REST"
         ${data}=    Create Dictionary    name=${name}    registeredModelID=${registeredModelID}
-        ${resp}=    POST    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/model_versions    json=${data}    expected_status=201
+        ${resp}=    POST    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/model_versions    json=${data}    expected_status=201
         Log to console    ${resp.json()}
         ${result}    Set Variable    ${resp.json()['id']}
     ELSE
@@ -56,7 +57,7 @@ I create a child ModelVersion
     [Arguments]  ${registeredModelID}  ${payload}
     IF  $MODE == "REST"
         Set To Dictionary    ${payload}    registeredModelID=${registeredModelID}
-        ${resp}=    POST    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/model_versions    json=&{payload}    expected_status=201
+        ${resp}=    POST    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/model_versions    json=&{payload}    expected_status=201
         Log to console    ${resp.json()}
         ${result}    Set Variable    ${resp.json()['id']}
     ELSE
@@ -71,7 +72,7 @@ I create a child ModelArtifact having
     IF  $MODE == "REST"
         ${data}=    Create Dictionary    uri=${uri}  artifactType=model-artifact
         Log to console    ${data}
-        ${resp}=    POST    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/model_versions/${modelversionId}/artifacts    json=${data}    expected_status=201
+        ${resp}=    POST    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/model_versions/${modelversionId}/artifacts    json=${data}    expected_status=201
         Log to console    ${resp.json()}
         ${result}    Set Variable    ${resp.json()['id']}
     ELSE
@@ -85,7 +86,7 @@ I create a child ModelArtifact having
 I create a child ModelArtifact
     [Arguments]  ${modelversionId}    ${payload}
     IF  $MODE == "REST"
-        ${resp}=    POST    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/model_versions/${modelversionId}/artifacts    json=&{payload}    expected_status=201
+        ${resp}=    POST    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/model_versions/${modelversionId}/artifacts    json=&{payload}    expected_status=201
         Log to console    ${resp.json()}
         ${result}    Set Variable    ${resp.json()['id']}
     ELSE
@@ -98,7 +99,7 @@ I create a child ModelArtifact
 I create a child Artifact
     [Arguments]  ${modelversionId}    ${payload}
     IF  $MODE == "REST"
-        ${resp}=    POST    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/model_versions/${modelversionId}/artifacts    json=&{payload}    expected_status=201
+        ${resp}=    POST    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/model_versions/${modelversionId}/artifacts    json=&{payload}    expected_status=201
         Log to console    ${resp.json()}
         ${result}    Set Variable    ${resp.json()['id']}
     ELSE
@@ -111,7 +112,7 @@ I create a child Artifact
 I get RegisteredModelByID
     [Arguments]    ${id}
     IF  $MODE == "REST"
-        ${resp}=    GET    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/registered_models/${id}    expected_status=200
+        ${resp}=    GET    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/registered_models/${id}    expected_status=200
         ${result}    Set Variable    ${resp.json()}
         Log to console    ${resp.json()}
     ELSE
@@ -124,7 +125,7 @@ I get RegisteredModelByID
 I get ModelVersionByID
     [Arguments]    ${id}
     IF  $MODE == "REST"
-        ${resp}=    GET    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/model_versions/${id}    expected_status=200
+        ${resp}=    GET    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/model_versions/${id}    expected_status=200
         ${result}    Set Variable    ${resp.json()}
         Log to console    ${resp.json()}
     ELSE
@@ -137,7 +138,7 @@ I get ModelVersionByID
 I get ModelArtifactByID
     [Arguments]    ${id}
     IF  $MODE == "REST"
-        ${resp}=    GET    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/model_artifacts/${id}    expected_status=200
+        ${resp}=    GET    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/model_artifacts/${id}    expected_status=200
         ${result}    Set Variable    ${resp.json()}
         Log to console    ${resp.json()}
     ELSE
@@ -150,7 +151,7 @@ I get ModelArtifactByID
 I get ArtifactsByModelVersionID
     [Arguments]    ${id}
     IF  $MODE == "REST"
-        ${resp}=    GET    url=http://${MR_HOST}:8080/api/model_registry/v1alpha2/model_versions/${id}/artifacts    expected_status=200
+        ${resp}=    GET    url=http://${MR_HOST}:${MR_PORT}/api/model_registry/v1alpha2/model_versions/${id}/artifacts    expected_status=200
         ${result}    Set Variable    ${resp.json()}
         Log to console    ${resp.json()}
     ELSE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is environment variable called `TEST_MR_HOST` for Robot Framework tests setting Model Registry host that can be used for testing Model Registry instance deployed anywhere, but there is not any environment variable for setting port of the instance for testing it.

This PR provides new environment variable called `TEST_MR_PORT` for setting test port of Robot Framework tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Deploy Model Registry instance anywhere with publicly reachable host and port.
2. Run Robot Framework tests against it with setting TEST_MR_HOST and TEST_MR_PORT environment variable:
```TEST_MR_HOST=<model-registry-hostname> TEST_MR_PORT=<model-registry-port> robot test/robot/UserStory.robot```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
