### PR TITLE
Add NotificationContext and useNotification hook

### DIFF
--- a/clients/ui/frontend/package-lock.json
+++ b/clients/ui/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/jest": "^29.5.13",
         "@types/lodash-es": "^4.17.8",
+        "@types/react-dom": "^18.3.1",
         "@types/react-router-dom": "^5.3.3",
         "@types/showdown": "^2.0.3",
         "chai-subset": "^1.6.0",
@@ -4484,6 +4485,16 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-router": {

--- a/clients/ui/frontend/package.json
+++ b/clients/ui/frontend/package.json
@@ -47,6 +47,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/jest": "^29.5.13",
     "@types/lodash-es": "^4.17.8",
+    "@types/react-dom": "^18.3.1",
     "@types/react-router-dom": "^5.3.3",
     "@types/showdown": "^2.0.3",
     "chai-subset": "^1.6.0",

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/components/Notification.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/components/Notification.ts
@@ -1,0 +1,7 @@
+export class ToastNotification {
+  constructor(private title: string) {}
+
+  find(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByText(this.title);
+  }
+}

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
@@ -133,7 +133,6 @@ class ModelRegistry {
     return this.findModelVersionsTable().find('tbody tr');
   }
 
-  // TODO: Uncomment when the table row is implemented
   getRow(name: string) {
     return new ModelRegistryTableRow(() =>
       this.findTable().find(`[data-label="Model name"]`).contains(name).parents('tr'),

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -96,7 +96,7 @@ declare global {
           options: {
             path: { modelRegistryName: string; apiVersion: string; modelVersionId: number };
           },
-          response: ApiResponse<ModelVersion | undefined>,
+          response: ApiResponse<ModelRegistryBody<ModelVersion | undefined>>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/:apiVersion/model_registry',

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
@@ -171,7 +171,7 @@ Cypress.Commands.add(
         if ($el.attr('aria-expanded') === 'false') {
           cy.wrap($el).click();
         }
-        return cy.wrap($el.parent()).findByRole('menuitem', { name });
+        return cy.get('body').findByRole('menuitem', { name });
       });
   },
 );
@@ -182,7 +182,7 @@ Cypress.Commands.add('findDropdownItem', { prevSubject: 'element' }, (subject, n
     if ($el.attr('aria-expanded') === 'false') {
       cy.wrap($el).click();
     }
-    return cy.wrap($el).parent().findByRole('menuitem', { name });
+    return cy.get('body').findByRole('menuitem', { name });
   });
 });
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelVersions.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelVersions.cy.ts
@@ -130,7 +130,7 @@ describe('Model Versions', () => {
   });
 
   it('Model versions table', () => {
-    // TODO: Uncomment when we fix finding dropdown items
+    // TODO: Uncomment when we fix finding listbox items
 
     initIntercepts({
       modelRegistries: [

--- a/clients/ui/frontend/src/app/App.tsx
+++ b/clients/ui/frontend/src/app/App.tsx
@@ -19,6 +19,7 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
+import ToastNotifications from '~/components/ToastNotifications';
 import NavSidebar from './NavSidebar';
 import AppRoutes from './AppRoutes';
 import { AppContext } from './AppContext';
@@ -112,6 +113,7 @@ const App: React.FC = () => {
         <ModelRegistrySelectorContextProvider>
           <AppRoutes />
         </ModelRegistrySelectorContextProvider>
+        <ToastNotifications />
       </Page>
     </AppContext.Provider>
   );

--- a/clients/ui/frontend/src/app/context/NotificationContext.tsx
+++ b/clients/ui/frontend/src/app/context/NotificationContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext } from 'react';
+import { Notification, NotificationActionTypes, NotificationAction } from '~/app/types';
+
+type NotificationContextProps = {
+  notifications: Notification[];
+  notificationCount: number;
+  updateNotificationCount: React.Dispatch<React.SetStateAction<number>>;
+  dispatch: React.Dispatch<NotificationAction>;
+};
+
+export const NotificationContext = createContext<NotificationContextProps>({
+  notifications: [],
+  notificationCount: 0,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  updateNotificationCount: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  dispatch: () => {},
+});
+
+const notificationReducer: React.Reducer<Notification[], NotificationAction> = (
+  notifications,
+  action,
+) => {
+  switch (action.type) {
+    case NotificationActionTypes.ADD_NOTIFICATION: {
+      return [
+        ...notifications,
+        {
+          status: action.payload.status,
+          title: action.payload.title,
+          timestamp: action.payload.timestamp,
+          message: action.payload.message,
+          id: action.payload.id,
+        },
+      ];
+    }
+    case NotificationActionTypes.DELETE_NOTIFICATION: {
+      return notifications.filter((t) => t.id !== action.payload.id);
+    }
+    default: {
+      return notifications;
+    }
+  }
+};
+
+type NotificationContextProviderProps = {
+  children: React.ReactNode;
+};
+
+export const NotificationContextProvider: React.FC<NotificationContextProviderProps> = ({
+  children,
+}) => {
+  const [notifications, dispatch] = React.useReducer(notificationReducer, []);
+  const [notificationCount, setNotificationCount] = React.useState(0);
+
+  return (
+    <NotificationContext.Provider
+      value={React.useMemo(
+        () => ({
+          notifications,
+          notificationCount,
+          updateNotificationCount: setNotificationCount,
+          dispatch,
+        }),
+        [notifications, notificationCount, setNotificationCount, dispatch],
+      )}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+};

--- a/clients/ui/frontend/src/app/hooks/useNotification.ts
+++ b/clients/ui/frontend/src/app/hooks/useNotification.ts
@@ -1,0 +1,112 @@
+import React, { useContext } from 'react';
+import { AlertVariant } from '@patternfly/react-core';
+import { NotificationActionTypes } from '~/app/types';
+import { NotificationContext } from '~/app/context/NotificationContext';
+
+enum NotificationTypes {
+  SUCCESS = 'success',
+  ERROR = 'error',
+  INFO = 'info',
+  WARNING = 'warning',
+}
+
+type NotificationProps = (title: string, message?: React.ReactNode) => void;
+
+type NotificationRemoveProps = (id: number | undefined) => void;
+
+type NotificationTypeFunc = {
+  [key in NotificationTypes]: NotificationProps;
+};
+
+interface NotificationFunc extends NotificationTypeFunc {
+  remove: NotificationRemoveProps;
+}
+
+export const useNotification = (): NotificationFunc => {
+  const { notificationCount, updateNotificationCount, dispatch } = useContext(NotificationContext);
+
+  const success: NotificationProps = React.useCallback(
+    (title, message?) => {
+      updateNotificationCount(notificationCount + 1);
+      dispatch({
+        type: NotificationActionTypes.ADD_NOTIFICATION,
+        payload: {
+          status: AlertVariant.success,
+          title,
+          timestamp: new Date(),
+          message,
+          id: notificationCount,
+        },
+      });
+    },
+    [dispatch, notificationCount, updateNotificationCount],
+  );
+
+  const warning: NotificationProps = React.useCallback(
+    (title, message?) => {
+      updateNotificationCount(notificationCount + 1);
+      dispatch({
+        type: NotificationActionTypes.ADD_NOTIFICATION,
+        payload: {
+          status: AlertVariant.warning,
+          title,
+          timestamp: new Date(),
+          message,
+          id: notificationCount,
+        },
+      });
+    },
+    [dispatch, notificationCount, updateNotificationCount],
+  );
+
+  const error: NotificationProps = React.useCallback(
+    (title, message?) => {
+      updateNotificationCount(notificationCount + 1);
+      dispatch({
+        type: NotificationActionTypes.ADD_NOTIFICATION,
+        payload: {
+          status: AlertVariant.danger,
+          title,
+          timestamp: new Date(),
+          message,
+          id: notificationCount,
+        },
+      });
+    },
+    [dispatch, notificationCount, updateNotificationCount],
+  );
+
+  const info: NotificationProps = React.useCallback(
+    (title, message?) => {
+      updateNotificationCount(notificationCount + 1);
+      dispatch({
+        type: NotificationActionTypes.ADD_NOTIFICATION,
+        payload: {
+          status: AlertVariant.info,
+          title,
+          timestamp: new Date(),
+          message,
+          id: notificationCount,
+        },
+      });
+    },
+    [dispatch, notificationCount, updateNotificationCount],
+  );
+
+  const remove: NotificationRemoveProps = React.useCallback(
+    (id) => {
+      dispatch({
+        type: NotificationActionTypes.DELETE_NOTIFICATION,
+        payload: { id },
+      });
+    },
+    [dispatch],
+  );
+
+  const notification = React.useMemo(
+    () => ({ success, error, info, warning, remove }),
+    [success, error, info, warning, remove],
+  );
+
+  return notification;
+};

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ArchiveModelVersionModal.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ArchiveModelVersionModal.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import DashboardModalFooter from '~/app/components/DashboardModalFooter';
+import { useNotification } from '~/app/hooks/useNotification';
 
 interface ArchiveModelVersionModalProps {
   onCancel: () => void;
@@ -27,6 +28,7 @@ export const ArchiveModelVersionModal: React.FC<ArchiveModelVersionModalProps> =
   const [error, setError] = React.useState<Error>();
   const [confirmInputValue, setConfirmInputValue] = React.useState('');
   const isDisabled = confirmInputValue.trim() !== modelVersionName || isSubmitting;
+  const notification = useNotification();
 
   const onClose = React.useCallback(() => {
     setConfirmInputValue('');
@@ -39,6 +41,7 @@ export const ArchiveModelVersionModal: React.FC<ArchiveModelVersionModalProps> =
     try {
       await onSubmit();
       onClose();
+      notification.success(`${modelVersionName} archived.`);
     } catch (e) {
       if (e instanceof Error) {
         setError(e);
@@ -46,7 +49,7 @@ export const ArchiveModelVersionModal: React.FC<ArchiveModelVersionModalProps> =
     } finally {
       setIsSubmitting(false);
     }
-  }, [onSubmit, onClose]);
+  }, [notification, modelVersionName, onSubmit, onClose]);
 
   const description = (
     <>

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal.tsx
@@ -9,8 +9,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import DashboardModalFooter from '~/app/components/DashboardModalFooter';
-
-// import useNotification from '~/utilities/useNotification'; // TODO: Implement useNotification
+import { useNotification } from '~/app/hooks/useNotification';
 
 interface ArchiveRegisteredModelModalProps {
   onCancel: () => void;
@@ -25,7 +24,7 @@ export const ArchiveRegisteredModelModal: React.FC<ArchiveRegisteredModelModalPr
   isOpen,
   registeredModelName,
 }) => {
-  // const notification = useNotification();
+  const notification = useNotification();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<Error>();
   const [confirmInputValue, setConfirmInputValue] = React.useState('');
@@ -42,7 +41,7 @@ export const ArchiveRegisteredModelModal: React.FC<ArchiveRegisteredModelModalPr
     try {
       await onSubmit();
       onClose();
-      // notification.success(`${registeredModelName} and all its versions archived.`);
+      notification.success(`${registeredModelName} and all its versions archived.`);
     } catch (e) {
       if (e instanceof Error) {
         setError(e);
@@ -50,7 +49,7 @@ export const ArchiveRegisteredModelModal: React.FC<ArchiveRegisteredModelModalPr
     } finally {
       setIsSubmitting(false);
     }
-  }, [onSubmit, onClose]);
+  }, [notification, registeredModelName, onSubmit, onClose]);
 
   const description = (
     <>

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/RestoreModelVersionModal.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/RestoreModelVersionModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Form, Modal, ModalHeader, ModalBody, Alert } from '@patternfly/react-core';
 import DashboardModalFooter from '~/app/components/DashboardModalFooter';
+import { useNotification } from '~/app/hooks/useNotification';
 
 interface RestoreModelVersionModalProps {
   onCancel: () => void;
@@ -17,6 +18,7 @@ export const RestoreModelVersionModal: React.FC<RestoreModelVersionModalProps> =
 }) => {
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<Error>();
+  const notification = useNotification();
 
   const onClose = React.useCallback(() => {
     onCancel();
@@ -28,6 +30,7 @@ export const RestoreModelVersionModal: React.FC<RestoreModelVersionModalProps> =
     try {
       await onSubmit();
       onClose();
+      notification.success(`${modelVersionName} restored.`);
     } catch (e) {
       if (e instanceof Error) {
         setError(e);
@@ -35,7 +38,7 @@ export const RestoreModelVersionModal: React.FC<RestoreModelVersionModalProps> =
     } finally {
       setIsSubmitting(false);
     }
-  }, [onSubmit, onClose]);
+  }, [notification, modelVersionName, onSubmit, onClose]);
 
   const description = (
     <>

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/RestoreRegisteredModel.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/RestoreRegisteredModel.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Alert, Form, ModalHeader, Modal, ModalBody } from '@patternfly/react-core';
 import DashboardModalFooter from '~/app/components/DashboardModalFooter';
-
-// import useNotification from '~/utilities/useNotification'; TODO: Implement useNotification
+import { useNotification } from '~/app/hooks/useNotification';
 
 interface RestoreRegisteredModelModalProps {
   onCancel: () => void;
@@ -17,7 +16,7 @@ export const RestoreRegisteredModelModal: React.FC<RestoreRegisteredModelModalPr
   isOpen,
   registeredModelName,
 }) => {
-  // const notification = useNotification();
+  const notification = useNotification();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<Error>();
 
@@ -31,7 +30,7 @@ export const RestoreRegisteredModelModal: React.FC<RestoreRegisteredModelModalPr
     try {
       await onSubmit();
       onClose();
-      // notification.success(`${registeredModelName} and all its versions restored.`);
+      notification.success(`${registeredModelName} and all its versions restored.`);
     } catch (e) {
       if (e instanceof Error) {
         setError(e);
@@ -39,7 +38,7 @@ export const RestoreRegisteredModelModal: React.FC<RestoreRegisteredModelModalPr
     } finally {
       setIsSubmitting(false);
     }
-  }, [onSubmit, onClose]);
+  }, [notification, registeredModelName, onSubmit, onClose]);
 
   const description = (
     <>

--- a/clients/ui/frontend/src/app/types.ts
+++ b/clients/ui/frontend/src/app/types.ts
@@ -1,3 +1,4 @@
+import { AlertVariant } from '@patternfly/react-core';
 import { APIOptions } from '~/app/api/types';
 
 export enum ModelState {
@@ -197,3 +198,28 @@ export type ModelRegistryAPIs = {
   patchRegisteredModel: PatchRegisteredModel;
   patchModelVersion: PatchModelVersion;
 };
+
+export type Notification = {
+  id?: number;
+  status: AlertVariant;
+  title: string;
+  message?: React.ReactNode;
+  hidden?: boolean;
+  read?: boolean;
+  timestamp: Date;
+};
+
+export enum NotificationActionTypes {
+  ADD_NOTIFICATION = 'add_notification',
+  DELETE_NOTIFICATION = 'delete_notification',
+}
+
+export type NotificationAction =
+  | {
+      type: NotificationActionTypes.ADD_NOTIFICATION;
+      payload: Notification;
+    }
+  | {
+      type: NotificationActionTypes.DELETE_NOTIFICATION;
+      payload: { id: Notification['id'] };
+    };

--- a/clients/ui/frontend/src/components/ToastNotification.tsx
+++ b/clients/ui/frontend/src/components/ToastNotification.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Alert, AlertActionCloseButton, AlertVariant } from '@patternfly/react-core';
+import { Notification } from '~/app/types';
+import { asEnumMember } from '~/app/utils';
+import { useNotification } from '~/app/hooks/useNotification';
+
+const TOAST_NOTIFICATION_TIMEOUT = 8 * 1000;
+
+interface ToastNotificationProps {
+  notification: Notification;
+}
+
+const ToastNotification: React.FC<ToastNotificationProps> = ({ notification }) => {
+  const notifications = useNotification();
+  const [timedOut, setTimedOut] = React.useState(false);
+  const [mouseOver, setMouseOver] = React.useState(false);
+
+  React.useEffect(() => {
+    const handle = setTimeout(() => {
+      setTimedOut(true);
+    }, TOAST_NOTIFICATION_TIMEOUT);
+    return () => {
+      clearTimeout(handle);
+    };
+  }, [setTimedOut]);
+
+  React.useEffect(() => {
+    if (!notification.hidden && timedOut && !mouseOver) {
+      notifications.remove(notification.id);
+    }
+  }, [mouseOver, notification, timedOut, notifications]);
+
+  if (notification.hidden) {
+    return null;
+  }
+
+  return (
+    <Alert
+      variant={asEnumMember(notification.status, AlertVariant) ?? undefined}
+      title={notification.title}
+      actionClose={<AlertActionCloseButton onClose={() => notifications.remove(notification.id)} />}
+      onMouseEnter={() => setMouseOver(true)}
+      onMouseLeave={() => setMouseOver(false)}
+    >
+      {notification.message}
+    </Alert>
+  );
+};
+
+export default ToastNotification;

--- a/clients/ui/frontend/src/components/ToastNotifications.tsx
+++ b/clients/ui/frontend/src/components/ToastNotifications.tsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { AlertGroup } from '@patternfly/react-core';
+import { NotificationContext } from '~/app/context/NotificationContext';
+import ToastNotification from './ToastNotification';
+
+const ToastNotifications: React.FC = () => {
+  const { notifications } = useContext(NotificationContext);
+
+  return (
+    <AlertGroup isToast isLiveRegion>
+      {notifications.map((notification) => (
+        <ToastNotification notification={notification} key={notification.id} />
+      ))}
+    </AlertGroup>
+  );
+};
+
+export default ToastNotifications;

--- a/clients/ui/frontend/src/index.tsx
+++ b/clients/ui/frontend/src/index.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import App from './app/App';
 import { BrowserStorageContextProvider } from './components/browserStorage/BrowserStorageContext';
+import { NotificationContextProvider } from './app/context/NotificationContext';
 
 const theme = createTheme({ cssVariables: true });
 const root = ReactDOM.createRoot(document.getElementById('root')!);
@@ -13,7 +14,9 @@ root.render(
     <Router>
       <BrowserStorageContextProvider>
         <ThemeProvider theme={theme}>
-          <App />
+          <NotificationContextProvider>
+            <App />
+          </NotificationContextProvider>
         </ThemeProvider>
       </BrowserStorageContextProvider>
     </Router>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a new global context for Notifications. I also added a `useNotification` hook to allow for easier dispatching by calling the specific method you want to use `notification.success` or `notification.error`. I also looped in the removal of notifications into this hook. You can call it like: 
```javascript
notifications = useNotification() // returns state for notifications
...
notifications.remove(notification.id)
```

![image](https://github.com/user-attachments/assets/9ded9694-e3af-4f50-bc73-dc8d29655510)


* I still not have tested restoring an archived version yet since I can't do it in mocked mode

There are a couple known issues at the moment:
1. The id count gets reset to 0 whenever you change pages meaning if you switch pages quickly and get another notification they will have the same id
2. The notification exit button looks out of place (I think it should be center aligned not in the top right corner)
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
