### PR TITLE
Test Python client against latest MR

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -65,6 +65,7 @@ jobs:
         working-directory: clients/python
         run: |
           if [[ ${{ matrix.session }} == "tests" ]]; then
+            make build-mr
             nox --python=${{ matrix.python }} -- --cov-report=xml
           elif [[ ${{ matrix.session }} == "mypy" ]]; then
             nox --python=${{ matrix.python }} ||\

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -11,6 +11,14 @@ install:
 clean:
 	rm -rf src/mr_openapi
 
+.PHONY: build-mr
+build-mr:
+	cd ../../ && make image/build
+
+.PHONY: test-e2e
+test-e2e: build-mr
+	poetry run pytest --e2e -s
+
 .PHONY: test
 test:
 	poetry run pytest -s

--- a/clients/python/noxfile.py
+++ b/clients/python/noxfile.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 package = "model_registry"
-python_versions = ["3.12", "3.11","3.10", "3.9"]
+python_versions = ["3.12", "3.11", "3.10", "3.9"]
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "tests",
@@ -63,6 +63,11 @@ def tests(session: Session) -> None:
     try:
         session.run(
             "pytest",
+            *session.posargs,
+        )
+        session.run(
+            "pytest",
+            "--e2e",
             "--cov",
             "--cov-config=pyproject.toml",
             *session.posargs,

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -70,6 +70,7 @@ line-length = 119
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = ["e2e: end-to-end testing"]
 
 [tool.ruff]
 target-version = "py39"

--- a/clients/python/tests/REST_bindings_test.py
+++ b/clients/python/tests/REST_bindings_test.py
@@ -1,7 +1,8 @@
 """Tests creation and retrieval of base models."""
 
-import mr_openapi
 import pytest
+
+import mr_openapi
 from mr_openapi import (
     Artifact,
     DocArtifact,
@@ -42,6 +43,7 @@ async def mv_create(client, rm_create) -> ModelVersionCreate:
     )
 
 
+@pytest.mark.e2e
 async def test_registered_model(client, rm_create):
     rm_create.custom_properties = {
         "key1": MetadataValue.from_dict(
@@ -63,6 +65,7 @@ async def test_registered_model(client, rm_create):
     assert new_rm.description == by_find.description
 
 
+@pytest.mark.e2e
 async def test_model_version(client, mv_create):
     mv_create.custom_properties = {
         "key1": MetadataValue.from_dict(
@@ -86,6 +89,7 @@ async def test_model_version(client, mv_create):
     assert new_mv.custom_properties == by_find.custom_properties
 
 
+@pytest.mark.e2e
 async def test_model_artifact(client, mv_create):
     mv = await client.create_model_version(mv_create)
     assert mv is not None

--- a/clients/python/tests/REST_bindings_test.py
+++ b/clients/python/tests/REST_bindings_test.py
@@ -1,8 +1,7 @@
 """Tests creation and retrieval of base models."""
 
-import pytest
-
 import mr_openapi
+import pytest
 from mr_openapi import (
     Artifact,
     DocArtifact,

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -24,6 +24,7 @@ def test_secure_client():
     assert "user token" in str(e.value).lower()
 
 
+@pytest.mark.e2e
 async def test_register_new(client: ModelRegistry):
     name = "test_model"
     version = "1.0.0"
@@ -44,6 +45,7 @@ async def test_register_new(client: ModelRegistry):
     assert ma
 
 
+@pytest.mark.e2e
 async def test_register_new_using_s3_uri_builder(client: ModelRegistry):
     name = "test_model"
     version = "1.0.0"
@@ -68,6 +70,7 @@ async def test_register_new_using_s3_uri_builder(client: ModelRegistry):
     assert ma.uri == uri
 
 
+@pytest.mark.e2e
 def test_register_existing_version(client: ModelRegistry):
     params = {
         "name": "test_model",
@@ -82,6 +85,7 @@ def test_register_existing_version(client: ModelRegistry):
         client.register_model(**params)
 
 
+@pytest.mark.e2e
 async def test_get(client: ModelRegistry):
     name = "test_model"
     version = "1.0.0"
@@ -112,6 +116,7 @@ async def test_get(client: ModelRegistry):
     assert ma.id == _ma.id
 
 
+@pytest.mark.e2e
 def test_get_registered_models(client: ModelRegistry):
     models = 21
 
@@ -142,6 +147,7 @@ def test_get_registered_models(client: ModelRegistry):
     assert i == models
 
 
+@pytest.mark.e2e
 def test_get_registered_models_and_reset(client: ModelRegistry):
     model_count = 6
     page = model_count // 2
@@ -166,6 +172,7 @@ def test_get_registered_models_and_reset(client: ModelRegistry):
     assert complete[:page] == models
 
 
+@pytest.mark.e2e
 def test_get_model_versions(client: ModelRegistry):
     name = "test_model"
     models = 21
@@ -197,6 +204,7 @@ def test_get_model_versions(client: ModelRegistry):
     assert i == models
 
 
+@pytest.mark.e2e
 def test_get_model_versions_and_reset(client: ModelRegistry):
     name = "test_model"
 
@@ -223,6 +231,7 @@ def test_get_model_versions_and_reset(client: ModelRegistry):
     assert complete[:page] == models
 
 
+@pytest.mark.e2e
 def test_hf_import(client: ModelRegistry):
     pytest.importorskip("huggingface_hub")
     name = "openai-community/gpt2"
@@ -250,6 +259,7 @@ def test_hf_import(client: ModelRegistry):
     assert client.get_model_artifact(name, version)
 
 
+@pytest.mark.e2e
 def test_hf_import_default_env(client: ModelRegistry):
     """Test setting environment variables, hence triggering defaults, does _not_ interfere with HF metadata"""
     pytest.importorskip("huggingface_hub")

--- a/clients/python/tests/test_core.py
+++ b/clients/python/tests/test_core.py
@@ -20,6 +20,7 @@ def client():
     return ModelRegistryAPIClient.insecure_connection(REGISTRY_HOST, REGISTRY_PORT)
 
 
+@pytest.mark.e2e
 async def test_insert_registered_model(client: ModelRegistryAPIClient):
     registered_model = RegisteredModel(name="test rm")
     rm = await client.upsert_registered_model(registered_model)
@@ -31,6 +32,7 @@ async def test_insert_registered_model(client: ModelRegistryAPIClient):
     assert rm.last_update_time_since_epoch
 
 
+@pytest.mark.e2e
 async def test_update_registered_model(client: ModelRegistryAPIClient):
     registered_model = RegisteredModel(name="updated rm")
     rm = await client.upsert_registered_model(registered_model)
@@ -49,6 +51,7 @@ async def registered_model(client: ModelRegistryAPIClient) -> RegisteredModel:
     )
 
 
+@pytest.mark.e2e
 async def test_get_registered_model_by_id(
     client: ModelRegistryAPIClient,
     registered_model: RegisteredModel,
@@ -57,6 +60,7 @@ async def test_get_registered_model_by_id(
     assert rm == registered_model
 
 
+@pytest.mark.e2e
 async def test_get_registered_model_by_name(
     client: ModelRegistryAPIClient,
     registered_model: RegisteredModel,
@@ -67,6 +71,7 @@ async def test_get_registered_model_by_name(
     assert rm == registered_model
 
 
+@pytest.mark.e2e
 async def test_get_registered_model_by_external_id(
     client: ModelRegistryAPIClient,
     registered_model: RegisteredModel,
@@ -79,6 +84,7 @@ async def test_get_registered_model_by_external_id(
     assert rm == registered_model
 
 
+@pytest.mark.e2e
 async def test_get_registered_models(
     client: ModelRegistryAPIClient, registered_model: RegisteredModel
 ):
@@ -88,6 +94,7 @@ async def test_get_registered_models(
     assert [registered_model, rm2] == rms
 
 
+@pytest.mark.e2e
 async def test_page_through_registered_models(client: ModelRegistryAPIClient):
     models = 6
     for i in range(models):
@@ -99,6 +106,7 @@ async def test_page_through_registered_models(client: ModelRegistryAPIClient):
     assert total == models
 
 
+@pytest.mark.e2e
 async def test_insert_model_version(
     client: ModelRegistryAPIClient,
     registered_model: RegisteredModel,
@@ -114,6 +122,7 @@ async def test_insert_model_version(
     assert mv.author == model_version.author
 
 
+@pytest.mark.e2e
 async def test_update_model_version(
     client: ModelRegistryAPIClient, registered_model: RegisteredModel
 ):
@@ -137,6 +146,7 @@ async def model_version(
     )
 
 
+@pytest.mark.e2e
 async def test_get_model_version_by_id(
     client: ModelRegistryAPIClient, model_version: ModelVersion
 ):
@@ -144,6 +154,7 @@ async def test_get_model_version_by_id(
     assert mv == model_version
 
 
+@pytest.mark.e2e
 async def test_get_model_version_by_name(
     client: ModelRegistryAPIClient,
     registered_model: RegisteredModel,
@@ -157,6 +168,7 @@ async def test_get_model_version_by_name(
     assert mv == model_version
 
 
+@pytest.mark.e2e
 async def test_get_model_version_by_external_id(
     client: ModelRegistryAPIClient, model_version: ModelVersion
 ):
@@ -168,6 +180,7 @@ async def test_get_model_version_by_external_id(
     assert mv == model_version
 
 
+@pytest.mark.e2e
 async def test_get_model_versions(
     client: ModelRegistryAPIClient,
     registered_model: RegisteredModel,
@@ -181,6 +194,7 @@ async def test_get_model_versions(
     assert [model_version, mv2] == mvs
 
 
+@pytest.mark.e2e
 async def test_page_through_model_versions(
     client: ModelRegistryAPIClient, registered_model: RegisteredModel
 ):
@@ -198,6 +212,7 @@ async def test_page_through_model_versions(
     assert total == models
 
 
+@pytest.mark.e2e
 async def test_insert_model_artifact(
     client: ModelRegistryAPIClient,
     model_version: ModelVersion,
@@ -228,6 +243,7 @@ async def test_insert_model_artifact(
     assert ma.service_account_name
 
 
+@pytest.mark.e2e
 async def test_update_model_artifact(
     client: ModelRegistryAPIClient, model_version: ModelVersion
 ):
@@ -252,6 +268,7 @@ async def model(
     )
 
 
+@pytest.mark.e2e
 async def test_get_model_artifact_by_id(
     client: ModelRegistryAPIClient, model: ModelArtifact
 ):
@@ -259,6 +276,7 @@ async def test_get_model_artifact_by_id(
     assert ma == model
 
 
+@pytest.mark.e2e
 async def test_get_model_artifact_by_name(
     client: ModelRegistryAPIClient, model_version: ModelVersion, model: ModelArtifact
 ):
@@ -270,6 +288,7 @@ async def test_get_model_artifact_by_name(
     assert ma == model
 
 
+@pytest.mark.e2e
 async def test_get_model_artifact_by_external_id(
     client: ModelRegistryAPIClient, model: ModelArtifact
 ):
@@ -281,6 +300,7 @@ async def test_get_model_artifact_by_external_id(
     assert ma == model
 
 
+@pytest.mark.e2e
 async def test_get_all_model_artifacts(
     client: ModelRegistryAPIClient, model_version: ModelVersion, model: ModelArtifact
 ):
@@ -292,6 +312,7 @@ async def test_get_all_model_artifacts(
     assert [model, ma2] == mas
 
 
+@pytest.mark.e2e
 async def test_get_model_artifacts_by_mv_id(
     client: ModelRegistryAPIClient, model_version: ModelVersion, model: ModelArtifact
 ):
@@ -303,6 +324,7 @@ async def test_get_model_artifacts_by_mv_id(
     assert [model, ma2] == mas
 
 
+@pytest.mark.e2e
 async def test_page_through_model_version_artifacts(
     client: ModelRegistryAPIClient,
     registered_model: RegisteredModel,


### PR DESCRIPTION
As the majority of Python client tests depend on the current implementation of MR, build it in favor of using the last pushed version.

This also creates a new (e2e) test mode for the Python client to highlight the dependencies.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Updated on GHA, ran `make test-e2e` locally. Also tested with nox.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
