### PR TITLE
fix GHA invocation of docker tag push script

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -54,8 +54,8 @@ jobs:
           BUILD_IMAGE: false
         run: |
           docker tag ${{ env.IMG }}:$VERSION ${{ env.IMG }}:latest
-          # BUILD_IMAGE=false skip the build
-          ./scripts/build_deploy.sh
+          # BUILD_IMAGE=false skip the build, just push the tag made above
+          VERSION=latest ./scripts/build_deploy.sh
       - name: Tag Main
         if: env.BUILD_CONTEXT == 'main'
         shell: bash
@@ -64,5 +64,5 @@ jobs:
           BUILD_IMAGE: false
         run: |
           docker tag ${{ env.IMG }}:$VERSION ${{ env.IMG }}:main
-          # BUILD_IMAGE=false skip the build
-          ./scripts/build_deploy.sh
+          # BUILD_IMAGE=false skip the build, just push the tag made above
+          VERSION=main ./scripts/build_deploy.sh


### PR DESCRIPTION
The goal of this PR is to fix 2 issues in the current GHA invocation:
- `VERSION` needed to be pass down to push the tagged layer (the layers and rolling tags are already pushed from the steps above, what needs to happen is GHA need to instruct the script to just-push the newly created tag)

## Description
With this change:
- ensure `latest` and `main` tag are synced to the most recent image produced (except of release versions)
- we can always introduce a `latest-release` tag following similar GHA snippet later

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
