### PR TITLE
chore(py): align ver in init to project toml

### DIFF
--- a/clients/python/src/model_registry/__init__.py
+++ b/clients/python/src/model_registry/__init__.py
@@ -1,6 +1,6 @@
 """Main package for the ODH model registry."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.3a1"
 
 from ._client import ModelRegistry
 


### PR DESCRIPTION
aligns to 

https://github.com/kubeflow/model-registry/blob/99372a5bc7007e6d8a9f3a2bab77cc9cf993ebfd/clients/python/pyproject.toml#L3
