### PR TITLE
Add displayName and description to GetServiceDetails

### DIFF
--- a/clients/ui/bff/internal/integrations/k8s.go
+++ b/clients/ui/bff/internal/integrations/k8s.go
@@ -3,14 +3,15 @@ package integrations
 import (
 	"context"
 	"fmt"
-	helper "github.com/kubeflow/model-registry/ui/bff/internal/helpers"
-	corev1 "k8s.io/api/core/v1"
 	"log/slog"
 	"os"
+	"time"
+
+	helper "github.com/kubeflow/model-registry/ui/bff/internal/helpers"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"time"
 )
 
 const componentName = "model-registry-server"
@@ -202,12 +203,22 @@ func (kc *KubernetesClient) GetServiceDetails() ([]ServiceDetails, error) {
 				continue
 			}
 
-			//TODO (acreasy) DisplayName and Description need to be included and not given a zero value once we
-			// know how this will be implemented.
+			displayName := service.Annotations["displayName"]
+			if displayName == "" {
+				kc.Logger.Error("service missing displayName annotation", "serviceName", service.Name)
+			}
+
+			description := service.Annotations["description"]
+			if description == "" {
+				kc.Logger.Error("service missing description annotation", "serviceName", service.Name)
+			}
+
 			serviceDetails := ServiceDetails{
-				Name:      service.Name,
-				ClusterIP: service.Spec.ClusterIP,
-				HTTPPort:  httpPort,
+				Name:        service.Name,
+				DisplayName: displayName,
+				Description: description,
+				ClusterIP:   service.Spec.ClusterIP,
+				HTTPPort:    httpPort,
 			}
 
 			services = append(services, serviceDetails)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add displayName and description when we get service details from the cluster. This is based off of the fact that we expect MR or the user deploying the MR service to add the `displayName` and `description` to `annotations` on the service.
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. To reproduce deploy a kind cluster locally following the [guide](https://github.com/kubeflow/model-registry/blob/main/clients/ui/bff/docs/dev-guide.md) 
2. Run BFF in live mode like `make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false`
3. Get model registries with `curl http://localhost:4000/api/v1/model_registry`. You should see the BFF log a couple errors because you will be missing a displayName and description
```
{
	"data": [
		{
			"name": "model-registry-service",
			"displayName": "",
			"description": ""
		}
	]
}
```
4. Now stop the BFF and add the `displayName` and `description` to the service annotations by running:
```
kubectl edit svc model-registry-service -n kubeflow
```
```
apiVersion: v1
kind: Service
metadata:
  annotations:
    description: a very nice model registry
    displayName: default model registry
...
```
5. Run the BFF again and curl for the model registries to see our displayName and description
```
{
	"data": [
		{
			"name": "model-registry-service",
			"displayName": "default model registry",
			"description": "a very nice model registry"
		}
	]
}
```
6. Also verify that the UI handles this change properly (I added another empty annotation service to compare side by side):
![Screenshot from 2024-10-17 14-45-34](https://github.com/user-attachments/assets/a9d673ea-cb08-48e0-a193-f04d89247f9a)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
