### PR TITLE
feat(csi): add CSI manifests

### DIFF
--- a/csi/GET_STARTED.md
+++ b/csi/GET_STARTED.md
@@ -26,7 +26,7 @@ We assume all [prerequisites](#prerequisites) are satisfied at this point.
 
 3. Setup local deployment of *Kserve* using the provided *Kserve quick installation* script
     ```bash
-    curl -s "https://raw.githubusercontent.com/kserve/kserve/release-0.12/hack/quick_install.sh" | bash
+    curl -s "https://raw.githubusercontent.com/kserve/kserve/release-0.14/hack/quick_install.sh" | bash
     ```
 
 4. Install *model registry* in the local cluster
@@ -257,5 +257,5 @@ EOF
     If you do not have DNS, you can still curl with the ingress gateway external IP using the HOST Header.
     ```bash
     SERVICE_HOSTNAME=$(kubectl get inferenceservice iris-model -n kserve-test -o jsonpath='{.status.url}' | cut -d "/" -f 3)
-    curl -v -H "Host: ${SERVICE_HOSTNAME}" -H "Content-Type: application/json" "http://${INGRESS_HOST}:${INGRESS_PORT}/v1/models/iris-v1:predict" -d @/tmp/iris-input.json
+    curl -v -H "Host: ${SERVICE_HOSTNAME}" -H "Content-Type: application/json" "http://${INGRESS_HOST}:${INGRESS_PORT}/v1/models/iris-model:predict" -d @/tmp/iris-input.json
     ```

--- a/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
+++ b/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
@@ -1,0 +1,20 @@
+apiVersion: "serving.kserve.io/v1alpha1"
+kind: ClusterStorageContainer
+metadata:
+  name: model-registry-storage-initializer-2
+spec:
+  container:
+    name: storage-initializer
+    image: kubeflow/model-registry-storage-initializer:latest
+    env:
+    - name: MODEL_REGISTRY_BASE_URL
+      value: "model-registry-service.kubeflow.svc.cluster.local:8080"
+    resources:
+      requests:
+        memory: 100Mi
+        cpu: 100m
+      limits:
+        memory: 1Gi
+        cpu: "1"
+  supportedUriFormats:
+    - prefix: model-registry://

--- a/manifests/kustomize/options/csi/kustomization.yaml
+++ b/manifests/kustomize/options/csi/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+
+resources:
+- clusterstoragecontainer.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added manifests for CSI deployment, the following:

```yaml
    - name: MODEL_REGISTRY_BASE_URL
      value: "model-registry-service.kubeflow.svc.cluster.local:8080"
```

cannot be parameterized as an env from configmap because the way kserve works is to use it as a template for an initcontainer that is injected into the serving deployment, so it has to be viewed as a fallback URL to reach the default model registry.

## How Has This Been Tested?
```bash
docker build . -f Dockerfile -t mr/mr:0.1.1
LOCAL=1 IMG=mr/mr:0.1.1 ./scripts/deploy_on_kind.sh
```

then followed the guide from csi/GET_STARTED.md

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

