### PR TITLE
chore(manifests): remove unnecessary -2 prefix from csi manifest

### DIFF
--- a/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
+++ b/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
@@ -1,7 +1,7 @@
 apiVersion: "serving.kserve.io/v1alpha1"
 kind: ClusterStorageContainer
 metadata:
-  name: model-registry-storage-initializer-2
+  name: model-registry-storage-initializer
 spec:
   container:
     name: storage-initializer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Removed an unnecessary suffix from the metadata name in csi manifests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

