### PR TITLE
Handle errors gracefully on routes

### DIFF
--- a/internal/apiutils/api_utils.go
+++ b/internal/apiutils/api_utils.go
@@ -1,6 +1,8 @@
 package apiutils
 
 import (
+	"fmt"
+
 	"github.com/kubeflow/model-registry/internal/converter"
 	"github.com/kubeflow/model-registry/internal/ml_metadata/proto"
 	"github.com/kubeflow/model-registry/pkg/api"
@@ -8,7 +10,6 @@ import (
 )
 
 func BuildListOperationOptions(listOptions api.ListOptions) (*proto.ListOperationOptions, error) {
-
 	result := proto.ListOperationOptions{}
 	if listOptions.PageSize != nil {
 		result.MaxResultSize = listOptions.PageSize
@@ -63,7 +64,7 @@ func BuildListOption(pageSize string, orderBy model.OrderByField, sortOrder mode
 	if pageSize != "" {
 		conv, err := converter.StringToInt32(pageSize)
 		if err != nil {
-			return api.ListOptions{}, err
+			return api.ListOptions{}, fmt.Errorf("%v: %w", err, api.ErrBadRequest)
 		}
 		pageSizeInt32 = &conv
 	}

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -12,6 +12,7 @@ package openapi
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/kubeflow/model-registry/internal/apiutils"
 	"github.com/kubeflow/model-registry/internal/converter"
@@ -40,83 +41,83 @@ func NewModelRegistryServiceAPIService(coreApi api.ModelRegistryApi) ModelRegist
 func (s *ModelRegistryServiceAPIService) CreateEnvironmentInferenceService(ctx context.Context, servingenvironmentId string, inferenceServiceCreate model.InferenceServiceCreate) (ImplResponse, error) {
 	inferenceServiceCreate.ServingEnvironmentId = servingenvironmentId
 	return s.CreateInferenceService(ctx, inferenceServiceCreate)
-	// TODO: return Response(404, Error{}), nil
+	// TODO: return Response(http.StatusNotFound, Error{}), nil
 }
 
 // CreateInferenceService - Create a InferenceService
 func (s *ModelRegistryServiceAPIService) CreateInferenceService(ctx context.Context, inferenceServiceCreate model.InferenceServiceCreate) (ImplResponse, error) {
 	entity, err := s.converter.ConvertInferenceServiceCreate(&inferenceServiceCreate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 
 	result, err := s.coreApi.UpsertInferenceService(entity)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(201, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusCreated, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // CreateInferenceServiceServe - Create a ServeModel action in a InferenceService
 func (s *ModelRegistryServiceAPIService) CreateInferenceServiceServe(ctx context.Context, inferenceserviceId string, serveModelCreate model.ServeModelCreate) (ImplResponse, error) {
 	entity, err := s.converter.ConvertServeModelCreate(&serveModelCreate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 
 	result, err := s.coreApi.UpsertServeModel(entity, &inferenceserviceId)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
 
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(201, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusCreated, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // CreateModelArtifact - Create a ModelArtifact
 func (s *ModelRegistryServiceAPIService) CreateModelArtifact(ctx context.Context, modelArtifactCreate model.ModelArtifactCreate) (ImplResponse, error) {
 	entity, err := s.converter.ConvertModelArtifactCreate(&modelArtifactCreate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 
 	result, err := s.coreApi.UpsertModelArtifact(entity, nil)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(201, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusCreated, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // CreateModelVersion - Create a ModelVersion
 func (s *ModelRegistryServiceAPIService) CreateModelVersion(ctx context.Context, modelVersionCreate model.ModelVersionCreate) (ImplResponse, error) {
 	modelVersion, err := s.converter.ConvertModelVersionCreate(&modelVersionCreate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 
 	result, err := s.coreApi.UpsertModelVersion(modelVersion, &modelVersionCreate.RegisteredModelId)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(201, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusCreated, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // CreateModelVersionArtifact - Create an Artifact in a ModelVersion
@@ -124,32 +125,32 @@ func (s *ModelRegistryServiceAPIService) CreateModelVersionArtifact(ctx context.
 	result, err := s.coreApi.UpsertArtifact(&artifact, &modelversionId)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(201, result), nil
+	return Response(http.StatusCreated, result), nil
 	// return Response(http.StatusNotImplemented, nil), errors.New("unsupported artifactType")
-	// TODO return Response(200, Artifact{}), nil
-	// TODO return Response(401, Error{}), nil
+	// TODO return Response(http.StatusOK, Artifact{}), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // CreateRegisteredModel - Create a RegisteredModel
 func (s *ModelRegistryServiceAPIService) CreateRegisteredModel(ctx context.Context, registeredModelCreate model.RegisteredModelCreate) (ImplResponse, error) {
 	registeredModel, err := s.converter.ConvertRegisteredModelCreate(&registeredModelCreate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 
 	result, err := s.coreApi.UpsertRegisteredModel(registeredModel)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(201, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusCreated, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // CreateRegisteredModelVersion - Create a ModelVersion in RegisteredModel
@@ -157,33 +158,33 @@ func (s *ModelRegistryServiceAPIService) CreateRegisteredModelVersion(ctx contex
 	result, err := s.coreApi.UpsertModelVersion(&modelVersion, apiutils.StrPtr(registeredmodelId))
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(201, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusCreated, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // CreateServingEnvironment - Create a ServingEnvironment
 func (s *ModelRegistryServiceAPIService) CreateServingEnvironment(ctx context.Context, servingEnvironmentCreate model.ServingEnvironmentCreate) (ImplResponse, error) {
 	entity, err := s.converter.ConvertServingEnvironmentCreate(&servingEnvironmentCreate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 
 	result, err := s.coreApi.UpsertServingEnvironment(entity)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(201, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusCreated, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // FindInferenceService - Get an InferenceServices that matches search parameters.
@@ -191,15 +192,15 @@ func (s *ModelRegistryServiceAPIService) FindInferenceService(ctx context.Contex
 	result, err := s.coreApi.GetInferenceServiceByParams(apiutils.StrPtr(name), apiutils.StrPtr(parentResourceId), apiutils.StrPtr(externalId))
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // FindModelArtifact - Get a ModelArtifact that matches search parameters.
@@ -207,15 +208,15 @@ func (s *ModelRegistryServiceAPIService) FindModelArtifact(ctx context.Context, 
 	result, err := s.coreApi.GetModelArtifactByParams(apiutils.StrPtr(name), apiutils.StrPtr(parentResourceId), apiutils.StrPtr(externalId))
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // FindModelVersion - Get a ModelVersion that matches search parameters.
@@ -223,15 +224,15 @@ func (s *ModelRegistryServiceAPIService) FindModelVersion(ctx context.Context, n
 	result, err := s.coreApi.GetModelVersionByParams(apiutils.StrPtr(name), apiutils.StrPtr(registeredModelId), apiutils.StrPtr(externalId))
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // FindRegisteredModel - Get a RegisteredModel that matches search parameters.
@@ -239,15 +240,15 @@ func (s *ModelRegistryServiceAPIService) FindRegisteredModel(ctx context.Context
 	result, err := s.coreApi.GetRegisteredModelByParams(apiutils.StrPtr(name), apiutils.StrPtr(externalID))
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // FindServingEnvironment - Find ServingEnvironment
@@ -255,12 +256,12 @@ func (s *ModelRegistryServiceAPIService) FindServingEnvironment(ctx context.Cont
 	result, err := s.coreApi.GetServingEnvironmentByParams(apiutils.StrPtr(name), apiutils.StrPtr(externalID))
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetEnvironmentInferenceServices - List All ServingEnvironment&#39;s InferenceServices
@@ -268,19 +269,19 @@ func (s *ModelRegistryServiceAPIService) GetEnvironmentInferenceServices(ctx con
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetInferenceServices(listOpts, apiutils.StrPtr(servingenvironmentId), nil)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetInferenceService - Get a InferenceService
@@ -288,12 +289,12 @@ func (s *ModelRegistryServiceAPIService) GetInferenceService(ctx context.Context
 	result, err := s.coreApi.GetInferenceServiceById(inferenceserviceId)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetInferenceServiceModel - Get InferenceService&#39;s RegisteredModel
@@ -301,12 +302,12 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceModel(ctx context.Co
 	result, err := s.coreApi.GetRegisteredModelByInferenceService(inferenceserviceId)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetInferenceServiceServes - List All InferenceService&#39;s ServeModel actions
@@ -314,19 +315,19 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceServes(ctx context.C
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetServeModels(listOpts, apiutils.StrPtr(inferenceserviceId))
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetInferenceServiceVersion - Get InferenceService&#39;s ModelVersion
@@ -334,12 +335,12 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceVersion(ctx context.
 	result, err := s.coreApi.GetModelVersionByInferenceService(inferenceserviceId)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetInferenceServices - List All InferenceServices
@@ -347,19 +348,19 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServices(ctx context.Contex
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetInferenceServices(listOpts, nil, nil)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetModelArtifact - Get a ModelArtifact
@@ -367,12 +368,12 @@ func (s *ModelRegistryServiceAPIService) GetModelArtifact(ctx context.Context, m
 	result, err := s.coreApi.GetModelArtifactById(modelartifactId)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetModelArtifacts - List All ModelArtifacts
@@ -380,22 +381,22 @@ func (s *ModelRegistryServiceAPIService) GetModelArtifacts(ctx context.Context, 
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelArtifacts(listOpts, nil)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetModelVersion - Get a ModelVersion
@@ -403,12 +404,12 @@ func (s *ModelRegistryServiceAPIService) GetModelVersion(ctx context.Context, mo
 	result, err := s.coreApi.GetModelVersionById(modelversionId)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetModelVersionArtifacts - List All ModelVersion&#39;s artifacts
@@ -418,19 +419,19 @@ func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Co
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetArtifacts(listOpts, apiutils.StrPtr(modelversionId))
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetModelVersions - List All ModelVersions
@@ -438,22 +439,22 @@ func (s *ModelRegistryServiceAPIService) GetModelVersions(ctx context.Context, p
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelVersions(listOpts, nil)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetRegisteredModel - Get a RegisteredModel
@@ -461,12 +462,12 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModel(ctx context.Context,
 	result, err := s.coreApi.GetRegisteredModelById(registeredmodelId)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetRegisteredModelVersions - List All RegisteredModel&#39;s ModelVersions
@@ -476,19 +477,19 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelVersions(listOpts, apiutils.StrPtr(registeredmodelId))
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetRegisteredModels - List All RegisteredModels
@@ -496,22 +497,22 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModels(ctx context.Context
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetRegisteredModels(listOpts)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetServingEnvironment - Get a ServingEnvironment
@@ -519,12 +520,12 @@ func (s *ModelRegistryServiceAPIService) GetServingEnvironment(ctx context.Conte
 	result, err := s.coreApi.GetServingEnvironmentById(servingenvironmentId)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO: return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // GetServingEnvironments - List All ServingEnvironments
@@ -532,122 +533,122 @@ func (s *ModelRegistryServiceAPIService) GetServingEnvironments(ctx context.Cont
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetServingEnvironments(listOpts)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // UpdateInferenceService - Update a InferenceService
 func (s *ModelRegistryServiceAPIService) UpdateInferenceService(ctx context.Context, inferenceserviceId string, inferenceServiceUpdate model.InferenceServiceUpdate) (ImplResponse, error) {
 	entity, err := s.converter.ConvertInferenceServiceUpdate(&inferenceServiceUpdate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 	entity.Id = &inferenceserviceId
 	result, err := s.coreApi.UpsertInferenceService(entity)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // UpdateModelArtifact - Update a ModelArtifact
 func (s *ModelRegistryServiceAPIService) UpdateModelArtifact(ctx context.Context, modelartifactId string, modelArtifactUpdate model.ModelArtifactUpdate) (ImplResponse, error) {
 	modelArtifact, err := s.converter.ConvertModelArtifactUpdate(&modelArtifactUpdate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 	modelArtifact.Id = &modelartifactId
 	result, err := s.coreApi.UpsertModelArtifact(modelArtifact, nil)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // UpdateModelVersion - Update a ModelVersion
 func (s *ModelRegistryServiceAPIService) UpdateModelVersion(ctx context.Context, modelversionId string, modelVersionUpdate model.ModelVersionUpdate) (ImplResponse, error) {
 	modelVersion, err := s.converter.ConvertModelVersionUpdate(&modelVersionUpdate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 	modelVersion.Id = &modelversionId
 	result, err := s.coreApi.UpsertModelVersion(modelVersion, nil)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // UpdateRegisteredModel - Update a RegisteredModel
 func (s *ModelRegistryServiceAPIService) UpdateRegisteredModel(ctx context.Context, registeredmodelId string, registeredModelUpdate model.RegisteredModelUpdate) (ImplResponse, error) {
 	registeredModel, err := s.converter.ConvertRegisteredModelUpdate(&registeredModelUpdate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 	registeredModel.Id = &registeredmodelId
 	result, err := s.coreApi.UpsertRegisteredModel(registeredModel)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }
 
 // UpdateServingEnvironment - Update a ServingEnvironment
 func (s *ModelRegistryServiceAPIService) UpdateServingEnvironment(ctx context.Context, servingenvironmentId string, servingEnvironmentUpdate model.ServingEnvironmentUpdate) (ImplResponse, error) {
 	entity, err := s.converter.ConvertServingEnvironmentUpdate(&servingEnvironmentUpdate)
 	if err != nil {
-		return Response(400, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 	}
 	entity.Id = &servingenvironmentId
 	result, err := s.coreApi.UpsertServingEnvironment(entity)
 	if err != nil {
 		if errors.Is(err, api.ErrBadRequest) {
-			return Response(400, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
 		}
 		if errors.Is(err, api.ErrNotFound) {
-			return Response(404, model.Error{Message: err.Error()}), nil
+			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
 		}
-		return Response(500, model.Error{Message: err.Error()}), nil
+		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
 	}
-	return Response(200, result), nil
-	// TODO return Response(401, Error{}), nil
+	return Response(http.StatusOK, result), nil
+	// TODO return Response(http.StatusUnauthorized, Error{}), nil
 }

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -11,7 +11,6 @@ package openapi
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/kubeflow/model-registry/internal/apiutils"
@@ -53,10 +52,8 @@ func (s *ModelRegistryServiceAPIService) CreateInferenceService(ctx context.Cont
 
 	result, err := s.coreApi.UpsertInferenceService(entity)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusCreated, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -71,14 +68,8 @@ func (s *ModelRegistryServiceAPIService) CreateInferenceServiceServe(ctx context
 
 	result, err := s.coreApi.UpsertServeModel(entity, &inferenceserviceId)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusCreated, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -93,10 +84,8 @@ func (s *ModelRegistryServiceAPIService) CreateModelArtifact(ctx context.Context
 
 	result, err := s.coreApi.UpsertModelArtifact(entity, nil)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusCreated, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -111,10 +100,8 @@ func (s *ModelRegistryServiceAPIService) CreateModelVersion(ctx context.Context,
 
 	result, err := s.coreApi.UpsertModelVersion(modelVersion, &modelVersionCreate.RegisteredModelId)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusCreated, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -124,10 +111,8 @@ func (s *ModelRegistryServiceAPIService) CreateModelVersion(ctx context.Context,
 func (s *ModelRegistryServiceAPIService) CreateModelVersionArtifact(ctx context.Context, modelversionId string, artifact model.Artifact) (ImplResponse, error) {
 	result, err := s.coreApi.UpsertArtifact(&artifact, &modelversionId)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusCreated, result), nil
 	// return Response(http.StatusNotImplemented, nil), errors.New("unsupported artifactType")
@@ -144,10 +129,8 @@ func (s *ModelRegistryServiceAPIService) CreateRegisteredModel(ctx context.Conte
 
 	result, err := s.coreApi.UpsertRegisteredModel(registeredModel)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusCreated, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -157,13 +140,8 @@ func (s *ModelRegistryServiceAPIService) CreateRegisteredModel(ctx context.Conte
 func (s *ModelRegistryServiceAPIService) CreateRegisteredModelVersion(ctx context.Context, registeredmodelId string, modelVersion model.ModelVersion) (ImplResponse, error) {
 	result, err := s.coreApi.UpsertModelVersion(&modelVersion, apiutils.StrPtr(registeredmodelId))
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusCreated, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -178,10 +156,8 @@ func (s *ModelRegistryServiceAPIService) CreateServingEnvironment(ctx context.Co
 
 	result, err := s.coreApi.UpsertServingEnvironment(entity)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusCreated, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -191,13 +167,8 @@ func (s *ModelRegistryServiceAPIService) CreateServingEnvironment(ctx context.Co
 func (s *ModelRegistryServiceAPIService) FindInferenceService(ctx context.Context, name string, externalId string, parentResourceId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetInferenceServiceByParams(apiutils.StrPtr(name), apiutils.StrPtr(parentResourceId), apiutils.StrPtr(externalId))
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -207,13 +178,8 @@ func (s *ModelRegistryServiceAPIService) FindInferenceService(ctx context.Contex
 func (s *ModelRegistryServiceAPIService) FindModelArtifact(ctx context.Context, name string, externalId string, parentResourceId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetModelArtifactByParams(apiutils.StrPtr(name), apiutils.StrPtr(parentResourceId), apiutils.StrPtr(externalId))
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -223,13 +189,8 @@ func (s *ModelRegistryServiceAPIService) FindModelArtifact(ctx context.Context, 
 func (s *ModelRegistryServiceAPIService) FindModelVersion(ctx context.Context, name string, externalId string, registeredModelId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetModelVersionByParams(apiutils.StrPtr(name), apiutils.StrPtr(registeredModelId), apiutils.StrPtr(externalId))
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -239,13 +200,8 @@ func (s *ModelRegistryServiceAPIService) FindModelVersion(ctx context.Context, n
 func (s *ModelRegistryServiceAPIService) FindRegisteredModel(ctx context.Context, name string, externalID string) (ImplResponse, error) {
 	result, err := s.coreApi.GetRegisteredModelByParams(apiutils.StrPtr(name), apiutils.StrPtr(externalID))
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -255,10 +211,8 @@ func (s *ModelRegistryServiceAPIService) FindRegisteredModel(ctx context.Context
 func (s *ModelRegistryServiceAPIService) FindServingEnvironment(ctx context.Context, name string, externalID string) (ImplResponse, error) {
 	result, err := s.coreApi.GetServingEnvironmentByParams(apiutils.StrPtr(name), apiutils.StrPtr(externalID))
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -268,17 +222,13 @@ func (s *ModelRegistryServiceAPIService) FindServingEnvironment(ctx context.Cont
 func (s *ModelRegistryServiceAPIService) GetEnvironmentInferenceServices(ctx context.Context, servingenvironmentId string, name string, externalID string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetInferenceServices(listOpts, apiutils.StrPtr(servingenvironmentId), nil)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -288,10 +238,8 @@ func (s *ModelRegistryServiceAPIService) GetEnvironmentInferenceServices(ctx con
 func (s *ModelRegistryServiceAPIService) GetInferenceService(ctx context.Context, inferenceserviceId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetInferenceServiceById(inferenceserviceId)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -301,10 +249,8 @@ func (s *ModelRegistryServiceAPIService) GetInferenceService(ctx context.Context
 func (s *ModelRegistryServiceAPIService) GetInferenceServiceModel(ctx context.Context, inferenceserviceId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetRegisteredModelByInferenceService(inferenceserviceId)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -314,17 +260,13 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceModel(ctx context.Co
 func (s *ModelRegistryServiceAPIService) GetInferenceServiceServes(ctx context.Context, inferenceserviceId string, name string, externalID string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetServeModels(listOpts, apiutils.StrPtr(inferenceserviceId))
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -334,10 +276,8 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceServes(ctx context.C
 func (s *ModelRegistryServiceAPIService) GetInferenceServiceVersion(ctx context.Context, inferenceserviceId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetModelVersionByInferenceService(inferenceserviceId)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -347,17 +287,13 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceVersion(ctx context.
 func (s *ModelRegistryServiceAPIService) GetInferenceServices(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetInferenceServices(listOpts, nil, nil)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -367,10 +303,8 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServices(ctx context.Contex
 func (s *ModelRegistryServiceAPIService) GetModelArtifact(ctx context.Context, modelartifactId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetModelArtifactById(modelartifactId)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -380,20 +314,13 @@ func (s *ModelRegistryServiceAPIService) GetModelArtifact(ctx context.Context, m
 func (s *ModelRegistryServiceAPIService) GetModelArtifacts(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelArtifacts(listOpts, nil)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -403,10 +330,8 @@ func (s *ModelRegistryServiceAPIService) GetModelArtifacts(ctx context.Context, 
 func (s *ModelRegistryServiceAPIService) GetModelVersion(ctx context.Context, modelversionId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetModelVersionById(modelversionId)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -418,17 +343,13 @@ func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Co
 	// TODO externalID unused
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetArtifacts(listOpts, apiutils.StrPtr(modelversionId))
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -438,20 +359,13 @@ func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Co
 func (s *ModelRegistryServiceAPIService) GetModelVersions(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelVersions(listOpts, nil)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -461,10 +375,8 @@ func (s *ModelRegistryServiceAPIService) GetModelVersions(ctx context.Context, p
 func (s *ModelRegistryServiceAPIService) GetRegisteredModel(ctx context.Context, registeredmodelId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetRegisteredModelById(registeredmodelId)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -476,17 +388,13 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.
 	// TODO externalID unused
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelVersions(listOpts, apiutils.StrPtr(registeredmodelId))
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -496,20 +404,13 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.
 func (s *ModelRegistryServiceAPIService) GetRegisteredModels(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetRegisteredModels(listOpts)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -519,10 +420,8 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModels(ctx context.Context
 func (s *ModelRegistryServiceAPIService) GetServingEnvironment(ctx context.Context, servingenvironmentId string) (ImplResponse, error) {
 	result, err := s.coreApi.GetServingEnvironmentById(servingenvironmentId)
 	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO: return Response(http.StatusUnauthorized, Error{}), nil
@@ -532,17 +431,13 @@ func (s *ModelRegistryServiceAPIService) GetServingEnvironment(ctx context.Conte
 func (s *ModelRegistryServiceAPIService) GetServingEnvironments(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetServingEnvironments(listOpts)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -557,13 +452,8 @@ func (s *ModelRegistryServiceAPIService) UpdateInferenceService(ctx context.Cont
 	entity.Id = &inferenceserviceId
 	result, err := s.coreApi.UpsertInferenceService(entity)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -578,13 +468,8 @@ func (s *ModelRegistryServiceAPIService) UpdateModelArtifact(ctx context.Context
 	modelArtifact.Id = &modelartifactId
 	result, err := s.coreApi.UpsertModelArtifact(modelArtifact, nil)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -599,13 +484,8 @@ func (s *ModelRegistryServiceAPIService) UpdateModelVersion(ctx context.Context,
 	modelVersion.Id = &modelversionId
 	result, err := s.coreApi.UpsertModelVersion(modelVersion, nil)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -620,13 +500,8 @@ func (s *ModelRegistryServiceAPIService) UpdateRegisteredModel(ctx context.Conte
 	registeredModel.Id = &registeredmodelId
 	result, err := s.coreApi.UpsertRegisteredModel(registeredModel)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil
@@ -641,13 +516,8 @@ func (s *ModelRegistryServiceAPIService) UpdateServingEnvironment(ctx context.Co
 	entity.Id = &servingenvironmentId
 	result, err := s.coreApi.UpsertServingEnvironment(entity)
 	if err != nil {
-		if errors.Is(err, api.ErrBadRequest) {
-			return Response(http.StatusBadRequest, model.Error{Message: err.Error()}), nil
-		}
-		if errors.Is(err, api.ErrNotFound) {
-			return Response(http.StatusNotFound, model.Error{Message: err.Error()}), nil
-		}
-		return Response(http.StatusInternalServerError, model.Error{Message: err.Error()}), nil
+		status := api.ErrToStatus(err)
+		return Response(status, model.Error{Message: err.Error()}), nil
 	}
 	return Response(http.StatusOK, result), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -267,6 +267,9 @@ func (s *ModelRegistryServiceAPIService) FindServingEnvironment(ctx context.Cont
 func (s *ModelRegistryServiceAPIService) GetEnvironmentInferenceServices(ctx context.Context, servingenvironmentId string, name string, externalID string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetInferenceServices(listOpts, apiutils.StrPtr(servingenvironmentId), nil)
@@ -310,6 +313,9 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceModel(ctx context.Co
 func (s *ModelRegistryServiceAPIService) GetInferenceServiceServes(ctx context.Context, inferenceserviceId string, name string, externalID string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetServeModels(listOpts, apiutils.StrPtr(inferenceserviceId))
@@ -340,6 +346,9 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceVersion(ctx context.
 func (s *ModelRegistryServiceAPIService) GetInferenceServices(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetInferenceServices(listOpts, nil, nil)
@@ -370,6 +379,9 @@ func (s *ModelRegistryServiceAPIService) GetModelArtifact(ctx context.Context, m
 func (s *ModelRegistryServiceAPIService) GetModelArtifacts(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelArtifacts(listOpts, nil)
@@ -405,6 +417,9 @@ func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Co
 	// TODO externalID unused
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetArtifacts(listOpts, apiutils.StrPtr(modelversionId))
@@ -422,6 +437,9 @@ func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Co
 func (s *ModelRegistryServiceAPIService) GetModelVersions(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelVersions(listOpts, nil)
@@ -457,6 +475,9 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.
 	// TODO externalID unused
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetModelVersions(listOpts, apiutils.StrPtr(registeredmodelId))
@@ -474,6 +495,9 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.
 func (s *ModelRegistryServiceAPIService) GetRegisteredModels(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetRegisteredModels(listOpts)
@@ -507,6 +531,9 @@ func (s *ModelRegistryServiceAPIService) GetServingEnvironment(ctx context.Conte
 func (s *ModelRegistryServiceAPIService) GetServingEnvironments(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	result, err := s.coreApi.GetServingEnvironments(listOpts)

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -511,6 +511,9 @@ func (s *ModelRegistryServiceAPIService) GetServingEnvironments(ctx context.Cont
 	}
 	result, err := s.coreApi.GetServingEnvironments(listOpts)
 	if err != nil {
+		if errors.Is(err, api.ErrBadRequest) {
+			return Response(400, model.Error{Message: err.Error()}), nil
+		}
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
 	return Response(200, result), nil

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -1,8 +1,22 @@
 package api
 
-import "errors"
+import (
+	"errors"
+	"net/http"
+)
 
 var (
 	ErrBadRequest = errors.New("bad request")
 	ErrNotFound   = errors.New("not found")
 )
+
+func ErrToStatus(err error) int {
+	switch err {
+	case ErrBadRequest:
+		return http.StatusBadRequest
+	case ErrNotFound:
+		return http.StatusNotFound
+	default:
+		return http.StatusInternalServerError
+	}
+}


### PR DESCRIPTION


## Description
This fixes an unhandled error on the GetEnvironmentEnvironments route, as well as standardizes error value treatment using an error to http status converter. All status codes now use the standard net/http consts (enum).

## How Has This Been Tested?
Tested with `make test`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
