### PR TITLE
chore(py): avoid use of assert for business logic

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -85,11 +85,11 @@ select = [
 ignore = [
     "D105", # missing docstring in magic method
     "E501", # line too long
-    "S101", # use of assert detected
 ]
 mccabe.max-complexity = 8
 per-file-ignores = { "tests/**/*.py" = [
     "D", # missing docstring in public module
+    "S101", # use of assert detected
 ] }
 
 [tool.ruff.lint.pydocstyle]

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -80,7 +80,9 @@ class ModelRegistry:
     def _register_new_version(
         self, rm: RegisteredModel, version: str, author: str, /, **kwargs
     ) -> ModelVersion:
-        assert rm.id is not None, "Registered model must have an ID"
+        if rm.id is None:
+            msg = "Registered model must have an ID"
+            raise ValueError(msg)
         if self._api.get_model_version_by_params(rm.id, version):
             msg = f"Version {version} already exists"
             raise StoreException(msg)
@@ -92,7 +94,9 @@ class ModelRegistry:
     def _register_model_artifact(
         self, mv: ModelVersion, uri: str, /, **kwargs
     ) -> ModelArtifact:
-        assert mv.id is not None, "Model version must have an ID"
+        if mv.id is None:
+            msg = "Model version must have an ID"
+            raise ValueError(msg)
         ma = ModelArtifact(mv.model_name, uri, **kwargs)
         self._api.upsert_model_artifact(ma, mv.id)
         return ma

--- a/clients/python/src/model_registry/types/artifacts.py
+++ b/clients/python/src/model_registry/types/artifacts.py
@@ -65,9 +65,9 @@ class BaseArtifact(ProtoBase):
     @override
     def unmap(cls, mlmd_obj: Artifact) -> BaseArtifact:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
-            py_obj, BaseArtifact
-        ), f"Expected BaseArtifact, got {type(py_obj)}"
+        if not isinstance(py_obj, BaseArtifact):
+            msg = f"Expected BaseArtifact, got {type(py_obj)}"
+            raise TypeError(msg)
         py_obj.uri = mlmd_obj.uri
         py_obj.state = ArtifactState(mlmd_obj.state)
         return py_obj
@@ -120,9 +120,9 @@ class ModelArtifact(BaseArtifact, Prefixable):
     @classmethod
     def unmap(cls, mlmd_obj: Artifact) -> ModelArtifact:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
-            py_obj, ModelArtifact
-        ), f"Expected ModelArtifact, got {type(py_obj)}"
+        if not isinstance(py_obj, ModelArtifact):
+            msg = f"Expected ModelArtifact, got {type(py_obj)}"
+            raise TypeError(msg)
         py_obj.model_format_name = mlmd_obj.properties["model_format_name"].string_value
         py_obj.model_format_version = mlmd_obj.properties[
             "model_format_version"

--- a/clients/python/src/model_registry/types/base.py
+++ b/clients/python/src/model_registry/types/base.py
@@ -178,7 +178,9 @@ class ProtoBase(Mappable, ABC):
         py_obj.id = str(mlmd_obj.id)
         if isinstance(py_obj, Prefixable):
             name: str = mlmd_obj.name
-            assert ":" in name, f"Expected {name} to be prefixed"
+            if ":" not in name:
+                msg = f"Expected {name} to be prefixed"
+                raise ValueError(msg)
             py_obj.name = name.split(":", 1)[1]
         else:
             py_obj.name = mlmd_obj.name

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -52,9 +52,9 @@ class BaseContext(ProtoBase, ABC):
     @override
     def unmap(cls, mlmd_obj: Context) -> BaseContext:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
-            py_obj, BaseContext
-        ), f"Expected BaseContext, got {type(py_obj)}"
+        if not isinstance(py_obj, BaseContext):
+            msg =  f"Expected BaseContext, got {type(py_obj)}"
+            raise TypeError(msg)
         py_obj.state = ContextState(mlmd_obj.properties["state"].string_value)
         return py_obj
 
@@ -92,9 +92,9 @@ class ModelVersion(BaseContext, Prefixable):
     @property
     @override
     def mlmd_name_prefix(self) -> str:
-        assert (
-            self._registered_model_id is not None
-        ), "There's no registered model associated with this version"
+        if self._registered_model_id is None:
+            msg = "There's no registered model associated with this version"
+            raise ValueError(msg)
         return self._registered_model_id
 
     @override
@@ -113,9 +113,9 @@ class ModelVersion(BaseContext, Prefixable):
     @override
     def unmap(cls, mlmd_obj: Context) -> ModelVersion:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
-            py_obj, ModelVersion
-        ), f"Expected ModelVersion, got {type(py_obj)}"
+        if not isinstance(py_obj, ModelVersion):
+            msg = f"Expected ModelVersion, got {type(py_obj)}"
+            raise TypeError(msg)
         py_obj.version = py_obj.name
         py_obj.model_name = mlmd_obj.properties["model_name"].string_value
         py_obj.author = mlmd_obj.properties["author"].string_value
@@ -150,8 +150,8 @@ class RegisteredModel(BaseContext):
     @override
     def unmap(cls, mlmd_obj: Context) -> RegisteredModel:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
-            py_obj, RegisteredModel
-        ), f"Expected RegisteredModel, got {type(py_obj)}"
+        if not isinstance(py_obj, RegisteredModel):
+            msg = f"Expected RegisteredModel, got {type(py_obj)}"
+            raise TypeError(msg)
         py_obj.owner = mlmd_obj.properties["owner"].string_value
         return py_obj


### PR DESCRIPTION
Avoid use of python `assert` use in application/runtime logic.

## Description
In a recent meetup ([Python Milano](https://www.youtube.com/live/-pHvc-xJE70?si=_Vhu6EVVqVAjgsqu&t=1146)) I've become aware use of `assert` in business logic is not robust.
In my understanding, this is the dual/analogous of the JVM: for Java is opt-in (`-ea`) while for Python is opt-out (`-O` or similar).
So it's not advisable to make use of `assert` in control-flow, as it's environment-dependent.

This PR rewrites with explicit checks using conditional instead of asserts.

This imho is relevant for environments we might not have control/visibility on, such as within a pipeline step (a container) or a custom/bespoke user environment.

## How Has This Been Tested?
- `nox -s lint-3.10`
- `pytest`
![image](https://github.com/kubeflow/model-registry/assets/1699252/9e5cd6bc-82dc-450a-a79d-72656d571bdf)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

cc: @isinyaaa wdyt?