### PR TITLE
fix: OpenAPI ModelVersion shall contain registeredModelId property

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -1047,10 +1047,11 @@ components:
       allOf:
         - $ref: "#/components/schemas/BaseResourceCreate"
         - $ref: "#/components/schemas/ModelVersionUpdate"
-      properties:
-        registeredModelId:
-          description: ID of the `RegisteredModel` to which this version belongs.
-          type: string
+        - type: object
+          properties:
+            registeredModelId:
+              description: ID of the `RegisteredModel` to which this version belongs.
+              type: string
     ModelVersionUpdate:
       description: Represents a ModelVersion belonging to a RegisteredModel.
       allOf:

--- a/internal/converter/generated/mlmd_openapi_converter.gen.go
+++ b/internal/converter/generated/mlmd_openapi_converter.gen.go
@@ -136,6 +136,11 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertModelVersion(source *proto.Context) 
 		openapiModelVersion.Name = converter.MapNameFromOwned((*source).Name)
 		openapiModelVersion.State = converter.MapModelVersionState((*source).Properties)
 		openapiModelVersion.Author = converter.MapPropertyAuthor((*source).Properties)
+		xstring2, err := converter.MapRegisteredModelIdFromOwned((*source).Name)
+		if err != nil {
+			return nil, fmt.Errorf("error setting field RegisteredModelId: %w", err)
+		}
+		openapiModelVersion.RegisteredModelId = xstring2
 		openapiModelVersion.Id = converter.Int64ToString((*source).Id)
 		openapiModelVersion.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
 		openapiModelVersion.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)

--- a/internal/converter/generated/openapi_converter.gen.go
+++ b/internal/converter/generated/openapi_converter.gen.go
@@ -302,6 +302,7 @@ func (c *OpenAPIConverterImpl) ConvertModelVersionCreate(source *openapi.ModelVe
 			pString4 = &xstring4
 		}
 		openapiModelVersion.Author = pString4
+		openapiModelVersion.RegisteredModelId = (*source).RegisteredModelId
 		pOpenapiModelVersion = &openapiModelVersion
 	}
 	return pOpenapiModelVersion, nil
@@ -636,6 +637,15 @@ func (c *OpenAPIConverterImpl) OverrideNotEditableForModelVersion(source convert
 		pString2 = &xstring
 	}
 	openapiModelVersion.Name = pString2
+	var pString3 *string
+	if source.Existing != nil {
+		pString3 = &source.Existing.RegisteredModelId
+	}
+	var xstring2 string
+	if pString3 != nil {
+		xstring2 = *pString3
+	}
+	openapiModelVersion.RegisteredModelId = xstring2
 	return openapiModelVersion, nil
 }
 func (c *OpenAPIConverterImpl) OverrideNotEditableForRegisteredModel(source converter.OpenapiUpdateWrapper[openapi.RegisteredModel]) (openapi.RegisteredModel, error) {

--- a/internal/converter/mlmd_converter_util_test.go
+++ b/internal/converter/mlmd_converter_util_test.go
@@ -570,6 +570,24 @@ func TestMapNameFromOwned(t *testing.T) {
 	assertion.Nil(name)
 }
 
+func TestMapRegisteredModelIdFromOwned(t *testing.T) {
+	assertion := setup(t)
+
+	result, err := MapRegisteredModelIdFromOwned(of("prefix:name"))
+	assertion.Nil(err)
+	assertion.Equal("prefix", result)
+
+	_, err = MapRegisteredModelIdFromOwned(of("name"))
+	assertion.NotNil(err)
+
+	_, err = MapRegisteredModelIdFromOwned(of("prefix:name:postfix"))
+	assertion.NotNil(err)
+
+	result, err = MapRegisteredModelIdFromOwned(nil)
+	assertion.Nil(err)
+	assertion.Equal("", result)
+}
+
 func TestMapArtifactType(t *testing.T) {
 	assertion := setup(t)
 

--- a/internal/converter/mlmd_openapi_converter.go
+++ b/internal/converter/mlmd_openapi_converter.go
@@ -19,6 +19,7 @@ type MLMDToOpenAPIConverter interface {
 	ConvertRegisteredModel(source *proto.Context) (*openapi.RegisteredModel, error)
 
 	// goverter:map Name | MapNameFromOwned
+	// goverter:map Name RegisteredModelId | MapRegisteredModelIdFromOwned
 	// goverter:map Properties Description | MapDescription
 	// goverter:map Properties State | MapModelVersionState
 	// goverter:map Properties Author | MapPropertyAuthor

--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -108,6 +108,18 @@ func MapPropertyAuthor(properties map[string]*proto.Value) *string {
 	return MapStringProperty(properties, "author")
 }
 
+func MapRegisteredModelIdFromOwned(source *string) (string, error) {
+	if source == nil {
+		return "", nil
+	}
+
+	exploded := strings.Split(*source, ":")
+	if len(exploded) != 2 {
+		return "", fmt.Errorf("wrong owned format")
+	}
+	return exploded[0], nil
+}
+
 // ARTIFACT
 
 func MapArtifactType(source *proto.Artifact) (string, error) {

--- a/internal/converter/openapi_converter.go
+++ b/internal/converter/openapi_converter.go
@@ -22,7 +22,7 @@ type OpenAPIConverter interface {
 	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch
 	ConvertModelVersionCreate(source *openapi.ModelVersionCreate) (*openapi.ModelVersion, error)
 
-	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Name
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Name RegisteredModelId
 	ConvertModelVersionUpdate(source *openapi.ModelVersionUpdate) (*openapi.ModelVersion, error)
 
 	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch ArtifactType

--- a/internal/server/openapi/type_asserts.go
+++ b/internal/server/openapi/type_asserts.go
@@ -62,16 +62,6 @@ func AssertArtifactStateConstraints(obj model.ArtifactState) error {
 	return nil
 }
 
-// AssertBaseArtifactCreateRequired checks if the required fields are not zero-ed
-func AssertBaseArtifactCreateRequired(obj model.BaseArtifactCreate) error {
-	return nil
-}
-
-// AssertBaseArtifactCreateConstraints checks if the values respects the defined constraints
-func AssertBaseArtifactCreateConstraints(obj model.BaseArtifactCreate) error {
-	return nil
-}
-
 // AssertBaseArtifactRequired checks if the required fields are not zero-ed
 func AssertBaseArtifactRequired(obj model.BaseArtifact) error {
 	return nil
@@ -79,6 +69,16 @@ func AssertBaseArtifactRequired(obj model.BaseArtifact) error {
 
 // AssertBaseArtifactConstraints checks if the values respects the defined constraints
 func AssertBaseArtifactConstraints(obj model.BaseArtifact) error {
+	return nil
+}
+
+// AssertBaseArtifactCreateRequired checks if the required fields are not zero-ed
+func AssertBaseArtifactCreateRequired(obj model.BaseArtifactCreate) error {
+	return nil
+}
+
+// AssertBaseArtifactCreateConstraints checks if the values respects the defined constraints
+func AssertBaseArtifactCreateConstraints(obj model.BaseArtifactCreate) error {
 	return nil
 }
 
@@ -92,16 +92,6 @@ func AssertBaseArtifactUpdateConstraints(obj model.BaseArtifactUpdate) error {
 	return nil
 }
 
-// AssertBaseExecutionCreateRequired checks if the required fields are not zero-ed
-func AssertBaseExecutionCreateRequired(obj model.BaseExecutionCreate) error {
-	return nil
-}
-
-// AssertBaseExecutionCreateConstraints checks if the values respects the defined constraints
-func AssertBaseExecutionCreateConstraints(obj model.BaseExecutionCreate) error {
-	return nil
-}
-
 // AssertBaseExecutionRequired checks if the required fields are not zero-ed
 func AssertBaseExecutionRequired(obj model.BaseExecution) error {
 	return nil
@@ -109,6 +99,16 @@ func AssertBaseExecutionRequired(obj model.BaseExecution) error {
 
 // AssertBaseExecutionConstraints checks if the values respects the defined constraints
 func AssertBaseExecutionConstraints(obj model.BaseExecution) error {
+	return nil
+}
+
+// AssertBaseExecutionCreateRequired checks if the required fields are not zero-ed
+func AssertBaseExecutionCreateRequired(obj model.BaseExecutionCreate) error {
+	return nil
+}
+
+// AssertBaseExecutionCreateConstraints checks if the values respects the defined constraints
+func AssertBaseExecutionCreateConstraints(obj model.BaseExecutionCreate) error {
 	return nil
 }
 
@@ -122,16 +122,6 @@ func AssertBaseExecutionUpdateConstraints(obj model.BaseExecutionUpdate) error {
 	return nil
 }
 
-// AssertBaseResourceCreateRequired checks if the required fields are not zero-ed
-func AssertBaseResourceCreateRequired(obj model.BaseResourceCreate) error {
-	return nil
-}
-
-// AssertBaseResourceCreateConstraints checks if the values respects the defined constraints
-func AssertBaseResourceCreateConstraints(obj model.BaseResourceCreate) error {
-	return nil
-}
-
 // AssertBaseResourceRequired checks if the required fields are not zero-ed
 func AssertBaseResourceRequired(obj model.BaseResource) error {
 	return nil
@@ -139,6 +129,16 @@ func AssertBaseResourceRequired(obj model.BaseResource) error {
 
 // AssertBaseResourceConstraints checks if the values respects the defined constraints
 func AssertBaseResourceConstraints(obj model.BaseResource) error {
+	return nil
+}
+
+// AssertBaseResourceCreateRequired checks if the required fields are not zero-ed
+func AssertBaseResourceCreateRequired(obj model.BaseResourceCreate) error {
+	return nil
+}
+
+// AssertBaseResourceCreateConstraints checks if the values respects the defined constraints
+func AssertBaseResourceCreateConstraints(obj model.BaseResourceCreate) error {
 	return nil
 }
 
@@ -222,26 +222,6 @@ func AssertExecutionStateConstraints(obj model.ExecutionState) error {
 	return nil
 }
 
-// AssertInferenceServiceCreateRequired checks if the required fields are not zero-ed
-func AssertInferenceServiceCreateRequired(obj model.InferenceServiceCreate) error {
-	elements := map[string]interface{}{
-		"registeredModelId":    obj.RegisteredModelId,
-		"servingEnvironmentId": obj.ServingEnvironmentId,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
-	return nil
-}
-
-// AssertInferenceServiceCreateConstraints checks if the values respects the defined constraints
-func AssertInferenceServiceCreateConstraints(obj model.InferenceServiceCreate) error {
-	return nil
-}
-
 // AssertInferenceServiceRequired checks if the required fields are not zero-ed
 func AssertInferenceServiceRequired(obj model.InferenceService) error {
 	elements := map[string]interface{}{
@@ -259,6 +239,26 @@ func AssertInferenceServiceRequired(obj model.InferenceService) error {
 
 // AssertInferenceServiceConstraints checks if the values respects the defined constraints
 func AssertInferenceServiceConstraints(obj model.InferenceService) error {
+	return nil
+}
+
+// AssertInferenceServiceCreateRequired checks if the required fields are not zero-ed
+func AssertInferenceServiceCreateRequired(obj model.InferenceServiceCreate) error {
+	elements := map[string]interface{}{
+		"registeredModelId":    obj.RegisteredModelId,
+		"servingEnvironmentId": obj.ServingEnvironmentId,
+	}
+	for name, el := range elements {
+		if isZero := IsZeroValue(el); isZero {
+			return &RequiredError{Field: name}
+		}
+	}
+
+	return nil
+}
+
+// AssertInferenceServiceCreateConstraints checks if the values respects the defined constraints
+func AssertInferenceServiceCreateConstraints(obj model.InferenceServiceCreate) error {
 	return nil
 }
 
@@ -456,16 +456,6 @@ func AssertMetadataValueConstraints(obj model.MetadataValue) error {
 	return nil
 }
 
-// AssertModelArtifactCreateRequired checks if the required fields are not zero-ed
-func AssertModelArtifactCreateRequired(obj model.ModelArtifactCreate) error {
-	return nil
-}
-
-// AssertModelArtifactCreateConstraints checks if the values respects the defined constraints
-func AssertModelArtifactCreateConstraints(obj model.ModelArtifactCreate) error {
-	return nil
-}
-
 // AssertModelArtifactRequired checks if the required fields are not zero-ed
 func AssertModelArtifactRequired(obj model.ModelArtifact) error {
 	elements := map[string]interface{}{
@@ -482,6 +472,16 @@ func AssertModelArtifactRequired(obj model.ModelArtifact) error {
 
 // AssertModelArtifactConstraints checks if the values respects the defined constraints
 func AssertModelArtifactConstraints(obj model.ModelArtifact) error {
+	return nil
+}
+
+// AssertModelArtifactCreateRequired checks if the required fields are not zero-ed
+func AssertModelArtifactCreateRequired(obj model.ModelArtifactCreate) error {
+	return nil
+}
+
+// AssertModelArtifactCreateConstraints checks if the values respects the defined constraints
+func AssertModelArtifactCreateConstraints(obj model.ModelArtifactCreate) error {
 	return nil
 }
 
@@ -521,6 +521,25 @@ func AssertModelArtifactUpdateConstraints(obj model.ModelArtifactUpdate) error {
 	return nil
 }
 
+// AssertModelVersionRequired checks if the required fields are not zero-ed
+func AssertModelVersionRequired(obj model.ModelVersion) error {
+	elements := map[string]interface{}{
+		"registeredModelId": obj.RegisteredModelId,
+	}
+	for name, el := range elements {
+		if isZero := IsZeroValue(el); isZero {
+			return &RequiredError{Field: name}
+		}
+	}
+
+	return nil
+}
+
+// AssertModelVersionConstraints checks if the values respects the defined constraints
+func AssertModelVersionConstraints(obj model.ModelVersion) error {
+	return nil
+}
+
 // AssertModelVersionCreateRequired checks if the required fields are not zero-ed
 func AssertModelVersionCreateRequired(obj model.ModelVersionCreate) error {
 	elements := map[string]interface{}{
@@ -537,16 +556,6 @@ func AssertModelVersionCreateRequired(obj model.ModelVersionCreate) error {
 
 // AssertModelVersionCreateConstraints checks if the values respects the defined constraints
 func AssertModelVersionCreateConstraints(obj model.ModelVersionCreate) error {
-	return nil
-}
-
-// AssertModelVersionRequired checks if the required fields are not zero-ed
-func AssertModelVersionRequired(obj model.ModelVersion) error {
-	return nil
-}
-
-// AssertModelVersionConstraints checks if the values respects the defined constraints
-func AssertModelVersionConstraints(obj model.ModelVersion) error {
 	return nil
 }
 
@@ -606,16 +615,6 @@ func AssertOrderByFieldConstraints(obj model.OrderByField) error {
 	return nil
 }
 
-// AssertRegisteredModelCreateRequired checks if the required fields are not zero-ed
-func AssertRegisteredModelCreateRequired(obj model.RegisteredModelCreate) error {
-	return nil
-}
-
-// AssertRegisteredModelCreateConstraints checks if the values respects the defined constraints
-func AssertRegisteredModelCreateConstraints(obj model.RegisteredModelCreate) error {
-	return nil
-}
-
 // AssertRegisteredModelRequired checks if the required fields are not zero-ed
 func AssertRegisteredModelRequired(obj model.RegisteredModel) error {
 	return nil
@@ -623,6 +622,16 @@ func AssertRegisteredModelRequired(obj model.RegisteredModel) error {
 
 // AssertRegisteredModelConstraints checks if the values respects the defined constraints
 func AssertRegisteredModelConstraints(obj model.RegisteredModel) error {
+	return nil
+}
+
+// AssertRegisteredModelCreateRequired checks if the required fields are not zero-ed
+func AssertRegisteredModelCreateRequired(obj model.RegisteredModelCreate) error {
+	return nil
+}
+
+// AssertRegisteredModelCreateConstraints checks if the values respects the defined constraints
+func AssertRegisteredModelCreateConstraints(obj model.RegisteredModelCreate) error {
 	return nil
 }
 
@@ -672,25 +681,6 @@ func AssertRegisteredModelUpdateConstraints(obj model.RegisteredModelUpdate) err
 	return nil
 }
 
-// AssertServeModelCreateRequired checks if the required fields are not zero-ed
-func AssertServeModelCreateRequired(obj model.ServeModelCreate) error {
-	elements := map[string]interface{}{
-		"modelVersionId": obj.ModelVersionId,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
-	return nil
-}
-
-// AssertServeModelCreateConstraints checks if the values respects the defined constraints
-func AssertServeModelCreateConstraints(obj model.ServeModelCreate) error {
-	return nil
-}
-
 // AssertServeModelRequired checks if the required fields are not zero-ed
 func AssertServeModelRequired(obj model.ServeModel) error {
 	elements := map[string]interface{}{
@@ -707,6 +697,25 @@ func AssertServeModelRequired(obj model.ServeModel) error {
 
 // AssertServeModelConstraints checks if the values respects the defined constraints
 func AssertServeModelConstraints(obj model.ServeModel) error {
+	return nil
+}
+
+// AssertServeModelCreateRequired checks if the required fields are not zero-ed
+func AssertServeModelCreateRequired(obj model.ServeModelCreate) error {
+	elements := map[string]interface{}{
+		"modelVersionId": obj.ModelVersionId,
+	}
+	for name, el := range elements {
+		if isZero := IsZeroValue(el); isZero {
+			return &RequiredError{Field: name}
+		}
+	}
+
+	return nil
+}
+
+// AssertServeModelCreateConstraints checks if the values respects the defined constraints
+func AssertServeModelCreateConstraints(obj model.ServeModelCreate) error {
 	return nil
 }
 
@@ -746,16 +755,6 @@ func AssertServeModelUpdateConstraints(obj model.ServeModelUpdate) error {
 	return nil
 }
 
-// AssertServingEnvironmentCreateRequired checks if the required fields are not zero-ed
-func AssertServingEnvironmentCreateRequired(obj model.ServingEnvironmentCreate) error {
-	return nil
-}
-
-// AssertServingEnvironmentCreateConstraints checks if the values respects the defined constraints
-func AssertServingEnvironmentCreateConstraints(obj model.ServingEnvironmentCreate) error {
-	return nil
-}
-
 // AssertServingEnvironmentRequired checks if the required fields are not zero-ed
 func AssertServingEnvironmentRequired(obj model.ServingEnvironment) error {
 	return nil
@@ -763,6 +762,16 @@ func AssertServingEnvironmentRequired(obj model.ServingEnvironment) error {
 
 // AssertServingEnvironmentConstraints checks if the values respects the defined constraints
 func AssertServingEnvironmentConstraints(obj model.ServingEnvironment) error {
+	return nil
+}
+
+// AssertServingEnvironmentCreateRequired checks if the required fields are not zero-ed
+func AssertServingEnvironmentCreateRequired(obj model.ServingEnvironmentCreate) error {
+	return nil
+}
+
+// AssertServingEnvironmentCreateConstraints checks if the values respects the defined constraints
+func AssertServingEnvironmentCreateConstraints(obj model.ServingEnvironmentCreate) error {
 	return nil
 }
 

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -970,6 +970,7 @@ func (suite *CoreTestSuite) TestCreateModelVersion() {
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
 	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Equal((*createdVersion).RegisteredModelId, registeredModelId, "RegisteredModelId should match the actual owner")
 
 	suite.NotNilf(createdVersion.Id, "created model version should not have nil Id")
 
@@ -1045,6 +1046,7 @@ func (suite *CoreTestSuite) TestUpdateModelVersion() {
 
 	updatedVersion, err := service.UpsertModelVersion(createdVersion, &registeredModelId)
 	suite.Nilf(err, "error updating new model version for %s: %v", registeredModelId, err)
+	suite.Equal((*updatedVersion).RegisteredModelId, registeredModelId, "RegisteredModelId should match the actual owner")
 
 	updateVersionId, _ := converter.StringToInt64(updatedVersion.Id)
 	suite.Equal(*createdVersionId, *updateVersionId, "created and updated model version should have same id")

--- a/pkg/openapi/model_model_version.go
+++ b/pkg/openapi/model_model_version.go
@@ -30,6 +30,8 @@ type ModelVersion struct {
 	State *ModelVersionState `json:"state,omitempty"`
 	// Name of the author.
 	Author *string `json:"author,omitempty"`
+	// ID of the `RegisteredModel` to which this version belongs.
+	RegisteredModelId string `json:"registeredModelId"`
 	// Output only. The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
@@ -42,10 +44,11 @@ type ModelVersion struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewModelVersion() *ModelVersion {
+func NewModelVersion(registeredModelId string) *ModelVersion {
 	this := ModelVersion{}
 	var state ModelVersionState = MODELVERSIONSTATE_LIVE
 	this.State = &state
+	this.RegisteredModelId = registeredModelId
 	return &this
 }
 
@@ -251,6 +254,30 @@ func (o *ModelVersion) SetAuthor(v string) {
 	o.Author = &v
 }
 
+// GetRegisteredModelId returns the RegisteredModelId field value
+func (o *ModelVersion) GetRegisteredModelId() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.RegisteredModelId
+}
+
+// GetRegisteredModelIdOk returns a tuple with the RegisteredModelId field value
+// and a boolean to check if the value has been set.
+func (o *ModelVersion) GetRegisteredModelIdOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.RegisteredModelId, true
+}
+
+// SetRegisteredModelId sets field value
+func (o *ModelVersion) SetRegisteredModelId(v string) {
+	o.RegisteredModelId = v
+}
+
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *ModelVersion) GetId() string {
 	if o == nil || IsNil(o.Id) {
@@ -375,6 +402,7 @@ func (o ModelVersion) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Author) {
 		toSerialize["author"] = o.Author
 	}
+	toSerialize["registeredModelId"] = o.RegisteredModelId
 	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}

--- a/pkg/openapi/model_model_version_create.go
+++ b/pkg/openapi/model_model_version_create.go
@@ -19,8 +19,6 @@ var _ MappedNullable = &ModelVersionCreate{}
 
 // ModelVersionCreate Represents a ModelVersion belonging to a RegisteredModel.
 type ModelVersionCreate struct {
-	// ID of the `RegisteredModel` to which this version belongs.
-	RegisteredModelId string `json:"registeredModelId"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -32,6 +30,8 @@ type ModelVersionCreate struct {
 	State *ModelVersionState `json:"state,omitempty"`
 	// Name of the author.
 	Author *string `json:"author,omitempty"`
+	// ID of the `RegisteredModel` to which this version belongs.
+	RegisteredModelId string `json:"registeredModelId"`
 }
 
 // NewModelVersionCreate instantiates a new ModelVersionCreate object
@@ -42,6 +42,7 @@ func NewModelVersionCreate(registeredModelId string) *ModelVersionCreate {
 	this := ModelVersionCreate{}
 	var state ModelVersionState = MODELVERSIONSTATE_LIVE
 	this.State = &state
+	this.RegisteredModelId = registeredModelId
 	return &this
 }
 
@@ -53,30 +54,6 @@ func NewModelVersionCreateWithDefaults() *ModelVersionCreate {
 	var state ModelVersionState = MODELVERSIONSTATE_LIVE
 	this.State = &state
 	return &this
-}
-
-// GetRegisteredModelId returns the RegisteredModelId field value
-func (o *ModelVersionCreate) GetRegisteredModelId() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.RegisteredModelId
-}
-
-// GetRegisteredModelIdOk returns a tuple with the RegisteredModelId field value
-// and a boolean to check if the value has been set.
-func (o *ModelVersionCreate) GetRegisteredModelIdOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.RegisteredModelId, true
-}
-
-// SetRegisteredModelId sets field value
-func (o *ModelVersionCreate) SetRegisteredModelId(v string) {
-	o.RegisteredModelId = v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -271,6 +248,30 @@ func (o *ModelVersionCreate) SetAuthor(v string) {
 	o.Author = &v
 }
 
+// GetRegisteredModelId returns the RegisteredModelId field value
+func (o *ModelVersionCreate) GetRegisteredModelId() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.RegisteredModelId
+}
+
+// GetRegisteredModelIdOk returns a tuple with the RegisteredModelId field value
+// and a boolean to check if the value has been set.
+func (o *ModelVersionCreate) GetRegisteredModelIdOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.RegisteredModelId, true
+}
+
+// SetRegisteredModelId sets field value
+func (o *ModelVersionCreate) SetRegisteredModelId(v string) {
+	o.RegisteredModelId = v
+}
+
 func (o ModelVersionCreate) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -281,7 +282,6 @@ func (o ModelVersionCreate) MarshalJSON() ([]byte, error) {
 
 func (o ModelVersionCreate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["registeredModelId"] = o.RegisteredModelId
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -300,6 +300,7 @@ func (o ModelVersionCreate) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Author) {
 		toSerialize["author"] = o.Author
 	}
+	toSerialize["registeredModelId"] = o.RegisteredModelId
 	return toSerialize, nil
 }
 

--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -17,6 +17,7 @@ As a MLOps engineer I would like to store Model name
           And Should be equal    ${r["name"]}    ${name}
     ${r}  Then I get ModelVersionByID    id=${vId}
           And Should be equal    ${r["name"]}    v1
+          And Should be equal    ${r["registeredModelId"]}    ${rId}
     ${r}  Then I get ModelArtifactByID    id=${aId}
           And Should be equal    ${r["uri"]}    s3://12345
 


### PR DESCRIPTION
need to adapt property definition in OpenAPI
to accomodate openapi-codegen result;
according to contract (as also visible in swagger)
<img width="1840" alt="Screenshot 2024-04-12 at 12 43 02" src="https://github.com/kubeflow/model-registry/assets/1699252/040af30f-5c5b-4b91-89ba-e6a4e96e84e1">


the `ModelVersion` is to contain property: `registeredModelId`

<!--- Provide a general summary of your changes in the Title above -->

## Description
- change OpenAPI definition to a variant which accomodates the intended openapi-codegen result we need
- implement goverter functions
- new unit test functions
- extend integration test 
- extend E2E test (robotframework)

## How Has This Been Tested?
- make test
- robot test/robot/UserStory.robot

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
