### PR TITLE
feat(bff): Use envtest for kubernetes testing instead of hardcoded mock

### DIFF
--- a/clients/ui/bff/Makefile
+++ b/clients/ui/bff/Makefile
@@ -3,6 +3,8 @@ IMG ?= model-registry-bff:latest
 PORT ?= 4000
 MOCK_K8S_CLIENT ?= false
 MOCK_MR_CLIENT ?= false
+# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+ENVTEST_K8S_VERSION = 1.29.0
 
 .PHONY: all
 all: build
@@ -32,7 +34,8 @@ vet:  .
 	go vet ./...
 
 .PHONY: test
-test:
+test: fmt vet envtest
+	ENVTEST_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	go test ./...
 
 .PHONY: build
@@ -54,8 +57,18 @@ LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
+## Tool Binaries
+ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+
+## Tool Versions
 GOLANGCI_LINT_VERSION ?= v1.57.2
+ENVTEST_VERSION ?= release-0.17
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.

--- a/clients/ui/bff/Makefile
+++ b/clients/ui/bff/Makefile
@@ -43,7 +43,8 @@ build: fmt vet test
 	go build -o bin/bff cmd/main.go
 
 .PHONY: run
-run: fmt vet
+run: fmt vet envtest
+	ENVTEST_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	go run ./cmd/main.go  --port=$(PORT) --mock-k8s-client=$(MOCK_K8S_CLIENT) --mock-mr-client=$(MOCK_MR_CLIENT)
 
 .PHONY: docker-build

--- a/clients/ui/bff/go.mod
+++ b/clients/ui/bff/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/brianvoe/gofakeit/v7 v7.0.4
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kubeflow/model-registry v0.2.9
+	github.com/onsi/ginkgo/v2 v2.19.0
+	github.com/onsi/gomega v1.33.1
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
@@ -22,15 +24,18 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -48,6 +53,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
@@ -55,6 +62,7 @@ require (
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -45,7 +45,8 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 	var err error
 	if cfg.MockK8Client {
 		//mock all k8s calls
-		k8sClient, err = mocks.NewKubernetesClient(logger)
+		ctx, cancel := context.WithCancel(context.Background())
+		k8sClient, err = mocks.NewKubernetesClient(logger, ctx, cancel)
 	} else {
 		k8sClient, err = integrations.NewKubernetesClient(logger)
 	}

--- a/clients/ui/bff/internal/api/model_registry_handler_test.go
+++ b/clients/ui/bff/internal/api/model_registry_handler_test.go
@@ -7,13 +7,16 @@ import (
 	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 	"github.com/stretchr/testify/assert"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
 func TestModelRegistryHandler(t *testing.T) {
-	mockK8sClient, _ := mocks.NewKubernetesClient(nil)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mockK8sClient, _ := mocks.NewKubernetesClient(logger)
 	mockMRClient, _ := mocks.NewModelRegistryClient(nil)
 
 	testApp := App{
@@ -40,9 +43,9 @@ func TestModelRegistryHandler(t *testing.T) {
 
 	var expected = ModelRegistryListEnvelope{
 		Data: []models.ModelRegistryModel{
-			{Name: "model-registry", Description: "Model registry description", DisplayName: "Model Registry"},
-			{Name: "model-registry-dora", Description: "Model registry dora description", DisplayName: "Model Registry Dora"},
-			{Name: "model-registry-bella", Description: "Model registry bella description", DisplayName: "Model Registry Bella"},
+			{Name: "model-registry", Description: "Model Registry Description", DisplayName: "Model Registry"},
+			{Name: "model-registry-bella", Description: "Model Registry Bella description", DisplayName: "Model Registry Bella"},
+			{Name: "model-registry-dora", Description: "Model Registry Dora description", DisplayName: "Model Registry Dora"},
 		},
 	}
 

--- a/clients/ui/bff/internal/api/model_versions_handler_test.go
+++ b/clients/ui/bff/internal/api/model_versions_handler_test.go
@@ -3,80 +3,90 @@ package api
 import (
 	"github.com/kubeflow/model-registry/pkg/openapi"
 	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"net/http"
-	"testing"
 )
 
-func TestGetModelVersionHandler(t *testing.T) {
-	data := mocks.GetModelVersionMocks()[0]
-	expected := ModelVersionEnvelope{Data: &data}
+var _ = Describe("TestGetModelVersionHandler", func() {
+	Context("testing Model Version Handler", Ordered, func() {
 
-	actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/model_versions/1", nil)
-	assert.NoError(t, err)
+		It("should retrieve a model version", func() {
+			By("fetching a model version")
+			data := mocks.GetModelVersionMocks()[0]
+			expected := ModelVersionEnvelope{Data: &data}
+			actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/model_versions/1", nil, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+			By("should match the expected model version")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Name).To(Equal(expected.Data.Name))
+		})
 
-	assert.Equal(t, http.StatusOK, rs.StatusCode)
-	assert.Equal(t, expected.Data.Name, actual.Data.Name)
-}
+		It("should create a model version", func() {
+			By("creating a model version")
+			data := mocks.GetModelVersionMocks()[0]
+			expected := ModelVersionEnvelope{Data: &data}
+			body := ModelVersionEnvelope{Data: openapi.NewModelVersion("Model One", "1")}
+			actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodPost, "/api/v1/model_registry/model-registry/model_versions", body, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-func TestCreateModelVersionHandler(t *testing.T) {
-	data := mocks.GetModelVersionMocks()[0]
-	expected := ModelVersionEnvelope{Data: &data}
+			By("should match the expected model version created")
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(actual.Data.Name).To(Equal(expected.Data.Name))
+			Expect(rs.Header.Get("Location")).To(Equal("/api/v1/model_registry/model-registry/model_versions/1"))
+		})
 
-	body := ModelVersionEnvelope{Data: openapi.NewModelVersion("Model One", "1")}
+		It("should updated a model version", func() {
+			By("updating a model version")
+			data := mocks.GetModelVersionMocks()[0]
+			expected := ModelVersionEnvelope{Data: &data}
 
-	actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodPost, "/api/v1/model_registry/model-registry/model_versions", body)
-	assert.NoError(t, err)
+			reqData := openapi.ModelVersionUpdate{
+				Description: openapi.PtrString("New description"),
+			}
+			body := ModelVersionUpdateEnvelope{Data: &reqData}
 
-	assert.Equal(t, http.StatusCreated, rs.StatusCode)
-	assert.Equal(t, expected.Data.Name, actual.Data.Name)
-	assert.Equal(t, rs.Header.Get("Location"), "/api/v1/model_registry/model-registry/model_versions/1")
-}
+			actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodPatch, "/api/v1/model_registry/model-registry/model_versions/1", body, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-func TestUpdateModelVersionHandler(t *testing.T) {
-	data := mocks.GetModelVersionMocks()[0]
-	expected := ModelVersionEnvelope{Data: &data}
+			By("should match the expected model version updated")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Name).To(Equal(expected.Data.Name))
+		})
 
-	reqData := openapi.ModelVersionUpdate{
-		Description: openapi.PtrString("New description"),
-	}
-	body := ModelVersionUpdateEnvelope{Data: &reqData}
+		It("get all model artifacts by a model version", func() {
+			By("getting a model artifacts by model version")
+			data := mocks.GetModelArtifactListMock()
+			expected := ModelArtifactListEnvelope{Data: &data}
+			actual, rs, err := setupApiTest[ModelArtifactListEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/model_versions/1/artifacts", nil, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-	actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodPatch, "/api/v1/model_registry/model-registry/model_versions/1", body)
-	assert.NoError(t, err)
+			By("should get all expected model version artifacts")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Size).To(Equal(expected.Data.Size))
+			Expect(actual.Data.PageSize).To(Equal(expected.Data.PageSize))
+			Expect(actual.Data.NextPageToken).To(Equal(expected.Data.NextPageToken))
+			Expect(len(actual.Data.Items)).To(Equal(len(expected.Data.Items)))
+		})
 
-	assert.Equal(t, http.StatusOK, rs.StatusCode)
-	assert.Equal(t, expected.Data.Name, actual.Data.Name)
-}
+		It("create Model Artifact By Model Version", func() {
+			By("creating a model version")
+			data := mocks.GetModelArtifactMocks()[0]
+			expected := ModelArtifactEnvelope{Data: &data}
 
-func TestGetAllModelArtifactsByModelVersionHandler(t *testing.T) {
-	data := mocks.GetModelArtifactListMock()
-	expected := ModelArtifactListEnvelope{Data: &data}
+			artifact := openapi.ModelArtifact{
+				Name:         openapi.PtrString("Artifact One"),
+				ArtifactType: "ARTIFACT_TYPE_ONE",
+			}
+			body := ModelArtifactEnvelope{Data: &artifact}
+			actual, rs, err := setupApiTest[ModelArtifactEnvelope](http.MethodPost, "/api/v1/model_registry/model-registry/model_versions/1/artifacts", body, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-	actual, rs, err := setupApiTest[ModelArtifactListEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/model_versions/1/artifacts", nil)
-	assert.NoError(t, err)
+			By("should get all expected model artifacts")
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(actual.Data.GetArtifactType()).To(Equal(expected.Data.GetArtifactType()))
+			Expect(rs.Header.Get("Location")).To(Equal("/api/v1/model_registry/model-registry/model_artifacts/1"))
 
-	assert.Equal(t, http.StatusOK, rs.StatusCode)
-	assert.Equal(t, expected.Data.Size, actual.Data.Size)
-	assert.Equal(t, expected.Data.PageSize, actual.Data.PageSize)
-	assert.Equal(t, expected.Data.NextPageToken, actual.Data.NextPageToken)
-	assert.Equal(t, len(expected.Data.Items), len(actual.Data.Items))
-}
-
-func TestCreateModelArtifactByModelVersionHandler(t *testing.T) {
-	data := mocks.GetModelArtifactMocks()[0]
-	expected := ModelArtifactEnvelope{Data: &data}
-
-	artifact := openapi.ModelArtifact{
-		Name:         openapi.PtrString("Artifact One"),
-		ArtifactType: "ARTIFACT_TYPE_ONE",
-	}
-	body := ModelArtifactEnvelope{Data: &artifact}
-
-	actual, rs, err := setupApiTest[ModelArtifactEnvelope](http.MethodPost, "/api/v1/model_registry/model-registry/model_versions/1/artifacts", body)
-	assert.NoError(t, err)
-
-	assert.Equal(t, http.StatusCreated, rs.StatusCode)
-	assert.Equal(t, expected.Data.GetArtifactType(), actual.Data.GetArtifactType())
-	assert.Equal(t, rs.Header.Get("Location"), "/api/v1/model_registry/model-registry/model_artifacts/1")
-}
+		})
+	})
+})

--- a/clients/ui/bff/internal/api/registered_models_handler_test.go
+++ b/clients/ui/bff/internal/api/registered_models_handler_test.go
@@ -3,92 +3,101 @@ package api
 import (
 	"github.com/kubeflow/model-registry/pkg/openapi"
 	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"net/http"
-	"testing"
 )
 
-func TestGetRegisteredModelHandler(t *testing.T) {
-	data := mocks.GetRegisteredModelMocks()[0]
-	expected := RegisteredModelEnvelope{Data: &data}
+var _ = Describe("TestGetRegisteredModelHandler", func() {
+	Context("testing registered models by id", Ordered, func() {
 
-	actual, rs, err := setupApiTest[RegisteredModelEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/registered_models/1", nil)
-	assert.NoError(t, err)
+		It("should retrieve a registered model", func() {
+			By("fetching all model registries")
+			data := mocks.GetRegisteredModelMocks()[0]
+			expected := RegisteredModelEnvelope{Data: &data}
+			actual, rs, err := setupApiTest[RegisteredModelEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/registered_models/1", nil, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+			By("should match the expected model registry")
+			//TODO assert the full structure, I couldn't get unmarshalling to work for the full customProperties values
+			// this issue is in the test only
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Name).To(Equal(expected.Data.Name))
+		})
 
-	//TODO assert the full structure, I couldn't get unmarshalling to work for the full customProperties values
-	// this issue is in the test only
-	assert.Equal(t, http.StatusOK, rs.StatusCode)
-	assert.Equal(t, expected.Data.Name, actual.Data.Name)
-}
+		It("should retrieve all registered models", func() {
+			By("fetching all registered models")
+			data := mocks.GetRegisteredModelListMock()
+			expected := RegisteredModelListEnvelope{Data: &data}
+			actual, rs, err := setupApiTest[RegisteredModelListEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/registered_models", nil, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+			By("should match the expected model registry")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Size).To(Equal(expected.Data.Size))
+			Expect(actual.Data.PageSize).To(Equal(expected.Data.PageSize))
+			Expect(actual.Data.NextPageToken).To(Equal(expected.Data.NextPageToken))
+			Expect(len(actual.Data.Items)).To(Equal(len(expected.Data.Items)))
+		})
 
-func TestGetAllRegisteredModelsHandler(t *testing.T) {
-	data := mocks.GetRegisteredModelListMock()
-	expected := RegisteredModelListEnvelope{Data: &data}
+		It("creating registered models", func() {
+			By("post to registered models")
+			data := mocks.GetRegisteredModelMocks()[0]
+			expected := RegisteredModelEnvelope{Data: &data}
+			body := RegisteredModelEnvelope{Data: openapi.NewRegisteredModel("Model One")}
+			actual, rs, err := setupApiTest[RegisteredModelEnvelope](http.MethodPost, "/api/v1/model_registry/model-registry/registered_models", body, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-	actual, rs, err := setupApiTest[RegisteredModelListEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/registered_models", nil)
-	assert.NoError(t, err)
+			By("should do a successful post")
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(actual.Data.Name).To(Equal(expected.Data.Name))
+			Expect(rs.Header.Get("location")).To(Equal("/api/v1/model_registry/model-registry/registered_models/1"))
+		})
 
-	assert.Equal(t, http.StatusOK, rs.StatusCode)
-	assert.Equal(t, expected.Data.Size, actual.Data.Size)
-	assert.Equal(t, expected.Data.PageSize, actual.Data.PageSize)
-	assert.Equal(t, expected.Data.NextPageToken, actual.Data.NextPageToken)
-	assert.Equal(t, len(expected.Data.Items), len(actual.Data.Items))
-}
+		It("updating registered models", func() {
+			By("path to registered models")
+			data := mocks.GetRegisteredModelMocks()[0]
+			expected := RegisteredModelEnvelope{Data: &data}
+			reqData := openapi.RegisteredModelUpdate{
+				Description: openapi.PtrString("This is a new description"),
+			}
+			body := RegisteredModelUpdateEnvelope{Data: &reqData}
+			actual, rs, err := setupApiTest[RegisteredModelEnvelope](http.MethodPatch, "/api/v1/model_registry/model-registry/registered_models/1", body, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-func TestCreateRegisteredModelHandler(t *testing.T) {
-	data := mocks.GetRegisteredModelMocks()[0]
-	expected := RegisteredModelEnvelope{Data: &data}
+			By("should do a successful patch")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Description).To(Equal(expected.Data.Description))
+		})
 
-	body := RegisteredModelEnvelope{Data: openapi.NewRegisteredModel("Model One")}
+		It("get all model versions for registered model", func() {
+			By("get to registered models versions")
+			data := mocks.GetModelVersionListMock()
+			expected := ModelVersionListEnvelope{Data: &data}
 
-	actual, rs, err := setupApiTest[RegisteredModelEnvelope](http.MethodPost, "/api/v1/model_registry/model-registry/registered_models", body)
-	assert.NoError(t, err)
+			actual, rs, err := setupApiTest[ModelVersionListEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/registered_models/1/versions", nil, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-	assert.Equal(t, http.StatusCreated, rs.StatusCode)
-	assert.Equal(t, expected.Data.Name, actual.Data.Name)
-	assert.Equal(t, rs.Header.Get("location"), "/api/v1/model_registry/model-registry/registered_models/1")
-}
+			By("should get all items")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Size).To(Equal(expected.Data.Size))
+			Expect(actual.Data.PageSize).To(Equal(expected.Data.PageSize))
+			Expect(actual.Data.NextPageToken).To(Equal(expected.Data.NextPageToken))
+			Expect(len(actual.Data.Items)).To(Equal(len(expected.Data.Items)))
+		})
 
-func TestUpdateRegisteredModelHandler(t *testing.T) {
-	data := mocks.GetRegisteredModelMocks()[0]
-	expected := RegisteredModelEnvelope{Data: &data}
+		It("create model version for registered model", func() {
+			By("doing a post to registered model versions")
+			data := mocks.GetModelVersionMocks()[0]
+			expected := ModelVersionEnvelope{Data: &data}
 
-	reqData := openapi.RegisteredModelUpdate{
-		Description: openapi.PtrString("This is a new description"),
-	}
-	body := RegisteredModelUpdateEnvelope{Data: &reqData}
+			body := ModelVersionEnvelope{Data: openapi.NewModelVersion("Version Fifty", "")}
+			actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodPost, "/api/v1/model_registry/model-registry/registered_models/1/versions", body, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-	actual, rs, err := setupApiTest[RegisteredModelEnvelope](http.MethodPatch, "/api/v1/model_registry/model-registry/registered_models/1", body)
-	assert.NoError(t, err)
+			By("should successfully create it")
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(actual.Data.Name).To(Equal(expected.Data.Name))
+			Expect(rs.Header.Get("Location")).To(Equal("/api/v1/model_registry/model-registry/model_versions/1"))
 
-	assert.Equal(t, http.StatusOK, rs.StatusCode)
-	//TODO when mock client can handle changing state, update this to verify the changes are made.
-	assert.Equal(t, expected.Data.Description, actual.Data.Description)
-}
-
-func TestGetAllModelVersionsForRegisteredModelHandler(t *testing.T) {
-	data := mocks.GetModelVersionListMock()
-	expected := ModelVersionListEnvelope{Data: &data}
-
-	actual, rs, err := setupApiTest[ModelVersionListEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/registered_models/1/versions", nil)
-	assert.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, rs.StatusCode)
-	assert.Equal(t, expected.Data.Size, actual.Data.Size)
-	assert.Equal(t, expected.Data.PageSize, actual.Data.PageSize)
-	assert.Equal(t, expected.Data.NextPageToken, actual.Data.NextPageToken)
-	assert.Equal(t, len(expected.Data.Items), len(actual.Data.Items))
-}
-
-func TestCreateModelVersionForRegisteredModelHandler(t *testing.T) {
-	data := mocks.GetModelVersionMocks()[0]
-	expected := ModelVersionEnvelope{Data: &data}
-
-	body := ModelVersionEnvelope{Data: openapi.NewModelVersion("Version Fifty", "")}
-	actual, rs, err := setupApiTest[ModelVersionEnvelope](http.MethodPost, "/api/v1/model_registry/model-registry/registered_models/1/versions", body)
-	assert.NoError(t, err)
-
-	assert.Equal(t, http.StatusCreated, rs.StatusCode)
-	assert.Equal(t, expected.Data.Name, actual.Data.Name)
-	assert.Equal(t, rs.Header.Get("Location"), "/api/v1/model_registry/model-registry/model_versions/1")
-}
+		})
+	})
+})

--- a/clients/ui/bff/internal/api/suite_test.go
+++ b/clients/ui/bff/internal/api/suite_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"context"
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
+	"log/slog"
+	"os"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"testing"
+)
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	k8sClient    k8s.KubernetesClientInterface
+	mockMRClient *mocks.ModelRegistryClientMock
+	ctx          context.Context
+	cancel       context.CancelFunc
+	logger       *slog.Logger
+	err          error
+)
+
+func TestAPI(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "API Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
+
+	By("bootstrapping test environment")
+	logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	k8sClient, err = mocks.NewKubernetesClient(logger, ctx, cancel)
+	Expect(err).NotTo(HaveOccurred())
+
+	mockMRClient, err = mocks.NewModelRegistryClient(nil)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	defer cancel()
+	err := k8sClient.Shutdown(ctx, logger)
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/clients/ui/bff/internal/api/test_utils.go
+++ b/clients/ui/bff/internal/api/test_utils.go
@@ -7,8 +7,10 @@ import (
 	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
 	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 )
 
 func setupApiTest[T any](method string, url string, body interface{}) (T, *http.Response, error) {
@@ -16,7 +18,8 @@ func setupApiTest[T any](method string, url string, body interface{}) (T, *http.
 	if err != nil {
 		return *new(T), nil, err
 	}
-	mockK8sClient, err := mocks.NewKubernetesClient(nil)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mockK8sClient, err := mocks.NewKubernetesClient(logger)
 	if err != nil {
 		return *new(T), nil, err
 	}

--- a/clients/ui/bff/internal/api/test_utils.go
+++ b/clients/ui/bff/internal/api/test_utils.go
@@ -4,22 +4,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
 	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
 	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"os"
 )
 
-func setupApiTest[T any](method string, url string, body interface{}) (T, *http.Response, error) {
+func setupApiTest[T any](method string, url string, body interface{}, k8sClient k8s.KubernetesClientInterface) (T, *http.Response, error) {
 	mockMRClient, err := mocks.NewModelRegistryClient(nil)
-	if err != nil {
-		return *new(T), nil, err
-	}
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	mockK8sClient, err := mocks.NewKubernetesClient(logger)
 	if err != nil {
 		return *new(T), nil, err
 	}
@@ -28,7 +22,7 @@ func setupApiTest[T any](method string, url string, body interface{}) (T, *http.
 
 	testApp := App{
 		repositories:     repositories.NewRepositories(mockMRClient),
-		kubernetesClient: mockK8sClient,
+		kubernetesClient: k8sClient,
 	}
 
 	var req *http.Request

--- a/clients/ui/bff/internal/mocks/k8s_mock.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock.go
@@ -2,45 +2,210 @@ package mocks
 
 import (
 	"context"
+	"fmt"
 	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
-	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 type KubernetesClientMock struct {
-	mock.Mock
+	*k8s.KubernetesClient
+	testEnv *envtest.Environment
 }
 
 func (m *KubernetesClientMock) Shutdown(ctx context.Context, logger *slog.Logger) error {
-	logger.Error("Shutdown was called in mock")
+	logger.Info("Shutdown was called in mock")
+	m.StopFn()
+	err := m.testEnv.Stop()
+	if err != nil {
+		logger.Error("timeout while waiting for Kubernetes manager to stop")
+		return fmt.Errorf("timeout while waiting for Kubernetes manager to stop")
+	}
+	logger.Info("Shutdown ended successfully")
 	return nil
 }
 
-func NewKubernetesClient(_ *slog.Logger) (k8s.KubernetesClientInterface, error) {
-	return &KubernetesClientMock{}, nil
+func NewKubernetesClient(logger *slog.Logger) (k8s.KubernetesClientInterface, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	projectRoot, err := getProjectRoot()
+	if err != nil {
+		logger.Error("failed to find project root to locate binaries", err)
+		cancel()
+		os.Exit(1)
+	}
+
+	testEnv := &envtest.Environment{
+		// The BinaryAssetsDirectory is only required if you want to run the tests directly without call the makefile target test.
+		// If not informed it will look for the default path defined in bff which is /usr/local/kubebuilder/.
+		// Note that you must have the required binaries setup under the bin directory to perform the tests directly.
+		// When we run make test it will be setup and used automatically.
+		BinaryAssetsDirectory: filepath.Join(projectRoot, "bin", "k8s", fmt.Sprintf("1.29.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		logger.Error("failed to start test environment", err)
+		cancel()
+		os.Exit(1)
+	}
+
+	mockK8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		logger.Error("failed to create Kubernetes client", err)
+		cancel()
+		os.Exit(1)
+	}
+
+	err = setupMock(mockK8sClient, ctx)
+	if err != nil {
+		logger.Error("failed on mock setup", err)
+		cancel()
+		os.Exit(1)
+	}
+
+	return &KubernetesClientMock{
+		KubernetesClient: &k8s.KubernetesClient{
+			Client: mockK8sClient,
+			Logger: logger,
+			StopFn: cancel,
+		},
+		testEnv: testEnv,
+	}, nil
 }
 
-func (m *KubernetesClientMock) GetServiceNames() ([]string, error) {
-	return []string{"model-registry", "model-registry-dora", "model-registry-bella"}, nil
+func getProjectRoot() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(currentDir, "go.mod")); err == nil {
+			// Found the project root where go.mod is located
+			return currentDir, nil
+		}
+
+		parentDir := filepath.Dir(currentDir)
+		if parentDir == currentDir {
+			// We reached the root directory and did not find the go.mod
+			return "", fmt.Errorf("could not find project root")
+		}
+
+		currentDir = parentDir
+	}
+}
+
+func setupMock(mockK8sClient client.Client, ctx context.Context) error {
+	err := createService(mockK8sClient, ctx, "model-registry", "default", "Model Registry", "Model Registry Description", "10.0.0.10")
+	if err != nil {
+		return err
+	}
+	err = createService(mockK8sClient, ctx, "model-registry-dora", "default", "Model Registry Dora", "Model Registry Dora description", "10.0.0.11")
+	if err != nil {
+		return err
+	}
+	err = createService(mockK8sClient, ctx, "model-registry-bella", "default", "Model Registry Bella", "Model Registry Bella description", "10.0.0.12")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *KubernetesClientMock) GetServiceDetails() ([]k8s.ServiceDetails, error) {
-	return []k8s.ServiceDetails{
-		{Name: "model-registry", Description: "Model registry description", DisplayName: "Model Registry"},
-		{Name: "model-registry-dora", Description: "Model registry dora description", DisplayName: "Model Registry Dora"},
-		{Name: "model-registry-bella", Description: "Model registry bella description", DisplayName: "Model Registry Bella"},
-	}, nil
+	originalServices, err := m.KubernetesClient.GetServiceDetails()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service details: %w", err)
+	}
+
+	for i := range originalServices {
+		originalServices[i].ClusterIP = "127.0.0.1"
+		originalServices[i].HTTPPort = 8080
+	}
+
+	return originalServices, nil
+}
+
+func (m *KubernetesClientMock) GetServiceDetailsByName(serviceName string) (k8s.ServiceDetails, error) {
+	originalService, err := m.KubernetesClient.GetServiceDetailsByName(serviceName)
+	if err != nil {
+		return k8s.ServiceDetails{}, fmt.Errorf("failed to get service details: %w", err)
+	}
+	//changing from cluster service ip to localhost
+	originalService.ClusterIP = "127.0.0.1"
+	originalService.HTTPPort = 8080
+
+	return originalService, nil
 }
 
 func (m *KubernetesClientMock) BearerToken() (string, error) {
 	return "FAKE BEARER TOKEN", nil
 }
 
-func (m *KubernetesClientMock) GetServiceDetailsByName(serviceName string) (k8s.ServiceDetails, error) {
-	//expected forward to docker compose -f docker-compose.yaml up
-	return k8s.ServiceDetails{
-		Name:      serviceName,
-		ClusterIP: "127.0.0.1",
-		HTTPPort:  8080,
-	}, nil
+func createService(k8sClient client.Client, ctx context.Context, name string, namespace string, displayName string, description string, clusterIP string) error {
+
+	annotations := map[string]string{}
+
+	if displayName != "" {
+		annotations["displayName"] = displayName
+	}
+
+	if description != "" {
+		annotations["description"] = description
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"component": k8s.ComponentName,
+			},
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: clusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:        "http-api",
+					Port:        8080,
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: strPtr("http"),
+				},
+				{
+					Name:        "grpc-api",
+					Port:        9090,
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: strPtr("grpc"),
+				},
+			},
+		},
+	}
+
+	err := k8sClient.Create(ctx, service)
+	if err != nil {
+		return fmt.Errorf("failed to create services: %w", err)
+	}
+
+	serviceList := &corev1.ServiceList{}
+
+	err = k8sClient.List(ctx, serviceList, &client.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list services: %w", err)
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func strPtr(s string) *string {
+	return &s
 }

--- a/clients/ui/bff/internal/mocks/k8s_mock.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock.go
@@ -32,8 +32,8 @@ func (m *KubernetesClientMock) Shutdown(ctx context.Context, logger *slog.Logger
 	return nil
 }
 
-func NewKubernetesClient(logger *slog.Logger) (k8s.KubernetesClientInterface, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+func NewKubernetesClient(logger *slog.Logger, ctx context.Context, cancel context.CancelFunc) (k8s.KubernetesClientInterface, error) {
+
 	projectRoot, err := getProjectRoot()
 	if err != nil {
 		logger.Error("failed to find project root to locate binaries", err)

--- a/clients/ui/bff/internal/mocks/k8s_mock.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock.go
@@ -36,7 +36,7 @@ func NewKubernetesClient(logger *slog.Logger, ctx context.Context, cancel contex
 
 	projectRoot, err := getProjectRoot()
 	if err != nil {
-		logger.Error("failed to find project root to locate binaries", err)
+		logger.Error("failed to find project root to locate binaries", slog.String("error", err.Error()))
 		cancel()
 		os.Exit(1)
 	}

--- a/clients/ui/bff/internal/mocks/k8s_mock_test.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock_test.go
@@ -1,67 +1,62 @@
 package mocks
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"log/slog"
-	"os"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestGetServiceDetails(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+var _ = Describe("Kubernetes Client Test", func() {
+	Context("with existing services", Ordered, func() {
 
-	k8sClient, err := NewKubernetesClient(logger)
-	require.NoError(t, err, "Failed to initialize KubernetesClientMock")
+		It("should retrieve the get all service successfully", func() {
 
-	services, err := k8sClient.GetServiceDetails()
-	require.NoError(t, err, "Failed to get service details")
+			By("getting service details")
+			services, err := k8sClient.GetServiceDetails()
+			Expect(err).NotTo(HaveOccurred(), "Failed to create HTTP request")
 
-	// Check that all services have the modified ClusterIP and HTTPPort
-	for _, service := range services {
-		assert.Equal(t, "127.0.0.1", service.ClusterIP, "ClusterIP should be set to 127.0.0.1")
-		assert.Equal(t, int32(8080), service.HTTPPort, "HTTPPort should be set to 8080")
-	}
+			By("checking that all services have the modified ClusterIP and HTTPPort")
+			for _, service := range services {
+				Expect(service.ClusterIP).To(Equal("127.0.0.1"), "ClusterIP should be set to 127.0.0.1")
+				Expect(service.HTTPPort).To(Equal(int32(8080)), "HTTPPort should be set to 8080")
 
-	//Check that a specific service exists
-	foundService := false
-	for _, service := range services {
-		if service.Name == "model-registry" {
-			foundService = true
-			assert.Equal(t, "Model Registry", service.DisplayName)
-			assert.Equal(t, "Model Registry Description", service.Description)
-			break
-		}
-	}
-	assert.True(t, foundService, "Expected to find service 'model-registry'")
-}
+			}
 
-func TestGetServiceDetailsByName(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+			By("checking that that a specific service exists")
+			foundService := false
+			for _, service := range services {
+				if service.Name == "model-registry" {
+					foundService = true
+					Expect(service.DisplayName).To(Equal("Model Registry"))
+					Expect(service.Description).To(Equal("Model Registry Description"))
+					break
+				}
+			}
+			Expect(foundService).To(Equal(true), "Expected to find service 'model-registry'")
+		})
 
-	k8sClient, err := NewKubernetesClient(logger)
-	require.NoError(t, err, "Failed to initialize KubernetesClientMock")
+		It("should retrieve the service details by name", func() {
 
-	service, err := k8sClient.GetServiceDetailsByName("model-registry-dora")
-	require.NoError(t, err, "Failed to get service details")
+			By("getting service by name")
+			service, err := k8sClient.GetServiceDetailsByName("model-registry-dora")
+			Expect(err).NotTo(HaveOccurred(), "Failed to create k8s request")
 
-	assert.Equal(t, "model-registry-dora", service.Name)
-	assert.Equal(t, "Model Registry Dora description", service.Description)
-	assert.Equal(t, "Model Registry Dora", service.DisplayName)
+			By("checking that service details are correct")
+			Expect(service.Name).To(Equal("model-registry-dora"))
+			Expect(service.Description).To(Equal("Model Registry Dora description"))
+			Expect(service.DisplayName).To(Equal("Model Registry Dora"))
+		})
 
-}
+		It("should retrieve the services names", func() {
 
-func TestGetService(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+			By("getting service by name")
+			services, err := k8sClient.GetServiceNames()
+			Expect(err).NotTo(HaveOccurred(), "Failed to create HTTP request")
 
-	k8sClient, err := NewKubernetesClient(logger)
-	require.NoError(t, err, "Failed to initialize KubernetesClientMock")
+			By("checking that service details are correct")
+			Expect(services[0]).To(Equal("model-registry"))
+			Expect(services[1]).To(Equal("model-registry-bella"))
+			Expect(services[2]).To(Equal("model-registry-dora"))
+		})
+	})
 
-	services, err := k8sClient.GetServiceNames()
-	require.NoError(t, err, "Failed to get service details")
-
-	assert.Equal(t, "model-registry", services[0])
-	assert.Equal(t, "model-registry-bella", services[1])
-	assert.Equal(t, "model-registry-dora", services[2])
-
-}
+})

--- a/clients/ui/bff/internal/mocks/k8s_mock_test.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock_test.go
@@ -1,0 +1,67 @@
+package mocks
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestGetServiceDetails(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	k8sClient, err := NewKubernetesClient(logger)
+	require.NoError(t, err, "Failed to initialize KubernetesClientMock")
+
+	services, err := k8sClient.GetServiceDetails()
+	require.NoError(t, err, "Failed to get service details")
+
+	// Check that all services have the modified ClusterIP and HTTPPort
+	for _, service := range services {
+		assert.Equal(t, "127.0.0.1", service.ClusterIP, "ClusterIP should be set to 127.0.0.1")
+		assert.Equal(t, int32(8080), service.HTTPPort, "HTTPPort should be set to 8080")
+	}
+
+	//Check that a specific service exists
+	foundService := false
+	for _, service := range services {
+		if service.Name == "model-registry" {
+			foundService = true
+			assert.Equal(t, "Model Registry", service.DisplayName)
+			assert.Equal(t, "Model Registry Description", service.Description)
+			break
+		}
+	}
+	assert.True(t, foundService, "Expected to find service 'model-registry'")
+}
+
+func TestGetServiceDetailsByName(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	k8sClient, err := NewKubernetesClient(logger)
+	require.NoError(t, err, "Failed to initialize KubernetesClientMock")
+
+	service, err := k8sClient.GetServiceDetailsByName("model-registry-dora")
+	require.NoError(t, err, "Failed to get service details")
+
+	assert.Equal(t, "model-registry-dora", service.Name)
+	assert.Equal(t, "Model Registry Dora description", service.Description)
+	assert.Equal(t, "Model Registry Dora", service.DisplayName)
+
+}
+
+func TestGetService(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	k8sClient, err := NewKubernetesClient(logger)
+	require.NoError(t, err, "Failed to initialize KubernetesClientMock")
+
+	services, err := k8sClient.GetServiceNames()
+	require.NoError(t, err, "Failed to get service details")
+
+	assert.Equal(t, "model-registry", services[0])
+	assert.Equal(t, "model-registry-bella", services[1])
+	assert.Equal(t, "model-registry-dora", services[2])
+
+}

--- a/clients/ui/bff/internal/mocks/suite_test.go
+++ b/clients/ui/bff/internal/mocks/suite_test.go
@@ -1,0 +1,52 @@
+package mocks
+
+import (
+	"context"
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	"log/slog"
+	"os"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"testing"
+)
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	k8sClient k8s.KubernetesClientInterface
+	ctx       context.Context
+	cancel    context.CancelFunc
+	logger    *slog.Logger
+	err       error
+)
+
+func TestAPI(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "API Suite")
+}
+
+var _ = BeforeSuite(func() {
+	defer GinkgoRecover()
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
+
+	By("bootstrapping test environment")
+	logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	k8sClient, err = NewKubernetesClient(logger, ctx, cancel)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	defer cancel()
+	err := k8sClient.Shutdown(ctx, logger)
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/clients/ui/bff/internal/repositories/model_registry_test.go
+++ b/clients/ui/bff/internal/repositories/model_registry_test.go
@@ -1,28 +1,28 @@
 package repositories
 
 import (
-	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
 	"github.com/kubeflow/model-registry/ui/bff/internal/models"
-	"github.com/stretchr/testify/assert"
-	"log/slog"
-	"os"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestFetchAllModelRegistry(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	mockK8sClient, _ := mocks.NewKubernetesClient(logger)
+var _ = Describe("TestFetchAllModelRegistry", func() {
+	Context("with existing model registries", Ordered, func() {
 
-	mrClient := NewModelRegistryRepository()
+		It("should retrieve the get all service successfully", func() {
 
-	registries, err := mrClient.FetchAllModelRegistries(mockK8sClient)
+			By("fetching all model registries in the repository")
+			modelRegistryRepository := NewModelRegistryRepository()
+			registries, err := modelRegistryRepository.FetchAllModelRegistries(k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 
-	assert.NoError(t, err)
-
-	expectedRegistries := []models.ModelRegistryModel{
-		{Name: "model-registry", Description: "Model Registry Description", DisplayName: "Model Registry"},
-		{Name: "model-registry-bella", Description: "Model Registry Bella description", DisplayName: "Model Registry Bella"},
-		{Name: "model-registry-dora", Description: "Model Registry Dora description", DisplayName: "Model Registry Dora"},
-	}
-	assert.Equal(t, expectedRegistries, registries)
-}
+			By("should match the expected model registries")
+			expectedRegistries := []models.ModelRegistryModel{
+				{Name: "model-registry", Description: "Model Registry Description", DisplayName: "Model Registry"},
+				{Name: "model-registry-bella", Description: "Model Registry Bella description", DisplayName: "Model Registry Bella"},
+				{Name: "model-registry-dora", Description: "Model Registry Dora description", DisplayName: "Model Registry Dora"},
+			}
+			Expect(registries).To(ConsistOf(expectedRegistries))
+		})
+	})
+})

--- a/clients/ui/bff/internal/repositories/model_registry_test.go
+++ b/clients/ui/bff/internal/repositories/model_registry_test.go
@@ -4,11 +4,14 @@ import (
 	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
 	"github.com/kubeflow/model-registry/ui/bff/internal/models"
 	"github.com/stretchr/testify/assert"
+	"log/slog"
+	"os"
 	"testing"
 )
 
 func TestFetchAllModelRegistry(t *testing.T) {
-	mockK8sClient, _ := mocks.NewKubernetesClient(nil)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mockK8sClient, _ := mocks.NewKubernetesClient(logger)
 
 	mrClient := NewModelRegistryRepository()
 
@@ -17,10 +20,9 @@ func TestFetchAllModelRegistry(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedRegistries := []models.ModelRegistryModel{
-		{Name: "model-registry", Description: "Model registry description", DisplayName: "Model Registry"},
-		{Name: "model-registry-dora", Description: "Model registry dora description", DisplayName: "Model Registry Dora"},
-		{Name: "model-registry-bella", Description: "Model registry bella description", DisplayName: "Model Registry Bella"},
+		{Name: "model-registry", Description: "Model Registry Description", DisplayName: "Model Registry"},
+		{Name: "model-registry-bella", Description: "Model Registry Bella description", DisplayName: "Model Registry Bella"},
+		{Name: "model-registry-dora", Description: "Model Registry Dora description", DisplayName: "Model Registry Dora"},
 	}
 	assert.Equal(t, expectedRegistries, registries)
-
 }

--- a/clients/ui/bff/internal/repositories/suite_test.go
+++ b/clients/ui/bff/internal/repositories/suite_test.go
@@ -1,0 +1,59 @@
+package repositories
+
+import (
+	"context"
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
+	"log/slog"
+	"os"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"testing"
+)
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	k8sClient    k8s.KubernetesClientInterface
+	mockMRClient *mocks.ModelRegistryClientMock
+	ctx          context.Context
+	cancel       context.CancelFunc
+	logger       *slog.Logger
+	err          error
+)
+
+func TestAPI(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "API Suite")
+
+}
+
+var _ = BeforeSuite(func() {
+	defer GinkgoRecover() // Ensure Ginkgo can handle any panic during setup
+
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
+
+	By("bootstrapping test environment")
+	logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	k8sClient, err = mocks.NewKubernetesClient(logger, ctx, cancel)
+	Expect(err).NotTo(HaveOccurred())
+
+	mockMRClient, err = mocks.NewModelRegistryClient(nil)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := k8sClient.Shutdown(ctx, logger)
+	defer cancel()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
Use envtest for kubernetes testing instead of hardcoded mock

## Description
This PR starts to use envtest for Kubernetes mocking. It also fixes a minor issue when there are no annotations on the service.

## How Has This Been Tested?
make run MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true and also ran the web app:

<img width="651" alt="Screenshot 2024-10-18 at 11 18 59 AM" src="https://github.com/user-attachments/assets/5eccd323-6119-4415-b3a8-9b1d592a38bb">

<img width="1263" alt="Screenshot 2024-10-18 at 11 19 24 AM" src="https://github.com/user-attachments/assets/c23e0709-c992-4f51-a638-1b334bee31bc">



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

No UI changes.
 