### PR TITLE
add specific K8s version when testing with Kind

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -34,6 +34,8 @@ jobs:
         run: ./scripts/build_deploy.sh
       - name: Start Kind Cluster
         uses: helm/kind-action@v1.9.0
+        with:
+          node_image: "kindest/node:v1.27.11"
       - name: Load Local Registry Test Image
         env:
           IMG: "${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- based on, and pending on #43 (this PR in draft as will be rebased after #43 gets merged)
- resolves #44 

## How Has This Been Tested?
uses Kind as part of GHA workflow

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [n/a] The developer has manually tested the changes and verified that the changes work
