### PR TITLE
demo storing label as custom property with empty string value

### DIFF
--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -58,3 +58,24 @@ As a MLOps engineer I would like to store a longer documentation for the model
     ${r}    Then I get ArtifactsByModelVersionID    id=${vId}
     ${cnt}  Then Get length    ${r["items"]}
             And Should Be Equal As Integers    ${cnt}    2
+
+As a MLOps engineer I would like to store some labels
+    # A custom property of type string, with empty string value, shall be considered a Label; this is also semantically compatible for properties having empty string values in general.
+    ${cp1}    Create Dictionary  my-label1=${{ {"string_value": "", "metadataType": "MetadataStringValue"} }}  my-label2=${{ {"string_value": "", "metadataType": "MetadataStringValue"} }}
+    Set To Dictionary    ${registered_model}    description=Lorem ipsum dolor sit amet  name=${name}  customProperties=${cp1}
+    ${cp2}    Create Dictionary  my-label3=${{ {"string_value": "", "metadataType": "MetadataStringValue"} }}  my-label4=${{ {"string_value": "", "metadataType": "MetadataStringValue"} }}
+    Set To Dictionary    ${model_version}    description=consectetur adipiscing elit  customProperties=${cp2}
+    ${cp3}    Create Dictionary  my-label5=${{ {"string_value": "", "metadataType": "MetadataStringValue"} }}  my-label6=${{ {"string_value": "", "metadataType": "MetadataStringValue"} }}
+    Set To Dictionary    ${model_artifact}    description=sed do eiusmod tempor incididunt  customProperties=${cp3}
+    ${rId}  Given I create a RegisteredModel    payload=${registered_model}
+    ${vId}  And I create a child ModelVersion    registeredModelID=${rId}  payload=&{model_version}
+    ${aId}  And I create a child ModelArtifact    modelversionId=${vId}  payload=&{model_artifact}
+    ${r}  Then I get RegisteredModelByID    id=${rId}
+          And Should be equal    ${r["description"]}    Lorem ipsum dolor sit amet
+          And Dictionaries Should Be Equal   ${r["customProperties"]}  ${cp1}
+    ${r}  Then I get ModelVersionByID    id=${vId}
+          And Should be equal    ${r["description"]}    consectetur adipiscing elit
+          And Dictionaries Should Be Equal   ${r["customProperties"]}  ${cp2}
+    ${r}  Then I get ModelArtifactByID    id=${aId}
+          And Should be equal    ${r["description"]}    sed do eiusmod tempor incididunt
+          And Dictionaries Should Be Equal   ${r["customProperties"]}  ${cp3}


### PR DESCRIPTION
In this demo,
- RegisteredModel gets labels: my-label1, my-label2
- ModelVersion gets labels: my-label3, my-label4
- ModelArtifact gets labels: my-label5, my-label6

<!--- Provide a general summary of your changes in the Title above -->

## Description
Custom property of type string, with empty string value, shall be considered a Label; this is also semantically compatible for properties having empty string values in general.

## How Has This Been Tested?
```
robot test/robot/UserStory.robot
```

Behind the scenes, request payload is exercised as:

```
POST Request : url=http://localhost:8080/api/model_registry/v1alpha3/registered_models 
 path_url=/api/model_registry/v1alpha3/registered_models 
 headers={'User-Agent': 'python-requests/2.31.0', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive', 'Content-Length': '235', 'Content-Type': 'application/json'} 
 body=b'{"name": "GkfjQxwk", "description": "Lorem ipsum dolor sit amet", "customProperties": {"my-label1": {"string_value": "", "metadataType": "MetadataStringValue"}, "my-label2": {"string_value": "", "metadataType": "MetadataStringValue"}}}' 
```

So we can notice this takes the general form of:

```
{
..., 
"customProperties":
  { "my-label1": {"string_value": "", "metadataType": "MetadataStringValue"}, 
    ...
```

And analogous response:

```
POST Response : url=http://localhost:8080/api/model_registry/v1alpha3/registered_models 
 status=201, reason=Created 
 headers={'Content-Type': 'application/json; charset=UTF-8', 'Vary': 'Origin', 'Date': 'Wed, 03 Apr 2024 06:36:10 GMT', 'Content-Length': '314'} 
 body={"createTimeSinceEpoch":"1712126170473","customProperties":{"my-label1":{"metadataType":"MetadataStringValue","string_value":""},"my-label2":{"metadataType":"MetadataStringValue","string_value":""}},"description":"Lorem ipsum dolor sit amet","id":"36","lastUpdateTimeSinceEpoch":"1712126170473","name":"GkfjQxwk"}
```

Resulting in:

![Screenshot 2024-04-03 at 08 47 22](https://github.com/kubeflow/model-registry/assets/1699252/1ab34023-e37d-47e5-a897-d325bcc13754)

as expected.

References:
- https://github.com/opendatahub-io/model-registry-bf4-kf/issues/151 
- https://issues.redhat.com/browse/RHOAIENG-893

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
