### PR TITLE
GHA: trigger CSI tests on go.mod update

### DIFF
--- a/.github/workflows/csi-test.yml
+++ b/.github/workflows/csi-test.yml
@@ -4,18 +4,20 @@ on:
     branches:
       - "main"
     paths-ignore:
-      - 'LICENSE*'
-      - '**.gitignore'
-      - '**.md'
-      - '**.txt'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/dependabot.yml'
-      - 'docs/**'
+      - "LICENSE*"
+      - "**.gitignore"
+      - "**.md"
+      - "**.txt"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/dependabot.yml"
+      - "docs/**"
   pull_request:
     paths:
       - "csi/**"
       - "internal/server/openapi/api_model_registry_service*"
       - "pkg/openapi/**"
+      # csi build depends on base go.mod https://github.com/kubeflow/model-registry/issues/311
+      - "go.mod"
 
 env:
   IMG_ORG: kubeflow
@@ -47,7 +49,7 @@ jobs:
           VERSION: ${{ steps.tags.outputs.tag }}
           PUSH_IMAGE: false
         run: ./scripts/build_deploy.sh
-      
+
       - name: Build local custom storage initializer
         working-directory: ./csi
         shell: bash


### PR DESCRIPTION
This prevents CSI dependencies from being out-of-date.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
