### PR TITLE
Py: Extend high-level API with paging

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -98,6 +98,31 @@ There are caveats to be noted when using this method:
     )
     ```
 
+### Listing models
+
+To list models you can use
+```py
+for model in registry.get_registered_models():
+    ...
+
+# and versions associated with a model
+for version in registry.get_model_versions("my-model"):
+    ...
+```
+
+To customize sorting order or query limits you can also use
+
+```py
+latest_updates = registry.get_model_versions("my-model").order_by_update_time().descending().limit(20)
+for version in latest_updates:
+    ...
+```
+
+You can use `order_by_creation_time`, `order_by_update_time`, or `order_by_id` to change the sorting order.
+
+> Note that the `limit()` method only limits the query size, not the actual loop boundaries -- even if your limit is 1
+> you will still get all the models, with one query each.
+
 ## Development
 
 Common tasks, such as building documentation and running tests, can be executed using [`nox`](https://github.com/wntrblm/nox) sessions.

--- a/clients/python/docs/reference.md
+++ b/clients/python/docs/reference.md
@@ -17,13 +17,13 @@ To create a client you should use the {py:meth}`model_registry.core.ModelRegistr
 ```py
 from model_registry.core import ModelRegistryAPIClient
 
-insecure_registry = ModelRegistryAPIClient.insecure_connection(
+insecure_mr_client = ModelRegistryAPIClient.insecure_connection(
     "server-address", "port",
     # optionally, you can identify yourself
     # user_token=os.environ["MY_TOKEN"]
 )
 
-insecure_registry = ModelRegistryAPIClient.insecure_connection(
+mr_client = ModelRegistryAPIClient.secure_connection(
     "server-address", "port",
     user_token=os.environ["MY_TOKEN"]  # this is necessary on a secure connection
     # optionally, use a custom_ca
@@ -42,7 +42,7 @@ from model_registry.types import RegisteredModel, ModelVersion, ModelArtifact
 from model_registry.utils import s3_uri_from
 
 async def register_a_model():
-    model = await registry.upsert_registered_model(
+    model = await mr_client.upsert_registered_model(
         RegisteredModel(
             name="HAL",
             owner="me <me@cool.inc>",
@@ -51,7 +51,7 @@ async def register_a_model():
     assert model.id  # this should be valid now
 
     # we need a registered model to associate the version to
-    version = await registry.upsert_model_version(
+    version = await mr_client.upsert_model_version(
         ModelVersion(
             name="9000",
             author="Mr. Tom A.I.",
@@ -62,7 +62,7 @@ async def register_a_model():
     assert version.id
 
     # we need a version to associate a trained model to
-    trained_model = await registry.upsert_model_artifact(
+    trained_model = await mr_client.upsert_model_artifact(
         ModelArtifact(
             name="HAL-core",
             uri=s3_uri_from("build/onnx/hal.onnx", "cool-bucket"),
@@ -80,6 +80,23 @@ async def register_a_model():
 
 As objects are only assigned IDs upon creation, you can use this property to verify whether an object exists.
 
+You can associate multiple artifacts with the same version as well:
+
+```py
+from model_registry.types import DocArtifact
+
+readme = await mr_client.upsert_model_version_artifact(
+    DocArtifact(
+        name="README",
+        uri="https://github.com/my-org/my-model/blob/main/README.md",
+        description="Model information"
+    ), version.id
+)
+```
+
+> Note: document artifacts currently have no `storage_*` attributes, so you have to keep track of any credentials
+> necessary to access it manually.
+
 ### Query objects
 
 There are several ways to get registered objects from the registry.
@@ -89,9 +106,9 @@ There are several ways to get registered objects from the registry.
 After upserting an object you can use its `id` to fetch it again.
 
 ```py
-new_model = await registry.upsert_registered_model(RegisteredModel("new_model"))
+new_model = await mr_client.upsert_registered_model(RegisteredModel("new_model"))
 
-maybe_new_model = await registry.get_registered_model_by_id(new_model.id)
+maybe_new_model = await mr_client.get_registered_model_by_id(new_model.id)
 
 assert maybe_new_model == new_model  # True
 ```
@@ -132,22 +149,22 @@ You can also perform queries by parameters:
 
 ```py
 # We can get the model artifact associated to a version
-another_trained_model = await registry.get_model_artifact_by_params(name="my_model_name", model_version_id=another_version.id)
+another_trained_model = await mr_client.get_model_artifact_by_params(name="my_model_name", model_version_id=another_version.id)
 
 # Or by its unique identifier
-trained_model = await registry.get_model_artifact_by_params(external_id="unique_reference")
+trained_model = await mr_client.get_model_artifact_by_params(external_id="unique_reference")
 
 # Same thing for a version
-version = await registry.get_model_version_by_params(external_id="unique_reference")
+version = await mr_client.get_model_version_by_params(external_id="unique_reference")
 
 # Or for a model
-model = await registry.get_registered_model_by_params(external_id="another_unique_reference")
+model = await mr_client.get_registered_model_by_params(external_id="another_unique_reference")
 
 # We can also get a version by its name and associated model id
-version = await registry.get_model_version_by_params(version="v1.0", registered_model_id="x")
+version = await mr_client.get_model_version_by_params(version="v1.0", registered_model_id="x")
 
 # And we can get a model by simply calling its name
-model = await registry.get_registered_model_by_params(name="my_model_name")
+model = await mr_client.get_registered_model_by_params(name="my_model_name")
 ```
 
 ### Query multiple objects
@@ -155,12 +172,12 @@ model = await registry.get_registered_model_by_params(name="my_model_name")
 We can query all objects of a type
 
 ```py
-models = await registry.get_registered_models()
+models = await mr_client.get_registered_models()
 
-versions = await registry.get_model_versions("registered_model_id")
+versions = await mr_client.get_model_versions("registered_model_id")
 
 # We can get a list of all model artifacts
-all_model_artifacts = await registry.get_model_artifacts()
+all_model_artifacts = await mr_client.get_model_artifacts()
 ```
 
 To limit or order the query, provide a {py:class}`model_registry.types.ListOptions` object.
@@ -170,12 +187,12 @@ from model_registry import ListOptions
 
 options = ListOptions(limit=50)
 
-first_50_models = await registry.get_registered_models(options)
+first_50_models = await mr_client.get_registered_models(options)
 
 # By default we get ascending order
 options = ListOptions.order_by_creation_time(is_asc=False)
 
-last_50_models = await registry.get_registered_models(options)
+last_50_models = await mr_client.get_registered_models(options)
 ```
 
 ```{eval-rst}
@@ -188,6 +205,8 @@ last_50_models = await registry.get_registered_models(options)
 
 Registry objects can be created by doing
 
+<!-- TODO: be explicit about possible ways to create MA that allow for serving -->
+
 ```py
 from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
 
@@ -195,6 +214,8 @@ trained_model = ModelArtifact(
     name="model-exec",
     uri="resource_URI",
     description="Model description",
+    model_format_name="onnx",
+    model_format_version="1",
 )
 
 version = ModelVersion(

--- a/clients/python/src/model_registry/core.py
+++ b/clients/python/src/model_registry/core.py
@@ -172,11 +172,14 @@ class ModelRegistryAPIClient:
             Registered models.
         """
         async with self.get_client() as client:
-            rms = await client.get_registered_models(
+            rm_list = await client.get_registered_models(
                 **(options or ListOptions()).as_options()
             )
 
-        return [RegisteredModel.from_basemodel(rm) for rm in rms.items or []]
+        if options:
+            options.next_page_token = rm_list.next_page_token
+
+        return [RegisteredModel.from_basemodel(rm) for rm in rm_list.items or []]
 
     async def upsert_model_version(
         self, model_version: ModelVersion, registered_model_id: str
@@ -236,11 +239,14 @@ class ModelRegistryAPIClient:
             Model versions.
         """
         async with self.get_client() as client:
-            mvs = await client.get_registered_model_versions(
+            mv_list = await client.get_registered_model_versions(
                 registered_model_id, **(options or ListOptions()).as_options()
             )
 
-        return [ModelVersion.from_basemodel(mv) for mv in mvs.items or []]
+        if options:
+            options.next_page_token = mv_list.next_page_token
+
+        return [ModelVersion.from_basemodel(mv) for mv in mv_list.items or []]
 
     @overload
     async def get_model_version_by_params(
@@ -415,17 +421,43 @@ class ModelRegistryAPIClient:
         """
         async with self.get_client() as client:
             if model_version_id:
-                arts = await client.get_model_version_artifacts(
+                art_list = await client.get_model_version_artifacts(
                     model_version_id, **(options or ListOptions()).as_options()
                 )
+                if options:
+                    options.next_page_token = art_list.next_page_token
                 models = []
-                for art in arts.items or []:
+                for art in art_list.items or []:
                     converted = Artifact.validate_artifact(art)
                     if isinstance(converted, ModelArtifact):
                         models.append(converted)
                 return models
 
-            mas = await client.get_model_artifacts(
+            ma_list = await client.get_model_artifacts(
                 **(options or ListOptions()).as_options()
             )
-            return [ModelArtifact.from_basemodel(ma) for ma in mas.items or []]
+            if options:
+                options.next_page_token = ma_list.next_page_token
+            return [ModelArtifact.from_basemodel(ma) for ma in ma_list.items or []]
+
+    async def get_model_version_artifacts(
+        self,
+        model_version_id: str,
+        options: ListOptions | None = None,
+    ) -> list[Artifact]:
+        """Fetches model artifacts.
+
+        Args:
+            model_version_id: ID of the associated model version.
+            options: Options for listing model artifacts.
+
+        Returns:
+            Model artifacts.
+        """
+        async with self.get_client() as client:
+            art_list = await client.get_model_version_artifacts(
+                model_version_id, **(options or ListOptions()).as_options()
+            )
+        if options:
+            options.next_page_token = art_list.next_page_token
+        return [Artifact.validate_artifact(art) for art in art_list.items or []]

--- a/clients/python/src/model_registry/types/__init__.py
+++ b/clients/python/src/model_registry/types/__init__.py
@@ -3,7 +3,7 @@
 Types are based on [ML Metadata](https://github.com/google/ml-metadata), with Pythonic class wrappers.
 """
 
-from .artifacts import Artifact, ArtifactState, ModelArtifact
+from .artifacts import Artifact, ArtifactState, DocArtifact, ModelArtifact
 from .base import SupportedTypes
 from .contexts import (
     ModelVersion,
@@ -17,6 +17,7 @@ __all__ = [
     # Artifacts
     "Artifact",
     "ArtifactState",
+    "DocArtifact",
     "ModelArtifact",
     # Contexts
     "ModelVersion",

--- a/clients/python/src/model_registry/types/__init__.py
+++ b/clients/python/src/model_registry/types/__init__.py
@@ -12,6 +12,7 @@ from .contexts import (
     RegisteredModelState,
 )
 from .options import ListOptions
+from .pager import Pager
 
 __all__ = [
     # Artifacts
@@ -27,4 +28,6 @@ __all__ = [
     "SupportedTypes",
     # Options
     "ListOptions",
+    # Pager
+    "Pager",
 ]

--- a/clients/python/src/model_registry/types/options.py
+++ b/clients/python/src/model_registry/types/options.py
@@ -19,11 +19,13 @@ class ListOptions:
         limit: Maximum number of objects to return.
         order_by: Field to order by.
         is_asc: Whether to order in ascending order. Defaults to True.
+        next_page_token: Token to use to retrieve next page of results.
     """
 
     limit: int | None = None
     order_by: OrderByField | None = None
     is_asc: bool = True
+    next_page_token: str | None = None
 
     @classmethod
     def order_by_creation_time(cls, **kwargs) -> ListOptions:
@@ -49,4 +51,6 @@ class ListOptions:
             options["order_by"] = self.order_by
         if self.is_asc is not None:
             options["sort_order"] = SortOrder.ASC if self.is_asc else SortOrder.DESC
+        if self.next_page_token is not None:
+            options["next_page_token"] = self.next_page_token
         return options

--- a/clients/python/src/model_registry/types/pager.py
+++ b/clients/python/src/model_registry/types/pager.py
@@ -1,0 +1,179 @@
+"""Pager for iterating over items."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Iterator
+from dataclasses import dataclass, field
+from typing import Callable, Generic, TypeVar, cast
+
+from .base import BaseModel
+from .options import ListOptions, OrderByField
+
+T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass
+class Pager(Generic[T], Iterator[T], AsyncIterator[T]):
+    """Pager for iterating over items.
+
+    Assumes that page_fn is a paged function that takes ListOptions and returns a list of items.
+    """
+
+    page_fn: (
+        Callable[[ListOptions], list[T]] | Callable[[ListOptions], Awaitable[list[T]]]
+    )
+    options: ListOptions = field(default_factory=ListOptions)
+
+    def __post_init__(self):
+        self.restart()
+        if asyncio.iscoroutinefunction(self.page_fn):
+            self.__next__ = NotImplemented
+            self.next_page = self._anext_page
+            self.next_item = self._anext_item
+        else:
+            self.__anext__ = NotImplemented
+            self.next_page = self._next_page
+            self.next_item = self._next_item
+
+    def restart(self) -> Pager[T]:
+        """Reset the pager.
+
+        This keeps the current options and page function, but resets the internal state.
+        """
+        # as MLMD loops over pages, we need to keep track of the first page or we'll loop forever
+        self._start = None
+        self._current_page = None
+        # tracks the next item on the current page
+        self._i = 0
+        self.options.next_page_token = None
+        return self
+
+    def order_by_creation_time(self) -> Pager[T]:
+        """Order items by creation time.
+
+        This resets the pager.
+        """
+        self.options.order_by = OrderByField.CREATE_TIME
+        return self.restart()
+
+    def order_by_update_time(self) -> Pager[T]:
+        """Order items by update time.
+
+        This resets the pager.
+        """
+        self.options.order_by = OrderByField.LAST_UPDATE_TIME
+        return self.restart()
+
+    def order_by_id(self) -> Pager[T]:
+        """Order items by ID.
+
+        This resets the pager.
+        """
+        self.options.order_by = OrderByField.ID
+        return self.restart()
+
+    def limit(self, limit: int) -> Pager[T]:
+        """Limit the number of items to return.
+
+        This resets the pager.
+        """
+        self.options.limit = limit
+        return self.restart()
+
+    def ascending(self) -> Pager[T]:
+        """Order items in ascending order.
+
+        This resets the pager.
+        """
+        self.options.is_asc = True
+        return self.restart()
+
+    def descending(self) -> Pager[T]:
+        """Order items in descending order.
+
+        This resets the pager.
+        """
+        self.options.is_asc = False
+        return self.restart()
+
+    def _next_page(self) -> list[T]:
+        """Get the next page of items.
+
+        This will automatically loop over pages.
+        """
+        return cast(list[T], self.page_fn(self.options))
+
+    async def _anext_page(self) -> list[T]:
+        """Get the next page of items.
+
+        This will automatically loop over pages.
+        """
+        return await cast(Awaitable[list[T]], self.page_fn(self.options))
+
+    def _needs_fetch(self) -> bool:
+        return not self._current_page or self._i >= len(self._current_page)
+
+    def _next_item(self) -> T:
+        """Get the next item in the pager.
+
+        This variant won't check for looping, so it's useful for manual iteration/scripting.
+
+        NOTE: This won't check for looping, so use with caution.
+        If you want to check for looping, use the pythonic `next()`.
+        """
+        if self._needs_fetch():
+            self._current_page = self._next_page()
+            self._i = 0
+        assert self._current_page
+
+        item = self._current_page[self._i]
+        self._i += 1
+        return item
+
+    async def _anext_item(self) -> T:
+        """Get the next item in the pager.
+
+        This variant won't check for looping, so it's useful for manual iteration/scripting.
+
+        NOTE: This won't check for looping, so use with caution.
+        If you want to check for looping, use the pythonic `next()`.
+        """
+        if self._needs_fetch():
+            self._current_page = await self._anext_page()
+            self._i = 0
+        assert self._current_page
+
+        item = self._current_page[self._i]
+        self._i += 1
+        return item
+
+    def __next__(self) -> T:
+        check_looping = self._needs_fetch()
+
+        item = self._next_item()
+
+        if not self._start:
+            self._start = self.options.next_page_token
+        elif check_looping and self.options.next_page_token == self._start:
+            raise StopIteration
+
+        return item
+
+    async def __anext__(self) -> T:
+        check_looping = self._needs_fetch()
+
+        item = await self._anext_item()
+
+        if not self._start:
+            self._start = self.options.next_page_token
+        elif check_looping and self.options.next_page_token == self._start:
+            raise StopAsyncIteration
+
+        return item
+
+    def __iter__(self) -> Iterator[T]:
+        return self
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        return self


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds listing methods for:
1. Registered Models, and
2. Model Versions associated with a Registered Model

The high-level listing methods manage a `ListOptions` instance providing a smart iterator.
The iterator can be configured in a builder style, and can be reused.

The Pager iterator can also be used at the core layer to provide a better experience for advanced users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated tests to verify paging is correct.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
