### PR TITLE
add testing of KF MR Manifests

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -31,3 +31,24 @@ jobs:
         env:
           VERSION: ${{ steps.tags.outputs.tag }}
         run: ./scripts/build_deploy.sh
+      - name: Start Kind Cluster
+        uses: helm/kind-action@v1.9.0
+      - name: Load Local Registry Test Image
+        env:
+          IMG: "quay.io/opendatahub/model-registry:${{ steps.tags.outputs.tag }}"
+        run: |
+          kind load docker-image -n chart-testing ${IMG}
+      - name: Create Test Registry
+        env:
+          IMG: "quay.io/opendatahub/model-registry:${{ steps.tags.outputs.tag }}"
+        run: |
+          echo "Deploying Model Registry using Manifests; branch ${BRANCH}"
+          kubectl create namespace kubeflow
+          cd manifests/kustomize/overlays/db
+          kustomize edit set image quay.io/opendatahub/model-registry:latest $IMG
+          kubectl apply -k .
+      - name: Wait for Test Registry Deployment
+        run: |
+          kubectl wait --for=condition=available -n kubeflow deployment/model-registry-db --timeout=5m
+          kubectl wait --for=condition=available -n kubeflow deployment/model-registry-deployment --timeout=5m
+          kubectl logs -n kubeflow deployment/model-registry-deployment


### PR DESCRIPTION
resolves #35 

## Description
Use Kind GHA script to dry-run the Model Registry image built on a pull_request, use [similarly to previously existing strategy](https://github.com/kubeflow/model-registry/pull/16), now adapted from using Operator pattern to use Manifest and Kind.

## How Has This Been Tested?
demo [here](https://github.com/kubeflow/model-registry/actions/runs/8232920576/job/22511345478?pr=36)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
