### PR TITLE
fix wrong indentation in makefile rule recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,11 +194,11 @@ proxy: build
 # login to docker
 .PHONY: docker/login
 docker/login:
-	ifdef IMG_REGISTRY
-		$(DOCKER) login -u "${DOCKER_USER}" -p "${DOCKER_PWD}" "${IMG_REGISTRY}"
-	else
-		$(DOCKER) login -u "${DOCKER_USER}" -p "${DOCKER_PWD}"
-	endif
+ifdef IMG_REGISTRY
+	$(DOCKER) login -u "${DOCKER_USER}" -p "${DOCKER_PWD}" "${IMG_REGISTRY}"
+else
+	$(DOCKER) login -u "${DOCKER_USER}" -p "${DOCKER_PWD}"
+endif
 
 
 # build docker image


### PR DESCRIPTION
wrong indentation of Makefile rule recipe as invoked by CI/GHA


## How Has This Been Tested?
Invoking `make docker/login` locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
