### PR TITLE
gha: fossa license scanning

### DIFF
--- a/.github/workflows/fossa-license-scanning.yml
+++ b/.github/workflows/fossa-license-scanning.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run FOSSA scan and upload build data
-        uses: fossa-contrib/fossa-action@v3
+        uses: fossas/fossa-action@v1.4.0
         with:
-          fossa-api-key: ${{ env.FOSSA_API_KEY }}
+          api-key: ${{ env.FOSSA_API_KEY }}
+          project: "github.com/kubeflow/model-registry"

--- a/.github/workflows/fossa-license-scanning.yml
+++ b/.github/workflows/fossa-license-scanning.yml
@@ -7,9 +7,13 @@ on:
     pull_request:
 
 jobs:
-  build:
+  fossa-scan:
+    if: github.repository_owner == 'kubeflow' # FOSSA is not intended to run on forks.
     runs-on: ubuntu-latest
-
+    env:
+      # push-only token, intentional; see https://github.com/fossa-contrib/fossa-action?tab=readme-ov-file#push-only-api-token
+      # this also how other CNCF projects are doing e.g. https://github.com/cncf/foundation/issues/109
+      FOSSA_API_KEY: 80871bdd477c2c97f65e9822cae99d20 # This is a push-only token that is safe to be exposed.
     steps:
       - name: Checkout tree
         uses: actions/checkout@v4
@@ -17,6 +21,4 @@ jobs:
       - name: Run FOSSA scan and upload build data
         uses: fossa-contrib/fossa-action@v3
         with:
-          # push-only token, intentional; see https://github.com/fossa-contrib/fossa-action?tab=readme-ov-file#push-only-api-token
-          # this also how other CNCF projects are doing e.g. https://github.com/cncf/foundation/issues/109
-          fossa-api-key: 80871bdd477c2c97f65e9822cae99d20
+          fossa-api-key: ${{ env.FOSSA_API_KEY }}

--- a/.github/workflows/fossa-license-scanning.yml
+++ b/.github/workflows/fossa-license-scanning.yml
@@ -1,0 +1,22 @@
+name: FOSSA License Scanning
+
+on:
+    push:
+      branches:
+        - main
+    pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@v4
+
+      - name: Run FOSSA scan and upload build data
+        uses: fossa-contrib/fossa-action@v3
+        with:
+          # push-only token, intentional; see https://github.com/fossa-contrib/fossa-action?tab=readme-ov-file#push-only-api-token
+          # this also how other CNCF projects are doing e.g. https://github.com/cncf/foundation/issues/109
+          fossa-api-key: 80871bdd477c2c97f65e9822cae99d20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,6 @@ The make command shipped with Mac OSX (at the time of writing) is a bit old:
 ```
 % make --version
 GNU Make 3.81
-Copyright (C) 2006  Free Software Foundation, Inc.
-This is free software; see the source for copying conditions.
-There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.
-
 This program built for i386-apple-darwin11.3.0
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/docker v27.2.1+incompatible
+	github.com/docker/docker v27.2.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/internal/testutils/test_container_utils.go
+++ b/internal/testutils/test_container_utils.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/kubeflow/model-registry/internal/ml_metadata/proto"
 	testcontainers "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -86,8 +85,13 @@ func SetupMLMetadataTestContainer(t *testing.T) (*grpc.ClientConn, proto.Metadat
 		Env: map[string]string{
 			"METADATA_STORE_SERVER_CONFIG_FILE": "/tmp/shared/conn_config.pb",
 		},
-		HostConfigModifier: func(hc *container.HostConfig) {
-			hc.Binds = []string{wd + ":/tmp/shared"}
+		Mounts: testcontainers.ContainerMounts{
+			testcontainers.ContainerMount{
+				Source: testcontainers.GenericBindMountSource{ // nolint keep deprecated method to avoid depending directly to docker api exposed by testcontainers' HostConfigModifier
+					HostPath: wd,
+				},
+				Target: "/tmp/shared",
+			},
 		},
 		WaitingFor: wait.ForLog("Server listening on"),
 	}


### PR DESCRIPTION
Please reference for a complete summary: https://github.com/kubeflow/model-registry/issues/323

## Description
Resolves #323 by introducing FOSSA license scanning, a tool supported by CNCF, in the way recommended by the tool documentation and as implemented by other projects.

## How Has This Been Tested?
n/a

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
