### PR TITLE
build: reorder type_asserts.go using Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ USER root
 RUN yum remove -y nodejs npm
 RUN yum module -y reset nodejs
 RUN yum module -y enable nodejs:18
-# install npm and java for openapi-generator-cli
-RUN yum install -y nodejs npm java-11
+# install npm and java for openapi-generator-cli, python for makefile scripts
+RUN yum install -y nodejs npm java-11 python3 \
+    && ln -s /usr/bin/python3 /usr/bin/python
 
 # Copy the go source
 COPY ["Makefile", "main.go", ".openapi-generator-ignore", "openapitools.json", "./"]

--- a/scripts/gen_type_asserts.sh
+++ b/scripts/gen_type_asserts.sh
@@ -42,43 +42,19 @@ EOF
 # Create the file and initialize it with the specified content
 echo -e "$INITIAL_CONTENT" >"$ASSERT_FILE_PATH"
 
-declare -A assert_functions
-pattern="\/\/ (\w+) checks(.|\n)+?\n\}\n"
-shell_pattern="\/\/ (\w+) checks[^\/?]+?"
-
 # Iterate over files starting with "model_" in the internal/server/openapi/ folder
 for file in "$PROJECT_ROOT"/internal/server/openapi/model_*; do
     # Check if the file is a regular file
     if [ -f "$file" ]; then
-
-        # grab all functions in the file
-        functions=$(grep -Pzo "$pattern" "${file}" | tr -d '\0')
-        while [[ $functions =~ $shell_pattern ]]; do
-
-          name="${BASH_REMATCH[1]}"
-          body="${BASH_REMATCH[0]}"
-
-          # add function to associative array
-          assert_functions["$name"]="$body"
-
-          # Remove the matched function to process next function
-          functions=${functions//"$body"/}
-        done
+        # Ignore first 15 lines containing license, package and imports
+        sed -n '13,$p' "$file" >>"$ASSERT_FILE_PATH"
 
         # Remove the merged file
         rm "$file"
     fi
 done
 
-# get sorted function names in another array
-sorted_names=$(for name in "${!assert_functions[@]}"; do
-  echo "$name"
-done | sort)
-
-# iterate over the sorted function names array and print bodies
-for name in $sorted_names; do
-  echo "${assert_functions[$name]}" >>"$ASSERT_FILE_PATH"
-done
+python "$PROJECT_ROOT"/scripts/reorder_type_asserts.py "$PROJECT_ROOT"/internal/server/openapi/type_asserts.go
 
 gofmt -w "$ASSERT_FILE_PATH"
 

--- a/scripts/reorder_type_asserts.py
+++ b/scripts/reorder_type_asserts.py
@@ -1,0 +1,38 @@
+import sys
+
+
+def reorder_go_functions(file_path):
+    with open(file_path, 'r') as f:
+        lines = f.readlines()
+
+    header = []
+    functions = []
+    current_function = []
+    inside_function = False
+
+    for line in lines:
+        if line.startswith("// Assert"):
+            inside_function = True
+        
+        if inside_function:
+            current_function.append(line)
+            if line.rstrip() == "}":
+                functions.append("".join(current_function))
+                current_function = []
+                inside_function = False
+        elif len(functions) == 0:
+            header.append(line)
+
+    functions.sort(key=lambda func: func.split('\n')[0].strip())
+
+    sorted_content = "".join(header) + "\n".join(functions)
+
+    with open(file_path, 'w') as f:
+        f.write(sorted_content)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        reorder_go_functions(sys.argv[1])
+    else:
+        print("Provide internal/server/openapi/type_asserts.go path as first argument")


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- restore gen_type_asserts to avoid regex ([restores example](https://github.com/kubeflow/model-registry/commit/3b002965dd2e0ad1b02753c2f041eb97b6188df7#diff-dc73cc76da6be422dd8548b1339b7b61757c82d12ff23984453c94328920baef))
- use Python for re-ordering without regex

## How Has This Been Tested?
change openapi.yaml and `make`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

wdyt @isinyaaa ?