### PR TITLE
fix(gha): prevent race condition on port-forward

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -125,15 +125,15 @@ jobs:
         uses: helm/kind-action@v1.10.0
         with:
           node_image: "kindest/node:v1.27.11"
+          cluster_name: chart-testing-py-${{ matrix.python }}
       - name: Load Local Registry Test Image
-        if: matrix.session == 'tests'
         env:
-          IMG: "docker.io/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"
+          IMG: "${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"
         run: |
-          kind load docker-image -n chart-testing ${IMG}
+          kind load docker-image -n chart-testing-py-${{ matrix.python }} ${IMG}
       - name: Deploy Model Registry using manifests
         env:
-          IMG: "docker.io/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"
+          IMG: "${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"
         run: ./scripts/deploy_on_kind.sh
       - name: Nox test end-to-end
         working-directory: clients/python

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -39,12 +39,11 @@ kubectl apply -k manifests/kustomize/overlays/db
 kubectl patch deployment -n "$MR_NAMESPACE" model-registry-deployment \
 --patch '{"spec": {"template": {"spec": {"containers": [{"name": "rest-container", "image": "'$IMG'", "imagePullPolicy": "IfNotPresent"}]}}}}'
 
-sleep 5
+kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m
 
 kubectl delete pod -n "$MR_NAMESPACE" --selector='component=model-registry-server'
 
 repeat_cmd_until "kubectl get pod -n "$MR_NAMESPACE" --selector='component=model-registry-server' \
 -o jsonpath=\"{.items[*].spec.containers[?(@.name=='rest-container')].image}\"" "= $IMG" 300 "kubectl describe pod -n $MR_NAMESPACE --selector='component=model-registry-server'"
 
-kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m
 kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-deployment --timeout=5m

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -2,7 +2,10 @@
 
 set -e
 
+DIR="$(dirname "$0")"
 MR_NAMESPACE="${MR_NAMESPACE:-kubeflow}"
+
+source ./${DIR}/utils.sh
 
 # modularity to allow re-use this script against a remote k8s cluster
 if [[ -n "$LOCAL" ]]; then
@@ -33,6 +36,15 @@ else
 fi
 
 kubectl apply -k manifests/kustomize/overlays/db
-kubectl set image -n kubeflow deployment/model-registry-deployment rest-container="$IMG"
+kubectl patch deployment -n "$MR_NAMESPACE" model-registry-deployment \
+--patch '{"spec": {"template": {"spec": {"containers": [{"name": "rest-container", "image": "'$IMG'", "imagePullPolicy": "IfNotPresent"}]}}}}'
+
+sleep 5
+
+kubectl delete pod -n "$MR_NAMESPACE" --selector='component=model-registry-server'
+
+repeat_cmd_until "kubectl get pod -n "$MR_NAMESPACE" --selector='component=model-registry-server' \
+-o jsonpath=\"{.items[*].spec.containers[?(@.name=='rest-container')].image}\"" "= $IMG" 300 "kubectl describe pod -n $MR_NAMESPACE --selector='component=model-registry-server'"
+
 kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m
 kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-deployment --timeout=5m

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+set -o xtrace
+
+repeat_cmd_until() {
+  local cmd=$1
+  local condition=$2
+  local max_wait_secs=$3
+  local debug_cmd=$4
+  local interval_secs=2
+  local start_time=$(date +%s)
+  local output
+
+  while true; do
+
+    current_time=$(date +%s)
+    if (( (current_time - start_time) > max_wait_secs )); then
+      echo "Waited for expression "$1" to satisfy condition "$2" for $max_wait_secs seconds without luck. Returning with error."
+      if [ -n "$debug_cmd" ]; then
+        echo "Running debug command: $debug_cmd"
+        eval $debug_cmd
+      fi
+      return 1
+    fi
+
+    output=$(eval $cmd)
+
+    if [ $output $condition ]; then
+      break
+    else
+      sleep $interval_secs
+    fi
+  done
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->


I have added the repeat_until function to wait while the pod rollout is done by kind, enabled the kind load job and made the action more reliable


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

run the deploy_on_kind.sh script locally, debug on CI

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

