### PR TITLE
Adds description and display name properties to mocked ModelRegistry responses

### DIFF
--- a/clients/ui/bff/api/model_registry_handler.go
+++ b/clients/ui/bff/api/model_registry_handler.go
@@ -7,7 +7,7 @@ import (
 
 func (app *App) ModelRegistryHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
-	registries, err := app.models.ModelRegistry.FetchAllModelRegistry(app.kubernetesClient)
+	registries, err := app.models.ModelRegistry.FetchAllModelRegistries(app.kubernetesClient)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/clients/ui/bff/api/model_registry_handler_test.go
+++ b/clients/ui/bff/api/model_registry_handler_test.go
@@ -39,15 +39,15 @@ func TestModelRegistryHandler(t *testing.T) {
 	actualModelRegistry := make([]data.ModelRegistryModel, 0)
 	for _, v := range modelRegistryRes["model_registry"].([]interface{}) {
 		model := v.(map[string]interface{})
-		actualModelRegistry = append(actualModelRegistry, data.ModelRegistryModel{Name: model["name"].(string)})
+		actualModelRegistry = append(actualModelRegistry, data.ModelRegistryModel{Name: model["name"].(string), Description: model["description"].(string), DisplayName: model["displayName"].(string)})
 	}
 	modelRegistryRes["model_registry"] = actualModelRegistry
 
 	var expected = Envelope{
 		"model_registry": []data.ModelRegistryModel{
-			{Name: "model-registry"},
-			{Name: "model-registry-dora"},
-			{Name: "model-registry-bella"},
+			{Name: "model-registry", Description: "Model registry description", DisplayName: "Model Registry"},
+			{Name: "model-registry-dora", Description: "Model registry dora description", DisplayName: "Model Registry Dora"},
+			{Name: "model-registry-bella", Description: "Model registry bella description", DisplayName: "Model Registry Bella"},
 		},
 	}
 

--- a/clients/ui/bff/data/model_registry.go
+++ b/clients/ui/bff/data/model_registry.go
@@ -7,20 +7,24 @@ import (
 )
 
 type ModelRegistryModel struct {
-	Name string `json:"name"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
 }
 
-func (m ModelRegistryModel) FetchAllModelRegistry(client k8s.KubernetesClientInterface) ([]ModelRegistryModel, error) {
+func (m ModelRegistryModel) FetchAllModelRegistries(client k8s.KubernetesClientInterface) ([]ModelRegistryModel, error) {
 
-	resources, err := client.GetServiceNames()
+	resources, err := client.GetServiceDetails()
 	if err != nil {
 		return nil, fmt.Errorf("error fetching model registries: %w", err)
 	}
 
-	var registries []ModelRegistryModel = []ModelRegistryModel{}
+	var registries []ModelRegistryModel
 	for _, item := range resources {
 		registry := ModelRegistryModel{
-			Name: item,
+			Name:        item.Name,
+			Description: item.Description,
+			DisplayName: item.DisplayName,
 		}
 		registries = append(registries, registry)
 	}

--- a/clients/ui/bff/data/model_registry_test.go
+++ b/clients/ui/bff/data/model_registry_test.go
@@ -11,14 +11,14 @@ func TestFetchAllModelRegistry(t *testing.T) {
 
 	model := ModelRegistryModel{}
 
-	registries, err := model.FetchAllModelRegistry(mockK8sClient)
+	registries, err := model.FetchAllModelRegistries(mockK8sClient)
 
 	assert.NoError(t, err)
 
 	expectedRegistries := []ModelRegistryModel{
-		{Name: "model-registry"},
-		{Name: "model-registry-dora"},
-		{Name: "model-registry-bella"},
+		{Name: "model-registry", Description: "Model registry description", DisplayName: "Model Registry"},
+		{Name: "model-registry-dora", Description: "Model registry dora description", DisplayName: "Model Registry Dora"},
+		{Name: "model-registry-bella", Description: "Model registry bella description", DisplayName: "Model Registry Bella"},
 	}
 	assert.Equal(t, expectedRegistries, registries)
 

--- a/clients/ui/bff/internals/mocks/k8s_mock.go
+++ b/clients/ui/bff/internals/mocks/k8s_mock.go
@@ -18,6 +18,14 @@ func (m *KubernetesClientMock) GetServiceNames() ([]string, error) {
 	return []string{"model-registry", "model-registry-dora", "model-registry-bella"}, nil
 }
 
+func (m *KubernetesClientMock) GetServiceDetails() ([]k8s.ServiceDetails, error) {
+	return []k8s.ServiceDetails{
+		{Name: "model-registry", Description: "Model registry description", DisplayName: "Model Registry"},
+		{Name: "model-registry-dora", Description: "Model registry dora description", DisplayName: "Model Registry Dora"},
+		{Name: "model-registry-bella", Description: "Model registry bella description", DisplayName: "Model Registry Bella"},
+	}, nil
+}
+
 func (m *KubernetesClientMock) BearerToken() (string, error) {
 	return "FAKE BEARER TOKEN", nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
the `GET /api/v1/model-registry` endpoint will now return description and display name when using mocked out data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run the BFF using something like `make run PORT=4000 MOCK_K8S_CLIENT=true`
2. Run the following  curl: `curl localhost:4000/api/v1/model-registry/`
3. Verify 200 response and payload includes `displayName` and `description` properties

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
