### PR TITLE
chore(frontend): Version bumps

### DIFF
--- a/clients/ui/frontend/package-lock.json
+++ b/clients/ui/frontend/package-lock.json
@@ -92,14 +92,14 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.5.0",
-        "@typescript-eslint/parser": "^8.5.0",
+        "@typescript-eslint/eslint-plugin": "^8.8.1",
+        "@typescript-eslint/parser": "^8.8.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-node": "^0.3.7",
         "eslint-import-resolver-typescript": "^3.5.3",
         "eslint-plugin-cypress": "^3.3.0",
-        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-no-relative-import-paths": "^1.5.2",
@@ -4987,17 +4987,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz",
-      "integrity": "sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.9.0.tgz",
+      "integrity": "sha512-Y1n621OCy4m7/vTXNlCbMVp87zSd7NH0L9cXD8aIpOaNlzeWxIK4+Q19A68gSmTNRZn92UjocVUWDthGxtqHFg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/type-utils": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/type-utils": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -5021,16 +5021,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.5.0.tgz",
-      "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.9.0.tgz",
+      "integrity": "sha512-U+BLn2rqTTHnc4FL3FJjxaXptTxmf9sNftJK62XLz4+GxG3hLHm/SUNaaXP5Y4uTiuYoL5YLy4JBCJe3+t8awQ==",
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/typescript-estree": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5050,14 +5050,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz",
-      "integrity": "sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.9.0.tgz",
+      "integrity": "sha512-bZu9bUud9ym1cabmOYH9S6TnbWRzpklVmwqICeOulTCZ9ue2/pczWzQvt/cGj2r2o1RdKoZbuEMalJJSYw3pHQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0"
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5068,14 +5068,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz",
-      "integrity": "sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.9.0.tgz",
+      "integrity": "sha512-JD+/pCqlKqAk5961vxCluK+clkppHY07IbV3vett97KOV+8C6l+CPEPwpUuiMwgbOz/qrN3Ke4zzjqbT+ls+1Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -5093,9 +5093,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.5.0.tgz",
-      "integrity": "sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.9.0.tgz",
+      "integrity": "sha512-SjgkvdYyt1FAPhU9c6FiYCXrldwYYlIQLkuc+LfAhCna6ggp96ACncdtlbn8FmnG72tUkXclrDExOpEYf1nfJQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5107,14 +5107,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz",
-      "integrity": "sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.9.0.tgz",
+      "integrity": "sha512-9iJYTgKLDG6+iqegehc5+EqE6sqaee7kb8vWpmHZ86EqwDjmlqNNHeqDVqb9duh+BY6WCNHfIGvuVU3Tf9Db0g==",
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -5149,16 +5149,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.5.0.tgz",
-      "integrity": "sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-PKgMmaSo/Yg/F7kIZvrgrWa1+Vwn036CdNUvYFEkYbPwOH4i8xvkaRlu148W3vtheWK9ckKRIz7PBP5oUlkrvQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/typescript-estree": "8.5.0"
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.9.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5172,13 +5172,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz",
-      "integrity": "sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.9.0.tgz",
+      "integrity": "sha512-Ht4y38ubk4L5/U8xKUBfKNYGmvKvA1CANoxiTRMM+tOLk3lbF3DvzZCxJCRSE+2GdCMSh6zq9VZJc3asc1XuAA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/types": "8.9.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -7518,9 +7518,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9529,9 +9529,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.11.0.tgz",
-      "integrity": "sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9599,9 +9599,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
-      "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
+      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9613,7 +9613,7 @@
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.9.0",
+        "eslint-module-utils": "^2.12.0",
         "hasown": "^2.0.2",
         "is-core-module": "^2.15.1",
         "is-glob": "^4.0.3",
@@ -9622,13 +9622,14 @@
         "object.groupby": "^1.0.3",
         "object.values": "^1.2.0",
         "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.8",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
@@ -10240,17 +10241,18 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",

--- a/clients/ui/frontend/package.json
+++ b/clients/ui/frontend/package.json
@@ -111,14 +111,14 @@
     "classnames": "^2.2.6"
   },
   "optionalDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.5.0",
-    "@typescript-eslint/parser": "^8.5.0",
+    "@typescript-eslint/eslint-plugin": "^8.8.1",
+    "@typescript-eslint/parser": "^8.8.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-node": "^0.3.7",
     "eslint-import-resolver-typescript": "^3.5.3",
     "eslint-plugin-cypress": "^3.3.0",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-no-relative-import-paths": "^1.5.2",

--- a/clients/ui/frontend/src/app/components/design/utils.ts
+++ b/clients/ui/frontend/src/app/components/design/utils.ts
@@ -4,6 +4,8 @@ import modelRegistryMissingModelImg from '~/images/no-models-model-registry.svg'
 import modelRegistryMissingVersionImg from '~/images/no-versions-model-registry.svg';
 
 import './vars.scss';
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+// These conditions are required for future object types that may be added later.
 
 export enum ProjectObjectType {
   registeredModels = 'registered-models',


### PR DESCRIPTION
## Description
In this PR:
	- Bump of @typescript-eslint/parser from 8.5.0 to 8.8.1
	- Bump of @typescript-eslint/eslint-plugin from 8.5.0 to 8.8.1
	- Bump of @typescript-eslint/eslint-plugin-import to 2.31.0
	- Ignore some eslint warnings on util.js
	- Bump of cookie (low sev cve)
 
## How Has This Been Tested?
Ran tests and web app.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
 