### PR TITLE
fix(csi): prevent race condition in ci tests step

### DIFF
--- a/csi/test/e2e_test.sh
+++ b/csi/test/e2e_test.sh
@@ -16,6 +16,8 @@ wait_for_port() {
 
 DIR="$(dirname "$0")"
 
+source ./${DIR}/test_utils.sh
+
 KUBECTL=${KUBECTL:-"kubectl"}
 
 # You can provide a local version of the model registry storage initializer
@@ -145,7 +147,7 @@ spec:
 EOF
 
 # wait for pod predictor to be initialized
-sleep 2
+repeat_cmd_until "kubectl get pod -n $KSERVE_TEST_NAMESPACE --selector='component=predictor' | wc -l" "-gt 0" 60
 predictor=$(kubectl get pod -n $KSERVE_TEST_NAMESPACE --selector="component=predictor" --output jsonpath='{.items[0].metadata.name}')
 kubectl wait --for=condition=Ready pod/$predictor -n $KSERVE_TEST_NAMESPACE --timeout=5m
 

--- a/csi/test/e2e_test.sh
+++ b/csi/test/e2e_test.sh
@@ -6,14 +6,6 @@ set -o xtrace
 # This test assumes there is a Kubernetes environment up and running.
 # It could be either a remote one or a local one (e.g., using KinD or minikube).
 
-# Function to check if the port is ready
-wait_for_port() {
-  local port=$1
-  while ! nc -z localhost $port; do
-    sleep 0.1
-  done
-}
-
 DIR="$(dirname "$0")"
 
 source ./${DIR}/test_utils.sh

--- a/csi/test/test_utils.sh
+++ b/csi/test/test_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+set -o xtrace
+
+repeat_cmd_until() {
+  local cmd=$1
+  local condition=$2
+  local max_wait_secs=$3
+  local interval_secs=2
+  local start_time=$(date +%s)
+  local output
+
+  while true; do
+
+    current_time=$(date +%s)
+    if (( (current_time - start_time) > max_wait_secs )); then
+      echo "Waited for expression "$1" to be true for $max_wait_secs seconds without luck. Returning with error."
+      return 1
+    fi
+
+    output=$(eval $cmd)
+
+    if [ $output $condition ]; then
+      break
+    else
+      sleep $interval_secs
+    fi
+  done
+}

--- a/csi/test/test_utils.sh
+++ b/csi/test/test_utils.sh
@@ -3,6 +3,14 @@
 set -e
 set -o xtrace
 
+# Function to check if the port is ready
+wait_for_port() {
+  local port=$1
+  while ! nc -z localhost $port; do
+    sleep 0.1
+  done
+}
+
 repeat_cmd_until() {
   local cmd=$1
   local condition=$2

--- a/csi/test/test_utils.sh
+++ b/csi/test/test_utils.sh
@@ -15,7 +15,7 @@ repeat_cmd_until() {
 
     current_time=$(date +%s)
     if (( (current_time - start_time) > max_wait_secs )); then
-      echo "Waited for expression "$1" to be true for $max_wait_secs seconds without luck. Returning with error."
+      echo "Waited for expression "$1" to satisfy condition "$2" for $max_wait_secs seconds without luck. Returning with error."
       return 1
     fi
 


### PR DESCRIPTION
## Description

fixes a race condition found in the ci CSI tests: https://github.com/opendatahub-io/model-registry/actions/runs/10997757515/job/30534062040#logs

## How Has This Been Tested?

run the ci

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
