### PR TITLE
Adds an endpoint to get a registered model by id

### DIFF
--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -54,21 +54,22 @@ make docker-build
 
 ### Endpoints
 
-| URL Pattern                                                   | Handler                 | Action                                       |
-|---------------------------------------------------------------|-------------------------|----------------------------------------------|
-| GET /v1/healthcheck                                           | HealthcheckHandler      | Show application information.                |
-| GET /v1/model-registry/                                       | ModelRegistryHandler    | Get all model registries,                    |
-| GET /v1/model-registry/{model_registry_id}/registered_models  | RegisteredModelsHandler | Gets a list of all RegisteredModel entities. |
-| POST /v1/model-registry/{model_registry_id}/registered_models | RegisteredModelsHandler | Create a RegisteredModel entity.             |
+| URL Pattern                                                                        | Handler                  | Action                                       |
+|------------------------------------------------------------------------------------|--------------------------|----------------------------------------------|
+| GET /v1/healthcheck                                                                | HealthcheckHandler       | Show application information.                |
+| GET /v1/model-registry/                                                            | ModelRegistryHandler     | Get all model registries,                    |
+| GET /v1/model-registry/{model_registry_id}/registered_models                       | RegisteredModelsHandler  | Gets a list of all RegisteredModel entities. |
+| POST /v1/model-registry/{model_registry_id}/registered_models                      | RegisteredModelsHandler  | Create a RegisteredModel entity.             |
+| GET /v1/model-registry/{model_registry_id}/registered_models/{registered_model_id} | RegisteredModelHandler   | Get a RegisteredModel entity by ID           |
 
 ### Sample local calls
 ```
 # GET /v1/healthcheck
-curl -i localhost:4000/api/v1/healthcheck/
+curl -i localhost:4000/api/v1/healthcheck
 ```
 ```
-# GET /v1/model-registry/ 
-curl -i localhost:4000/api/v1/model-registry/
+# GET /v1/model-registry 
+curl -i localhost:4000/api/v1/model-registry
 ```
 ```
 # GET /v1/model-registry/{model_registry_id}/registered_models
@@ -91,4 +92,8 @@ curl -i -X POST "http://localhost:4000/api/v1/model-registry/model-registry/regi
   "owner": "eder",
   "state": "LIVE"
 }'
+```
+```
+# GET /v1/model-registry/{model_registry_id}/registered_models/{registered_model_id}
+curl -i localhost:4000/api/v1/model-registry/model-registry/registered_models/1
 ```

--- a/clients/ui/bff/api/app.go
+++ b/clients/ui/bff/api/app.go
@@ -2,23 +2,24 @@ package api
 
 import (
 	"fmt"
+	"github.com/julienschmidt/httprouter"
 	"github.com/kubeflow/model-registry/ui/bff/config"
 	"github.com/kubeflow/model-registry/ui/bff/data"
 	"github.com/kubeflow/model-registry/ui/bff/integrations"
 	"github.com/kubeflow/model-registry/ui/bff/internals/mocks"
 	"log/slog"
 	"net/http"
-
-	"github.com/julienschmidt/httprouter"
 )
 
 const (
 	Version              = "1.0.0"
 	PathPrefix           = "/api/v1"
 	ModelRegistryId      = "model_registry_id"
-	HealthCheckPath      = PathPrefix + "/healthcheck/"
-	ModelRegistry        = PathPrefix + "/model-registry/"
-	RegisteredModelsPath = ModelRegistry + ":" + ModelRegistryId + "/registered_models"
+	RegisteredModelId    = "registered_model_id"
+	HealthCheckPath      = PathPrefix + "/healthcheck"
+	ModelRegistry        = PathPrefix + "/model-registry"
+	RegisteredModelsPath = ModelRegistry + "/:" + ModelRegistryId + "/registered_models"
+	RegisteredModelPath  = RegisteredModelsPath + "/:" + RegisteredModelId
 )
 
 type App struct {
@@ -59,6 +60,7 @@ func (app *App) Routes() http.Handler {
 	// HTTP client routes
 	router.GET(HealthCheckPath, app.HealthcheckHandler)
 	router.GET(RegisteredModelsPath, app.AttachRESTClient(app.GetRegisteredModelsHandler))
+	router.GET(RegisteredModelPath, app.AttachRESTClient(app.GetRegisteredModelHandler))
 	router.POST(RegisteredModelsPath, app.AttachRESTClient(app.CreateRegisteredModelHandler))
 
 	// Kubernetes client routes

--- a/clients/ui/bff/api/registered_models_handler.go
+++ b/clients/ui/bff/api/registered_models_handler.go
@@ -20,7 +20,7 @@ func (app *App) GetRegisteredModelsHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	modelList, err := data.FetchAllRegisteredModels(client)
+	modelList, err := data.GetAllRegisteredModels(client)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -81,5 +81,33 @@ func (app *App) CreateRegisteredModelHandler(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("error writing JSON"))
 		return
+	}
+}
+
+func (app *App) GetRegisteredModelHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(httpClientKey).(integrations.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("REST client not found"))
+		return
+	}
+
+	model, err := data.GetRegisteredModel(client, ps.ByName(RegisteredModelId))
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if _, ok := model.GetNameOk(); !ok {
+		app.notFoundResponse(w, r)
+		return
+	}
+
+	result := Envelope{
+		"registered_model": model,
+	}
+
+	err = app.WriteJSON(w, http.StatusOK, result, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
 	}
 }

--- a/clients/ui/bff/data/registered_model.go
+++ b/clients/ui/bff/data/registered_model.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"github.com/kubeflow/model-registry/pkg/openapi"
 	"github.com/kubeflow/model-registry/ui/bff/integrations"
+	"net/url"
 )
 
 const registerModelPath = "/registered_models"
 
-func FetchAllRegisteredModels(client integrations.HTTPClientInterface) (*openapi.RegisteredModelList, error) {
+func GetAllRegisteredModels(client integrations.HTTPClientInterface) (*openapi.RegisteredModelList, error) {
 
 	responseData, err := client.GET(registerModelPath)
 	if err != nil {
@@ -30,6 +31,25 @@ func CreateRegisteredModel(client integrations.HTTPClientInterface, jsonData []b
 
 	if err != nil {
 		return nil, fmt.Errorf("error posting registered model: %w", err)
+	}
+
+	var model openapi.RegisteredModel
+	if err := json.Unmarshal(responseData, &model); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &model, nil
+}
+
+func GetRegisteredModel(client integrations.HTTPClientInterface, id string) (*openapi.RegisteredModel, error) {
+	path, err := url.JoinPath(registerModelPath, id)
+	if err != nil {
+		return nil, err
+	}
+	responseData, err := client.GET(path)
+
+	if err != nil {
+		return nil, fmt.Errorf("error fetching registered model: %w", err)
 	}
 
 	var model openapi.RegisteredModel

--- a/clients/ui/bff/data/registered_model_test.go
+++ b/clients/ui/bff/data/registered_model_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestFetchAllRegisteredModels(t *testing.T) {
+func TestGetAllRegisteredModels(t *testing.T) {
 	gofakeit.Seed(0)
 
 	expected := mocks.GenerateMockRegisteredModelList()
@@ -20,7 +20,7 @@ func TestFetchAllRegisteredModels(t *testing.T) {
 	mockClient := new(mocks.MockHTTPClient)
 	mockClient.On("GET", registerModelPath).Return(mockData, nil)
 
-	actual, err := FetchAllRegisteredModels(mockClient)
+	actual, err := GetAllRegisteredModels(mockClient)
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)
 	assert.Equal(t, expected.NextPageToken, actual.NextPageToken)
@@ -46,6 +46,26 @@ func TestCreateRegisteredModel(t *testing.T) {
 	assert.NoError(t, err)
 
 	actual, err := CreateRegisteredModel(mockClient, jsonInput)
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, expected.Name, actual.Name)
+	assert.Equal(t, *expected.Owner, *actual.Owner)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestGetRegisteredModel(t *testing.T) {
+	gofakeit.Seed(0)
+
+	expected := mocks.GenerateRegisteredModel()
+
+	mockData, err := json.Marshal(expected)
+	assert.NoError(t, err)
+
+	mockClient := new(mocks.MockHTTPClient)
+	mockClient.On("GET", registerModelPath+"/"+expected.GetId()).Return(mockData, nil)
+
+	actual, err := GetRegisteredModel(mockClient, expected.GetId())
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)
 	assert.Equal(t, expected.Name, actual.Name)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds an endpoint to fetch registered models by id.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test rig setup:
1. Deploy MR backend (you can follow the guide using kind in the docs)
2. Deploy BFF with e.g. `make run PORT=4000 MOCK_K8S_CLIENT=true`
3. Add a model to one of the registries: 
```
curl -i -X POST "http://localhost:4000/api/v1/model-registry/model-registry/registered_models" \
     -H "Content-Type: application/json" \
     -d '{
  "customProperties": {
    "my-label9": {
      "metadataType": "MetadataStringValue",
      "string_value": "val"
    }
  },
  "description": "bella description",
  "externalId": "9927",
  "name": "bella",
  "owner": "eder",
  "state": "LIVE"
}'
```

Test routine:
1. Verify the endpoint returns a 200 and the model from the endpoint: `curl -i localhost:4000/api/v1/model-registry/model-registry/registered_models/1`
2. Try with a different non existent id and verify that a 404 is returned: `curl -i localhost:4000/api/v1/model-registry/model-registry/registered_models/fluglebinder`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
