### PR TITLE
test: show s3_uri_from format in pure REST test

### DIFF
--- a/test/robot/MRkeywords.resource
+++ b/test/robot/MRkeywords.resource
@@ -207,3 +207,9 @@ I get ArtifactsByModelVersionID
         Fail    Not Implemented
     END
     RETURN    ${result}
+
+
+I use util s3_uri_from
+    [Arguments]    ${path}  ${bucket}  ${endpoint}  ${region}
+    ${result}=  s3_uri_from  path=${path}  bucket=${bucket}  endpoint=${endpoint}  region=${region}
+    RETURN    ${result}

--- a/test/robot/ModelRegistry.py
+++ b/test/robot/ModelRegistry.py
@@ -1,6 +1,7 @@
 from model_registry.core import ModelRegistryAPIClient
 from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
 from robot.libraries.BuiltIn import BuiltIn
+import model_registry.utils
 
 
 def write_to_console(s):
@@ -32,6 +33,12 @@ class ModelRegistry:
         p = ModelArtifact(**model_artifact)
         write_to_console(p)
         return (await self.api.upsert_model_artifact(p, model_version_id)).id
+
+    def s3_uri_from(self, path, bucket, endpoint, region) -> str:
+        """
+        Expose util to RobotFramework
+        """
+        return model_registry.utils.s3_uri_from(path=path, bucket=bucket, endpoint=endpoint, region=region)
 
 
 async def test():

--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -96,3 +96,32 @@ As a MLOps engineer I would like to store an owner for the RegisteredModel
     ${r}  Then I get RegisteredModelByID    id=${rId}
           And Should be equal    ${r["description"]}    Lorem ipsum dolor sit amet
           And Should be equal    ${r["owner"]}    My owner
+
+As a MLOps engineer I want to track a Model from an S3 bucket Data Connection
+    ${data_connection_name}  Set Variable   aws-connection-my-data-connection
+    ${s3_bucket}  Set Variable  my-bucket
+    ${s3_path}  Set Variable  my-path
+    ${s3_endpoint}  Set Variable  https://minio-api.acme.org
+    ${s3_region}  Set Variable  us-east-1
+
+    Set To Dictionary    ${registered_model}    description=The Model  name=${name}
+    Set To Dictionary    ${model_version}    description=The Version  name=v1.0  
+    ${art_uri}  I use util s3_uri_from  path=${s3_path}  bucket=${s3_bucket}  endpoint=${s3_endpoint}  region=${s3_region}
+    Set To Dictionary    ${model_artifact}    description=The Artifact  uri=${art_uri}  modelFormatName=onnx  modelFormatVersion=1  storageKey=${data_connection_name}  storagePath=${s3_path}
+    Log to console  ${model_artifact}
+
+    ${rId}  Given I create a RegisteredModel    payload=${registered_model}
+    ${vId}  And I create a child ModelVersion    registeredModelID=${rId}  payload=&{model_version}
+    ${aId}  And I create a child ModelArtifact    modelversionId=${vId}  payload=&{model_artifact}
+    ${r}  Then I get RegisteredModelByID    id=${rId}
+          And Should be equal    ${r["description"]}    The Model
+    ${r}  Then I get ModelVersionByID    id=${vId}
+          And Should be equal    ${r["description"]}    The Version
+          And Should be equal    ${r["name"]}    v1.0
+    ${r}  Then I get ModelArtifactByID    id=${aId}
+          And Should be equal    ${r["description"]}    The Artifact
+          And Should be equal    ${r["uri"]}    s3://my-bucket/my-path?endpoint=https://minio-api.acme.org&defaultRegion=us-east-1
+          And Should be equal    ${r["modelFormatName"]}    onnx
+          And Should be equal    ${r["modelFormatVersion"]}    1
+          And Should be equal    ${r["storageKey"]}    aws-connection-my-data-connection
+          And Should be equal    ${r["storagePath"]}    my-path


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Show use of the format from `s3_uri_from` using REST based testing with RobotFramework

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
