### PR TITLE
fix: made install_protoc.sh compatible with wget2

### DIFF
--- a/scripts/install_protoc.sh
+++ b/scripts/install_protoc.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -euxo pipefail
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_PARENT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
 
 VERSION="24.3"
 OS="linux"
@@ -14,9 +14,9 @@ if [[ "$(uname -m)" == "arm"* ]]; then
   ARCH="aarch_64"
 fi
 
-mkdir -p ${SCRIPT_DIR}/../bin
+mkdir -p ${SCRIPT_PARENT_DIR}/bin
 
-wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-${OS}-${ARCH}.zip -O ${SCRIPT_DIR}/../protoc.zip && \
-  unzip -qo ${SCRIPT_DIR}/../protoc.zip -d ${SCRIPT_DIR}/.. && \
+wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-${OS}-${ARCH}.zip -O ${SCRIPT_PARENT_DIR}/protoc.zip && \
+  unzip -qo ${SCRIPT_PARENT_DIR}/protoc.zip -d ${SCRIPT_PARENT_DIR} && \
   bin/protoc --version && \
-  rm ${SCRIPT_DIR}/../protoc.zip
+  rm ${SCRIPT_PARENT_DIR}/protoc.zip


### PR DESCRIPTION
fixes #254 

## Description

Switches paths from relative to absolute for wget and any other command that uses it, to make it work with wget and wget2.

## How Has This Been Tested?

I tested this on my local machine by running `make bin/protoc`, and also by building the docker image.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
