### PR TITLE
feat(docs): add kind - ingress instructions to deploy model registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,22 @@ to your PATH from your bashrc like:
 
 and now you can substitute `gmake` every time the make command is mentioned in guides (or perform the path management per the caveat).
 
+## Local kubernetes deployment of Model Registry
+
+To test the Model Registry locally without mocking the k8s calls, the Model Registry backend can be deployed using Kind.
+
+### Prerequisites
+
+The following tools need to be installed in your local environment:
+
+- [Podman](https://podman.io/) (Docker should also work)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
+### Ingress guide
+
+Follow the [Ingress guide](docs/mr_kind_deploy_ingress.md) to set up the Ingress controller and deploy the Model Registry on the cluster.
+
 ## Docker engine
 
 Several options of docker engines are available for Mac.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,18 @@ The following tools need to be installed in your local environment:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
 
+Choose the networking setup that fits your needs, either port-forwarding or Ingress.
+
+### Port-forwarding guide
+
+Create a Kind cluster with the following command:
+
+```sh
+kind create cluster
+```
+
+and then follow the steps from this link [Installation guide](https://www.kubeflow.org/docs/components/model-registry/installation/#standalone-installation) to set up the port-forwarding and deploy the Model Registry on the cluster.
+
 ### Ingress guide
 
 Follow the [Ingress guide](docs/mr_kind_deploy_ingress.md) to set up the Ingress controller and deploy the Model Registry on the cluster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Create a Kind cluster with the following command:
 kind create cluster
 ```
 
-and then follow the steps from this link [Installation guide](https://www.kubeflow.org/docs/components/model-registry/installation/#standalone-installation) to set up the port-forwarding and deploy the Model Registry on the cluster.
+and then follow the steps from the [Installation guide](https://www.kubeflow.org/docs/components/model-registry/installation/#standalone-installation) on the Kubeflow website, to set up the port-forwarding and deploy the Model Registry on the cluster.
 
 ### Ingress guide
 

--- a/docs/mr_kind_deploy_ingress.md
+++ b/docs/mr_kind_deploy_ingress.md
@@ -4,7 +4,7 @@
 
 1. Create a file named `kind-config.yaml` with the following content:
 
-```
+```yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -55,14 +55,14 @@ kubectl patch deployment -n ingress-nginx ingress-nginx-controller   --type='jso
 
 1. Create a file named `mr-ingress.yaml` with the following content:
 
-```
+```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: model-registry
 spec:
   rules:
-  - host: "model-registry.io" // choose a name of your liking
+  - host: "model-registry.io" # choose a name of your liking
     http:
       paths:
       - pathType: Prefix

--- a/docs/mr_kind_deploy_ingress.md
+++ b/docs/mr_kind_deploy_ingress.md
@@ -37,7 +37,7 @@ nodes:
 
 2. Patch the ports inside the controller's deployment, by running the following commands:
 
-```
+```shell
 kubectl patch deployment -n ingress-nginx ingress-nginx-controller   --type='json'   -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/ports/0/hostPort", "value": 3080}]'
 
 kubectl patch deployment -n ingress-nginx ingress-nginx-controller   --type='json'   -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/ports/1/hostPort", "value": 30443}]'
@@ -84,7 +84,7 @@ spec:
 
 Run `curl http://model-registry.io:3080/api/model_registry/v1alpha3/registered_models`, you should see and output similar to this:
 
-```
+```json
 {"items":[],"nextPageToken":"","pageSize":0,"size":0}
 ```
 

--- a/docs/mr_kind_deploy_ingress.md
+++ b/docs/mr_kind_deploy_ingress.md
@@ -1,0 +1,93 @@
+# Model Registry - Kind Ingress Guide
+
+## Create a Kind cluster ready for the ingress controller
+
+1. Create a file named `kind-config.yaml` with the following content:
+
+```
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 3080
+    hostPort: 3080
+    protocol: TCP
+  - containerPort: 30443
+    hostPort: 30443
+    protocol: TCP
+```
+
+> 📖 **NOTE**
+>
+> ContainerPorts 3080 and 30443 are customisable, you can change them to any other port number, but make sure to update the port number in the following kubectl patch commands.
+
+2. Run the following command `kind create cluster --config=kind-config.yaml`
+
+## Install the ingress controller (nginx) on the cluster
+
+1. Install the controller by using `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml`
+
+
+2. Patch the ports inside the controller's deployment, by running the following commands:
+
+```
+kubectl patch deployment -n ingress-nginx ingress-nginx-controller   --type='json'   -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/ports/0/hostPort", "value": 3080}]'
+
+kubectl patch deployment -n ingress-nginx ingress-nginx-controller   --type='json'   -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/ports/1/hostPort", "value": 30443}]'
+```
+
+## Install model registry on the cluster
+
+`kubectl create namespace kubeflow`
+
+`kubectl apply -k "https://github.com/kubeflow/model-registry/manifests/kustomize/overlays/db"`
+
+`kubectl wait --for=condition=available -n kubeflow deployment/model-registry-deployment --timeout=1m`
+
+## Apply the ingress
+
+1. Create a file named `mr-ingress.yaml` with the following content:
+
+```
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: model-registry
+spec:
+  rules:
+  - host: "model-registry.io" // choose a name of your liking
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: model-registry-service
+            port:
+              number: 8080
+```
+
+2. Run the following command `kubectl apply -f mr-ingress.yaml -n kubeflow`
+
+3. Add the following line to the file `/etc/hosts`:
+
+`127.0.0.1 model-registry.io`
+
+## Test the ingress
+
+Run `curl http://model-registry.io:3080/api/model_registry/v1alpha3/registered_models`, you should see and output similar to this:
+
+```
+{"items":[],"nextPageToken":"","pageSize":0,"size":0}
+```
+
+## Teardown
+
+kind delete cluster


### PR DESCRIPTION
## Description

I have added a small guide to deploy model registry on a kind cluster using an ingress instead of port-forward, hoping people will find it useful for local testing

## How Has This Been Tested?

followed locally the steps described in the guide

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

