### PR TITLE
enable standalone artifacts

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -391,8 +391,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-      operationId: createModelVersionArtifact
-      summary: Create an Artifact in a ModelVersion
+      operationId: upsertModelVersionArtifact
+      summary: Upsert an Artifact in a ModelVersion
       description: Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
     parameters:
       - name: modelversionId

--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -1224,9 +1224,8 @@ components:
           properties:
             id:
               format: int64
-              description: Output only. The unique server generated id of the resource.
+              description: The unique server generated id of the resource.
               type: string
-              readOnly: true
             createTimeSinceEpoch:
               format: int64
               description: Output only. Create time of the resource in millisecond since epoch.

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -28,8 +28,7 @@ test:
 
 .PHONY: lint
 lint:
-	poetry run ruff check
-	poetry run black src/mr_openapi --check
+	poetry run ruff check src/model_registry
 
 .PHONY: tidy
 tidy:

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -121,7 +121,7 @@ class ModelRegistry:
         self, mv: ModelVersion, name: str, uri: str, /, **kwargs
     ) -> ModelArtifact:
         assert mv.id is not None, "Model version must have an ID"
-        return await self._api.upsert_model_artifact(
+        return await self._api.upsert_model_version_artifact(
             ModelArtifact(name=name, uri=uri, **kwargs), mv.id
         )
 
@@ -206,8 +206,8 @@ class ModelRegistry:
         if isinstance(model, RegisteredModel):
             return self.async_runner(self._api.upsert_registered_model(model))
         if isinstance(model, ModelVersion):
-            return self.async_runner(self._api.upsert_model_version(model, model.id))
-        return self.async_runner(self._api.upsert_model_artifact(model, model.id))
+            return self.async_runner(self._api.upsert_model_version(model, None))
+        return self.async_runner(self._api.upsert_model_artifact(model))
 
     def register_hf_model(
         self,

--- a/clients/python/src/mr_openapi/README.md
+++ b/clients/python/src/mr_openapi/README.md
@@ -79,7 +79,6 @@ Class | Method | HTTP request | Description
 *ModelRegistryServiceApi* | [**create_inference_service_serve**](mr_openapi/docs/ModelRegistryServiceApi.md#create_inference_service_serve) | **POST** /api/model_registry/v1alpha3/inference_services/{inferenceserviceId}/serves | Create a ServeModel action in a InferenceService
 *ModelRegistryServiceApi* | [**create_model_artifact**](mr_openapi/docs/ModelRegistryServiceApi.md#create_model_artifact) | **POST** /api/model_registry/v1alpha3/model_artifacts | Create a ModelArtifact
 *ModelRegistryServiceApi* | [**create_model_version**](mr_openapi/docs/ModelRegistryServiceApi.md#create_model_version) | **POST** /api/model_registry/v1alpha3/model_versions | Create a ModelVersion
-*ModelRegistryServiceApi* | [**create_model_version_artifact**](mr_openapi/docs/ModelRegistryServiceApi.md#create_model_version_artifact) | **POST** /api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts | Create an Artifact in a ModelVersion
 *ModelRegistryServiceApi* | [**create_registered_model**](mr_openapi/docs/ModelRegistryServiceApi.md#create_registered_model) | **POST** /api/model_registry/v1alpha3/registered_models | Create a RegisteredModel
 *ModelRegistryServiceApi* | [**create_registered_model_version**](mr_openapi/docs/ModelRegistryServiceApi.md#create_registered_model_version) | **POST** /api/model_registry/v1alpha3/registered_models/{registeredmodelId}/versions | Create a ModelVersion in RegisteredModel
 *ModelRegistryServiceApi* | [**create_serving_environment**](mr_openapi/docs/ModelRegistryServiceApi.md#create_serving_environment) | **POST** /api/model_registry/v1alpha3/serving_environments | Create a ServingEnvironment
@@ -109,6 +108,7 @@ Class | Method | HTTP request | Description
 *ModelRegistryServiceApi* | [**update_model_version**](mr_openapi/docs/ModelRegistryServiceApi.md#update_model_version) | **PATCH** /api/model_registry/v1alpha3/model_versions/{modelversionId} | Update a ModelVersion
 *ModelRegistryServiceApi* | [**update_registered_model**](mr_openapi/docs/ModelRegistryServiceApi.md#update_registered_model) | **PATCH** /api/model_registry/v1alpha3/registered_models/{registeredmodelId} | Update a RegisteredModel
 *ModelRegistryServiceApi* | [**update_serving_environment**](mr_openapi/docs/ModelRegistryServiceApi.md#update_serving_environment) | **PATCH** /api/model_registry/v1alpha3/serving_environments/{servingenvironmentId} | Update a ServingEnvironment
+*ModelRegistryServiceApi* | [**upsert_model_version_artifact**](mr_openapi/docs/ModelRegistryServiceApi.md#upsert_model_version_artifact) | **POST** /api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts | Upsert an Artifact in a ModelVersion
 
 
 ## Documentation For Models

--- a/clients/python/src/mr_openapi/api/model_registry_service_api.py
+++ b/clients/python/src/mr_openapi/api/model_registry_service_api.py
@@ -1318,272 +1318,6 @@ class ModelRegistryServiceApi:
         )
 
     @validate_call
-    async def create_model_version_artifact(
-        self,
-        modelversion_id: Annotated[StrictStr, Field(description="A unique identifier for a `ModelVersion`.")],
-        artifact: Annotated[
-            Artifact, Field(description="A new or existing `Artifact` to be associated with the `ModelVersion`.")
-        ],
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            tuple[Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]],
-        ] = None,
-        _request_auth: Optional[dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> Artifact:
-        """Create an Artifact in a ModelVersion.
-
-        Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
-
-        :param modelversion_id: A unique identifier for a `ModelVersion`. (required)
-        :type modelversion_id: str
-        :param artifact: A new or existing `Artifact` to be associated with the `ModelVersion`. (required)
-        :type artifact: Artifact
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """  # noqa: E501
-        _param = self._create_model_version_artifact_serialize(
-            modelversion_id=modelversion_id,
-            artifact=artifact,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
-        )
-
-        _response_types_map: dict[str, Optional[str]] = {
-            "200": "Artifact",
-            "201": "Artifact",
-            "400": "Error",
-            "401": "Error",
-            "404": "Error",
-            "500": "Error",
-        }
-        response_data = await self.api_client.call_api(*_param, _request_timeout=_request_timeout)
-        await response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        ).data
-
-    @validate_call
-    async def create_model_version_artifact_with_http_info(
-        self,
-        modelversion_id: Annotated[StrictStr, Field(description="A unique identifier for a `ModelVersion`.")],
-        artifact: Annotated[
-            Artifact, Field(description="A new or existing `Artifact` to be associated with the `ModelVersion`.")
-        ],
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            tuple[Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]],
-        ] = None,
-        _request_auth: Optional[dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> ApiResponse[Artifact]:
-        """Create an Artifact in a ModelVersion.
-
-        Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
-
-        :param modelversion_id: A unique identifier for a `ModelVersion`. (required)
-        :type modelversion_id: str
-        :param artifact: A new or existing `Artifact` to be associated with the `ModelVersion`. (required)
-        :type artifact: Artifact
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """  # noqa: E501
-        _param = self._create_model_version_artifact_serialize(
-            modelversion_id=modelversion_id,
-            artifact=artifact,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
-        )
-
-        _response_types_map: dict[str, Optional[str]] = {
-            "200": "Artifact",
-            "201": "Artifact",
-            "400": "Error",
-            "401": "Error",
-            "404": "Error",
-            "500": "Error",
-        }
-        response_data = await self.api_client.call_api(*_param, _request_timeout=_request_timeout)
-        await response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        )
-
-    @validate_call
-    async def create_model_version_artifact_without_preload_content(
-        self,
-        modelversion_id: Annotated[StrictStr, Field(description="A unique identifier for a `ModelVersion`.")],
-        artifact: Annotated[
-            Artifact, Field(description="A new or existing `Artifact` to be associated with the `ModelVersion`.")
-        ],
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            tuple[Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]],
-        ] = None,
-        _request_auth: Optional[dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> RESTResponseType:
-        """Create an Artifact in a ModelVersion.
-
-        Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
-
-        :param modelversion_id: A unique identifier for a `ModelVersion`. (required)
-        :type modelversion_id: str
-        :param artifact: A new or existing `Artifact` to be associated with the `ModelVersion`. (required)
-        :type artifact: Artifact
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """  # noqa: E501
-        _param = self._create_model_version_artifact_serialize(
-            modelversion_id=modelversion_id,
-            artifact=artifact,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
-        )
-
-        _response_types_map: dict[str, Optional[str]] = {
-            "200": "Artifact",
-            "201": "Artifact",
-            "400": "Error",
-            "401": "Error",
-            "404": "Error",
-            "500": "Error",
-        }
-        response_data = await self.api_client.call_api(*_param, _request_timeout=_request_timeout)
-        return response_data.response
-
-    def _create_model_version_artifact_serialize(
-        self,
-        modelversion_id,
-        artifact,
-        _request_auth,
-        _content_type,
-        _headers,
-        _host_index,
-    ) -> RequestSerialized:
-
-        _host = None
-
-        _collection_formats: dict[str, str] = {}
-
-        _path_params: dict[str, str] = {}
-        _query_params: list[tuple[str, str]] = []
-        _header_params: dict[str, Optional[str]] = _headers or {}
-        _form_params: list[tuple[str, str]] = []
-        _files: dict[str, Union[str, bytes]] = {}
-        _body_params: Optional[bytes] = None
-
-        # process the path parameters
-        if modelversion_id is not None:
-            _path_params["modelversionId"] = modelversion_id
-        # process the query parameters
-        # process the header parameters
-        # process the form parameters
-        # process the body parameter
-        if artifact is not None:
-            _body_params = artifact
-
-        # set the HTTP header `Accept`
-        _header_params["Accept"] = self.api_client.select_header_accept(["application/json"])
-
-        # set the HTTP header `Content-Type`
-        if _content_type:
-            _header_params["Content-Type"] = _content_type
-        else:
-            _default_content_type = self.api_client.select_header_content_type(["application/json"])
-            if _default_content_type is not None:
-                _header_params["Content-Type"] = _default_content_type
-
-        # authentication setting
-        _auth_settings: list[str] = ["Bearer"]
-
-        return self.api_client.param_serialize(
-            method="POST",
-            resource_path="/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts",
-            path_params=_path_params,
-            query_params=_query_params,
-            header_params=_header_params,
-            body=_body_params,
-            post_params=_form_params,
-            files=_files,
-            auth_settings=_auth_settings,
-            collection_formats=_collection_formats,
-            _host=_host,
-            _request_auth=_request_auth,
-        )
-
-    @validate_call
     async def create_registered_model(
         self,
         registered_model_create: Annotated[
@@ -9495,6 +9229,272 @@ class ModelRegistryServiceApi:
         return self.api_client.param_serialize(
             method="PATCH",
             resource_path="/api/model_registry/v1alpha3/serving_environments/{servingenvironmentId}",
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth,
+        )
+
+    @validate_call
+    async def upsert_model_version_artifact(
+        self,
+        modelversion_id: Annotated[StrictStr, Field(description="A unique identifier for a `ModelVersion`.")],
+        artifact: Annotated[
+            Artifact, Field(description="A new or existing `Artifact` to be associated with the `ModelVersion`.")
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            tuple[Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]],
+        ] = None,
+        _request_auth: Optional[dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> Artifact:
+        """Upsert an Artifact in a ModelVersion.
+
+        Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
+
+        :param modelversion_id: A unique identifier for a `ModelVersion`. (required)
+        :type modelversion_id: str
+        :param artifact: A new or existing `Artifact` to be associated with the `ModelVersion`. (required)
+        :type artifact: Artifact
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+        _param = self._upsert_model_version_artifact_serialize(
+            modelversion_id=modelversion_id,
+            artifact=artifact,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: dict[str, Optional[str]] = {
+            "200": "Artifact",
+            "201": "Artifact",
+            "400": "Error",
+            "401": "Error",
+            "404": "Error",
+            "500": "Error",
+        }
+        response_data = await self.api_client.call_api(*_param, _request_timeout=_request_timeout)
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+    @validate_call
+    async def upsert_model_version_artifact_with_http_info(
+        self,
+        modelversion_id: Annotated[StrictStr, Field(description="A unique identifier for a `ModelVersion`.")],
+        artifact: Annotated[
+            Artifact, Field(description="A new or existing `Artifact` to be associated with the `ModelVersion`.")
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            tuple[Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]],
+        ] = None,
+        _request_auth: Optional[dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[Artifact]:
+        """Upsert an Artifact in a ModelVersion.
+
+        Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
+
+        :param modelversion_id: A unique identifier for a `ModelVersion`. (required)
+        :type modelversion_id: str
+        :param artifact: A new or existing `Artifact` to be associated with the `ModelVersion`. (required)
+        :type artifact: Artifact
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+        _param = self._upsert_model_version_artifact_serialize(
+            modelversion_id=modelversion_id,
+            artifact=artifact,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: dict[str, Optional[str]] = {
+            "200": "Artifact",
+            "201": "Artifact",
+            "400": "Error",
+            "401": "Error",
+            "404": "Error",
+            "500": "Error",
+        }
+        response_data = await self.api_client.call_api(*_param, _request_timeout=_request_timeout)
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+    @validate_call
+    async def upsert_model_version_artifact_without_preload_content(
+        self,
+        modelversion_id: Annotated[StrictStr, Field(description="A unique identifier for a `ModelVersion`.")],
+        artifact: Annotated[
+            Artifact, Field(description="A new or existing `Artifact` to be associated with the `ModelVersion`.")
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            tuple[Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]],
+        ] = None,
+        _request_auth: Optional[dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Upsert an Artifact in a ModelVersion.
+
+        Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
+
+        :param modelversion_id: A unique identifier for a `ModelVersion`. (required)
+        :type modelversion_id: str
+        :param artifact: A new or existing `Artifact` to be associated with the `ModelVersion`. (required)
+        :type artifact: Artifact
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+        _param = self._upsert_model_version_artifact_serialize(
+            modelversion_id=modelversion_id,
+            artifact=artifact,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: dict[str, Optional[str]] = {
+            "200": "Artifact",
+            "201": "Artifact",
+            "400": "Error",
+            "401": "Error",
+            "404": "Error",
+            "500": "Error",
+        }
+        response_data = await self.api_client.call_api(*_param, _request_timeout=_request_timeout)
+        return response_data.response
+
+    def _upsert_model_version_artifact_serialize(
+        self,
+        modelversion_id,
+        artifact,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: dict[str, str] = {}
+
+        _path_params: dict[str, str] = {}
+        _query_params: list[tuple[str, str]] = []
+        _header_params: dict[str, Optional[str]] = _headers or {}
+        _form_params: list[tuple[str, str]] = []
+        _files: dict[str, Union[str, bytes]] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if modelversion_id is not None:
+            _path_params["modelversionId"] = modelversion_id
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+        if artifact is not None:
+            _body_params = artifact
+
+        # set the HTTP header `Accept`
+        _header_params["Accept"] = self.api_client.select_header_accept(["application/json"])
+
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params["Content-Type"] = _content_type
+        else:
+            _default_content_type = self.api_client.select_header_content_type(["application/json"])
+            if _default_content_type is not None:
+                _header_params["Content-Type"] = _default_content_type
+
+        # authentication setting
+        _auth_settings: list[str] = ["Bearer"]
+
+        return self.api_client.param_serialize(
+            method="POST",
+            resource_path="/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts",
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/clients/python/src/mr_openapi/models/base_artifact.py
+++ b/clients/python/src/mr_openapi/models/base_artifact.py
@@ -45,9 +45,7 @@ class BaseArtifact(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -101,10 +99,8 @@ class BaseArtifact(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/base_execution.py
+++ b/clients/python/src/mr_openapi/models/base_execution.py
@@ -41,9 +41,7 @@ class BaseExecution(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -96,10 +94,8 @@ class BaseExecution(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/base_resource.py
+++ b/clients/python/src/mr_openapi/models/base_resource.py
@@ -39,9 +39,7 @@ class BaseResource(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -93,10 +91,8 @@ class BaseResource(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/doc_artifact.py
+++ b/clients/python/src/mr_openapi/models/doc_artifact.py
@@ -46,9 +46,7 @@ class DocArtifact(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -102,10 +100,8 @@ class DocArtifact(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/inference_service.py
+++ b/clients/python/src/mr_openapi/models/inference_service.py
@@ -40,9 +40,7 @@ class InferenceService(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -113,10 +111,8 @@ class InferenceService(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/model_artifact.py
+++ b/clients/python/src/mr_openapi/models/model_artifact.py
@@ -46,9 +46,7 @@ class ModelArtifact(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -120,10 +118,8 @@ class ModelArtifact(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/model_version.py
+++ b/clients/python/src/mr_openapi/models/model_version.py
@@ -44,9 +44,7 @@ class ModelVersion(BaseModel):
     registered_model_id: StrictStr = Field(
         description="ID of the `RegisteredModel` to which this version belongs.", alias="registeredModelId"
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -101,10 +99,8 @@ class ModelVersion(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/registered_model.py
+++ b/clients/python/src/mr_openapi/models/registered_model.py
@@ -39,9 +39,7 @@ class RegisteredModel(BaseModel):
     name: StrictStr = Field(
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set."
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -97,10 +95,8 @@ class RegisteredModel(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/serve_model.py
+++ b/clients/python/src/mr_openapi/models/serve_model.py
@@ -41,9 +41,7 @@ class ServeModel(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -100,10 +98,8 @@ class ServeModel(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/clients/python/src/mr_openapi/models/serving_environment.py
+++ b/clients/python/src/mr_openapi/models/serving_environment.py
@@ -39,9 +39,7 @@ class ServingEnvironment(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
-    id: StrictStr | None = Field(
-        default=None, description="Output only. The unique server generated id of the resource."
-    )
+    id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(
         default=None,
         description="Output only. Create time of the resource in millisecond since epoch.",
@@ -93,10 +91,8 @@ class ServingEnvironment(BaseModel):
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: set[str] = {
-            "id",
             "create_time_since_epoch",
             "last_update_time_since_epoch",
         }

--- a/docs/mr_go_library.md
+++ b/docs/mr_go_library.md
@@ -1,7 +1,7 @@
 # Model Registry
 
 > ⚠️  NOTE: UNSTABLE API  ⚠️
-> This library is provided as a convenience for Kubeflow developers.
+> This library is provided as a convenience for Kubeflow Model Registry developers.
 > If you are not actively involved in the development of Model Registry, please prefer the [REST API](https://editor.swagger.io/?url=https://raw.githubusercontent.com/kubeflow/model-registry/main/api/openapi/model-registry.yaml).
 
 ## Getting Started

--- a/internal/server/openapi/api.go
+++ b/internal/server/openapi/api.go
@@ -67,7 +67,6 @@ type ModelRegistryServiceAPIServicer interface {
 	CreateInferenceServiceServe(context.Context, string, model.ServeModelCreate) (ImplResponse, error)
 	CreateModelArtifact(context.Context, model.ModelArtifactCreate) (ImplResponse, error)
 	CreateModelVersion(context.Context, model.ModelVersionCreate) (ImplResponse, error)
-	CreateModelVersionArtifact(context.Context, string, model.Artifact) (ImplResponse, error)
 	CreateRegisteredModel(context.Context, model.RegisteredModelCreate) (ImplResponse, error)
 	CreateRegisteredModelVersion(context.Context, string, model.ModelVersion) (ImplResponse, error)
 	CreateServingEnvironment(context.Context, model.ServingEnvironmentCreate) (ImplResponse, error)
@@ -97,4 +96,5 @@ type ModelRegistryServiceAPIServicer interface {
 	UpdateModelVersion(context.Context, string, model.ModelVersionUpdate) (ImplResponse, error)
 	UpdateRegisteredModel(context.Context, string, model.RegisteredModelUpdate) (ImplResponse, error)
 	UpdateServingEnvironment(context.Context, string, model.ServingEnvironmentUpdate) (ImplResponse, error)
+	UpsertModelVersionArtifact(context.Context, string, model.Artifact) (ImplResponse, error)
 }

--- a/internal/server/openapi/api_model_registry_service.go
+++ b/internal/server/openapi/api_model_registry_service.go
@@ -77,11 +77,6 @@ func (c *ModelRegistryServiceAPIController) Routes() Routes {
 			"/api/model_registry/v1alpha3/model_versions",
 			c.CreateModelVersion,
 		},
-		"CreateModelVersionArtifact": Route{
-			strings.ToUpper("Post"),
-			"/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts",
-			c.CreateModelVersionArtifact,
-		},
 		"CreateRegisteredModel": Route{
 			strings.ToUpper("Post"),
 			"/api/model_registry/v1alpha3/registered_models",
@@ -227,6 +222,11 @@ func (c *ModelRegistryServiceAPIController) Routes() Routes {
 			"/api/model_registry/v1alpha3/serving_environments/{servingenvironmentId}",
 			c.UpdateServingEnvironment,
 		},
+		"UpsertModelVersionArtifact": Route{
+			strings.ToUpper("Post"),
+			"/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts",
+			c.UpsertModelVersionArtifact,
+		},
 	}
 }
 
@@ -358,34 +358,6 @@ func (c *ModelRegistryServiceAPIController) CreateModelVersion(w http.ResponseWr
 		return
 	}
 	result, err := c.service.CreateModelVersion(r.Context(), modelVersionCreateParam)
-	// If an error occurred, encode the error with the status code
-	if err != nil {
-		c.errorHandler(w, r, err, &result)
-		return
-	}
-	// If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
-}
-
-// CreateModelVersionArtifact - Create an Artifact in a ModelVersion
-func (c *ModelRegistryServiceAPIController) CreateModelVersionArtifact(w http.ResponseWriter, r *http.Request) {
-	modelversionIdParam := chi.URLParam(r, "modelversionId")
-	artifactParam := model.Artifact{}
-	d := json.NewDecoder(r.Body)
-	d.DisallowUnknownFields()
-	if err := d.Decode(&artifactParam); err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
-	if err := AssertArtifactRequired(artifactParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	if err := AssertArtifactConstraints(artifactParam); err != nil {
-		c.errorHandler(w, r, err, nil)
-		return
-	}
-	result, err := c.service.CreateModelVersionArtifact(r.Context(), modelversionIdParam, artifactParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -942,6 +914,34 @@ func (c *ModelRegistryServiceAPIController) UpdateServingEnvironment(w http.Resp
 		return
 	}
 	result, err := c.service.UpdateServingEnvironment(r.Context(), servingenvironmentIdParam, servingEnvironmentUpdateParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	EncodeJSONResponse(result.Body, &result.Code, w)
+}
+
+// UpsertModelVersionArtifact - Upsert an Artifact in a ModelVersion
+func (c *ModelRegistryServiceAPIController) UpsertModelVersionArtifact(w http.ResponseWriter, r *http.Request) {
+	modelversionIdParam := chi.URLParam(r, "modelversionId")
+	artifactParam := model.Artifact{}
+	d := json.NewDecoder(r.Body)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&artifactParam); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	if err := AssertArtifactRequired(artifactParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	if err := AssertArtifactConstraints(artifactParam); err != nil {
+		c.errorHandler(w, r, err, nil)
+		return
+	}
+	result, err := c.service.UpsertModelVersionArtifact(r.Context(), modelversionIdParam, artifactParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -107,11 +107,16 @@ func (s *ModelRegistryServiceAPIService) CreateModelVersion(ctx context.Context,
 
 // CreateModelVersionArtifact - Create an Artifact in a ModelVersion
 func (s *ModelRegistryServiceAPIService) UpsertModelVersionArtifact(ctx context.Context, modelversionId string, artifact model.Artifact) (ImplResponse, error) {
+	creating := (artifact.DocArtifact != nil && artifact.DocArtifact.Id == nil) || (artifact.ModelArtifact != nil && artifact.ModelArtifact.Id == nil)
+
 	result, err := s.coreApi.UpsertModelVersionArtifact(&artifact, modelversionId)
 	if err != nil {
 		return ErrorResponse(api.ErrToStatus(err), err), err
 	}
-	return Response(http.StatusCreated, result), nil
+	if creating {
+		return Response(http.StatusCreated, result), nil
+	}
+	return Response(http.StatusOK, result), nil
 	// return Response(http.StatusNotImplemented, nil), errors.New("unsupported artifactType")
 	// TODO return Response(http.StatusOK, Artifact{}), nil
 	// TODO return Response(http.StatusUnauthorized, Error{}), nil

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -82,7 +82,7 @@ func (s *ModelRegistryServiceAPIService) CreateModelArtifact(ctx context.Context
 		return ErrorResponse(http.StatusBadRequest, err), err
 	}
 
-	result, err := s.coreApi.UpsertModelArtifact(entity, nil)
+	result, err := s.coreApi.UpsertModelArtifact(entity)
 	if err != nil {
 		return ErrorResponse(api.ErrToStatus(err), err), err
 	}
@@ -106,8 +106,8 @@ func (s *ModelRegistryServiceAPIService) CreateModelVersion(ctx context.Context,
 }
 
 // CreateModelVersionArtifact - Create an Artifact in a ModelVersion
-func (s *ModelRegistryServiceAPIService) CreateModelVersionArtifact(ctx context.Context, modelversionId string, artifact model.Artifact) (ImplResponse, error) {
-	result, err := s.coreApi.UpsertArtifact(&artifact, &modelversionId)
+func (s *ModelRegistryServiceAPIService) UpsertModelVersionArtifact(ctx context.Context, modelversionId string, artifact model.Artifact) (ImplResponse, error) {
+	result, err := s.coreApi.UpsertModelVersionArtifact(&artifact, modelversionId)
 	if err != nil {
 		return ErrorResponse(api.ErrToStatus(err), err), err
 	}
@@ -445,7 +445,7 @@ func (s *ModelRegistryServiceAPIService) UpdateModelArtifact(ctx context.Context
 	if err != nil {
 		return ErrorResponse(http.StatusBadRequest, err), err
 	}
-	result, err := s.coreApi.UpsertModelArtifact(&update, nil)
+	result, err := s.coreApi.UpsertModelArtifact(&update)
 	if err != nil {
 		return ErrorResponse(api.ErrToStatus(err), err), err
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,7 +52,9 @@ type ModelRegistryApi interface {
 
 	// ARTIFACT
 
-	UpsertArtifact(artifact *openapi.Artifact, modelVersionId *string) (*openapi.Artifact, error)
+	UpsertModelVersionArtifact(artifact *openapi.Artifact, modelVersionId string) (*openapi.Artifact, error)
+
+	UpsertArtifact(artifact *openapi.Artifact) (*openapi.Artifact, error)
 
 	GetArtifactById(id string) (*openapi.Artifact, error)
 
@@ -60,9 +62,8 @@ type ModelRegistryApi interface {
 
 	// MODEL ARTIFACT
 
-	// UpsertModelArtifact create a new Artifact or update an Artifact associated to a specific
-	// ModelVersion identified by modelVersionId parameter
-	UpsertModelArtifact(modelArtifact *openapi.ModelArtifact, modelVersionId *string) (*openapi.ModelArtifact, error)
+	// UpsertModelArtifact creates or inserts an Artifact
+	UpsertModelArtifact(modelArtifact *openapi.ModelArtifact) (*openapi.ModelArtifact, error)
 
 	// GetModelArtifactById retrieve ModelArtifact by id
 	GetModelArtifactById(id string) (*openapi.ModelArtifact, error)

--- a/pkg/core/inference_service.go
+++ b/pkg/core/inference_service.go
@@ -18,6 +18,9 @@ import (
 // UpsertInferenceService creates a new inference service if the provided inference service's ID is nil,
 // or updates an existing inference service if the ID is provided.
 func (serv *ModelRegistryService) UpsertInferenceService(inferenceService *openapi.InferenceService) (*openapi.InferenceService, error) {
+	if inferenceService == nil {
+		return nil, fmt.Errorf("invalid inference service pointer, can't upsert nil: %w", api.ErrBadRequest)
+	}
 	var err error
 	var existing *openapi.InferenceService
 	var servingEnvironment *openapi.ServingEnvironment

--- a/pkg/core/inference_service_test.go
+++ b/pkg/core/inference_service_test.go
@@ -70,6 +70,10 @@ func (suite *CoreTestSuite) TestCreateInferenceServiceFailure() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()
 
+	_, err := service.UpsertInferenceService(nil)
+	suite.NotNil(err)
+	suite.Equal("invalid inference service pointer, can't upsert nil: bad request", err.Error())
+
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
 		ExternalId:           &entityExternalId2,
@@ -82,7 +86,7 @@ func (suite *CoreTestSuite) TestCreateInferenceServiceFailure() {
 		},
 	}
 
-	_, err := service.UpsertInferenceService(eut)
+	_, err = service.UpsertInferenceService(eut)
 	suite.NotNil(err)
 	suite.Equal("no serving environment found for id 9999: not found", err.Error())
 
@@ -115,7 +119,7 @@ func (suite *CoreTestSuite) TestUpdateInferenceService() {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
 
 	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 
@@ -209,7 +213,7 @@ func (suite *CoreTestSuite) TestUpdateInferenceServiceFailure() {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
 
 	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 
@@ -251,7 +255,7 @@ func (suite *CoreTestSuite) TestGetInferenceServiceById() {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
 
 	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
@@ -294,7 +298,7 @@ func (suite *CoreTestSuite) TestGetRegisteredModelByInferenceServiceId() {
 		},
 	}
 	createdEntity, err := service.UpsertInferenceService(eut)
-	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
 	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 
 	getRM, err := service.GetRegisteredModelByInferenceService(*createdEntity.Id)
@@ -337,7 +341,7 @@ func (suite *CoreTestSuite) TestGetModelVersionByInferenceServiceId() {
 		},
 	}
 	createdEntity, err := service.UpsertInferenceService(eut)
-	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
 
 	getVModel, err := service.GetModelVersionByInferenceService(*createdEntity.Id)
 	suite.Nilf(err, "error getting using id %s", *createdEntity.Id)
@@ -346,7 +350,7 @@ func (suite *CoreTestSuite) TestGetModelVersionByInferenceServiceId() {
 	// here we used the returned entity (so ID is populated), and we update to specify the "ID of the ModelVersion to serve"
 	createdEntity.ModelVersionId = &createdVersion1Id
 	_, err = service.UpsertInferenceService(createdEntity)
-	suite.Nilf(err, "error updating eut for %v", parentResourceId)
+	suite.Nilf(err, "error updating eut for %s", parentResourceId)
 
 	getVModel, err = service.GetModelVersionByInferenceService(*createdEntity.Id)
 	suite.Nilf(err, "error getting using id %s", *createdEntity.Id)
@@ -390,7 +394,7 @@ func (suite *CoreTestSuite) TestGetModelArtifactByInferenceServiceId() {
 		ModelVersionId:       nil, // first we test by unspecified
 	}
 	createdEntity, err := service.UpsertInferenceService(eut)
-	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
 
 	getModelArt, err := service.GetModelArtifactByInferenceService(*createdEntity.Id)
 	suite.Nilf(err, "error getting using id %s", *createdEntity.Id)
@@ -399,7 +403,7 @@ func (suite *CoreTestSuite) TestGetModelArtifactByInferenceServiceId() {
 	// here we used the returned entity (so ID is populated), and we update to specify the "ID of the ModelVersion to serve"
 	createdEntity.ModelVersionId = createdVersion1.Id
 	_, err = service.UpsertInferenceService(createdEntity)
-	suite.Nilf(err, "error updating eut for %v", parentResourceId)
+	suite.Nilf(err, "error updating eut for %s", parentResourceId)
 
 	getModelArt, err = service.GetModelArtifactByInferenceService(*createdEntity.Id)
 	suite.Nilf(err, "error getting using id %s", *createdEntity.Id)
@@ -438,7 +442,7 @@ func (suite *CoreTestSuite) TestGetInferenceServiceByParamsName() {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
 
 	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
@@ -481,7 +485,7 @@ func (suite *CoreTestSuite) TestGetInfernenceServiceByParamsExternalId() {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
 
 	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)

--- a/pkg/core/inference_service_test.go
+++ b/pkg/core/inference_service_test.go
@@ -366,8 +366,9 @@ func (suite *CoreTestSuite) TestGetModelArtifactByInferenceServiceId() {
 	suite.Nilf(err, "error creating new model version for %s", registeredModelId)
 	modelArtifact1Name := "v1-artifact"
 	modelArtifact1 := &openapi.ModelArtifact{Name: &modelArtifact1Name}
-	createdArtifact1, err := service.UpsertModelArtifact(modelArtifact1, createdVersion1.Id)
+	art1, err := service.UpsertModelVersionArtifact(&openapi.Artifact{ModelArtifact: modelArtifact1}, *createdVersion1.Id)
 	suite.Nilf(err, "error creating new model artifact for %s", *createdVersion1.Id)
+	ma1 := art1.ModelArtifact
 
 	modelVersion2Name := "v2"
 	modelVersion2 := &openapi.ModelVersion{Name: modelVersion2Name, Description: &modelVersionDescription}
@@ -375,8 +376,9 @@ func (suite *CoreTestSuite) TestGetModelArtifactByInferenceServiceId() {
 	suite.Nilf(err, "error creating new model version for %s", registeredModelId)
 	modelArtifact2Name := "v2-artifact"
 	modelArtifact2 := &openapi.ModelArtifact{Name: &modelArtifact2Name}
-	createdArtifact2, err := service.UpsertModelArtifact(modelArtifact2, createdVersion2.Id)
+	art2, err := service.UpsertModelVersionArtifact(&openapi.Artifact{ModelArtifact: modelArtifact2}, *createdVersion2.Id)
 	suite.Nilf(err, "error creating new model artifact for %s", *createdVersion2.Id)
+	ma2 := art2.ModelArtifact
 	// end of data preparation
 
 	eut := &openapi.InferenceService{
@@ -392,7 +394,7 @@ func (suite *CoreTestSuite) TestGetModelArtifactByInferenceServiceId() {
 
 	getModelArt, err := service.GetModelArtifactByInferenceService(*createdEntity.Id)
 	suite.Nilf(err, "error getting using id %s", *createdEntity.Id)
-	suite.Equal(*createdArtifact2.Id, *getModelArt.Id, "returned id shall be the latest ModelVersion by creation order")
+	suite.Equal(*ma2.Id, *getModelArt.Id, "returned id shall be the latest ModelVersion by creation order")
 
 	// here we used the returned entity (so ID is populated), and we update to specify the "ID of the ModelVersion to serve"
 	createdEntity.ModelVersionId = createdVersion1.Id
@@ -401,7 +403,7 @@ func (suite *CoreTestSuite) TestGetModelArtifactByInferenceServiceId() {
 
 	getModelArt, err = service.GetModelArtifactByInferenceService(*createdEntity.Id)
 	suite.Nilf(err, "error getting using id %s", *createdEntity.Id)
-	suite.Equal(*createdArtifact1.Id, *getModelArt.Id, "returned id shall be the specified one")
+	suite.Equal(*ma1.Id, *getModelArt.Id, "returned id shall be the specified one")
 }
 
 func (suite *CoreTestSuite) TestGetInferenceServiceByParamsWithNoResults() {

--- a/pkg/core/model_version.go
+++ b/pkg/core/model_version.go
@@ -17,6 +17,9 @@ import (
 // UpsertModelVersion creates a new model version if the provided model version's ID is nil,
 // or updates an existing model version if the ID is provided.
 func (serv *ModelRegistryService) UpsertModelVersion(modelVersion *openapi.ModelVersion, registeredModelId *string) (*openapi.ModelVersion, error) {
+	if modelVersion == nil {
+		return nil, fmt.Errorf("invalid model version pointer, can't upsert nil: %w", api.ErrBadRequest)
+	}
 	var err error
 	var existing *openapi.ModelVersion
 	var registeredModel *openapi.RegisteredModel

--- a/pkg/core/model_version_test.go
+++ b/pkg/core/model_version_test.go
@@ -61,6 +61,10 @@ func (suite *CoreTestSuite) TestCreateModelVersionFailure() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()
 
+	_, err := service.UpsertModelVersion(nil, nil)
+	suite.NotNil(err)
+	suite.Equal("invalid model version pointer, can't upsert nil: bad request", err.Error())
+
 	registeredModelId := "9999"
 
 	modelVersion := &openapi.ModelVersion{
@@ -69,7 +73,7 @@ func (suite *CoreTestSuite) TestCreateModelVersionFailure() {
 		Author:     &author,
 	}
 
-	_, err := service.UpsertModelVersion(modelVersion, nil)
+	_, err = service.UpsertModelVersion(modelVersion, nil)
 	suite.NotNil(err)
 	suite.Equal("missing registered model id, cannot create model version without registered model: bad request", err.Error())
 

--- a/pkg/core/serve_model.go
+++ b/pkg/core/serve_model.go
@@ -17,6 +17,9 @@ import (
 // UpsertServeModel creates a new serve model if the provided serve model's ID is nil,
 // or updates an existing serve model if the ID is provided.
 func (serv *ModelRegistryService) UpsertServeModel(serveModel *openapi.ServeModel, inferenceServiceId *string) (*openapi.ServeModel, error) {
+	if serveModel == nil {
+		return nil, fmt.Errorf("invalid serve model pointer, can't upsert nil: %w", api.ErrBadRequest)
+	}
 	var err error
 	var existing *openapi.ServeModel
 

--- a/pkg/core/serve_model_test.go
+++ b/pkg/core/serve_model_test.go
@@ -26,7 +26,7 @@ func (suite *CoreTestSuite) TestCreateServeModel() {
 		Author:      &author,
 	}
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %s", registeredModelId)
 	createdVersionId := *createdVersion.Id
 	createdVersionIdAsInt, _ := converter.StringToInt64(&createdVersionId)
 	// end of data preparation
@@ -84,6 +84,10 @@ func (suite *CoreTestSuite) TestCreateServeModelFailure() {
 	inferenceServiceId := suite.registerInferenceService(service, registeredModelId, nil, nil, nil, nil)
 	// end of data preparation
 
+	_, err := service.UpsertServeModel(nil, nil)
+	suite.NotNil(err)
+	suite.Equal("invalid serve model pointer, can't upsert nil: bad request", err.Error())
+
 	eut := &openapi.ServeModel{
 		LastKnownState: (*openapi.ExecutionState)(&executionState),
 		ExternalId:     &entityExternalId2,
@@ -97,7 +101,7 @@ func (suite *CoreTestSuite) TestCreateServeModelFailure() {
 		},
 	}
 
-	_, err := service.UpsertServeModel(eut, nil)
+	_, err = service.UpsertServeModel(eut, nil)
 	suite.NotNil(err)
 	suite.Equal("missing inferenceServiceId, cannot create ServeModel without parent resource InferenceService: bad request", err.Error())
 
@@ -206,7 +210,7 @@ func (suite *CoreTestSuite) TestUpdateServeModelFailure() {
 	newState := "UNKNOWN"
 	createdEntity.LastKnownState = (*openapi.ExecutionState)(&newState)
 	updatedEntity, err := service.UpsertServeModel(createdEntity, &inferenceServiceId)
-	suite.Nilf(err, "error updating entity for %d: %v", inferenceServiceId, err)
+	suite.Nilf(err, "error updating entity for %s: %v", inferenceServiceId, err)
 
 	wrongId := "9998"
 	updatedEntity.Id = &wrongId
@@ -229,7 +233,7 @@ func (suite *CoreTestSuite) TestGetServeModelById() {
 		Author:      &author,
 	}
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %s", registeredModelId)
 	createdVersionId := *createdVersion.Id
 	// end of data preparation
 
@@ -247,10 +251,10 @@ func (suite *CoreTestSuite) TestGetServeModelById() {
 	}
 
 	createdEntity, err := service.UpsertServeModel(eut, &inferenceServiceId)
-	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %s", inferenceServiceId)
 
 	getById, err := service.GetServeModelById(*createdEntity.Id)
-	suite.Nilf(err, "error getting entity by id %d", *createdEntity.Id)
+	suite.Nilf(err, "error getting entity by id %s", *createdEntity.Id)
 
 	state, _ := openapi.NewExecutionStateFromValue(executionState)
 	suite.NotNil(createdEntity.Id, "created artifact id should not be nil")
@@ -272,19 +276,19 @@ func (suite *CoreTestSuite) TestGetServeModels() {
 	modelVersion1Name := "v1"
 	modelVersion1 := &openapi.ModelVersion{Name: modelVersion1Name, Description: &modelVersionDescription}
 	createdVersion1, err := service.UpsertModelVersion(modelVersion1, &registeredModelId)
-	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %s", registeredModelId)
 	createdVersion1Id := *createdVersion1.Id
 
 	modelVersion2Name := "v2"
 	modelVersion2 := &openapi.ModelVersion{Name: modelVersion2Name, Description: &modelVersionDescription}
 	createdVersion2, err := service.UpsertModelVersion(modelVersion2, &registeredModelId)
-	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %s", registeredModelId)
 	createdVersion2Id := *createdVersion2.Id
 
 	modelVersion3Name := "v3"
 	modelVersion3 := &openapi.ModelVersion{Name: modelVersion3Name, Description: &modelVersionDescription}
 	createdVersion3, err := service.UpsertModelVersion(modelVersion3, &registeredModelId)
-	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %s", registeredModelId)
 	createdVersion3Id := *createdVersion3.Id
 	// end of data preparation
 
@@ -328,11 +332,11 @@ func (suite *CoreTestSuite) TestGetServeModels() {
 	}
 
 	createdEntity1, err := service.UpsertServeModel(eut1, &inferenceServiceId)
-	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %s", inferenceServiceId)
 	createdEntity2, err := service.UpsertServeModel(eut2, &inferenceServiceId)
-	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %s", inferenceServiceId)
 	createdEntity3, err := service.UpsertServeModel(eut3, &inferenceServiceId)
-	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %s", inferenceServiceId)
 
 	createdEntityId1, _ := converter.StringToInt64(createdEntity1.Id)
 	createdEntityId2, _ := converter.StringToInt64(createdEntity2.Id)
@@ -351,8 +355,8 @@ func (suite *CoreTestSuite) TestGetServeModels() {
 		OrderBy:   &orderByLastUpdate,
 		SortOrder: &descOrderDirection,
 	}, &inferenceServiceId)
-	suite.Nilf(err, "error getting all ServeModels for %d", inferenceServiceId)
-	suite.Equalf(int32(3), getAllByInferenceService.Size, "expected three ServeModels for InferenceServiceId %d", inferenceServiceId)
+	suite.Nilf(err, "error getting all ServeModels for %s", inferenceServiceId)
+	suite.Equalf(int32(3), getAllByInferenceService.Size, "expected three ServeModels for InferenceServiceId %s", inferenceServiceId)
 
 	suite.Equal(*converter.Int64ToString(createdEntityId1), *getAllByInferenceService.Items[2].Id)
 	suite.Equal(*converter.Int64ToString(createdEntityId2), *getAllByInferenceService.Items[1].Id)

--- a/pkg/openapi/api_model_registry_service.go
+++ b/pkg/openapi/api_model_registry_service.go
@@ -772,165 +772,6 @@ func (a *ModelRegistryServiceAPIService) CreateModelVersionExecute(r ApiCreateMo
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ApiCreateModelVersionArtifactRequest struct {
-	ctx            context.Context
-	ApiService     *ModelRegistryServiceAPIService
-	modelversionId string
-	artifact       *Artifact
-}
-
-// A new or existing &#x60;Artifact&#x60; to be associated with the &#x60;ModelVersion&#x60;.
-func (r ApiCreateModelVersionArtifactRequest) Artifact(artifact Artifact) ApiCreateModelVersionArtifactRequest {
-	r.artifact = &artifact
-	return r
-}
-
-func (r ApiCreateModelVersionArtifactRequest) Execute() (*Artifact, *http.Response, error) {
-	return r.ApiService.CreateModelVersionArtifactExecute(r)
-}
-
-/*
-CreateModelVersionArtifact Create an Artifact in a ModelVersion
-
-Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
-
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param modelversionId A unique identifier for a `ModelVersion`.
-	@return ApiCreateModelVersionArtifactRequest
-*/
-func (a *ModelRegistryServiceAPIService) CreateModelVersionArtifact(ctx context.Context, modelversionId string) ApiCreateModelVersionArtifactRequest {
-	return ApiCreateModelVersionArtifactRequest{
-		ApiService:     a,
-		ctx:            ctx,
-		modelversionId: modelversionId,
-	}
-}
-
-// Execute executes the request
-//
-//	@return Artifact
-func (a *ModelRegistryServiceAPIService) CreateModelVersionArtifactExecute(r ApiCreateModelVersionArtifactRequest) (*Artifact, *http.Response, error) {
-	var (
-		localVarHTTPMethod  = http.MethodPost
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue *Artifact
-	)
-
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRegistryServiceAPIService.CreateModelVersionArtifact")
-	if err != nil {
-		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
-	}
-
-	localVarPath := localBasePath + "/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts"
-	localVarPath = strings.Replace(localVarPath, "{"+"modelversionId"+"}", url.PathEscape(parameterValueToString(r.modelversionId, "modelversionId")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-	if r.artifact == nil {
-		return localVarReturnValue, nil, reportError("artifact is required and must be specified")
-	}
-
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{"application/json"}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	// body params
-	localVarPostBody = r.artifact
-	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
-	if err != nil {
-		return localVarReturnValue, nil, err
-	}
-
-	localVarHTTPResponse, err := a.client.callAPI(req)
-	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
-		}
-		if localVarHTTPResponse.StatusCode == 400 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return localVarReturnValue, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 401 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return localVarReturnValue, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 404 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return localVarReturnValue, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 500 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
-	}
-
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: err.Error(),
-		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
-	}
-
-	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
 type ApiCreateRegisteredModelRequest struct {
 	ctx                   context.Context
 	ApiService            *ModelRegistryServiceAPIService
@@ -5499,6 +5340,165 @@ func (a *ModelRegistryServiceAPIService) UpdateServingEnvironmentExecute(r ApiUp
 	}
 	// body params
 	localVarPostBody = r.servingEnvironmentUpdate
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type ApiUpsertModelVersionArtifactRequest struct {
+	ctx            context.Context
+	ApiService     *ModelRegistryServiceAPIService
+	modelversionId string
+	artifact       *Artifact
+}
+
+// A new or existing &#x60;Artifact&#x60; to be associated with the &#x60;ModelVersion&#x60;.
+func (r ApiUpsertModelVersionArtifactRequest) Artifact(artifact Artifact) ApiUpsertModelVersionArtifactRequest {
+	r.artifact = &artifact
+	return r
+}
+
+func (r ApiUpsertModelVersionArtifactRequest) Execute() (*Artifact, *http.Response, error) {
+	return r.ApiService.UpsertModelVersionArtifactExecute(r)
+}
+
+/*
+UpsertModelVersionArtifact Upsert an Artifact in a ModelVersion
+
+Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param modelversionId A unique identifier for a `ModelVersion`.
+	@return ApiUpsertModelVersionArtifactRequest
+*/
+func (a *ModelRegistryServiceAPIService) UpsertModelVersionArtifact(ctx context.Context, modelversionId string) ApiUpsertModelVersionArtifactRequest {
+	return ApiUpsertModelVersionArtifactRequest{
+		ApiService:     a,
+		ctx:            ctx,
+		modelversionId: modelversionId,
+	}
+}
+
+// Execute executes the request
+//
+//	@return Artifact
+func (a *ModelRegistryServiceAPIService) UpsertModelVersionArtifactExecute(r ApiUpsertModelVersionArtifactRequest) (*Artifact, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodPost
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *Artifact
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ModelRegistryServiceAPIService.UpsertModelVersionArtifact")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts"
+	localVarPath = strings.Replace(localVarPath, "{"+"modelversionId"+"}", url.PathEscape(parameterValueToString(r.modelversionId, "modelversionId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.artifact == nil {
+		return localVarReturnValue, nil, reportError("artifact is required and must be specified")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.artifact
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/pkg/openapi/model_base_artifact.go
+++ b/pkg/openapi/model_base_artifact.go
@@ -30,7 +30,7 @@ type BaseArtifact struct {
 	State *ArtifactState `json:"state,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name *string `json:"name,omitempty"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_base_execution.go
+++ b/pkg/openapi/model_base_execution.go
@@ -28,7 +28,7 @@ type BaseExecution struct {
 	ExternalId *string `json:"externalId,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name *string `json:"name,omitempty"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_base_resource.go
+++ b/pkg/openapi/model_base_resource.go
@@ -27,7 +27,7 @@ type BaseResource struct {
 	ExternalId *string `json:"externalId,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name *string `json:"name,omitempty"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_doc_artifact.go
+++ b/pkg/openapi/model_doc_artifact.go
@@ -31,7 +31,7 @@ type DocArtifact struct {
 	State *ArtifactState `json:"state,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name *string `json:"name,omitempty"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_inference_service.go
+++ b/pkg/openapi/model_inference_service.go
@@ -27,7 +27,7 @@ type InferenceService struct {
 	ExternalId *string `json:"externalId,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name *string `json:"name,omitempty"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_model_artifact.go
+++ b/pkg/openapi/model_model_artifact.go
@@ -31,7 +31,7 @@ type ModelArtifact struct {
 	State *ArtifactState `json:"state,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name *string `json:"name,omitempty"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_model_version.go
+++ b/pkg/openapi/model_model_version.go
@@ -32,7 +32,7 @@ type ModelVersion struct {
 	Author *string `json:"author,omitempty"`
 	// ID of the `RegisteredModel` to which this version belongs.
 	RegisteredModelId string `json:"registeredModelId"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_registered_model.go
+++ b/pkg/openapi/model_registered_model.go
@@ -27,7 +27,7 @@ type RegisteredModel struct {
 	ExternalId *string `json:"externalId,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name string `json:"name"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_serve_model.go
+++ b/pkg/openapi/model_serve_model.go
@@ -28,7 +28,7 @@ type ServeModel struct {
 	ExternalId *string `json:"externalId,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name *string `json:"name,omitempty"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`

--- a/pkg/openapi/model_serving_environment.go
+++ b/pkg/openapi/model_serving_environment.go
@@ -27,7 +27,7 @@ type ServingEnvironment struct {
 	ExternalId *string `json:"externalId,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name *string `json:"name,omitempty"`
-	// Output only. The unique server generated id of the resource.
+	// The unique server generated id of the resource.
 	Id *string `json:"id,omitempty"`
 	// Output only. Create time of the resource in millisecond since epoch.
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`


### PR DESCRIPTION
Fixes: #231

## Description
To undo some confusion around https://github.com/opendatahub-io/model-registry-bf4-kf/pull/289 and re-enable standalone artifact support on both the `/model_artifacts` endpoint and the go core API.

TODO:
- [x] Test standalone artifacts through REST API (via Python)
- [x] Test late binding of standalone artifacts to model versions (in Go and via REST)
- [x] Update REST response status code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
