### PR TITLE
Dependency Update: bump go from 1.19 to 1.21@latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 PROJECT_BIN := $(PROJECT_PATH)/bin
-GO := $(PROJECT_BIN)/go1.19
+GO := $(PROJECT_BIN)/go1.21.9
 
 # add tools bin directory
 PATH := $(PROJECT_BIN):$(PATH)
@@ -109,8 +109,8 @@ clean/odh:
 	rm -Rf ./model-registry
 
 bin/go:
-	GOBIN=$(PROJECT_BIN) go install golang.org/dl/go1.19@latest
-	$(PROJECT_BIN)/go1.19 download
+	GOBIN=$(PROJECT_BIN) go install golang.org/dl/go1.21.9@latest
+	$(PROJECT_BIN)/go1.21.9 download
 
 bin/protoc:
 	./scripts/install_protoc.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/model-registry
 
-go 1.19
+go 1.21
 
 require (
 	github.com/go-chi/chi/v5 v5.0.12


### PR DESCRIPTION
This commit will update go from go1.19 to go1.21@latest


