### PR TITLE
docker: align docker-compose image to upstream

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./test/config/ml-metadata:/tmp/shared
   model-registry:
-    image: quay.io/opendatahub/model-registry:latest
+    image: docker.io/kubeflow/model-registry:latest
     command: ["proxy", "--hostname", "0.0.0.0", "--mlmd-hostname", "mlmd-server", "--mlmd-port", "8080"]
     container_name: model-registry
     ports:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Aligns `docker-compose.yaml` image to consume upstream Kubeflow from dockerhub.

## How Has This Been Tested?
1.
`poetry run pytest` from `clients/python`:

![Screenshot 2024-07-30 at 16 14 00](https://github.com/user-attachments/assets/634bee61-6266-4b33-ac58-b63117633da7)

2.
from `/`:
- `docker compose -f docker-compose.yaml up`
- `robot test/robot/UserStory.robot`

![Screenshot 2024-07-30 at 16 15 47 (2)](https://github.com/user-attachments/assets/f9bbbe65-9071-412e-b377-b41953d816f8)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
