### PR TITLE
add `owner` to `RegisteredModel` logical model

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -1033,6 +1033,8 @@ components:
         - $ref: "#/components/schemas/BaseResourceUpdate"
         - type: object
           properties:
+            owner:
+              type: string
             state:
               $ref: "#/components/schemas/RegisteredModelState"
     ModelVersion:

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -129,11 +129,22 @@ class RegisteredModel(BaseContext):
 
     Attributes:
         name: Registered model name.
+        owner: Owner of this Registered Model.
         description: Description of the object.
         external_id: Customizable ID. Has to be unique among instances of the same type.
     """
 
     name: str
+    owner: str = None
+
+    @override
+    def map(self, type_id: int) -> Context:
+        mlmd_obj = super().map(type_id)
+        props = {
+            "owner": self.owner
+        }
+        self._map_props(props, mlmd_obj.properties)
+        return mlmd_obj
 
     @classmethod
     @override
@@ -142,4 +153,5 @@ class RegisteredModel(BaseContext):
         assert isinstance(
             py_obj, RegisteredModel
         ), f"Expected RegisteredModel, got {type(py_obj)}"
+        py_obj.owner = mlmd_obj.properties["owner"].string_value
         return py_obj

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -89,7 +89,9 @@ def plain_wrapper(request, mlmd_conn: MetadataStoreClientConfig) -> MLMDStore:
 
     request.addfinalizer(teardown)
 
-    return MLMDStore(mlmd_conn)
+    to_return = MLMDStore(mlmd_conn)
+    sanity_check_mlmd_connection_to_db(to_return)
+    return to_return
 
 
 def set_type_attrs(mlmd_obj: ProtoTypeType, name: str, props: list[str]):
@@ -97,6 +99,24 @@ def set_type_attrs(mlmd_obj: ProtoTypeType, name: str, props: list[str]):
     for key in props:
         mlmd_obj.properties[key] = metadata_store_pb2.STRING
     return mlmd_obj
+
+
+def sanity_check_mlmd_connection_to_db(overview: MLMDStore):
+    # sanity check before each test: connect to MLMD directly, and dry-run any of the gRPC (read) operations;
+	# on newer Podman might delay in recognising volume mount files for sqlite3 db,
+	# hence in case of error "Cannot connect sqlite3 database: unable to open database file" make some retries.
+    retry_count = 0
+    while retry_count < 3:
+        retry_count += 1
+        try:
+            overview._mlmd_store.get_artifact_types()
+            return
+        except Exception as e:
+            if str(e) == "Cannot connect sqlite3 database: unable to open database file":
+                time.sleep(1)
+            else:
+                raise RuntimeError(f"Failed to sanity check before each test, another type of error detected: {str(e)}")
+    raise RuntimeError(f"Failed to sanity check before each test.")
 
 
 @pytest.fixture()

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -103,8 +103,8 @@ def set_type_attrs(mlmd_obj: ProtoTypeType, name: str, props: list[str]):
 
 def sanity_check_mlmd_connection_to_db(overview: MLMDStore):
     # sanity check before each test: connect to MLMD directly, and dry-run any of the gRPC (read) operations;
-	# on newer Podman might delay in recognising volume mount files for sqlite3 db,
-	# hence in case of error "Cannot connect sqlite3 database: unable to open database file" make some retries.
+    # on newer Podman might delay in recognising volume mount files for sqlite3 db,
+    # hence in case of error "Cannot connect sqlite3 database: unable to open database file" make some retries.
     retry_count = 0
     while retry_count < 3:
         retry_count += 1
@@ -115,8 +115,10 @@ def sanity_check_mlmd_connection_to_db(overview: MLMDStore):
             if str(e) == "Cannot connect sqlite3 database: unable to open database file":
                 time.sleep(1)
             else:
-                raise RuntimeError(f"Failed to sanity check before each test, another type of error detected: {str(e)}")
-    raise RuntimeError(f"Failed to sanity check before each test.")
+                msg = "Failed to sanity check before each test, another type of error detected."
+                raise RuntimeError(msg) from e
+    msg = "Failed to sanity check before each test."
+    raise RuntimeError(msg)
 
 
 @pytest.fixture()

--- a/clients/python/tests/types/test_context_mapping.py
+++ b/clients/python/tests/types/test_context_mapping.py
@@ -108,7 +108,7 @@ def minimal_registered_model() -> Mapped:
     proto_version.properties["owner"].string_value = "my owner"
 
     py_regmodel = RegisteredModel(name="mnist",
-        owner="my owner", 
+        owner="my owner",
         external_id="test_external_id",
         description="test description")
     return Mapped(proto_version, py_regmodel)

--- a/docs/logical_model.md
+++ b/docs/logical_model.md
@@ -442,10 +442,12 @@ This diagram summarizes the relationship between the entities:
 classDiagram
     class RegisteredModel{
         +String name
+        +String owner
         +Map customProperties
     }
     class ModelVersion{
         +String name
+        +String author
         +Map customProperties
     }
     class Artifact{

--- a/internal/converter/generated/mlmd_openapi_converter.gen.go
+++ b/internal/converter/generated/mlmd_openapi_converter.gen.go
@@ -173,6 +173,7 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertRegisteredModel(source *proto.Contex
 		openapiRegisteredModel.Id = converter.Int64ToString((*source).Id)
 		openapiRegisteredModel.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
 		openapiRegisteredModel.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)
+		openapiRegisteredModel.Owner = converter.MapOwner((*source).Properties)
 		openapiRegisteredModel.State = converter.MapRegisteredModelState((*source).Properties)
 		pOpenapiRegisteredModel = &openapiRegisteredModel
 	}

--- a/internal/converter/generated/openapi_converter.gen.go
+++ b/internal/converter/generated/openapi_converter.gen.go
@@ -379,6 +379,12 @@ func (c *OpenAPIConverterImpl) ConvertRegisteredModelCreate(source *openapi.Regi
 			pString3 = &xstring3
 		}
 		openapiRegisteredModel.Name = pString3
+		var pString4 *string
+		if (*source).Owner != nil {
+			xstring4 := *(*source).Owner
+			pString4 = &xstring4
+		}
+		openapiRegisteredModel.Owner = pString4
 		var pOpenapiRegisteredModelState *openapi.RegisteredModelState
 		if (*source).State != nil {
 			openapiRegisteredModelState := openapi.RegisteredModelState(*(*source).State)
@@ -414,6 +420,12 @@ func (c *OpenAPIConverterImpl) ConvertRegisteredModelUpdate(source *openapi.Regi
 			pString2 = &xstring2
 		}
 		openapiRegisteredModel.ExternalId = pString2
+		var pString3 *string
+		if (*source).Owner != nil {
+			xstring3 := *(*source).Owner
+			pString3 = &xstring3
+		}
+		openapiRegisteredModel.Owner = pString3
 		var pOpenapiRegisteredModelState *openapi.RegisteredModelState
 		if (*source).State != nil {
 			openapiRegisteredModelState := openapi.RegisteredModelState(*(*source).State)

--- a/internal/converter/mlmd_converter_util_test.go
+++ b/internal/converter/mlmd_converter_util_test.go
@@ -414,6 +414,20 @@ func TestMapDescription(t *testing.T) {
 	assertion.Equal("my-description", *extracted)
 }
 
+func TestMapOwner(t *testing.T) {
+	assertion := setup(t)
+
+	extracted := MapOwner(map[string]*proto.Value{
+		"owner": {
+			Value: &proto.Value_StringValue{
+				StringValue: "my-owner",
+			},
+		},
+	})
+
+	assertion.Equal("my-owner", *extracted)
+}
+
 func TestPropertyRuntime(t *testing.T) {
 	assertion := setup(t)
 

--- a/internal/converter/mlmd_openapi_converter.go
+++ b/internal/converter/mlmd_openapi_converter.go
@@ -15,6 +15,7 @@ import (
 // goverter:extend MapMLMDCustomProperties
 type MLMDToOpenAPIConverter interface {
 	// goverter:map Properties Description | MapDescription
+	// goverter:map Properties Owner | MapOwner
 	// goverter:map Properties State | MapRegisteredModelState
 	ConvertRegisteredModel(source *proto.Context) (*openapi.RegisteredModel, error)
 

--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -211,6 +211,10 @@ func MapDescription(properties map[string]*proto.Value) *string {
 	return MapStringProperty(properties, "description")
 }
 
+func MapOwner(properties map[string]*proto.Value) *string {
+	return MapStringProperty(properties, "owner")
+}
+
 func MapModelArtifactFormatName(properties map[string]*proto.Value) *string {
 	return MapStringProperty(properties, "model_format_name")
 }

--- a/internal/converter/openapi_converter.go
+++ b/internal/converter/openapi_converter.go
@@ -52,7 +52,7 @@ type OpenAPIConverter interface {
 	// Ignore all fields that ARE editable
 	// goverter:default InitRegisteredModelWithUpdate
 	// goverter:autoMap Existing
-	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalId CustomProperties State
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalId CustomProperties State Owner
 	OverrideNotEditableForRegisteredModel(source OpenapiUpdateWrapper[openapi.RegisteredModel]) (openapi.RegisteredModel, error)
 
 	// Ignore all fields that ARE editable

--- a/internal/converter/openapi_mlmd_converter_util.go
+++ b/internal/converter/openapi_mlmd_converter_util.go
@@ -123,6 +123,14 @@ func PrefixWhenOwned(ownerId *string, entityName string) string {
 func MapRegisteredModelProperties(source *openapi.RegisteredModel) (map[string]*proto.Value, error) {
 	props := make(map[string]*proto.Value)
 	if source != nil {
+		if source.Owner != nil {
+			props["owner"] = &proto.Value{
+				Value: &proto.Value_StringValue{
+					StringValue: *source.Owner,
+				},
+			}
+		}
+
 		if source.Description != nil {
 			props["description"] = &proto.Value{
 				Value: &proto.Value_StringValue{

--- a/internal/mlmdtypes/mlmdtypes.go
+++ b/internal/mlmdtypes/mlmdtypes.go
@@ -44,6 +44,7 @@ func CreateMLMDTypes(cc grpc.ClientConnInterface, nameConfig MLMDTypeNamesConfig
 			Name: &nameConfig.RegisteredModelTypeName,
 			Properties: map[string]proto.PropertyType{
 				"description": proto.PropertyType_STRING,
+				"owner":       proto.PropertyType_STRING,
 				"state":       proto.PropertyType_STRING,
 			},
 		},

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -26,8 +26,9 @@ var (
 	// registered models
 	modelName        string
 	modelDescription string
+	modelOwner       string
 	modelExternalId  string
-	owner            string
+	myCustomProp     string
 	// model version
 	modelVersionName        string
 	modelVersionDescription string
@@ -86,8 +87,9 @@ func (suite *CoreTestSuite) SetupTest() {
 	customString = "this is a customString value"
 	modelName = "MyAwesomeModel"
 	modelDescription = "reg model description"
+	modelOwner = "reg model owner"
 	modelExternalId = "org.myawesomemodel"
-	owner = "owner"
+	myCustomProp = "owner"
 	modelVersionName = "v1"
 	modelVersionDescription = "model version description"
 	versionExternalId = "org.myawesomemodel@v1"
@@ -131,8 +133,8 @@ func (suite *CoreTestSuite) registerModel(service api.ModelRegistryApi, override
 		ExternalId:  &modelExternalId,
 		Description: &modelDescription,
 		CustomProperties: &map[string]openapi.MetadataValue{
-			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}
@@ -161,8 +163,8 @@ func (suite *CoreTestSuite) registerServingEnvironment(service api.ModelRegistry
 		ExternalId:  &eutExtID,
 		Description: &entityDescription,
 		CustomProperties: &map[string]openapi.MetadataValue{
-			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}
@@ -225,8 +227,8 @@ func (suite *CoreTestSuite) registerInferenceService(service api.ModelRegistryAp
 		RegisteredModelId:    registerdModelId,
 		ServingEnvironmentId: servingEnvironmentId,
 		CustomProperties: &map[string]openapi.MetadataValue{
-			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}
@@ -348,7 +350,7 @@ func (suite *CoreTestSuite) TestModelRegistryStartupWithExistingEmptyTypes() {
 	})
 	suite.NotNilf(regModelResp.ContextType, "registered model type %s should exists", *registeredModelTypeName)
 	suite.Equal(*registeredModelTypeName, *regModelResp.ContextType.Name)
-	suite.Equal(2, len(regModelResp.ContextType.Properties))
+	suite.Equal(3, len(regModelResp.ContextType.Properties))
 
 	modelVersionResp, _ = suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: modelVersionTypeName,
@@ -573,10 +575,11 @@ func (suite *CoreTestSuite) TestCreateRegisteredModel() {
 		Name:        &modelName,
 		ExternalId:  &modelExternalId,
 		Description: &modelDescription,
+		Owner:       &modelOwner,
 		State:       &state,
 		CustomProperties: &map[string]openapi.MetadataValue{
-			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}
@@ -600,8 +603,9 @@ func (suite *CoreTestSuite) TestCreateRegisteredModel() {
 	suite.Equal(modelName, *ctx.Name, "saved model name should match the provided one")
 	suite.Equal(modelExternalId, *ctx.ExternalId, "saved external id should match the provided one")
 	suite.Equal(modelDescription, ctx.Properties["description"].GetStringValue(), "saved description should match the provided one")
+	suite.Equal(modelOwner, ctx.Properties["owner"].GetStringValue(), "saved owner should match the provided one")
 	suite.Equal(string(state), ctx.Properties["state"].GetStringValue(), "saved state should match the provided one")
-	suite.Equal(owner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	suite.Equal(myCustomProp, ctx.CustomProperties["myCustomProp"].GetStringValue(), "saved myCustomProp custom property should match the provided one")
 
 	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
 	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
@@ -617,8 +621,8 @@ func (suite *CoreTestSuite) TestUpdateRegisteredModel() {
 		Name:       &modelName,
 		ExternalId: &modelExternalId,
 		CustomProperties: &map[string]openapi.MetadataValue{
-			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}
@@ -702,8 +706,8 @@ func (suite *CoreTestSuite) TestGetRegisteredModelById() {
 		ExternalId: &modelExternalId,
 		State:      &state,
 		CustomProperties: &map[string]openapi.MetadataValue{
-			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}
@@ -1936,8 +1940,8 @@ func (suite *CoreTestSuite) TestCreateServingEnvironment() {
 		ExternalId:  &entityExternalId,
 		Description: &entityDescription,
 		CustomProperties: &map[string]openapi.MetadataValue{
-			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}
@@ -1961,7 +1965,7 @@ func (suite *CoreTestSuite) TestCreateServingEnvironment() {
 	suite.Equal(entityName, *ctx.Name, "saved name should match the provided one")
 	suite.Equal(entityExternalId, *ctx.ExternalId, "saved external id should match the provided one")
 	suite.Equal(entityDescription, ctx.Properties["description"].GetStringValue(), "saved description should match the provided one")
-	suite.Equal(owner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	suite.Equal(myCustomProp, ctx.CustomProperties["myCustomProp"].GetStringValue(), "saved myCustomProp custom property should match the provided one")
 
 	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
 	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
@@ -1978,7 +1982,7 @@ func (suite *CoreTestSuite) TestUpdateServingEnvironment() {
 		ExternalId: &entityExternalId,
 		CustomProperties: &map[string]openapi.MetadataValue{
 			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}
@@ -2061,7 +2065,7 @@ func (suite *CoreTestSuite) TestGetServingEnvironmentById() {
 		ExternalId: &entityExternalId,
 		CustomProperties: &map[string]openapi.MetadataValue{
 			"owner": {
-				MetadataStringValue: converter.NewMetadataStringValue(owner),
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
 			},
 		},
 	}

--- a/pkg/openapi/model_registered_model.go
+++ b/pkg/openapi/model_registered_model.go
@@ -33,6 +33,7 @@ type RegisteredModel struct {
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`
 	// Output only. Last update time of the resource since epoch in millisecond since epoch.
 	LastUpdateTimeSinceEpoch *string               `json:"lastUpdateTimeSinceEpoch,omitempty"`
+	Owner                    *string               `json:"owner,omitempty"`
 	State                    *RegisteredModelState `json:"state,omitempty"`
 }
 
@@ -281,6 +282,38 @@ func (o *RegisteredModel) SetLastUpdateTimeSinceEpoch(v string) {
 	o.LastUpdateTimeSinceEpoch = &v
 }
 
+// GetOwner returns the Owner field value if set, zero value otherwise.
+func (o *RegisteredModel) GetOwner() string {
+	if o == nil || IsNil(o.Owner) {
+		var ret string
+		return ret
+	}
+	return *o.Owner
+}
+
+// GetOwnerOk returns a tuple with the Owner field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RegisteredModel) GetOwnerOk() (*string, bool) {
+	if o == nil || IsNil(o.Owner) {
+		return nil, false
+	}
+	return o.Owner, true
+}
+
+// HasOwner returns a boolean if a field has been set.
+func (o *RegisteredModel) HasOwner() bool {
+	if o != nil && !IsNil(o.Owner) {
+		return true
+	}
+
+	return false
+}
+
+// SetOwner gets a reference to the given string and assigns it to the Owner field.
+func (o *RegisteredModel) SetOwner(v string) {
+	o.Owner = &v
+}
+
 // GetState returns the State field value if set, zero value otherwise.
 func (o *RegisteredModel) GetState() RegisteredModelState {
 	if o == nil || IsNil(o.State) {
@@ -343,6 +376,9 @@ func (o RegisteredModel) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.LastUpdateTimeSinceEpoch) {
 		toSerialize["lastUpdateTimeSinceEpoch"] = o.LastUpdateTimeSinceEpoch
+	}
+	if !IsNil(o.Owner) {
+		toSerialize["owner"] = o.Owner
 	}
 	if !IsNil(o.State) {
 		toSerialize["state"] = o.State

--- a/pkg/openapi/model_registered_model_create.go
+++ b/pkg/openapi/model_registered_model_create.go
@@ -27,6 +27,7 @@ type RegisteredModelCreate struct {
 	ExternalId *string `json:"externalId,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name  *string               `json:"name,omitempty"`
+	Owner *string               `json:"owner,omitempty"`
 	State *RegisteredModelState `json:"state,omitempty"`
 }
 
@@ -179,6 +180,38 @@ func (o *RegisteredModelCreate) SetName(v string) {
 	o.Name = &v
 }
 
+// GetOwner returns the Owner field value if set, zero value otherwise.
+func (o *RegisteredModelCreate) GetOwner() string {
+	if o == nil || IsNil(o.Owner) {
+		var ret string
+		return ret
+	}
+	return *o.Owner
+}
+
+// GetOwnerOk returns a tuple with the Owner field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RegisteredModelCreate) GetOwnerOk() (*string, bool) {
+	if o == nil || IsNil(o.Owner) {
+		return nil, false
+	}
+	return o.Owner, true
+}
+
+// HasOwner returns a boolean if a field has been set.
+func (o *RegisteredModelCreate) HasOwner() bool {
+	if o != nil && !IsNil(o.Owner) {
+		return true
+	}
+
+	return false
+}
+
+// SetOwner gets a reference to the given string and assigns it to the Owner field.
+func (o *RegisteredModelCreate) SetOwner(v string) {
+	o.Owner = &v
+}
+
 // GetState returns the State field value if set, zero value otherwise.
 func (o *RegisteredModelCreate) GetState() RegisteredModelState {
 	if o == nil || IsNil(o.State) {
@@ -232,6 +265,9 @@ func (o RegisteredModelCreate) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
+	}
+	if !IsNil(o.Owner) {
+		toSerialize["owner"] = o.Owner
 	}
 	if !IsNil(o.State) {
 		toSerialize["state"] = o.State

--- a/pkg/openapi/model_registered_model_update.go
+++ b/pkg/openapi/model_registered_model_update.go
@@ -25,6 +25,7 @@ type RegisteredModelUpdate struct {
 	Description *string `json:"description,omitempty"`
 	// The external id that come from the clients’ system. This field is optional. If set, it must be unique among all resources within a database instance.
 	ExternalId *string               `json:"externalId,omitempty"`
+	Owner      *string               `json:"owner,omitempty"`
 	State      *RegisteredModelState `json:"state,omitempty"`
 }
 
@@ -145,6 +146,38 @@ func (o *RegisteredModelUpdate) SetExternalId(v string) {
 	o.ExternalId = &v
 }
 
+// GetOwner returns the Owner field value if set, zero value otherwise.
+func (o *RegisteredModelUpdate) GetOwner() string {
+	if o == nil || IsNil(o.Owner) {
+		var ret string
+		return ret
+	}
+	return *o.Owner
+}
+
+// GetOwnerOk returns a tuple with the Owner field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RegisteredModelUpdate) GetOwnerOk() (*string, bool) {
+	if o == nil || IsNil(o.Owner) {
+		return nil, false
+	}
+	return o.Owner, true
+}
+
+// HasOwner returns a boolean if a field has been set.
+func (o *RegisteredModelUpdate) HasOwner() bool {
+	if o != nil && !IsNil(o.Owner) {
+		return true
+	}
+
+	return false
+}
+
+// SetOwner gets a reference to the given string and assigns it to the Owner field.
+func (o *RegisteredModelUpdate) SetOwner(v string) {
+	o.Owner = &v
+}
+
 // GetState returns the State field value if set, zero value otherwise.
 func (o *RegisteredModelUpdate) GetState() RegisteredModelState {
 	if o == nil || IsNil(o.State) {
@@ -195,6 +228,9 @@ func (o RegisteredModelUpdate) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.ExternalId) {
 		toSerialize["externalId"] = o.ExternalId
+	}
+	if !IsNil(o.Owner) {
+		toSerialize["owner"] = o.Owner
 	}
 	if !IsNil(o.State) {
 		toSerialize["state"] = o.State

--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -80,3 +80,10 @@ As a MLOps engineer I would like to store some labels
     ${r}  Then I get ModelArtifactByID    id=${aId}
           And Should be equal    ${r["description"]}    sed do eiusmod tempor incididunt
           And Dictionaries Should Be Equal   ${r["customProperties"]}  ${cp3}
+
+As a MLOps engineer I would like to store an owner for the RegisteredModel
+    Set To Dictionary    ${registered_model}    description=Lorem ipsum dolor sit amet  name=${name}  owner=My owner
+    ${rId}  Given I create a RegisteredModel    payload=${registered_model}
+    ${r}  Then I get RegisteredModelByID    id=${rId}
+          And Should be equal    ${r["description"]}    Lorem ipsum dolor sit amet
+          And Should be equal    ${r["owner"]}    My owner


### PR DESCRIPTION
In the logical model for `RegisteredModel`, add property `owner` of type string.

> [!NOTE]  
> Sanity checks to work better with local testing while using Podman (5.0.1) has been implemented as part of this PR.

## Description
- add to OpenAPI logical model
- regenerate server, Go struct
- implement goverter mappings
- implement unit and integration test on Go side
- align structure in Python client
- implement test in Python client
- implement e2e testing with RobotFramework
- update documentation of logical model

## How Has This Been Tested?
- make test for Go
- poetry run pytest for Python
<img width="1728" alt="Screenshot 2024-04-22 at 17 46 16" src="https://github.com/kubeflow/model-registry/assets/1699252/1863cdc3-586d-4122-b177-f0240a310e86">

- run RobotFramework manually raising MLMD in docker and running model-registry proxy
<img width="1728" alt="Screenshot 2024-04-22 at 17 20 48" src="https://github.com/kubeflow/model-registry/assets/1699252/b9653c7f-cd5a-463a-8a62-1a6cfa421251">

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
