### PR TITLE
alpha release: py: bump pyproject.toml to next

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "model-registry"
-version = "0.2.0a1"
+version = "0.2.1a1"
 description = "Client for Kubeflow Model Registry"
 authors = ["Isabella Basso do Amaral <idoamara@redhat.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
roll up next pyproject.toml version to 0.2.1a1

follow up of: https://github.com/kubeflow/model-registry/pull/71
