### PR TITLE
keep deprecated method for mount for TestContainers to avoid direct API dep.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/docker v27.2.1+incompatible
+	github.com/docker/docker v27.2.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/internal/testutils/test_container_utils.go
+++ b/internal/testutils/test_container_utils.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/kubeflow/model-registry/internal/ml_metadata/proto"
 	testcontainers "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -86,8 +85,13 @@ func SetupMLMetadataTestContainer(t *testing.T) (*grpc.ClientConn, proto.Metadat
 		Env: map[string]string{
 			"METADATA_STORE_SERVER_CONFIG_FILE": "/tmp/shared/conn_config.pb",
 		},
-		HostConfigModifier: func(hc *container.HostConfig) {
-			hc.Binds = []string{wd + ":/tmp/shared"}
+		Mounts: testcontainers.ContainerMounts{
+			testcontainers.ContainerMount{
+				Source: testcontainers.GenericBindMountSource{ // nolint keep deprecated method to avoid depending directly to docker api exposed by testcontainers' HostConfigModifier
+					HostPath: wd,
+				},
+				Target: "/tmp/shared",
+			},
 		},
 		WaitingFor: wait.ForLog("Server listening on"),
 	}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
extract single commit from PR https://github.com/kubeflow/model-registry/pull/324 until that will be merged 
so to avoid continue rebasing due to dependency tree updates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
