### PR TITLE
Add Dockerfile for serving containerised frontend

### DIFF
--- a/clients/ui/docker-compose.yaml
+++ b/clients/ui/docker-compose.yaml
@@ -1,0 +1,23 @@
+services:
+  frontend:
+    build: ./frontend
+    container_name: model-registry-ui
+    ports:
+      - 8080:8080
+    environment:
+      API_URL: http://model-registry-bff:4001
+    networks:
+      - model_registry
+    depends_on:
+      - bff
+  bff:
+    build: ./bff
+    container_name: model-registry-bff
+    command:
+      - "--mock-k8s-client=true"
+    networks:
+      - model_registry
+
+networks:
+  model_registry:
+    name: model_registry

--- a/clients/ui/frontend/.dockerignore
+++ b/clients/ui/frontend/.dockerignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/clients/ui/frontend/Dockerfile
+++ b/clients/ui/frontend/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:18 AS build-stage
+
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+
+RUN npm cache clean --force
+RUN npm ci --omit=optional
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged
+
+ENV API_URL="http://localhost:4001"
+ENV NGINX_ENVSUBST_FILTER="API_URL"
+
+COPY --from=build-stage /usr/src/app/dist/ "/usr/share/nginx/html"
+COPY --from=build-stage /usr/src/app/nginx.conf "/etc/nginx/templates/default.conf.template"

--- a/clients/ui/frontend/Makefile
+++ b/clients/ui/frontend/Makefile
@@ -1,0 +1,13 @@
+CONTAINER_TOOL ?= docker
+IMG ?= model-registry-ui:latest
+
+.PHONY: all
+all: docker-build
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY: docker-build
+docker-build:
+	$(CONTAINER_TOOL) build -t ${IMG} .

--- a/clients/ui/frontend/config/webpack.dev.js
+++ b/clients/ui/frontend/config/webpack.dev.js
@@ -6,6 +6,9 @@ const common = require('./webpack.common.js');
 const { stylePaths } = require('./stylePaths');
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || '9000';
+const PROXY_HOST = process.env.PROXY_HOST || 'localhost';
+const PROXY_PORT = process.env.PROXY_PORT || '4000';
+const PROXY_PROTOCOL = process.env.PROXY_PROTOCOL || 'http:';
 const relativeDir = path.resolve(__dirname, '..');
 
 module.exports = merge(common('development'), {
@@ -21,7 +24,16 @@ module.exports = merge(common('development'), {
     },
     client: {
       overlay: true
-    }
+    },
+    proxy: {
+      '/api': {
+        target: {
+          host: PROXY_HOST,
+          protocol: PROXY_PROTOCOL,
+          port: PROXY_PORT,
+        },
+      },
+    },
   },
   module: {
     rules: [

--- a/clients/ui/frontend/nginx.conf
+++ b/clients/ui/frontend/nginx.conf
@@ -1,0 +1,21 @@
+server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+        gzip         on;
+        access_log   /dev/stdout main;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        location /api/ {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass ${API_URL};
+         }
+    }
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR allows the frontend to be served in a container using nginx and adds:
  * Dockerfile for serving the frontend and proxying calls to the bff.
  * An example docker-compose for running the stack.
  * Webpack config for proxying and url rewriting for the frontend in dev mode.
  * A frontend Makefile for building the docker image

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Run the example docker-compose file: `podman compose up -d` (swap podman for docker if that's your bag)
* Verify the frontend loads in a browser at: `localhost:8080`
* Verify the reverse proxy to the backend works via curl: `curl localhost:8080/api/v1/model-registry/` - this should return a valid response from the bff
* Run the frontend in dev mode using: `npm run start:dev` - run the bff directly using `make run PORT=4000 MOCK_K8S_CLIENT=true` in a separate terminal and verify the dashboard loads in a browser and the proxy functions by running: `curl localhost:9000/api/v1/model-registry/`.
* Run the frontend Makefile `make CONTAINER_TOOL=podman` (leave out the CONTAINER_TOOL param to use docker)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
