### PR TITLE
add Kustomize 5.2.1 in Kind GHA testing

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -33,6 +33,10 @@ jobs:
         env:
           VERSION: ${{ steps.tags.outputs.tag }}
         run: ./scripts/build_deploy.sh
+      - name: Install Kustomize
+        uses: karancode/kustomize-github-action@v1.3.2
+        with:
+          kustomize_version: '5.2.1'
       - name: Start Kind Cluster
         uses: helm/kind-action@v1.9.0
       - name: Load Local Registry Test Image
@@ -44,11 +48,13 @@ jobs:
         env:
           IMG: "${{ env.IMG }}:${{ steps.tags.outputs.tag }}"
         run: |
+          echo "Display Kustomize version"
+          kustomize version 
           echo "Deploying Model Registry using Manifests; branch ${BRANCH}"
           kubectl create namespace kubeflow
           cd manifests/kustomize/overlays/db
           kustomize edit set image kubeflow/model-registry:latest $IMG
-          kubectl apply -k .
+          kustomize build | kubectl apply -f -
       - name: Wait for Test Registry Deployment
         run: |
           kubectl wait --for=condition=available -n kubeflow deployment/model-registry-db --timeout=5m


### PR DESCRIPTION
Resolves https://github.com/kubeflow/model-registry/issues/42

## Description
As part of KF 1.9 release checklist, make sure Kustomize 5.2.1. is used when testing the Model Registry manifests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [n/a] The developer has manually tested the changes and verified that the changes work
