### PR TITLE
gha: fix typo in labeler config and quote

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,33 +1,33 @@
 "Area/UI":
 - changed-files:
-  - any-glob-to-any-file: clients/UI/**
+  - any-glob-to-any-file: "clients/ui/**"
 
 "Area/MR Python client":
 - changed-files:
-  - any-glob-to-any-file: clients/python/**
+  - any-glob-to-any-file: "clients/python/**"
 
 "Area/Go REST server":
 - changed-files:
   - any-glob-to-any-file:
-    - api/**
-    - cmd/**
-    - internal/**
-    - patches/**
-    - pkg/**
-    - templates/go-server/**
+    - "api/**"
+    - "cmd/**"
+    - "internal/**"
+    - "patches/**"
+    - "pkg/**"
+    - "templates/go-server/**"
 
 "Area/CSI":
 - changed-files:
-  - any-glob-to-any-file: csi/**
+  - any-glob-to-any-file: "csi/**"
 
 "Area/Manifests":
 - changed-files:
-  - any-glob-to-any-file: manifests/**
+  - any-glob-to-any-file: "manifests/**"
 
 "Area/Documentation":
 - changed-files:
-  - any-glob-to-any-file: docs/**
+  - any-glob-to-any-file: "docs/**"
 
 "Area/GitHub":
 - changed-files:
-  - any-glob-to-any-file: .github/**
+  - any-glob-to-any-file: ".github/**"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix typo in labeler config (lowercase `ui`) and quote all paths

## How Has This Been Tested?
n/a

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
