### PR TITLE
py: set author as owner when creating RegisteredModel

### DIFF
--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -69,11 +69,11 @@ class ModelRegistry:
                 server_address, port, user_token
             )
 
-    def _register_model(self, name: str) -> RegisteredModel:
+    def _register_model(self, name: str, **kwargs) -> RegisteredModel:
         if rm := self._api.get_registered_model_by_params(name):
             return rm
 
-        rm = RegisteredModel(name)
+        rm = RegisteredModel(name, **kwargs)
         self._api.upsert_registered_model(rm)
         return rm
 
@@ -109,6 +109,7 @@ class ModelRegistry:
         storage_path: str | None = None,
         service_account_name: str | None = None,
         author: str | None = None,
+        owner: str | None = None,
         description: str | None = None,
         metadata: dict[str, ScalarType] | None = None,
     ) -> RegisteredModel:
@@ -132,6 +133,7 @@ class ModelRegistry:
             model_format_version: Version of the model format.
             description: Description of the model.
             author: Author of the model. Defaults to the client author.
+            owner: Owner of the model. Defaults to the client author.
             storage_key: Storage key.
             storage_path: Storage path.
             service_account_name: Service account name.
@@ -140,7 +142,7 @@ class ModelRegistry:
         Returns:
             Registered model.
         """
-        rm = self._register_model(name)
+        rm = self._register_model(name, owner=owner or self._author)
         mv = self._register_new_version(
             rm,
             version,
@@ -169,6 +171,7 @@ class ModelRegistry:
         model_format_name: str,
         model_format_version: str,
         author: str | None = None,
+        owner: str | None = None,
         model_name: str | None = None,
         description: str | None = None,
         git_ref: str = "main",
@@ -187,6 +190,7 @@ class ModelRegistry:
             model_format_name: Name of the model format.
             model_format_version: Version of the model format.
             author: Author of the model. Defaults to repo owner.
+            owner: Owner of the model. Defaults to the client author.
             model_name: Name of the model. Defaults to the repo name.
             description: Description of the model.
             git_ref: Git reference to use. Defaults to `main`.
@@ -244,6 +248,7 @@ class ModelRegistry:
             model_name or model_info.id,
             source_uri,
             author=author or model_author,
+            owner=owner or self._author,
             version=version,
             model_format_name=model_format_name,
             model_format_version=model_format_version,

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -135,14 +135,12 @@ class RegisteredModel(BaseContext):
     """
 
     name: str
-    owner: str = None
+    owner: str | None = None
 
     @override
     def map(self, type_id: int) -> Context:
         mlmd_obj = super().map(type_id)
-        props = {
-            "owner": self.owner
-        }
+        props = {"owner": self.owner}
         self._map_props(props, mlmd_obj.properties)
         return mlmd_obj
 

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -160,6 +160,7 @@ def store_wrapper(plain_wrapper: MLMDStore) -> MLMDStore:
         [
             "description",
             "state",
+            "owner",
         ],
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This makes the owner property usable from the high-level Python API.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
