### PR TITLE
docs(py): document workaround using MR client with newer py versions

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -102,6 +102,30 @@ There are caveats to be noted when using this method:
     )
     ```
 
+## Advanced use-cases
+
+### Using Model Registry Python Client with newer Python versions
+
+> [!CAUTION]
+> The mechanism described in this section is a temporary workaround and likely will never be supported.
+> This workaround is ONLY applicable if your Python/Notebook project does NOT make use of MLMD directly or indirectly.
+
+<!-- a longer-term plan to address this ties to the investigations to rebase this client on top of MR REST api directly,
+so to avoid having to wrap the MLMD Wheel. See more: https://github.com/kubeflow/model-registry/pull/59 -->
+
+This project _currently_ wraps Google's MLMD and aligns with its supported Python versions (see more [here](https://pypi.org/project/ml-metadata/#files)),
+hence the reason of this project's [specified constraints](https://github.com/kubeflow/model-registry/blob/8d77c13100c6cc5a9465d4293403114a3576fdd7/clients/python/pyproject.toml#L14).
+
+To circumvent this current limitation, **and only IF your Python/Notebook project does NOT make use of MLMD directly or indirectly**,
+you could opt-in using a non-constrained variant of that dependency supporting _only_ remote gRPC calls and not constrained by Python versions or architecture.
+
+```
+!pip install "https://github.com/opendatahub-io/ml-metadata/releases/download/v1.14.0%2Bremote.1/ml_metadata-1.14.0+remote.1-py3-none-any.whl" # need a Python 3.11 compatible version
+!pip install --no-deps --ignore-requires-python --pre "model-registry" # ignore dependencies because of the above override
+```
+
+You can read more about this use-case, in the [Remote-only packaging of MLMD Python lib](https://github.com/kubeflow/model-registry/blob/main/docs/remote_only_packaging_of_MLMD_Python_lib.md) document.
+
 ## Development
 
 Common tasks, such as building documentation and running tests, can be executed using [`nox`](https://github.com/wntrblm/nox) sessions.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -104,7 +104,7 @@ There are caveats to be noted when using this method:
 
 ## Advanced use-cases
 
-### Using Model Registry Python Client with newer Python versions
+### Using Model Registry Python Client with newer Python versions (>=3.11)
 
 > [!CAUTION]
 > The mechanism described in this section is a temporary workaround and likely will never be supported.
@@ -113,11 +113,11 @@ There are caveats to be noted when using this method:
 <!-- a longer-term plan to address this ties to the investigations to rebase this client on top of MR REST api directly,
 so to avoid having to wrap the MLMD Wheel. See more: https://github.com/kubeflow/model-registry/pull/59 -->
 
-This project _currently_ wraps Google's MLMD and aligns with its supported Python versions (see more [here](https://pypi.org/project/ml-metadata/#files)),
-hence the reason of this project's [specified constraints](https://github.com/kubeflow/model-registry/blob/8d77c13100c6cc5a9465d4293403114a3576fdd7/clients/python/pyproject.toml#L14).
+This project _currently_ depends for internal implementations on the Google's [MLMD Python library](https://pypi.org/project/ml-metadata/).
+Due to this dependency, this project supports [only the Python versions](https://github.com/kubeflow/model-registry/blob/8d77c13100c6cc5a9465d4293403114a3576fdd7/clients/python/pyproject.toml#L14) which are also available for the MLMD library (see more [here](https://pypi.org/project/ml-metadata/#files)).
 
-To circumvent this current limitation, **and only IF your Python/Notebook project does NOT make use of MLMD directly or indirectly**,
-you could opt-in using a non-constrained variant of that dependency supporting _only_ remote gRPC calls and not constrained by Python versions or architecture.
+As a workaround, **only IF your Python/Notebook project does NOT make use of MLMD directly or indirectly**,
+you could opt-in to make use of a non-constrained variant of the MLMD dependency supporting _only_ remote gRPC calls (and not constrained by specific Python versions or architectures):
 
 ```
 !pip install "https://github.com/opendatahub-io/ml-metadata/releases/download/v1.14.0%2Bremote.1/ml_metadata-1.14.0+remote.1-py3-none-any.whl" # need a Python 3.11 compatible version

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/kubeflow/model-registry"
 "Issues" = "https://github.com/kubeflow/model-registry/issues"
 
 [tool.poetry.dependencies]
-python = ">= 3.9, < 3.11"
+python = ">= 3.9, < 3.11" # mainly aligns constraints with: https://pypi.org/project/ml-metadata/#files
 attrs = "^21.0"
 ml-metadata = "^1.14.0"
 # you might consider using locally the following alternative, when developing on Apple-silicon/ARM-based computers:


### PR DESCRIPTION
Until we will rebase the MR py client on top of MR REST API,

I'm suggesting to expand on documentation as proposed in this PR.

This also follow-up to: https://github.com/kubeflow/model-registry/issues/90#issuecomment-2141063884

## Description
Expand on use-case of the [Remote-only packaging of MLMD Python lib](https://github.com/kubeflow/model-registry/blob/main/docs/remote_only_packaging_of_MLMD_Python_lib.md) document, in relation to the MR python client.

## How Has This Been Tested?
- A notebook project NOT depending on MLMD either directly or indirectly,
- using Python > 3.10
- connecting to MR

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
