### PR TITLE
fix: make tests work on fedora

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,25 @@ export TESTCONTAINERS_RYUK_PRIVILEGED=true
 
 when running TestContainer-based Model Registry Python tests (for more information, see [here](https://pypi.org/project/testcontainers/#:~:text=TESTCONTAINERS_RYUK_PRIVILEGED)).
 
+#### Fedora
+
+Fedora requires further setup to make testcontainers work with Podman, the following steps are required:
+
+- start the podman socket service
+
+```sh
+systemctl --user start podman.socket
+```
+
+- set the environment variables
+
+```sh
+export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+export TESTCONTAINERS_RYUK_PRIVILEGED=true
+```
+
+If you need more information, please refer to the [Testcontainers using Podman](https://golang.testcontainers.org/system_requirements/using_podman/).
+
 ### Colima
 
 Colima offers Rosetta (Apple specific) emulation which is handy since the Google MLMD project dependency is x86 specific.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,11 +94,10 @@ Fedora requires further setup to make testcontainers work with Podman, the follo
 systemctl --user start podman.socket
 ```
 
-- set the environment variables
+- set the environment variable
 
 ```sh
 export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
-export TESTCONTAINERS_RYUK_PRIVILEGED=true
 ```
 
 If you need more information, please refer to the [Testcontainers using Podman](https://golang.testcontainers.org/system_requirements/using_podman/).

--- a/internal/testutils/test_container_utils.go
+++ b/internal/testutils/test_container_utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
@@ -90,6 +91,7 @@ func SetupMLMetadataTestContainer(t *testing.T) (*grpc.ClientConn, proto.Metadat
 			hc.Binds = []string{wd + ":/tmp/shared"}
 		},
 		WaitingFor: wait.ForLog("Server listening on"),
+		Privileged: true,
 	}
 
 	useProvider := defaultProvider
@@ -164,5 +166,5 @@ func tryDetectPodmanRunning() bool {
 	if err != nil {
 		return false
 	}
-	return info.Host.MachineState == "Running"
+	return info.Host.MachineState == "Running" || strings.Contains(os.Getenv("DOCKER_HOST"), "podman.sock")
 }


### PR DESCRIPTION
fixes #268 

## Description
I set Privileged to true to test containers because SELinux prevented containers from reading metadata from the `conn_config.pb` file, which caused the container to use the in-memory database that does not persist data instead of the SQLite one, causing all tests to fail.

I also improved podman detection on systems that do not require a machine by adding a check to the `DOCKER_HOST` environment variable.

It's worth noting that I tried other ways to get it to work, both disabling Ryuk and trying to set different SELinux policies by following the [testcontainers podman guide](https://golang.testcontainers.org/system_requirements/using_podman/#fedora), but none of them worked.

## How Has This Been Tested?
I tested this on my local machine by running `make test`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
