### PR TITLE
chore: remove go from bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 PROJECT_BIN := $(PROJECT_PATH)/bin
-GO := $(PROJECT_BIN)/go1.21.9
+GO ?= "$(shell which go)"
 
 # add tools bin directory
 PATH := $(PROJECT_BIN):$(PATH)
@@ -108,10 +108,6 @@ clean:
 clean/odh:
 	rm -Rf ./model-registry
 
-bin/go:
-	GOBIN=$(PROJECT_BIN) go install golang.org/dl/go1.21.9@latest
-	$(PROJECT_BIN)/go1.21.9 download
-
 bin/protoc:
 	./scripts/install_protoc.sh
 
@@ -155,7 +151,7 @@ clean/deps:
 	rm -Rf bin/*
 
 .PHONY: deps
-deps: bin/go bin/protoc bin/go-enum bin/protoc-gen-go bin/protoc-gen-go-grpc bin/golangci-lint bin/goverter bin/openapi-generator-cli
+deps: bin/protoc bin/go-enum bin/protoc-gen-go bin/protoc-gen-go-grpc bin/golangci-lint bin/goverter bin/openapi-generator-cli
 
 .PHONY: vendor
 vendor:


### PR DESCRIPTION
implements https://github.com/kubeflow/model-registry/pull/265#issuecomment-2292505884:~:text=5%20days%20ago-,My%20biggest%20issue%20was%20the%20go%20binary%20in%20the%20bin%20directory.%20I%20thought%20that%20was%20an%20overkill,-.%20I%20was%20ok isolated from #265

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
