### PR TITLE
Fix http error codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # Test binary, built with `go test -c`
 *.test
 
+__debug*
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -11,7 +11,7 @@ var (
 )
 
 func ErrToStatus(err error) int {
-	switch err {
+	switch errors.Unwrap(err) {
 	case ErrBadRequest:
 		return http.StatusBadRequest
 	case ErrNotFound:

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -20,10 +20,10 @@ import (
 // ModelRegistryService is the core library of the model registry
 type ModelRegistryService struct {
 	mlmdClient  proto.MetadataStoreServiceClient
-	nameConfig  mlmdtypes.MLMDTypeNamesConfig
 	typesMap    map[string]int64
 	mapper      *mapper.Mapper
 	openapiConv *generated.OpenAPIConverterImpl
+	nameConfig  mlmdtypes.MLMDTypeNamesConfig
 }
 
 // NewModelRegistryService creates a new instance of the ModelRegistryService, initializing it with the provided gRPC client connection.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As error codes were switched without being unwrapped, the full error (with custom data) was never matched against the actual error enum, and was only providing a patched message with the wrong status code (making tests pass even though the resulting status was wrong).

Remaining commits were WIP and can be sent separately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified with httpie client.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
