### PR TITLE
Add Pull Request Template for UI team

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 ## Description
 <!--- Describe your changes in detail -->
+<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
 
 ## How Has This Been Tested?
 <!--- Please describe in detail how you tested your changes. -->
@@ -12,6 +13,14 @@
 <!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 
-- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
+- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
 - [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
-- [ ] The developer has manually tested the changes and verified that the changes work
+- [ ] The developer has manually tested the changes and verified that the changes work.
+- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
+
+If you have UI changes
+
+<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
+- [ ] The developer has added tests or explained why testing cannot be added.
+- [ ] Included any necessary screenshots or gifs if it was a UI change.
+- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Following [github's pull request template instructions](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository), allow custom PR Template for UI contributions.

By default the common PR Template would appear, with a link to the UI one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
