### PR TITLE
Adds support for PATCH requests in live cluster mode

### DIFF
--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -110,17 +110,7 @@ curl -i localhost:4000/api/v1/model_registry/model-registry/registered_models/1
 curl -i -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1" \
 -H "Content-Type: application/json" \
 -d '{ "data": {
-"customProperties": {
-"my-label9": {
-"metadataType": "MetadataStringValue",
-"string_value": "val"
-}
-},
-"description": "bella description",
-"externalId": "9927",
-"name": "bella",
-"owner": "eder",
-"state": "LIVE"
+  "description": "New description"
 }}'
 ```
 ```
@@ -150,19 +140,8 @@ curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/mode
 # PATCH /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}
 curl -i -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1" \
      -H "Content-Type: application/json" \
-     -d '{ "data": {
-  "customProperties": {
-    "my-label9": {
-      "metadataType": "MetadataStringValue",
-      "string_value": "val"
-    }
-  },
-  "description": "New description",
-  "externalId": "9927",
-  "name": "ModelVersion One",
-  "state": "LIVE",
-  "author": "alex",
-  "registeredModelId": "1"
+-d '{ "data": {
+  "description": "New description 2"
 }}'
 ```
 ```
@@ -180,11 +159,12 @@ curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/regi
       "string_value": "val"
     }
   },
-  "description": "New description",
-  "externalId": "9927",
+  "description": "Description",
+  "externalId": "9928",
   "name": "ModelVersion One",
   "state": "LIVE",
   "author": "alex"
+  "registeredModelId: "1"
 }}'
 ```
 ```

--- a/clients/ui/bff/api/model_versions_handler.go
+++ b/clients/ui/bff/api/model_versions_handler.go
@@ -13,6 +13,8 @@ import (
 
 type ModelVersionEnvelope Envelope[*openapi.ModelVersion, None]
 type ModelVersionListEnvelope Envelope[*openapi.ModelVersionList, None]
+type ModelVersionUpdateEnvelope Envelope[*openapi.ModelVersionUpdate, None]
+
 type ModelArtifactListEnvelope Envelope[*openapi.ModelArtifactList, None]
 type ModelArtifactEnvelope Envelope[*openapi.ModelArtifact, None]
 
@@ -105,7 +107,7 @@ func (app *App) UpdateModelVersionHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var envelope ModelVersionEnvelope
+	var envelope ModelVersionUpdateEnvelope
 	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("error decoding JSON:: %v", err.Error()))
 		return
@@ -113,10 +115,7 @@ func (app *App) UpdateModelVersionHandler(w http.ResponseWriter, r *http.Request
 
 	data := *envelope.Data
 
-	if err := validation.ValidateModelVersion(data); err != nil {
-		app.badRequestResponse(w, r, fmt.Errorf("validation error:: %v", err.Error()))
-		return
-	}
+	//TODO add validation - note updating requires different rules to create as fields are optional.
 
 	jsonData, err := json.Marshal(data)
 	if err != nil {

--- a/clients/ui/bff/api/model_versions_handler_test.go
+++ b/clients/ui/bff/api/model_versions_handler_test.go
@@ -37,7 +37,10 @@ func TestUpdateModelVersionHandler(t *testing.T) {
 	data := mocks.GetModelVersionMocks()[0]
 	expected := ModelVersionEnvelope{Data: &data}
 
-	body := ModelVersionEnvelope{Data: openapi.NewModelVersion("Model One", "1")}
+	reqData := openapi.ModelVersionUpdate{
+		Description: openapi.PtrString("New description"),
+	}
+	body := ModelVersionUpdateEnvelope{Data: &reqData}
 
 	actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodPatch, "/api/v1/model_registry/model-registry/model_versions/1", body)
 	assert.NoError(t, err)

--- a/clients/ui/bff/api/registered_models_handler.go
+++ b/clients/ui/bff/api/registered_models_handler.go
@@ -13,6 +13,7 @@ import (
 
 type RegisteredModelEnvelope Envelope[*openapi.RegisteredModel, None]
 type RegisteredModelListEnvelope Envelope[*openapi.RegisteredModelList, None]
+type RegisteredModelUpdateEnvelope Envelope[*openapi.RegisteredModelUpdate, None]
 
 func (app *App) GetAllRegisteredModelsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	//TODO (ederign) implement pagination
@@ -127,7 +128,7 @@ func (app *App) UpdateRegisteredModelHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	var envelope RegisteredModelEnvelope
+	var envelope RegisteredModelUpdateEnvelope
 	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("error decoding JSON:: %v", err.Error()))
 		return
@@ -135,10 +136,7 @@ func (app *App) UpdateRegisteredModelHandler(w http.ResponseWriter, r *http.Requ
 
 	data := *envelope.Data
 
-	if err := validation.ValidateRegisteredModel(data); err != nil {
-		app.badRequestResponse(w, r, fmt.Errorf("validation error:: %v", err.Error()))
-		return
-	}
+	//TODO Validate body, note validation requirements are different to POST (fields are optional)
 
 	jsonData, err := json.Marshal(data)
 	if err != nil {
@@ -146,7 +144,7 @@ func (app *App) UpdateRegisteredModelHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	patchedModel, err := app.modelRegistryClient.UpdateRegisteredModel(client, ps.ByName("id"), jsonData)
+	patchedModel, err := app.modelRegistryClient.UpdateRegisteredModel(client, ps.ByName(RegisteredModelId), jsonData)
 	if err != nil {
 		var httpErr *integrations.HTTPError
 		if errors.As(err, &httpErr) {

--- a/clients/ui/bff/api/registered_models_handler_test.go
+++ b/clients/ui/bff/api/registered_models_handler_test.go
@@ -53,13 +53,17 @@ func TestUpdateRegisteredModelHandler(t *testing.T) {
 	data := mocks.GetRegisteredModelMocks()[0]
 	expected := RegisteredModelEnvelope{Data: &data}
 
-	body := RegisteredModelEnvelope{Data: openapi.NewRegisteredModel("Model One")}
+	reqData := openapi.RegisteredModelUpdate{
+		Description: openapi.PtrString("This is a new description"),
+	}
+	body := RegisteredModelUpdateEnvelope{Data: &reqData}
 
 	actual, rs, err := setupApiTest[RegisteredModelEnvelope](http.MethodPatch, "/api/v1/model_registry/model-registry/registered_models/1", body)
 	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, rs.StatusCode)
-	assert.Equal(t, expected.Data.Name, actual.Data.Name)
+	//TODO when mock client can handle changing state, update this to verify the changes are made.
+	assert.Equal(t, expected.Data.Description, actual.Data.Description)
 }
 
 func TestGetAllModelVersionsForRegisteredModelHandler(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds support for PATCH requests when mock mode is disabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
### Test Environment Setup
  * Deploy MR to kind
  * Run BFF locally with MR API mock mode disabled, e.g. `make run PORT=4000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=false`
  * Create a RegisteredModel to work with: 
```
curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models" \
     -H "Content-Type: application/json" \
     -d '{ "data": {
  "customProperties": {
    "my-label9": {
      "metadataType": "MetadataStringValue",
      "string_value": "val"
    }
  },
  "description": "Old description",
  "externalId": "9927",
  "name": "bella",
  "owner": "eder",
  "state": "LIVE"
}}'
```
  * Create a ModelVersion to work with: 
 ```
curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1/versions" \
     -H "Content-Type: application/json" \
     -d '{ "data": {
  "customProperties": {
    "my-label9": {
      "metadataType": "MetadataStringValue",
      "string_value": "val"
    }
  },
  "description": "Old description",
  "externalId": "9928",
  "name": "ModelVersion One",
  "state": "LIVE",
  "author": "alex",
  "registeredModelId": "1"
}}'
```
### Test method
*NOTE: when performing the PATCH steps, you may need to change the IDs at the end of the path, based on the IDs returned when you created the models in the environment setup stages*
1. Perform a PATCH on the RegisteredModel:
```
curl -i -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1" \
-H "Content-Type: application/json" \
-d '{ "data": {
  "description": "New description"
}}'
```
2. Verify you get a 200 response and the returned body contains the updated description.
3. Perform a PATCH on the ModelVersion:
```
curl -i -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1" \
     -H "Content-Type: application/json" \
-d '{ "data": {
  "description": "New description"
}}'
```
4. Verify you get a 200 response and the returned body contains the updated description.
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
