### PR TITLE
Update API models to use envelope format consistently

### DIFF
--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -73,13 +73,13 @@ curl -i localhost:4000/api/v1/model_registry
 ```
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models
-curl -i localhost:4000/api/v1/model_registry/model_registry_1/registered_models
+curl -i localhost:4000/api/v1/model_registry/model-registry/registered_models
 ```
 ```
 #POST /v1/model_registry/{model_registry_id}/registered_models
-curl -i -X POST "http://localhost:4000/api/v1/model_registry/model_registry/registered_models" \
+curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models" \
      -H "Content-Type: application/json" \
-     -d '{
+     -d '{ "data": {
   "customProperties": {
     "my-label9": {
       "metadataType": "MetadataStringValue",
@@ -91,9 +91,9 @@ curl -i -X POST "http://localhost:4000/api/v1/model_registry/model_registry/regi
   "name": "bella",
   "owner": "eder",
   "state": "LIVE"
-}'
+}}'
 ```
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}
-curl -i localhost:4000/api/v1/model_registry/model_registry/registered_models/1
+curl -i localhost:4000/api/v1/model_registry/model-registry/registered_models/1
 ```

--- a/clients/ui/bff/api/errors.go
+++ b/clients/ui/bff/api/errors.go
@@ -18,6 +18,10 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
+type ErrorEnvelope struct {
+	Error *integrations.HTTPError `json:"error"`
+}
+
 func (app *App) LogError(r *http.Request, err error) {
 	var (
 		method = r.Method
@@ -40,7 +44,7 @@ func (app *App) badRequestResponse(w http.ResponseWriter, r *http.Request, err e
 
 func (app *App) errorResponse(w http.ResponseWriter, r *http.Request, error *integrations.HTTPError) {
 
-	env := Envelope{"error": error}
+	env := ErrorEnvelope{Error: error}
 
 	err := app.WriteJSON(w, error.StatusCode, env, nil)
 

--- a/clients/ui/bff/api/helpers.go
+++ b/clients/ui/bff/api/helpers.go
@@ -9,9 +9,12 @@ import (
 	"strings"
 )
 
-type Envelope map[string]interface{}
+type Envelope[D any, M any] struct {
+	Data     D `json:"data,omitempty"`
+	Metadata M `json:"metadata,omitempty"`
+}
 
-type TypedEnvelope[T any] map[string]T
+type None *struct{}
 
 func (app *App) WriteJSON(w http.ResponseWriter, status int, data any, headers http.Header) error {
 
@@ -29,7 +32,11 @@ func (app *App) WriteJSON(w http.ResponseWriter, status int, data any, headers h
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	w.Write(js)
+	_, err = w.Write(js)
+
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/clients/ui/bff/api/model_registry_handler.go
+++ b/clients/ui/bff/api/model_registry_handler.go
@@ -2,8 +2,11 @@ package api
 
 import (
 	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/model-registry/ui/bff/data"
 	"net/http"
 )
+
+type ModelRegistryListEnvelope Envelope[[]data.ModelRegistryModel, None]
 
 func (app *App) ModelRegistryHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
@@ -13,8 +16,8 @@ func (app *App) ModelRegistryHandler(w http.ResponseWriter, r *http.Request, ps 
 		return
 	}
 
-	modelRegistryRes := Envelope{
-		"model_registry": registries,
+	modelRegistryRes := ModelRegistryListEnvelope{
+		Data: registries,
 	}
 
 	err = app.WriteJSON(w, http.StatusOK, modelRegistryRes, nil)

--- a/clients/ui/bff/api/model_registry_handler_test.go
+++ b/clients/ui/bff/api/model_registry_handler_test.go
@@ -29,28 +29,20 @@ func TestModelRegistryHandler(t *testing.T) {
 	defer rs.Body.Close()
 	body, err := io.ReadAll(rs.Body)
 	assert.NoError(t, err)
-	var modelRegistryRes Envelope
-	err = json.Unmarshal(body, &modelRegistryRes)
+	var actual ModelRegistryListEnvelope
+	err = json.Unmarshal(body, &actual)
 	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	// Convert the unmarshalled data to the expected type
-	actualModelRegistry := make([]data.ModelRegistryModel, 0)
-	for _, v := range modelRegistryRes["model_registry"].([]interface{}) {
-		model := v.(map[string]interface{})
-		actualModelRegistry = append(actualModelRegistry, data.ModelRegistryModel{Name: model["name"].(string), Description: model["description"].(string), DisplayName: model["displayName"].(string)})
-	}
-	modelRegistryRes["model_registry"] = actualModelRegistry
-
-	var expected = Envelope{
-		"model_registry": []data.ModelRegistryModel{
+	var expected = ModelRegistryListEnvelope{
+		Data: []data.ModelRegistryModel{
 			{Name: "model-registry", Description: "Model registry description", DisplayName: "Model Registry"},
 			{Name: "model-registry-dora", Description: "Model registry dora description", DisplayName: "Model Registry Dora"},
 			{Name: "model-registry-bella", Description: "Model registry bella description", DisplayName: "Model Registry Bella"},
 		},
 	}
 
-	assert.Equal(t, expected, modelRegistryRes)
+	assert.Equal(t, expected, actual)
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Updates the BFF API contract to use envelopes more consistently.
* All endpoints now use the standard `data` key for the primary payload
* POST/PATCH endpoints now accept a request body that matches the envelope format and formats the response body in the same way

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Run through the examples CURLs in the README
* Verify that the endpoints use the new envelope format ```{ "data": ... }``` for both request and response bodies

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
