### PR TITLE
fix: ensure consistency ns(omitted) for istio manifests

### DIFF
--- a/manifests/kustomize/options/istio/kustomization.yaml
+++ b/manifests/kustomize/options/istio/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kubeflow
 
 resources:
 - istio-authorization-policy.yaml

--- a/manifests/kustomize/options/istio/virtual-service.yaml
+++ b/manifests/kustomize/options/istio/virtual-service.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: model-registry
-  namespace: kubeflow
 spec:
   gateways:
   - kubeflow-gateway


### PR DESCRIPTION
for consistency, do not tie down to a given namespace

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
`kubectl apply -n kubeflow -k manifests/kustomize/options/istio`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
