### PR TITLE
add dockerhub container registry use

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,10 +14,11 @@ on:
       - '.github/dependabot.yml'
       - 'docs/**'
 env:
-  QUAY_ORG: opendatahub
-  QUAY_IMG_REPO: model-registry
-  QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-  QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+  IMG_ORG: kubeflow
+  IMG_REPO: model-registry
+  IMG: ${{ env.IMG_ORG }}/${{ env.IMG_REPO }}
+  DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKER_PWD: ${{ secrets.DOCKERHUB_TOKEN }}
   PUSH_IMAGE: true
 jobs:
   build-image:
@@ -50,8 +51,7 @@ jobs:
         if: env.BUILD_CONTEXT == 'main'
         shell: bash
         env:
-          IMG: quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_IMG_REPO }}
-          BUILD_IMAGE: false
+          BUILD_IMAGE: false # image is already built in "Build and Push Image" step
         run: |
           docker tag ${{ env.IMG }}:$VERSION ${{ env.IMG }}:latest
           # BUILD_IMAGE=false skip the build, just push the tag made above
@@ -60,8 +60,7 @@ jobs:
         if: env.BUILD_CONTEXT == 'main'
         shell: bash
         env:
-          IMG: quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_IMG_REPO }}
-          BUILD_IMAGE: false
+          BUILD_IMAGE: false # image is already built in "Build and Push Image" step
         run: |
           docker tag ${{ env.IMG }}:$VERSION ${{ env.IMG }}:main
           # BUILD_IMAGE=false skip the build, just push the tag made above

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -11,7 +11,9 @@ on:
       - 'docs/**'
       - 'clients/python/**'
 env:
-  QUAY_IMG_REPO: model-registry
+  IMG_ORG: kubeflow
+  IMG_REPO: model-registry
+  IMG: ${{ env.IMG_ORG }}/${{ env.IMG_REPO }}
   PUSH_IMAGE: false
   BRANCH: ${{ github.base_ref }}
 jobs:
@@ -35,17 +37,17 @@ jobs:
         uses: helm/kind-action@v1.9.0
       - name: Load Local Registry Test Image
         env:
-          IMG: "quay.io/opendatahub/model-registry:${{ steps.tags.outputs.tag }}"
+          IMG: "${{ env.IMG }}:${{ steps.tags.outputs.tag }}"
         run: |
           kind load docker-image -n chart-testing ${IMG}
       - name: Create Test Registry
         env:
-          IMG: "quay.io/opendatahub/model-registry:${{ steps.tags.outputs.tag }}"
+          IMG: "${{ env.IMG }}:${{ steps.tags.outputs.tag }}"
         run: |
           echo "Deploying Model Registry using Manifests; branch ${BRANCH}"
           kubectl create namespace kubeflow
           cd manifests/kustomize/overlays/db
-          kustomize edit set image quay.io/opendatahub/model-registry:latest $IMG
+          kustomize edit set image kubeflow/model-registry:latest $IMG
           kubectl apply -k .
       - name: Wait for Test Registry Deployment
         run: |

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,20 @@ MLMD_VERSION ?= 1.14.0
 DOCKER ?= docker
 # default Dockerfile
 DOCKERFILE ?= Dockerfile
-# container registry
-IMG_REGISTRY ?= quay.io
+# container registry, default to empty (dockerhub) if not explicitly set
+IMG_REGISTRY ?= 
 # container image organization
-IMG_ORG ?= opendatahub
+IMG_ORG ?= kubeflow
 # container image version
 IMG_VERSION ?= main
 # container image repository
 IMG_REPO ?= model-registry
 # container image
-IMG ?= ${IMG_REGISTRY}/$(IMG_ORG)/$(IMG_REPO)
+ifdef IMG_REGISTRY
+    IMG := ${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}
+else
+    IMG := ${IMG_ORG}/${IMG_REPO}
+endif
 
 model-registry: build
 
@@ -190,7 +194,12 @@ proxy: build
 # login to docker
 .PHONY: docker/login
 docker/login:
-	$(DOCKER) login -u "${DOCKER_USER}" -p "${DOCKER_PWD}" "${IMG_REGISTRY}"
+	ifdef IMG_REGISTRY
+		$(DOCKER) login -u "${DOCKER_USER}" -p "${DOCKER_PWD}" "${IMG_REGISTRY}"
+	else
+		$(DOCKER) login -u "${DOCKER_USER}" -p "${DOCKER_PWD}"
+	endif
+
 
 # build docker image
 .PHONY: image/build

--- a/manifests/kustomize/base/model-registry-deployment.yaml
+++ b/manifests/kustomize/base/model-registry-deployment.yaml
@@ -24,7 +24,7 @@ spec:
           command:
             - /model-registry
             - proxy
-          image: quay.io/opendatahub/model-registry:latest
+          image: kubeflow/model-registry:latest
           # empty placeholder environment for patching
           env: []
           ports:

--- a/scripts/build_deploy.sh
+++ b/scripts/build_deploy.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-# quay.io credentials
-QUAY_REGISTRY=quay.io
-QUAY_ORG="${QUAY_ORG:-opendatahub}"
-QUAY_IMG_REPO="${QUAY_IMG_REPO:-model-registry}"
-QUAY_USERNAME="${QUAY_USERNAME}"
-QUAY_PASSWORD="${QUAY_PASSWORD}"
+# see Makefile for the IMG_ variables semantic
+IMG_REGISTRY=""
+IMG_ORG="${IMG_ORG:-kubeflow}"
+IMG_REPO="${IMG_REPO:-model-registry}"
+DOCKER_USER="${DOCKER_USER}"
+DOCKER_PWD="${DOCKER_PWD}"
 
 # image version
 HASH="$(git rev-parse --short=7 HEAD)"
@@ -27,15 +27,15 @@ SKIP_IF_EXISTING="${SKIP_IF_EXISTING:-false}"
 # assure docker exists
 docker -v foo >/dev/null 2>&1 || { echo >&2 "::error:: Docker is required.  Aborting."; exit 1; }
 
-# skip if image already existing
-if [[ "${SKIP_IF_EXISTING,,}" == "true" ]]; then
-  TAGS=$(curl --request GET "https://$QUAY_REGISTRY/api/v1/repository/${QUAY_ORG}/${QUAY_IMG_REPO}/tag/?specificTag=${VERSION}")
+# if quay.io, can opt to skip if image already existing
+if [[ "${SKIP_IF_EXISTING,,}" == "true" && "${IMG_REGISTRY,,}" == "quay.io" ]]; then
+  TAGS=$(curl --request GET "https://$IMG_REGISTRY/api/v1/repository/${IMG_ORG}/${IMG_REPO}/tag/?specificTag=${VERSION}")
   LATEST_TAG_HAS_END_TS=$(echo $TAGS | jq .tags - | jq 'sort_by(.start_ts) | reverse' | jq '.[0].end_ts')
   NOT_EMPTY=$(echo ${TAGS} | jq .tags - | jq any)
 
   # Image only exists if there is a tag that does not have "end_ts" (i.e. it is still present).
   if [[ "$NOT_EMPTY" == "true" && $LATEST_TAG_HAS_END_TS == "null" ]]; then
-      echo "::error:: The image ${QUAY_ORG}/${QUAY_IMG_REPO}:${VERSION} already exists"
+      echo "::error:: The image ${IMG_ORG}/${IMG_REPO}:${VERSION} already exists"
       exit 1
   else
       echo "Image does not exist...proceeding with build & push."
@@ -46,9 +46,9 @@ fi
 if [[ "${BUILD_IMAGE,,}" == "true" ]]; then
   echo "Building container image.."
   make \
-    IMG_REGISTRY="${QUAY_REGISTRY}" \
-    IMG_ORG="${QUAY_ORG}" \
-    IMG_REPO="${QUAY_IMG_REPO}" \
+    IMG_REGISTRY="${IMG_REGISTRY}" \
+    IMG_ORG="${IMG_ORG}" \
+    IMG_REPO="${IMG_REPO}" \
     IMG_VERSION="${VERSION}" \
     image/build
 else
@@ -59,12 +59,12 @@ fi
 if [[ "${PUSH_IMAGE,,}" == "true" ]]; then
   echo "Pushing container image.."
   make \
-    IMG_REGISTRY="${QUAY_REGISTRY}" \
-    IMG_ORG="${QUAY_ORG}" \
-    IMG_REPO="${QUAY_IMG_REPO}" \
+    IMG_REGISTRY="${IMG_REGISTRY}" \
+    IMG_ORG="${IMG_ORG}" \
+    IMG_REPO="${IMG_REPO}" \
     IMG_VERSION="${VERSION}" \
-    DOCKER_USER="${QUAY_USERNAME}"\
-    DOCKER_PWD="${QUAY_PASSWORD}" \
+    DOCKER_USER="${DOCKER_USER}"\
+    DOCKER_PWD="${DOCKER_PWD}" \
     docker/login \
     image/push
 else


### PR DESCRIPTION
... replaces quay.io use in CI/CD/container-registry-use which was available originally through quay.io

Resolves #23 

## Description
Originally (before Kubeflow code "uplift") quay.io was used for Container Registry; as requested during KF community meeting, this changes to make use of dockerhub as default.

The goal as intended was to keep build infra (makefile, scripts, GHAs) design, but to adapt it to KF community request, while preserving extensibility and customization for any downstream consumer.

## How Has This Been Tested?
- dry run (don't have the psw) of `make image/build`
results as expected:
```
docker build . -f Dockerfile -t kubeflow/model-registry:main
```
- dry run (don't have the psw) of `IMG_REGISTRY=quay.io make image/build`
results as expected:
```
docker build . -f Dockerfile -t quay.io/kubeflow/model-registry:main
```
- dry run (don't have the pws) of `./scripts/build_deploy.sh`
results as expected:
```
Building container image..
docker build . -f Dockerfile -t kubeflow/model-registry:cfb4712
```
- GHAs: this PR will be used.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
