### PR TITLE
chore(py): make intentional asserts are for dev phase

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -85,11 +85,11 @@ select = [
 ignore = [
     "D105", # missing docstring in magic method
     "E501", # line too long
-    "S101", # use of assert detected
 ]
 mccabe.max-complexity = 8
 per-file-ignores = { "tests/**/*.py" = [
     "D", # missing docstring in public module
+    "S101", # use of assert detected
 ] }
 
 [tool.ruff.lint.pydocstyle]

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -80,7 +80,7 @@ class ModelRegistry:
     def _register_new_version(
         self, rm: RegisteredModel, version: str, author: str, /, **kwargs
     ) -> ModelVersion:
-        assert rm.id is not None, "Registered model must have an ID"
+        assert rm.id is not None, "Registered model must have an ID" # noqa: S101 helpful for dev phase, not runtime
         if self._api.get_model_version_by_params(rm.id, version):
             msg = f"Version {version} already exists"
             raise StoreException(msg)
@@ -92,7 +92,7 @@ class ModelRegistry:
     def _register_model_artifact(
         self, mv: ModelVersion, uri: str, /, **kwargs
     ) -> ModelArtifact:
-        assert mv.id is not None, "Model version must have an ID"
+        assert mv.id is not None, "Model version must have an ID" # noqa: S101 helpful for dev phase, not runtime
         ma = ModelArtifact(mv.model_name, uri, **kwargs)
         self._api.upsert_model_artifact(ma, mv.id)
         return ma

--- a/clients/python/src/model_registry/types/artifacts.py
+++ b/clients/python/src/model_registry/types/artifacts.py
@@ -65,7 +65,7 @@ class BaseArtifact(ProtoBase):
     @override
     def unmap(cls, mlmd_obj: Artifact) -> BaseArtifact:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
+        assert isinstance( # noqa: S101 helpful for dev phase, not runtime
             py_obj, BaseArtifact
         ), f"Expected BaseArtifact, got {type(py_obj)}"
         py_obj.uri = mlmd_obj.uri
@@ -120,7 +120,7 @@ class ModelArtifact(BaseArtifact, Prefixable):
     @classmethod
     def unmap(cls, mlmd_obj: Artifact) -> ModelArtifact:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
+        assert isinstance( # noqa: S101 helpful for dev phase, not runtime
             py_obj, ModelArtifact
         ), f"Expected ModelArtifact, got {type(py_obj)}"
         py_obj.model_format_name = mlmd_obj.properties["model_format_name"].string_value

--- a/clients/python/src/model_registry/types/base.py
+++ b/clients/python/src/model_registry/types/base.py
@@ -178,7 +178,7 @@ class ProtoBase(Mappable, ABC):
         py_obj.id = str(mlmd_obj.id)
         if isinstance(py_obj, Prefixable):
             name: str = mlmd_obj.name
-            assert ":" in name, f"Expected {name} to be prefixed"
+            assert ":" in name, f"Expected {name} to be prefixed" # noqa: S101 helpful for dev phase, not runtime
             py_obj.name = name.split(":", 1)[1]
         else:
             py_obj.name = mlmd_obj.name

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -52,7 +52,7 @@ class BaseContext(ProtoBase, ABC):
     @override
     def unmap(cls, mlmd_obj: Context) -> BaseContext:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
+        assert isinstance( # noqa: S101 helpful for dev phase, not runtime
             py_obj, BaseContext
         ), f"Expected BaseContext, got {type(py_obj)}"
         py_obj.state = ContextState(mlmd_obj.properties["state"].string_value)
@@ -92,7 +92,7 @@ class ModelVersion(BaseContext, Prefixable):
     @property
     @override
     def mlmd_name_prefix(self) -> str:
-        assert (
+        assert ( # noqa: S101 helpful for dev phase, not runtime
             self._registered_model_id is not None
         ), "There's no registered model associated with this version"
         return self._registered_model_id
@@ -113,7 +113,7 @@ class ModelVersion(BaseContext, Prefixable):
     @override
     def unmap(cls, mlmd_obj: Context) -> ModelVersion:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
+        assert isinstance( # noqa: S101 helpful for dev phase, not runtime
             py_obj, ModelVersion
         ), f"Expected ModelVersion, got {type(py_obj)}"
         py_obj.version = py_obj.name
@@ -150,7 +150,7 @@ class RegisteredModel(BaseContext):
     @override
     def unmap(cls, mlmd_obj: Context) -> RegisteredModel:
         py_obj = super().unmap(mlmd_obj)
-        assert isinstance(
+        assert isinstance( # noqa: S101 helpful for dev phase, not runtime
             py_obj, RegisteredModel
         ), f"Expected RegisteredModel, got {type(py_obj)}"
         py_obj.owner = mlmd_obj.properties["owner"].string_value


### PR DESCRIPTION
superseeds #136
make intentional/explicit the use of asserts in app logic is only helpful harness during development cycles

## Description
onboard https://github.com/kubeflow/model-registry/pull/136#issuecomment-2160641431
and for posterity make it explicit/intentional, as a noqa note.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

cc @isinyaaa wdyt?
This way the "next one" looking into this will find intentional override/note and not have the same doubt per my original #136