### PR TITLE
build(deps): bump @patternfly/react-{core|icons|style}

### DIFF
--- a/clients/ui/frontend/docs/dev-setup.md
+++ b/clients/ui/frontend/docs/dev-setup.md
@@ -37,7 +37,7 @@ npm run build
 This is the default context for running a local UI.  Make sure you build the project using the instructions above prior to running the command below.
 
 ```bash
-npm run start
+npm run start:dev
 ```
 
 For in-depth local run guidance review the [contribution guidelines](../CONTRIBUTING.md).

--- a/clients/ui/frontend/package-lock.json
+++ b/clients/ui/frontend/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@patternfly/react-core": "6.0.0-alpha.68",
-        "@patternfly/react-icons": "6.0.0-alpha.34",
-        "@patternfly/react-styles": "6.0.0-alpha.34",
+        "@patternfly/react-core": "6.0.0-alpha.102",
+        "@patternfly/react-icons": "6.0.0-alpha.35",
+        "@patternfly/react-styles": "6.0.0-alpha.35",
         "npm-run-all": "^4.1.5",
         "react": "^18",
         "react-dom": "^18"
@@ -3290,13 +3290,13 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.0.0-alpha.68",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.0.0-alpha.68.tgz",
-      "integrity": "sha512-YhZY4xuDF0WJyDAAzHdvhgYCECs5bY4+QYUbkPe+dGLNLnwVMU3ZwZlLD9ARHRwfXDRV3g+ttS8HRbigbHgtpQ==",
+      "version": "6.0.0-alpha.102",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.0.0-alpha.102.tgz",
+      "integrity": "sha512-NjnLhgYwJ3LuA3/DDwzM10X9dlZyR9ICAKOXI2FlxRM0kTAnAK0kLx7MuQjZ7wboIjxpRaA3lG8c9zlHDrCWdQ==",
       "dependencies": {
-        "@patternfly/react-icons": "^6.0.0-alpha.24",
-        "@patternfly/react-styles": "^6.0.0-alpha.24",
-        "@patternfly/react-tokens": "^6.0.0-alpha.24",
+        "@patternfly/react-icons": "^6.0.0-alpha.36",
+        "@patternfly/react-styles": "^6.0.0-alpha.35",
+        "@patternfly/react-tokens": "^6.0.0-alpha.35",
         "focus-trap": "7.5.4",
         "react-dropzone": "^14.2.3",
         "tslib": "^2.6.2"
@@ -3306,24 +3306,33 @@
         "react-dom": "^17 || ^18"
       }
     },
+    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-icons": {
+      "version": "6.0.0-alpha.36",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0-alpha.36.tgz",
+      "integrity": "sha512-9gxJr3UxqZnUKwtPfV1JrzcH76hN/5hHM5CL5HJVWnAhI6WjRm3oQ9dA/PLo91Kyo3tN6TQKV1b2x/LhPiBscw==",
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0-alpha.34.tgz",
-      "integrity": "sha512-YApbSfIEevWhTila9OzG6RHmbu/f+08XCUiNjTri2ZY54flvX/+GZDdt6gLzS+JQlysA6MCtzRxLgWAKh27Uew==",
+      "version": "6.0.0-alpha.35",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0-alpha.35.tgz",
+      "integrity": "sha512-3gdFXGME/BVUW647W6wt3w+P95/l5zrK/EtLQ59Gx11faOlClwGniqloxRC5Cv+yo8kPpIFezjiZiia4vGGO7w==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.0.0-alpha.34.tgz",
-      "integrity": "sha512-mJSpYrgI/Sgu+gwSv5h8ZP+prvzNUbfEkWP+LV6hZuw70N0UnarJacTsMD0zouCWUwIVt1NOJfawLOVmzAsxbA=="
+      "version": "6.0.0-alpha.35",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.0.0-alpha.35.tgz",
+      "integrity": "sha512-9ddQpDJ1CXDbsuV5lYmynw8hqGncKXxnhNwvUKc+s/i50pNBAMmNO9CP5dkKhnZPcjHQj0A35aleQ7xdRgNWQw=="
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.0.0-alpha.24",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.0.0-alpha.24.tgz",
-      "integrity": "sha512-jIVaGxxZD8Wsp2Xbf8z9mrpfYQx4NzlWlUza0IoTuwslEdcxt77Yo3sh0qlyfRBDNx+Q01tdEFXftJ+6OZQ3Gw=="
+      "version": "6.0.0-alpha.35",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.0.0-alpha.35.tgz",
+      "integrity": "sha512-TYLYxyx7tDVRYeso+72eGZbM/O3G90brLzHQai2JtKI66XE3T2R89N0VxPT65gbc1cnqNkiTtUKkpUUHmOK9qg=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/clients/ui/frontend/package.json
+++ b/clients/ui/frontend/package.json
@@ -83,9 +83,9 @@
     "webpack-merge": "^6.0.1"
   },
   "dependencies": {
-    "@patternfly/react-core": "6.0.0-alpha.68",
-    "@patternfly/react-icons": "6.0.0-alpha.34",
-    "@patternfly/react-styles": "6.0.0-alpha.34",
+    "@patternfly/react-core": "6.0.0-alpha.102",
+    "@patternfly/react-icons": "6.0.0-alpha.35",
+    "@patternfly/react-styles": "6.0.0-alpha.35",
     "npm-run-all": "^4.1.5",
     "react": "^18",
     "react-dom": "^18"

--- a/clients/ui/frontend/src/app/Dashboard/Dashboard.tsx
+++ b/clients/ui/frontend/src/app/Dashboard/Dashboard.tsx
@@ -1,31 +1,31 @@
 import * as React from 'react';
 import {
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateFooter,
-  EmptyStateVariant,
-  PageSection,
-  Text,
-  TextContent
+    Button,
+    Content,
+    ContentVariants,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateFooter,
+    EmptyStateVariant,
+    PageSection,
 } from '@patternfly/react-core';
-import { CubesIcon } from '@patternfly/react-icons';
+import {CubesIcon} from '@patternfly/react-icons';
 
 const Dashboard: React.FunctionComponent = () => (
-  <PageSection>
-    <EmptyState variant={EmptyStateVariant.full} titleText="Empty State (Dashboard Module)" icon={CubesIcon}>
-      <EmptyStateBody>
-        <TextContent>
-          <Text component="p">
-            This represents an the empty state pattern in Patternfly 6. Hopefully it&apos;s simple enough to use but
-            flexible enough to meet a variety of needs.
-          </Text>
-        </TextContent>
-      </EmptyStateBody><EmptyStateFooter>
-      <Button variant="primary">Primary Action</Button>
+    <PageSection>
+        <EmptyState variant={EmptyStateVariant.full} titleText="Empty State (Dashboard Module)" icon={CubesIcon}>
+            <EmptyStateBody>
+                <Content component={ContentVariants.p}>
+                    This represents an the empty state pattern in Patternfly 6. Hopefully it&apos;s simple enough to use
+                    but
+                    flexible enough to meet a variety of needs.
+                </Content>
 
-    </EmptyStateFooter></EmptyState>
-  </PageSection>
+            </EmptyStateBody><EmptyStateFooter>
+            <Button variant="primary">Primary Action</Button>
+
+        </EmptyStateFooter></EmptyState>
+    </PageSection>
 );
 
-export { Dashboard };
+export {Dashboard};

--- a/clients/ui/frontend/src/app/Settings/Admin.tsx
+++ b/clients/ui/frontend/src/app/Settings/Admin.tsx
@@ -1,31 +1,30 @@
 import * as React from 'react';
-import { CubesIcon } from '@patternfly/react-icons';
+import {CubesIcon} from '@patternfly/react-icons';
 import {
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateFooter,
-  EmptyStateVariant,
-  PageSection,
-  Text,
-  TextContent
+    Button,
+    Content,
+    ContentVariants,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateFooter,
+    EmptyStateVariant,
+    PageSection,
 } from '@patternfly/react-core';
 
 const Admin: React.FunctionComponent = () => (
-  <PageSection>
-    <EmptyState variant={EmptyStateVariant.full} titleText="Empty State (Stub Admin Module)" icon={CubesIcon}>
-      <EmptyStateBody>
-        <TextContent>
-          <Text component="p">
-            This represents an the empty state pattern in Patternfly 6. Hopefully it&apos;s simple enough to use but
-            flexible enough to meet a variety of needs.
-          </Text>
-        </TextContent>
-      </EmptyStateBody><EmptyStateFooter>
-      <Button variant="primary">Primary Action</Button>
+    <PageSection>
+        <EmptyState variant={EmptyStateVariant.full} titleText="Empty State (Stub Admin Module)" icon={CubesIcon}>
+            <EmptyStateBody>
+                <Content component={ContentVariants.p}>
+                    This represents an the empty state pattern in Patternfly 6. Hopefully it&apos;s simple enough to use
+                    but
+                    flexible enough to meet a variety of needs.
+                </Content>
+            </EmptyStateBody><EmptyStateFooter>
+            <Button variant="primary">Primary Action</Button>
 
-    </EmptyStateFooter></EmptyState>
-  </PageSection>
+        </EmptyStateFooter></EmptyState>
+    </PageSection>
 );
 
-export { Admin };
+export {Admin};

--- a/clients/ui/frontend/src/app/Support/Support.tsx
+++ b/clients/ui/frontend/src/app/Support/Support.tsx
@@ -1,31 +1,31 @@
 import * as React from 'react';
-import { CubesIcon } from '@patternfly/react-icons';
+import {CubesIcon} from '@patternfly/react-icons';
 import {
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateFooter,
-  EmptyStateVariant,
-  PageSection,
-  Text,
-  TextContent
+    Button,
+    Content,
+    ContentVariants,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateFooter,
+    EmptyStateVariant,
+    PageSection,
 } from '@patternfly/react-core';
 
 const Support: React.FunctionComponent = () => (
-  <PageSection>
-    <EmptyState variant={EmptyStateVariant.full} titleText="Empty State (Stub Support Module)" icon={CubesIcon}>
-      <EmptyStateBody>
-        <TextContent>
-          <Text component="p">
-            This represents an the empty state pattern in Patternfly 6. Hopefully it&apos;s simple enough to use but
-            flexible enough to meet a variety of needs.
-          </Text>
-        </TextContent>
-      </EmptyStateBody><EmptyStateFooter>
-      <Button variant="primary">Primary Action</Button>
-
-    </EmptyStateFooter></EmptyState>
-  </PageSection>
+    <PageSection>
+        <EmptyState variant={EmptyStateVariant.full} titleText="Empty State (Stub Support Module)" icon={CubesIcon}>
+            <EmptyStateBody>
+                <Content component={ContentVariants.p}>
+                    This represents an the empty state pattern in Patternfly 6. Hopefully it&apos;s simple enough to
+                    use but
+                    flexible enough to meet a variety of needs.
+                </Content>
+            </EmptyStateBody>
+            <EmptyStateFooter>
+                <Button variant="primary">Primary Action</Button>
+            </EmptyStateFooter>
+        </EmptyState>
+    </PageSection>
 );
 
-export { Support };
+export {Support};


### PR DESCRIPTION
## Description
Bumps [@patternfly/react-core](https://github.com/patternfly/patternfly-react) from 6.0.0-alpha.68 to 6.0.0-alpha.102.
Bumps [@patternfly/react-icons](https://github.com/patternfly/patternfly-react) from 6.0.0-alpha.34 to 6.0.0-alpha.35.
Bumps [@patternfly/react-styles](https://github.com/patternfly/patternfly-react) from 6.0.0-alpha.34 to 6.0.0-alpha.35.

The code changes was related to removal of <TextContent><Text component="p"> to  <Content component={ContentVariants.p}> from patternfly APIs.

## How Has This Been Tested?
```
npm run test:cypress-ci
```

## Merge criteria:
- [X ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ X] The developer has manually tested the changes and verified that the changes work
