### PR TITLE
Bump mysql container image to one with an aarch64 image

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -37,6 +37,11 @@ jobs:
         uses: helm/kind-action@v1.12.0
         with:
           node_image: "kindest/node:v1.27.11"
+      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
+        run: |
+          set -x
+          sudo apt-get install apparmor-profiles
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Load Local Registry Test Image
         env:
           IMG: "${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"

--- a/.github/workflows/csi-test.yml
+++ b/.github/workflows/csi-test.yml
@@ -63,6 +63,12 @@ jobs:
         with:
           node_image: "kindest/node:v1.27.11"
 
+      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
+        run: |
+          set -x
+          sudo apt-get install apparmor-profiles
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+
       - name: Install kustomize
         run: ./test/scripts/install_kustomize.sh
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -140,6 +140,11 @@ jobs:
           node_image: kindest/node:${{ matrix.kubernetes-version }}
           cluster_name: chart-testing-py-${{ matrix.python }}
           kubectl_version: ${{ matrix.kubernetes-version }}
+      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
+        run: |
+          set -x
+          sudo apt-get install apparmor-profiles
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Load Local Registry Test Image
         env:
           IMG: "${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"

--- a/manifests/kustomize/overlays/db/kustomization.yaml
+++ b/manifests/kustomize/overlays/db/kustomization.yaml
@@ -26,7 +26,7 @@ generatorOptions:
 images:
 - name: mysql
   newName: mysql
-  newTag: 8.0.3
+  newTag: 8.0.39
 
 vars:
 - fieldref:

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -41,6 +41,8 @@ kubectl patch deployment -n "$MR_NAMESPACE" model-registry-deployment \
 
 if ! kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m ; then
     kubectl events -A
+    kubectl describe deployment/model-registry-db -n kubeflow
+    kubectl logs deployment/model-registry-db -n kubeflow
     exit 1
 fi
 

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -39,7 +39,10 @@ kubectl apply -k manifests/kustomize/overlays/db
 kubectl patch deployment -n "$MR_NAMESPACE" model-registry-deployment \
 --patch '{"spec": {"template": {"spec": {"containers": [{"name": "rest-container", "image": "'$IMG'", "imagePullPolicy": "IfNotPresent"}]}}}}'
 
-kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m
+if ! kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m ; then
+    kubectl events -A
+    exit 1
+fi
 
 kubectl delete pod -n "$MR_NAMESPACE" --selector='component=model-registry-server'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* #266

Bumps the version of the MySQL container image in the overlays/db kustomization to 8.0.39 which is multi-arch (amd64 / aarch64)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed to a local `kind` cluster on an apple silicon MacBook, using official instructions to deploy using `kind` on macOS.

*[https://www.kubeflow.org/docs/components/pipelines/legacy-v1/installation/localcluster-deployment/#kind](https://www.kubeflow.org/docs/components/pipelines/legacy-v1/installation/localcluster-deployment/#kind)
*[https://www.kubeflow.org/docs/components/model-registry/installation/#standalone-installation](https://www.kubeflow.org/docs/components/model-registry/installation/#standalone-installation
)

The only variation of above was that I deployed to kind using my branch of the manifest:
```kubectl apply -k "https://github.com/alexcreasy/model-registry/manifests/kustomize/overlays/db?ref=kind"```

I've verified I'm able to deploy as above, create a port forward to the service, and query the rest endpoint as indicated in the example above and receive a 200 response.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
