### PR TITLE
temporarly bump on path-to-regexp

### DIFF
--- a/clients/ui/frontend/package-lock.json
+++ b/clients/ui/frontend/package-lock.json
@@ -17425,9 +17425,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
       "dev": true,
       "license": "MIT"
     },

--- a/clients/ui/frontend/package.json
+++ b/clients/ui/frontend/package.json
@@ -118,5 +118,10 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0"
+  },
+  "overrides": {
+    "serve": {
+      "path-to-regexp": "3.3.0"
+    }
   }
 }


### PR DESCRIPTION
## Description

[serve](https://www.npmjs.com/package/serve) is used on our dev environment to run cypress tests. It depends on path-to-regexp that has a known vulnerability. This is not a risk issue for our project because it's only a dev dependency but triggers dependabot alerts.

 While we wait for an upgrade of serve library (https://github.com/vercel/serve/issues/811 and https://github.com/vercel/serve-handler/issues/211#issuecomment-2352276383), I've decided to manually patch in our dependencies to a [version](https://github.com/pillarjs/path-to-regexp/releases/tag/v3.3.0) with the fix. 
 
Meanwhile, we are also investigating migrating from serve to another HTTP serve library to run our cypress tests.
 
## How Has This Been Tested?
 ````
➜  frontend git:(remove-serve) npm audit                                          (kind-nbv2-1/default)
found 0 vulnerabilities
````
npm run test:cypress-ci

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- [X] All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
 
