### PR TITLE
use deployed MR for python e2e tests

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -1,5 +1,6 @@
 name: Test container image build and deployment
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - "LICENSE*"
@@ -9,7 +10,7 @@ on:
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/dependabot.yml"
       - "docs/**"
-      - "clients/python/docs/**"
+      - "clients/python/**"
 env:
   IMG_ORG: kubeflow
   IMG_REPO: model-registry
@@ -30,8 +31,8 @@ jobs:
       - name: Build Image
         shell: bash
         env:
-          VERSION: ${{ steps.tags.outputs.tag }}
-        run: ./scripts/build_deploy.sh
+          IMG_VERSION: ${{ steps.tags.outputs.tag }}
+        run: make image/build
       - name: Start Kind Cluster
         uses: helm/kind-action@v1.10.0
         with:
@@ -41,25 +42,12 @@ jobs:
           IMG: "${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"
         run: |
           kind load docker-image -n chart-testing ${IMG}
-      - name: Create Test Registry
+      - name: Deploy Model Registry using manifests
         env:
           IMG: "${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"
+        run: ./scripts/deploy_on_kind.sh
+      - name: Deployment logs
         run: |
-          echo "Download kustomize 5.2.1"
-          mkdir $GITHUB_WORKSPACE/kustomize
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s "5.2.1" "$GITHUB_WORKSPACE/kustomize"
-          PATH=$GITHUB_WORKSPACE/kustomize:$PATH
-          echo "Display Kustomize version"
-          kustomize version 
-          echo "Deploying Model Registry using Manifests; branch ${BRANCH}"
-          kubectl create namespace kubeflow
-          cd manifests/kustomize/overlays/db
-          kustomize edit set image kubeflow/model-registry:latest $IMG
-          kustomize build | kubectl apply -f -
-      - name: Wait for Test Registry Deployment
-        run: |
-          kubectl wait --for=condition=available -n kubeflow deployment/model-registry-db --timeout=5m
-          kubectl wait --for=condition=available -n kubeflow deployment/model-registry-deployment --timeout=5m
           kubectl logs -n kubeflow deployment/model-registry-deployment
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - "LICENSE*"
@@ -12,26 +13,146 @@ on:
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/dependabot.yml"
       - "docs/**"
+
 jobs:
-  tests:
-    name: ${{ matrix.session }} ${{ matrix.python }}
+  lint:
+    name: ${{ matrix.session }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python: ["3.12"]
-        session: [lint, tests, mypy, docs-build]
-        include:
-          - python: "3.9"
-            session: tests
-          - python: "3.10"
-            session: tests
-          - python: "3.11"
-            session: tests
+        session: [lint, mypy]
     env:
       NOXSESSION: ${{ matrix.session }}
       FORCE_COLOR: "1"
-      PRE_COMMIT_COLOR: "always"
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Upgrade pip
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt pip
+          pip --version
+      - name: Upgrade pip in virtual environments
+        shell: python
+        run: |
+          import os
+          import pip
+
+          with open(os.environ["GITHUB_ENV"], mode="a") as io:
+              print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
+      - name: Install Poetry
+        # use absolute path as recommended with: https://github.com/pypa/pipx/issues/1331
+        run: |
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
+          poetry --version
+      - name: Install Nox
+        run: |
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
+          nox --version
+      - name: Nox lint
+        working-directory: clients/python
+        run: |
+          if [[ ${{ matrix.session }} == "mypy" ]]; then
+            nox --python=${{ matrix.python }} ||\
+              echo "::error title='mypy failure'::Check the logs for more details"
+          else
+            nox --python=${{ matrix.python }}
+          fi
+
+  test:
+    name: Test against Py ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.12", "3.11", "3.10", "3.9"]
+    env:
+      FORCE_COLOR: "1"
+      IMG_ORG: kubeflow
+      IMG_REPO: model-registry
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Upgrade pip
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt pip
+          pip --version
+      - name: Upgrade pip in virtual environments
+        shell: python
+        run: |
+          import os
+          import pip
+
+          with open(os.environ["GITHUB_ENV"], mode="a") as io:
+              print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
+      - name: Install Poetry
+        # use absolute path as recommended with: https://github.com/pypa/pipx/issues/1331
+        run: |
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
+          poetry --version
+      - name: Install Nox
+        run: |
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
+          nox --version
+      - name: Nox test
+        working-directory: clients/python
+        run: |
+          nox --python=${{ matrix.python }} --session=tests
+      - name: Generate Tag
+        shell: bash
+        id: tags
+        run: |
+          commit_sha=${{ github.event.after }}
+          tag=main-${commit_sha:0:7}
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+      - name: Build Image
+        shell: bash
+        env:
+          IMG_VERSION: ${{ steps.tags.outputs.tag }}
+        run: make image/build
+      - name: Start Kind Cluster
+        uses: helm/kind-action@v1.10.0
+        with:
+          node_image: "kindest/node:v1.27.11"
+      - name: Load Local Registry Test Image
+        if: matrix.session == 'tests'
+        env:
+          IMG: "docker.io/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"
+        run: |
+          kind load docker-image -n chart-testing ${IMG}
+      - name: Deploy Model Registry using manifests
+        env:
+          IMG: "docker.io/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"
+        run: ./scripts/deploy_on_kind.sh
+      - name: Nox test end-to-end
+        working-directory: clients/python
+        run: |
+          kubectl port-forward -n kubeflow service/model-registry-service 8080:8080 &
+          sleep 2
+          nox --python=${{ matrix.python }} --session=e2e -- --cov-report=xml
+
+  docs-build:
+    name: ${{ matrix.session }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.12"]
+        session: [docs-build]
+    env:
+      NOXSESSION: ${{ matrix.session }}
+      FORCE_COLOR: "1"
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -64,24 +185,14 @@ jobs:
       - name: Run Nox
         working-directory: clients/python
         run: |
-          if [[ ${{ matrix.session }} == "tests" ]]; then
-            make build-mr
-            nox --python=${{ matrix.python }} -- --cov-report=xml
-            poetry build
-          elif [[ ${{ matrix.session }} == "mypy" ]]; then
-            nox --python=${{ matrix.python }} ||\
-              echo "::error title='mypy failure'::Check the logs for more details"
-          else
-            nox --python=${{ matrix.python }}
-          fi
+          nox --python=${{ matrix.python }}
+          poetry build
       - name: Upload dist
-        if: matrix.session == 'tests' && matrix.python == '3.12'
         uses: actions/upload-artifact@v4
         with:
           name: py-dist
           path: clients/python/dist
       - name: Upload documentation
-        if: matrix.session == 'docs-build'
         uses: actions/upload-artifact@v4
         with:
           name: py-docs

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -1,6 +1,5 @@
 all: install tidy
 
-IMG_REGISTRY ?= docker.io
 IMG_VERSION ?= latest 
 
 .PHONY: install
@@ -14,12 +13,13 @@ install:
 clean:
 	rm -rf src/mr_openapi
 
-.PHONY: build-mr
-build-mr:
-	cd ../../ && IMG_REGISTRY=${IMG_REGISTRY} IMG_VERSION=${IMG_VERSION} make image/build
+.PHONY: deploy-latest-mr
+deploy-latest-mr:
+	cd ../../ && IMG_VERSION=${IMG_VERSION} make image/build && LOCAL=1 ./scripts/deploy_on_kind.sh
+	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 &
 
 .PHONY: test-e2e
-test-e2e: build-mr
+test-e2e: deploy-latest-mr
 	poetry run pytest --e2e -s
 
 .PHONY: test

--- a/clients/python/noxfile.py
+++ b/clients/python/noxfile.py
@@ -41,8 +41,8 @@ def lint(session: Session) -> None:
 @session(python=python_versions)
 def mypy(session: Session) -> None:
     """Type check using mypy."""
-    session.install(".")
     session.install(
+        ".",
         "mypy",
         "types-python-dateutil",
     )
@@ -53,21 +53,31 @@ def mypy(session: Session) -> None:
 @session(python=python_versions)
 def tests(session: Session) -> None:
     """Run the test suite."""
-    session.install(".")
     session.install(
-        "coverage[toml]",
+        ".",
+        "requests",
         "pytest",
         "pytest-asyncio",
-        "nest-asyncio",
+    )
+    session.run(
+        "pytest",
+        *session.posargs,
+    )
+
+
+@session(name="e2e", python=python_versions)
+def e2e_tests(session: Session) -> None:
+    """Run the test suite."""
+    session.install(
+        ".",
+        "requests",
+        "pytest",
+        "pytest-asyncio",
+        "coverage[toml]",
         "pytest-cov",
-        "pygments",
         "huggingface-hub",
     )
     try:
-        session.run(
-            "pytest",
-            *session.posargs,
-        )
         session.run(
             "pytest",
             "--e2e",
@@ -101,8 +111,12 @@ def docs_build(session: Session) -> None:
     if not session.posargs and "FORCE_COLOR" in os.environ:
         args.insert(0, "--color")
 
-    session.install(".")
-    session.install("sphinx", "myst-parser[linkify]", "furo")
+    session.install(
+        ".",
+        "sphinx",
+        "myst-parser[linkify]",
+        "furo",
+    )
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():
@@ -115,8 +129,13 @@ def docs_build(session: Session) -> None:
 def docs(session: Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]
-    session.install(".")
-    session.install("sphinx", "myst-parser[linkify]", "furo", "sphinx-autobuild")
+    session.install(
+        ".",
+        "sphinx",
+        "myst-parser[linkify]",
+        "furo",
+        "sphinx-autobuild",
+    )
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():

--- a/clients/python/poetry.lock
+++ b/clients/python/poetry.lock
@@ -1460,7 +1460,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/clients/python/tests/regression_test.py
+++ b/clients/python/tests/regression_test.py
@@ -26,7 +26,7 @@ def test_create_tagged_version(client: ModelRegistry):
 
 
 @pytest.mark.e2e
-def test_get_model_without_user_token(setup_env_user_token, client):
+def test_get_model_without_user_token(setup_env_user_token, client: ModelRegistry):
     """Test regression for using client methods without an user_token in the init arguments.
 
     Reported on: https://github.com/kubeflow/model-registry/issues/340

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -393,6 +393,9 @@ def test_get_model_versions(client: ModelRegistry):
 
 
 @pytest.mark.e2e
+@pytest.mark.xfail(
+    reason="MLMD issue tracked on: https://github.com/kubeflow/model-registry/issues/358"
+)
 def test_get_model_versions_order_by(client: ModelRegistry):
     name = "test_model"
     models = 5

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+MR_NAMESPACE="${MR_NAMESPACE:-kubeflow}"
+TEST_DB_NAME="${TEST_DB_NAME:-metadb}"
+
+SQL_CMD=$(
+    cat <<EOF
+DELETE FROM Artifact;
+DELETE FROM ArtifactProperty;
+DELETE FROM Association;
+DELETE FROM Attribution;
+DELETE FROM Context;
+DELETE FROM ContextProperty;
+DELETE FROM Event;
+DELETE FROM EventPath;
+DELETE FROM Execution;
+DELETE FROM ExecutionProperty;
+DELETE FROM ParentContext;
+COMMIT;
+EOF
+)
+
+if [[ -n "$LOCAL" ]]; then
+    echo 'Cleaning up local sqlite DB'
+
+    sqlite3 test/config/ml-metadata/metadata.sqlite.db <<<"BEGIN TRANSACTION; $SQL_CMD"
+else
+    echo 'Cleaning up kubernetes MySQL DB'
+
+    kubectl exec -n "$MR_NAMESPACE" -it "$(kubectl get pods -l component=db -o jsonpath="{.items[0].metadata.name}" -n "$MR_NAMESPACE")" \
+        -- mysql -u root -ptest -D "$TEST_DB_NAME" -e "START TRANSACTION; $SQL_CMD"
+fi

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -4,6 +4,7 @@ set -e
 
 MR_NAMESPACE="${MR_NAMESPACE:-kubeflow}"
 
+# modularity to allow re-use this script against a remote k8s cluster
 if [[ -n "$LOCAL" ]]; then
     CLUSTER_NAME="${CLUSTER_NAME:-kind}"
     IMG="${IMG:-docker.io/kubeflow/model-registry:main}"

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -10,15 +10,28 @@ if [[ -n "$LOCAL" ]]; then
     IMG="${IMG:-docker.io/kubeflow/model-registry:main}"
 
     echo 'Creating local Kind cluster and loading image'
-    kind create cluster -n "$CLUSTER_NAME"
+
+    if [[ $(kind get clusters || false) =~ $CLUSTER_NAME ]]; then
+        echo 'Cluster already exists, skipping creation'
+
+        kubectl config use-context "kind-$CLUSTER_NAME"
+    else
+        kind create cluster -n "$CLUSTER_NAME"
+    fi
+
     kind load docker-image -n "$CLUSTER_NAME" "$IMG"
+
     echo 'Image loaded into kind cluster - use this command to port forward the mr service:'
     echo "kubectl port-forward -n $MR_NAMESPACE service/model-registry-service 8080:8080 &"
 fi
 
 echo 'Deploying model registry to Kind cluster'
+if [[ $(kubectl get namespaces || false) =~ $MR_NAMESPACE ]]; then
+    echo 'Namespace already exists, skipping creation'
+else
+    kubectl create namespace "$MR_NAMESPACE"
+fi
 
-kubectl create namespace "$MR_NAMESPACE"
 kubectl apply -k manifests/kustomize/overlays/db
 kubectl set image -n kubeflow deployment/model-registry-deployment rest-container="$IMG"
 kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -7,7 +7,7 @@ MR_NAMESPACE="${MR_NAMESPACE:-kubeflow}"
 # modularity to allow re-use this script against a remote k8s cluster
 if [[ -n "$LOCAL" ]]; then
     CLUSTER_NAME="${CLUSTER_NAME:-kind}"
-    IMG="${IMG:-docker.io/kubeflow/model-registry:main}"
+    IMG="${IMG:-kubeflow/model-registry:latest}"
 
     echo 'Creating local Kind cluster and loading image'
 

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+MR_NAMESPACE="${MR_NAMESPACE:-kubeflow}"
+
+if [[ -n "$LOCAL" ]]; then
+    CLUSTER_NAME="${CLUSTER_NAME:-kind}"
+    IMG="${IMG:-docker.io/kubeflow/model-registry:main}"
+
+    echo 'Creating local Kind cluster and loading image'
+    kind create cluster -n "$CLUSTER_NAME"
+    kind load docker-image -n "$CLUSTER_NAME" "$IMG"
+    echo 'Image loaded into kind cluster - use this command to port forward the mr service:'
+    echo "kubectl port-forward -n $MR_NAMESPACE service/model-registry-service 8080:8080 &"
+fi
+
+echo 'Deploying model registry to Kind cluster'
+
+kubectl create namespace "$MR_NAMESPACE"
+kubectl apply -k manifests/kustomize/overlays/db
+kubectl set image -n kubeflow deployment/model-registry-deployment rest-container="$IMG"
+kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m
+kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-deployment --timeout=5m


### PR DESCRIPTION
Fixes: #380

## Description
Python e2e tests will use an environment variable to MR, delegating clean-up to a separate script.
The script is made environment-aware using envvars.

The CI has been updated to account for the changes, separating the Python workflows into 3 types to make it clearer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
