### PR TITLE
py: fix access token parsing

### DIFF
--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -55,7 +55,7 @@ class ModelRegistry:
             # /var/run/secrets/kubernetes.io/serviceaccount/token
             sa_token = os.environ.get("KF_PIPELINES_SA_TOKEN_PATH")
             if sa_token:
-                user_token = Path(sa_token).read_bytes()
+                user_token = Path(sa_token).read_text()
             else:
                 warn("User access token is missing", stacklevel=2)
 

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -137,9 +137,8 @@ def client() -> ModelRegistry:
 
 @pytest.fixture(scope="module")
 def setup_env_user_token():
-    token_file = tempfile.NamedTemporaryFile(delete=False)
-    token_file.write(b"Token")
-    token_file.close()
+    with tempfile.NamedTemporaryFile(delete=False) as token_file:
+        token_file.write(b"Token")
     old_token_path = os.getenv("KF_PIPELINES_SA_TOKEN_PATH")
     os.environ["KF_PIPELINES_SA_TOKEN_PATH"] = token_file.name
 

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import os
 import subprocess
+import tempfile
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -133,3 +134,19 @@ def event_loop():
 @cleanup
 def client() -> ModelRegistry:
     return ModelRegistry(REGISTRY_HOST, REGISTRY_PORT, author="author", is_secure=False)
+
+@pytest.fixture(scope="module")
+def setup_env_user_token():
+    token_file = tempfile.NamedTemporaryFile(delete=False)
+    token_file.write(b"Token")
+    token_file.close()
+    old_token_path = os.getenv("KF_PIPELINES_SA_TOKEN_PATH")
+    os.environ["KF_PIPELINES_SA_TOKEN_PATH"] = token_file.name
+
+    yield token_file.name
+
+    if old_token_path is None:
+        del os.environ["KF_PIPELINES_SA_TOKEN_PATH"]
+    else:
+        os.environ["KF_PIPELINES_SA_TOKEN_PATH"] = old_token_path
+    os.remove(token_file.name)

--- a/clients/python/tests/regression_test.py
+++ b/clients/python/tests/regression_test.py
@@ -22,3 +22,25 @@ def test_create_tagged_version(client: ModelRegistry):
     mv = client.get_model_version(name, version)
     assert mv
     assert mv.id
+
+@pytest.mark.e2e
+def test_get_model_without_user_token(setup_env_user_token, client):
+    """Test regression for using client methods without an user_token in the init arguments.
+
+    Reported on: https://github.com/kubeflow/model-registry/issues/340
+    """
+    assert setup_env_user_token != ""
+    name = "test_model"
+    version = "1.0.0"
+    metadata = {"a": 1, "b": "2"}
+    rm = client.register_model(
+        name,
+        "s3",
+        model_format_name="test_format",
+        model_format_version="test_version",
+        version=version,
+        metadata=metadata,
+    )
+    assert rm.id
+    assert (_rm := client.get_registered_model(name))
+    assert rm.id == _rm.id


### PR DESCRIPTION
## Description

fixes #340

After running `registry.get_registered_model("X")` without providing an user_token in ModelRegistry initialization, I got the following error:

```
File /opt/app-root/lib64/python3.9/site-packages/mr_openapi/configuration.py:357, in Configuration.auth_settings(self)

350 auth = {}
351 if self.access_token is not None:
352 auth["Bearer"] = {
353 "type": "bearer",
354 "in": "header",
355 "format": "JWT",
356 "key": "Authorization", -->
357 "value": "Bearer " + self.access_token, <- affected line
358 }
359 return auth

TypeError: can only concatenate str (not "bytes") to str
```

thanks to @isinyaaa , we figured out that there was a bug in the token parsing function in the client code and switched from reading it from "bytes mode" to "text mode"


## How Has This Been Tested?

Uploaded the wheel on the notebook and rerun.

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
