### PR TITLE
fix istio VirtualService manifest

### DIFF
--- a/manifests/kustomize/base/model-registry-deployment.yaml
+++ b/manifests/kustomize/base/model-registry-deployment.yaml
@@ -11,6 +11,8 @@ spec:
       component: model-registry-server
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         component: model-registry-server
     spec:

--- a/manifests/kustomize/base/model-registry-service.yaml
+++ b/manifests/kustomize/base/model-registry-service.yaml
@@ -11,7 +11,9 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
+    appProtocol: http
     name: http-api
   - port: 9090
     protocol: TCP
+    appProtocol: grpc
     name: grpc-api

--- a/manifests/kustomize/options/istio/virtual-service.yaml
+++ b/manifests/kustomize/options/istio/virtual-service.yaml
@@ -7,18 +7,23 @@ spec:
   - kubeflow-gateway
   hosts:
   - '*'
-  tcp:
+  http:
   - match:
-    - port: 8080
+    - uri:
+        prefix: /api/model_registry/
     route:
     - destination:
         host: model-registry-service.kubeflow.svc.cluster.local
         port:
           number: 8080
   - match:
-      - port: 9090
+    - port: 9090
+    - authority:
+        regex: model-registry-service(\..+)?(:9090)?
+    - uri:
+        prefix: /ml_metadata.MetadataStoreService/
     route:
-      - destination:
-          host: model-registry-service.kubeflow.svc.cluster.local
-          port:
-            number: 9090
+    - destination:
+        host: model-registry-service.kubeflow.svc.cluster.local
+        port:
+          number: 9090

--- a/manifests/kustomize/overlays/db/kustomization.yaml
+++ b/manifests/kustomize/overlays/db/kustomization.yaml
@@ -36,3 +36,10 @@ vars:
     apiVersion: v1
     kind: Service
     name: model-registry-db
+- name: MYSQL_PORT
+  objref:
+    kind: ConfigMap
+    name: model-registry-db-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.MYSQL_PORT

--- a/manifests/kustomize/overlays/db/patches/model-registry-deployment.yaml
+++ b/manifests/kustomize/overlays/db/patches/model-registry-deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: model-registry-deployment
 spec:
   template:
+    metadata:
+      annotations:
+        # db doesn't use istio
+        traffic.sidecar.istio.io/excludeOutboundPorts: $(MYSQL_PORT)
     spec:
       containers:
         - name: rest-container

--- a/manifests/kustomize/overlays/postgres/kustomization.yaml
+++ b/manifests/kustomize/overlays/postgres/kustomization.yaml
@@ -36,3 +36,10 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
+- name: POSTGRES_PORT
+  objref:
+    kind: ConfigMap
+    name: model-registry-db-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.POSTGRES_PORT

--- a/manifests/kustomize/overlays/postgres/patches/model-registry-deployment.yaml
+++ b/manifests/kustomize/overlays/postgres/patches/model-registry-deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: model-registry-deployment
 spec:
   template:
+    metadata:
+      annotations:
+        # db doesn't use istio
+        traffic.sidecar.istio.io/excludeOutboundPorts: $(POSTGRES_PORT)
     spec:
       containers:
         - name: grpc-container


### PR DESCRIPTION
Seems to me the definition proposed in this changed manifest makes it working, and it's aligned with other Kubeflow components' approach.

## Description
Before, I was not able to reach by e2e test (from outside the cluster) the Model Registry REST API endpoint --unless of manual p.fwd.

This solution aligns for the REST API endpoint (the one on 8080) following similar strategy of other Kubeflow components: see [here for some examples](https://github.com/search?q=repo%3Akubeflow%2Fmanifests+%22kind%3A+VirtualService%22+language%3AYAML&type=code&l=YAML).

This way, request on the gateway for `/model-registry/...` will be routed to the correct service accordingly.

## How Has This Been Tested?

Install vanilla KF, used `1.9.0-rc.0` without networkpolicies.
(I'm skipping networkpolicies as _this PR_ I considered propaedeutic work to later work on networkpolicy for model registry)

Execute required step of p.fwd the istio-ingressgateway per normal vanilla KF installation:

```
INGRESS_GATEWAY_SERVICE=$(kubectl get svc --namespace istio-system --selector="app=istio-ingressgateway" --output jsonpath='{.items[0].metadata.name}')
kubectl port-forward --namespace istio-system svc/${INGRESS_GATEWAY_SERVICE} 8080:80
```

In another terminal:

```
export KF_TOKEN="$(kubectl -n default create token default)"

curl -H "Authorization: Bearer "$KF_TOKEN http://localhost:8080/model-registry/api/model_registry/v1alpha3/registered_models
```

## Alternative solution (explored, but not adopted here)
I've explored with alternative solution of:

```yaml
spec:
  gateways:
  - kubeflow-gateway
  hosts:
  - '*'
  http:
  - match:
      - headers:
          Host:
            exact: model-registry-service.kubeflow.svc.cluster.local
    route:
    - destination:
        host: model-registry-service.kubeflow.svc.cluster.local
        port:
          number: 8080
...
```

which works too, using:

```
export KF_TOKEN="$(kubectl -n default create token default)"
curl -H "Host: model-registry-service.kubeflow.svc.cluster.local" -H "Authorization: Bearer "$KF_TOKEN http://localhost:8080/model-registry/api/model_registry/v1alpha3/registered_models
```

The reasons I'm not proposing this solution:
- does not align with other Kubeflow components VirtualService definitions
- would require `Host: model-registry-service.kubeflow.svc.cluster.local` in the header of the REST api request, which is _not_ allowed by front-end (JS) code.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
