### PR TITLE
doc: migrate User Story from Robot to pytest

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -108,6 +108,53 @@ async def test_update_models(client: ModelRegistry):
 
 
 @pytest.mark.e2e
+async def test_update_logical_model_with_labels(client: ModelRegistry):
+    """As a MLOps engineer I would like to store some labels
+
+    A custom property of type string, with empty string value, shall be considered a Label; this is also semantically compatible for properties having empty string values in general.
+    """
+    name = "test_model"
+    version = "1.0.0"
+    rm = client.register_model(
+        name,
+        "s3",
+        model_format_name="test_format",
+        model_format_version="test_version",
+        version=version,
+    )
+    assert rm.id
+    mv = client.get_model_version(name, version)
+    assert mv.id
+    ma = client.get_model_artifact(name, version)
+    assert ma.id
+
+    rm_labels = {
+        "my-label1": "",
+        "my-label2": "",
+    }
+    rm.custom_properties = rm_labels
+    client.update(rm)
+
+    mv_labels = {
+        "my-label3": "",
+        "my-label4": "",
+    }
+    mv.custom_properties = mv_labels
+    client.update(mv)
+
+    ma_labels = {
+        "my-label5": "",
+        "my-label6": "",
+    }
+    ma.custom_properties = ma_labels
+    client.update(ma)
+
+    assert client.get_registered_model(name).custom_properties == rm_labels
+    assert client.get_model_version(name, version).custom_properties == mv_labels
+    assert client.get_model_artifact(name, version).custom_properties == ma_labels
+
+
+@pytest.mark.e2e
 async def test_update_preserves_model_info(client: ModelRegistry):
     name = "test_model"
     version = "1.0.0"

--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -70,6 +70,7 @@ As a MLOps engineer I would like to store a longer documentation for the model
             And Should Be Equal As Integers    ${cnt}    2
 
 As a MLOps engineer I would like to store some labels
+    # MIGRATED TO test_update_logical_model_with_labels in pytest
     # A custom property of type string, with empty string value, shall be considered a Label; this is also semantically compatible for properties having empty string values in general.
     ${cp1}    Create Dictionary  my-label1=${{ {"string_value": "", "metadataType": "MetadataStringValue"} }}  my-label2=${{ {"string_value": "", "metadataType": "MetadataStringValue"} }}
     Set To Dictionary    ${registered_model}    description=Lorem ipsum dolor sit amet  name=${name}  customProperties=${cp1}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
migrate User Story _from_ RobotFramework:

https://github.com/kubeflow/model-registry/blob/12f6cb9593c5f2381fa099053fce8e1eadc6d4db/test/robot/UserStory.robot#L72-L91

_to_ pytest,

following awesome work from @isinyaaa to introduce e2e testing directly with pytest:
- https://github.com/kubeflow/model-registry/pull/326

## How Has This Been Tested?
`make test-e2e`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
