### PR TITLE
OpenAPI: do not require artifactType

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -1093,50 +1093,43 @@ components:
       type: string
     ModelArtifact:
       description: An ML model artifact.
-      type: object
-      required:
-        - artifactType
-      properties:
-        artifactType:
-          type: string
-          default: "model-artifact"
       allOf:
         - $ref: "#/components/schemas/BaseArtifact"
         - $ref: "#/components/schemas/ModelArtifactCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "model-artifact"
     DocArtifact:
       description: A document.
-      type: object
-      required:
-        - artifactType
-      properties:
-        artifactType:
-          type: string
-          default: "doc-artifact"
       allOf:
         - $ref: "#/components/schemas/BaseArtifact"
         - $ref: "#/components/schemas/DocArtifactCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
     DocArtifactCreate:
       description: A document artifact to be created.
-      type: object
-      required:
-        - artifactType
-      properties:
-        artifactType:
-          type: string
-          default: "doc-artifact"
       allOf:
         - $ref: "#/components/schemas/BaseArtifactCreate"
         - $ref: "#/components/schemas/DocArtifactUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
     DocArtifactUpdate:
       description: A document artifact to be updated.
-      required:
-        - artifactType
-      properties:
-        artifactType:
-          type: string
-          default: "doc-artifact"
       allOf:
         - $ref: "#/components/schemas/BaseArtifactUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
     RegisteredModel:
       description: A registered model in model registry. A registered model has ModelVersion children.
       allOf:
@@ -1247,7 +1240,6 @@ components:
         - $ref: "#/components/schemas/BaseExecutionUpdate"
         - $ref: "#/components/schemas/BaseResourceCreate"
     BaseExecutionUpdate:
-      type: object
       allOf:
         - type: object
           properties:
@@ -1438,16 +1430,13 @@ components:
         - $ref: "#/components/schemas/BaseResourceList"
     ModelArtifactUpdate:
       description: An ML model artifact to be updated.
-      required:
-        - artifactType
-      properties:
-        artifactType:
-          type: string
-          default: "model-artifact"
       allOf:
         - $ref: "#/components/schemas/BaseArtifactUpdate"
         - type: object
           properties:
+            artifactType:
+              type: string
+              default: "model-artifact"
             modelFormatName:
               description: Name of the model format.
               type: string
@@ -1465,8 +1454,6 @@ components:
               type: string
     ModelArtifactCreate:
       description: An ML model artifact.
-      required:
-        - artifactType
       properties:
         artifactType:
           type: string
@@ -1562,7 +1549,6 @@ components:
       description: A Model Serving environment for serving `RegisteredModels`.
       allOf:
         - $ref: "#/components/schemas/BaseResource"
-        - type: object
         - $ref: "#/components/schemas/ServingEnvironmentCreate"
     ServingEnvironmentUpdate:
       description: A Model Serving environment for serving `RegisteredModels`.

--- a/clients/python/src/mr_openapi/models/doc_artifact.py
+++ b/clients/python/src/mr_openapi/models/doc_artifact.py
@@ -25,7 +25,6 @@ from mr_openapi.models.metadata_value import MetadataValue
 class DocArtifact(BaseModel):
     """A document."""  # noqa: E501
 
-    artifact_type: StrictStr = Field(alias="artifactType")
     custom_properties: dict[str, MetadataValue] | None = Field(
         default=None,
         description="User provided custom properties which are not defined by its type.",
@@ -57,6 +56,7 @@ class DocArtifact(BaseModel):
         description="Output only. Last update time of the resource since epoch in millisecond since epoch.",
         alias="lastUpdateTimeSinceEpoch",
     )
+    artifact_type: StrictStr | None = Field(default="doc-artifact", alias="artifactType")
     __properties: ClassVar[list[str]] = [
         "customProperties",
         "description",

--- a/clients/python/src/mr_openapi/models/doc_artifact_create.py
+++ b/clients/python/src/mr_openapi/models/doc_artifact_create.py
@@ -25,7 +25,6 @@ from mr_openapi.models.metadata_value import MetadataValue
 class DocArtifactCreate(BaseModel):
     """A document artifact to be created."""  # noqa: E501
 
-    artifact_type: StrictStr = Field(alias="artifactType")
     custom_properties: dict[str, MetadataValue] | None = Field(
         default=None,
         description="User provided custom properties which are not defined by its type.",
@@ -46,6 +45,7 @@ class DocArtifactCreate(BaseModel):
         default=None,
         description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.",
     )
+    artifact_type: StrictStr | None = Field(default="doc-artifact", alias="artifactType")
     __properties: ClassVar[list[str]] = [
         "customProperties",
         "description",

--- a/clients/python/src/mr_openapi/models/doc_artifact_update.py
+++ b/clients/python/src/mr_openapi/models/doc_artifact_update.py
@@ -25,7 +25,6 @@ from mr_openapi.models.metadata_value import MetadataValue
 class DocArtifactUpdate(BaseModel):
     """A document artifact to be updated."""  # noqa: E501
 
-    artifact_type: StrictStr = Field(alias="artifactType")
     custom_properties: dict[str, MetadataValue] | None = Field(
         default=None,
         description="User provided custom properties which are not defined by its type.",
@@ -42,7 +41,15 @@ class DocArtifactUpdate(BaseModel):
         description="The uniform resource identifier of the physical artifact. May be empty if there is no physical artifact.",
     )
     state: ArtifactState | None = None
-    __properties: ClassVar[list[str]] = ["customProperties", "description", "externalId", "uri", "state"]
+    artifact_type: StrictStr | None = Field(default="doc-artifact", alias="artifactType")
+    __properties: ClassVar[list[str]] = [
+        "customProperties",
+        "description",
+        "externalId",
+        "uri",
+        "state",
+        "artifactType",
+    ]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -110,5 +117,6 @@ class DocArtifactUpdate(BaseModel):
                 "externalId": obj.get("externalId"),
                 "uri": obj.get("uri"),
                 "state": obj.get("state"),
+                "artifactType": obj.get("artifactType") if obj.get("artifactType") is not None else "doc-artifact",
             }
         )

--- a/clients/python/src/mr_openapi/models/model_artifact.py
+++ b/clients/python/src/mr_openapi/models/model_artifact.py
@@ -25,7 +25,6 @@ from mr_openapi.models.metadata_value import MetadataValue
 class ModelArtifact(BaseModel):
     """An ML model artifact."""  # noqa: E501
 
-    artifact_type: StrictStr = Field(alias="artifactType")
     custom_properties: dict[str, MetadataValue] | None = Field(
         default=None,
         description="User provided custom properties which are not defined by its type.",
@@ -57,6 +56,7 @@ class ModelArtifact(BaseModel):
         description="Output only. Last update time of the resource since epoch in millisecond since epoch.",
         alias="lastUpdateTimeSinceEpoch",
     )
+    artifact_type: StrictStr | None = Field(default="model-artifact", alias="artifactType")
     model_format_name: StrictStr | None = Field(
         default=None, description="Name of the model format.", alias="modelFormatName"
     )

--- a/clients/python/src/mr_openapi/models/model_artifact_create.py
+++ b/clients/python/src/mr_openapi/models/model_artifact_create.py
@@ -25,7 +25,7 @@ from mr_openapi.models.metadata_value import MetadataValue
 class ModelArtifactCreate(BaseModel):
     """An ML model artifact."""  # noqa: E501
 
-    artifact_type: StrictStr = Field(alias="artifactType")
+    artifact_type: StrictStr | None = Field(default="model-artifact", alias="artifactType")
     custom_properties: dict[str, MetadataValue] | None = Field(
         default=None,
         description="User provided custom properties which are not defined by its type.",

--- a/clients/python/src/mr_openapi/models/model_artifact_update.py
+++ b/clients/python/src/mr_openapi/models/model_artifact_update.py
@@ -25,7 +25,6 @@ from mr_openapi.models.metadata_value import MetadataValue
 class ModelArtifactUpdate(BaseModel):
     """An ML model artifact to be updated."""  # noqa: E501
 
-    artifact_type: StrictStr = Field(alias="artifactType")
     custom_properties: dict[str, MetadataValue] | None = Field(
         default=None,
         description="User provided custom properties which are not defined by its type.",
@@ -42,6 +41,7 @@ class ModelArtifactUpdate(BaseModel):
         description="The uniform resource identifier of the physical artifact. May be empty if there is no physical artifact.",
     )
     state: ArtifactState | None = None
+    artifact_type: StrictStr | None = Field(default="model-artifact", alias="artifactType")
     model_format_name: StrictStr | None = Field(
         default=None, description="Name of the model format.", alias="modelFormatName"
     )
@@ -61,6 +61,7 @@ class ModelArtifactUpdate(BaseModel):
         "externalId",
         "uri",
         "state",
+        "artifactType",
         "modelFormatName",
         "storageKey",
         "storagePath",
@@ -134,6 +135,7 @@ class ModelArtifactUpdate(BaseModel):
                 "externalId": obj.get("externalId"),
                 "uri": obj.get("uri"),
                 "state": obj.get("state"),
+                "artifactType": obj.get("artifactType") if obj.get("artifactType") is not None else "model-artifact",
                 "modelFormatName": obj.get("modelFormatName"),
                 "storageKey": obj.get("storageKey"),
                 "storagePath": obj.get("storagePath"),

--- a/clients/python/src/mr_openapi/models/registered_model.py
+++ b/clients/python/src/mr_openapi/models/registered_model.py
@@ -37,7 +37,7 @@ class RegisteredModel(BaseModel):
         alias="externalId",
     )
     name: StrictStr = Field(
-        description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set."
+        description="The client provided name of the model. It must be unique among all the RegisteredModels of the same type within a Model Registry instance and cannot be changed once set."
     )
     id: StrictStr | None = Field(default=None, description="The unique server generated id of the resource.")
     create_time_since_epoch: StrictStr | None = Field(

--- a/clients/python/src/mr_openapi/models/registered_model_create.py
+++ b/clients/python/src/mr_openapi/models/registered_model_create.py
@@ -37,7 +37,7 @@ class RegisteredModelCreate(BaseModel):
         alias="externalId",
     )
     name: StrictStr = Field(
-        description="The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set."
+        description="The client provided name of the model. It must be unique among all the RegisteredModels of the same type within a Model Registry instance and cannot be changed once set."
     )
     owner: StrictStr | None = None
     state: RegisteredModelState | None = None

--- a/internal/converter/generated/mlmd_openapi_converter.gen.go
+++ b/internal/converter/generated/mlmd_openapi_converter.gen.go
@@ -16,11 +16,6 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertDocArtifact(source *proto.Artifact) 
 	var pOpenapiDocArtifact *openapi.DocArtifact
 	if source != nil {
 		var openapiDocArtifact openapi.DocArtifact
-		xstring, err := converter.MapArtifactType(source)
-		if err != nil {
-			return nil, fmt.Errorf("error setting field ArtifactType: %w", err)
-		}
-		openapiDocArtifact.ArtifactType = xstring
 		mapStringOpenapiMetadataValue, err := converter.MapMLMDCustomProperties((*source).CustomProperties)
 		if err != nil {
 			return nil, fmt.Errorf("error setting field CustomProperties: %w", err)
@@ -28,18 +23,23 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertDocArtifact(source *proto.Artifact) 
 		openapiDocArtifact.CustomProperties = &mapStringOpenapiMetadataValue
 		openapiDocArtifact.Description = converter.MapDescription((*source).Properties)
 		if (*source).ExternalId != nil {
-			xstring2 := *(*source).ExternalId
-			openapiDocArtifact.ExternalId = &xstring2
+			xstring := *(*source).ExternalId
+			openapiDocArtifact.ExternalId = &xstring
 		}
 		if (*source).Uri != nil {
-			xstring3 := *(*source).Uri
-			openapiDocArtifact.Uri = &xstring3
+			xstring2 := *(*source).Uri
+			openapiDocArtifact.Uri = &xstring2
 		}
 		openapiDocArtifact.State = converter.MapMLMDArtifactState((*source).State)
 		openapiDocArtifact.Name = converter.MapNameFromOwned((*source).Name)
 		openapiDocArtifact.Id = converter.Int64ToString((*source).Id)
 		openapiDocArtifact.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
 		openapiDocArtifact.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)
+		pString, err := converter.MapArtifactType(source)
+		if err != nil {
+			return nil, fmt.Errorf("error setting field ArtifactType: %w", err)
+		}
+		openapiDocArtifact.ArtifactType = pString
 		pOpenapiDocArtifact = &openapiDocArtifact
 	}
 	return pOpenapiDocArtifact, nil
@@ -75,11 +75,6 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertModelArtifact(source *proto.Artifact
 	var pOpenapiModelArtifact *openapi.ModelArtifact
 	if source != nil {
 		var openapiModelArtifact openapi.ModelArtifact
-		xstring, err := converter.MapArtifactType(source)
-		if err != nil {
-			return nil, fmt.Errorf("error setting field ArtifactType: %w", err)
-		}
-		openapiModelArtifact.ArtifactType = xstring
 		mapStringOpenapiMetadataValue, err := converter.MapMLMDCustomProperties((*source).CustomProperties)
 		if err != nil {
 			return nil, fmt.Errorf("error setting field CustomProperties: %w", err)
@@ -87,18 +82,23 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertModelArtifact(source *proto.Artifact
 		openapiModelArtifact.CustomProperties = &mapStringOpenapiMetadataValue
 		openapiModelArtifact.Description = converter.MapDescription((*source).Properties)
 		if (*source).ExternalId != nil {
-			xstring2 := *(*source).ExternalId
-			openapiModelArtifact.ExternalId = &xstring2
+			xstring := *(*source).ExternalId
+			openapiModelArtifact.ExternalId = &xstring
 		}
 		if (*source).Uri != nil {
-			xstring3 := *(*source).Uri
-			openapiModelArtifact.Uri = &xstring3
+			xstring2 := *(*source).Uri
+			openapiModelArtifact.Uri = &xstring2
 		}
 		openapiModelArtifact.State = converter.MapMLMDArtifactState((*source).State)
 		openapiModelArtifact.Name = converter.MapNameFromOwned((*source).Name)
 		openapiModelArtifact.Id = converter.Int64ToString((*source).Id)
 		openapiModelArtifact.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
 		openapiModelArtifact.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)
+		pString, err := converter.MapArtifactType(source)
+		if err != nil {
+			return nil, fmt.Errorf("error setting field ArtifactType: %w", err)
+		}
+		openapiModelArtifact.ArtifactType = pString
 		openapiModelArtifact.ModelFormatName = converter.MapModelArtifactFormatName((*source).Properties)
 		openapiModelArtifact.StorageKey = converter.MapModelArtifactStorageKey((*source).Properties)
 		openapiModelArtifact.StoragePath = converter.MapModelArtifactStoragePath((*source).Properties)

--- a/internal/converter/generated/openapi_converter.gen.go
+++ b/internal/converter/generated/openapi_converter.gen.go
@@ -649,18 +649,19 @@ func (c *OpenAPIConverterImpl) OverrideNotEditableForModelArtifact(source conver
 	openapiModelArtifact := converter.InitWithUpdate(source)
 	var pString *string
 	if source.Existing != nil {
-		pString = &source.Existing.ArtifactType
+		pString = source.Existing.Name
 	}
 	if pString != nil {
-		openapiModelArtifact.ArtifactType = *pString
+		xstring := *pString
+		openapiModelArtifact.Name = &xstring
 	}
 	var pString2 *string
 	if source.Existing != nil {
-		pString2 = source.Existing.Name
+		pString2 = source.Existing.ArtifactType
 	}
 	if pString2 != nil {
-		xstring := *pString2
-		openapiModelArtifact.Name = &xstring
+		xstring2 := *pString2
+		openapiModelArtifact.ArtifactType = &xstring2
 	}
 	return openapiModelArtifact, nil
 }

--- a/internal/converter/mlmd_converter_util_test.go
+++ b/internal/converter/mlmd_converter_util_test.go
@@ -618,19 +618,19 @@ func TestMapArtifactType(t *testing.T) {
 		Type: of(defaults.ModelArtifactTypeName),
 	})
 	assertion.Nil(err)
-	assertion.Equal("model-artifact", artifactType)
+	assertion.Equal(of("model-artifact"), artifactType)
 
 	artifactType, err = MapArtifactType(&proto.Artifact{
 		Type: of(defaults.DocArtifactTypeName),
 	})
 	assertion.Nil(err)
-	assertion.Equal("doc-artifact", artifactType)
+	assertion.Equal(of("doc-artifact"), artifactType)
 
 	artifactType, err = MapArtifactType(&proto.Artifact{
 		Type: of("Invalid"),
 	})
 	assertion.NotNil(err)
-	assertion.Equal("", artifactType)
+	assertion.Nil(artifactType)
 }
 
 func TestMapMLMDArtifactState(t *testing.T) {

--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -134,17 +134,17 @@ func MapRegisteredModelIdFromOwned(source *string) (string, error) {
 
 // ARTIFACT
 
-func MapArtifactType(source *proto.Artifact) (string, error) {
+func MapArtifactType(source *proto.Artifact) (*string, error) {
 	if source.Type == nil {
-		return "", fmt.Errorf("artifact type is nil")
+		return nil, fmt.Errorf("artifact type is nil")
 	}
 	switch *source.Type {
 	case defaults.ModelArtifactTypeName:
-		return "model-artifact", nil
+		return of("model-artifact"), nil
 	case defaults.DocArtifactTypeName:
-		return "doc-artifact", nil
+		return of("doc-artifact"), nil
 	default:
-		return "", fmt.Errorf("invalid artifact type found: %v", source.Type)
+		return nil, fmt.Errorf("invalid artifact type found: %v", source.Type)
 	}
 }
 

--- a/internal/server/openapi/type_asserts.go
+++ b/internal/server/openapi/type_asserts.go
@@ -205,29 +205,11 @@ func AssertDocArtifactCreateConstraints(obj model.DocArtifactCreate) error {
 
 // AssertDocArtifactCreateRequired checks if the required fields are not zero-ed
 func AssertDocArtifactCreateRequired(obj model.DocArtifactCreate) error {
-	elements := map[string]interface{}{
-		"artifactType": obj.ArtifactType,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
 	return nil
 }
 
 // AssertDocArtifactRequired checks if the required fields are not zero-ed
 func AssertDocArtifactRequired(obj model.DocArtifact) error {
-	elements := map[string]interface{}{
-		"artifactType": obj.ArtifactType,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
 	return nil
 }
 
@@ -238,15 +220,6 @@ func AssertDocArtifactUpdateConstraints(obj model.DocArtifactUpdate) error {
 
 // AssertDocArtifactUpdateRequired checks if the required fields are not zero-ed
 func AssertDocArtifactUpdateRequired(obj model.DocArtifactUpdate) error {
-	elements := map[string]interface{}{
-		"artifactType": obj.ArtifactType,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
 	return nil
 }
 
@@ -526,15 +499,6 @@ func AssertModelArtifactCreateConstraints(obj model.ModelArtifactCreate) error {
 
 // AssertModelArtifactCreateRequired checks if the required fields are not zero-ed
 func AssertModelArtifactCreateRequired(obj model.ModelArtifactCreate) error {
-	elements := map[string]interface{}{
-		"artifactType": obj.ArtifactType,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
 	return nil
 }
 
@@ -566,15 +530,6 @@ func AssertModelArtifactListRequired(obj model.ModelArtifactList) error {
 
 // AssertModelArtifactRequired checks if the required fields are not zero-ed
 func AssertModelArtifactRequired(obj model.ModelArtifact) error {
-	elements := map[string]interface{}{
-		"artifactType": obj.ArtifactType,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
 	return nil
 }
 
@@ -585,15 +540,6 @@ func AssertModelArtifactUpdateConstraints(obj model.ModelArtifactUpdate) error {
 
 // AssertModelArtifactUpdateRequired checks if the required fields are not zero-ed
 func AssertModelArtifactUpdateRequired(obj model.ModelArtifactUpdate) error {
-	elements := map[string]interface{}{
-		"artifactType": obj.ArtifactType,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/openapi/model_doc_artifact.go
+++ b/pkg/openapi/model_doc_artifact.go
@@ -19,7 +19,6 @@ var _ MappedNullable = &DocArtifact{}
 
 // DocArtifact A document.
 type DocArtifact struct {
-	ArtifactType string `json:"artifactType"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -37,16 +36,19 @@ type DocArtifact struct {
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`
 	// Output only. Last update time of the resource since epoch in millisecond since epoch.
 	LastUpdateTimeSinceEpoch *string `json:"lastUpdateTimeSinceEpoch,omitempty"`
+	ArtifactType             *string `json:"artifactType,omitempty"`
 }
 
 // NewDocArtifact instantiates a new DocArtifact object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDocArtifact(artifactType string) *DocArtifact {
+func NewDocArtifact() *DocArtifact {
 	this := DocArtifact{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "doc-artifact"
+	this.ArtifactType = &artifactType
 	return &this
 }
 
@@ -55,35 +57,11 @@ func NewDocArtifact(artifactType string) *DocArtifact {
 // but it doesn't guarantee that properties required by API are set
 func NewDocArtifactWithDefaults() *DocArtifact {
 	this := DocArtifact{}
-	var artifactType string = "doc-artifact"
-	this.ArtifactType = artifactType
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "doc-artifact"
+	this.ArtifactType = &artifactType
 	return &this
-}
-
-// GetArtifactType returns the ArtifactType field value
-func (o *DocArtifact) GetArtifactType() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.ArtifactType
-}
-
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
-// and a boolean to check if the value has been set.
-func (o *DocArtifact) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.ArtifactType, true
-}
-
-// SetArtifactType sets field value
-func (o *DocArtifact) SetArtifactType(v string) {
-	o.ArtifactType = v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -374,6 +352,38 @@ func (o *DocArtifact) SetLastUpdateTimeSinceEpoch(v string) {
 	o.LastUpdateTimeSinceEpoch = &v
 }
 
+// GetArtifactType returns the ArtifactType field value if set, zero value otherwise.
+func (o *DocArtifact) GetArtifactType() string {
+	if o == nil || IsNil(o.ArtifactType) {
+		var ret string
+		return ret
+	}
+	return *o.ArtifactType
+}
+
+// GetArtifactTypeOk returns a tuple with the ArtifactType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DocArtifact) GetArtifactTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.ArtifactType) {
+		return nil, false
+	}
+	return o.ArtifactType, true
+}
+
+// HasArtifactType returns a boolean if a field has been set.
+func (o *DocArtifact) HasArtifactType() bool {
+	if o != nil && !IsNil(o.ArtifactType) {
+		return true
+	}
+
+	return false
+}
+
+// SetArtifactType gets a reference to the given string and assigns it to the ArtifactType field.
+func (o *DocArtifact) SetArtifactType(v string) {
+	o.ArtifactType = &v
+}
+
 func (o DocArtifact) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -384,7 +394,6 @@ func (o DocArtifact) MarshalJSON() ([]byte, error) {
 
 func (o DocArtifact) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["artifactType"] = o.ArtifactType
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -411,6 +420,9 @@ func (o DocArtifact) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.LastUpdateTimeSinceEpoch) {
 		toSerialize["lastUpdateTimeSinceEpoch"] = o.LastUpdateTimeSinceEpoch
+	}
+	if !IsNil(o.ArtifactType) {
+		toSerialize["artifactType"] = o.ArtifactType
 	}
 	return toSerialize, nil
 }

--- a/pkg/openapi/model_doc_artifact_create.go
+++ b/pkg/openapi/model_doc_artifact_create.go
@@ -19,7 +19,6 @@ var _ MappedNullable = &DocArtifactCreate{}
 
 // DocArtifactCreate A document artifact to be created.
 type DocArtifactCreate struct {
-	ArtifactType string `json:"artifactType"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -30,17 +29,20 @@ type DocArtifactCreate struct {
 	Uri   *string        `json:"uri,omitempty"`
 	State *ArtifactState `json:"state,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
-	Name *string `json:"name,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	ArtifactType *string `json:"artifactType,omitempty"`
 }
 
 // NewDocArtifactCreate instantiates a new DocArtifactCreate object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDocArtifactCreate(artifactType string) *DocArtifactCreate {
+func NewDocArtifactCreate() *DocArtifactCreate {
 	this := DocArtifactCreate{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "doc-artifact"
+	this.ArtifactType = &artifactType
 	return &this
 }
 
@@ -49,35 +51,11 @@ func NewDocArtifactCreate(artifactType string) *DocArtifactCreate {
 // but it doesn't guarantee that properties required by API are set
 func NewDocArtifactCreateWithDefaults() *DocArtifactCreate {
 	this := DocArtifactCreate{}
-	var artifactType string = "doc-artifact"
-	this.ArtifactType = artifactType
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "doc-artifact"
+	this.ArtifactType = &artifactType
 	return &this
-}
-
-// GetArtifactType returns the ArtifactType field value
-func (o *DocArtifactCreate) GetArtifactType() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.ArtifactType
-}
-
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
-// and a boolean to check if the value has been set.
-func (o *DocArtifactCreate) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.ArtifactType, true
-}
-
-// SetArtifactType sets field value
-func (o *DocArtifactCreate) SetArtifactType(v string) {
-	o.ArtifactType = v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -272,6 +250,38 @@ func (o *DocArtifactCreate) SetName(v string) {
 	o.Name = &v
 }
 
+// GetArtifactType returns the ArtifactType field value if set, zero value otherwise.
+func (o *DocArtifactCreate) GetArtifactType() string {
+	if o == nil || IsNil(o.ArtifactType) {
+		var ret string
+		return ret
+	}
+	return *o.ArtifactType
+}
+
+// GetArtifactTypeOk returns a tuple with the ArtifactType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DocArtifactCreate) GetArtifactTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.ArtifactType) {
+		return nil, false
+	}
+	return o.ArtifactType, true
+}
+
+// HasArtifactType returns a boolean if a field has been set.
+func (o *DocArtifactCreate) HasArtifactType() bool {
+	if o != nil && !IsNil(o.ArtifactType) {
+		return true
+	}
+
+	return false
+}
+
+// SetArtifactType gets a reference to the given string and assigns it to the ArtifactType field.
+func (o *DocArtifactCreate) SetArtifactType(v string) {
+	o.ArtifactType = &v
+}
+
 func (o DocArtifactCreate) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -282,7 +292,6 @@ func (o DocArtifactCreate) MarshalJSON() ([]byte, error) {
 
 func (o DocArtifactCreate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["artifactType"] = o.ArtifactType
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -300,6 +309,9 @@ func (o DocArtifactCreate) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
+	}
+	if !IsNil(o.ArtifactType) {
+		toSerialize["artifactType"] = o.ArtifactType
 	}
 	return toSerialize, nil
 }

--- a/pkg/openapi/model_doc_artifact_update.go
+++ b/pkg/openapi/model_doc_artifact_update.go
@@ -19,7 +19,6 @@ var _ MappedNullable = &DocArtifactUpdate{}
 
 // DocArtifactUpdate A document artifact to be updated.
 type DocArtifactUpdate struct {
-	ArtifactType string `json:"artifactType"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -27,18 +26,21 @@ type DocArtifactUpdate struct {
 	// The external id that come from the clients’ system. This field is optional. If set, it must be unique among all resources within a database instance.
 	ExternalId *string `json:"externalId,omitempty"`
 	// The uniform resource identifier of the physical artifact. May be empty if there is no physical artifact.
-	Uri   *string        `json:"uri,omitempty"`
-	State *ArtifactState `json:"state,omitempty"`
+	Uri          *string        `json:"uri,omitempty"`
+	State        *ArtifactState `json:"state,omitempty"`
+	ArtifactType *string        `json:"artifactType,omitempty"`
 }
 
 // NewDocArtifactUpdate instantiates a new DocArtifactUpdate object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDocArtifactUpdate(artifactType string) *DocArtifactUpdate {
+func NewDocArtifactUpdate() *DocArtifactUpdate {
 	this := DocArtifactUpdate{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "doc-artifact"
+	this.ArtifactType = &artifactType
 	return &this
 }
 
@@ -47,35 +49,11 @@ func NewDocArtifactUpdate(artifactType string) *DocArtifactUpdate {
 // but it doesn't guarantee that properties required by API are set
 func NewDocArtifactUpdateWithDefaults() *DocArtifactUpdate {
 	this := DocArtifactUpdate{}
-	var artifactType string = "doc-artifact"
-	this.ArtifactType = artifactType
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "doc-artifact"
+	this.ArtifactType = &artifactType
 	return &this
-}
-
-// GetArtifactType returns the ArtifactType field value
-func (o *DocArtifactUpdate) GetArtifactType() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.ArtifactType
-}
-
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
-// and a boolean to check if the value has been set.
-func (o *DocArtifactUpdate) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.ArtifactType, true
-}
-
-// SetArtifactType sets field value
-func (o *DocArtifactUpdate) SetArtifactType(v string) {
-	o.ArtifactType = v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -238,6 +216,38 @@ func (o *DocArtifactUpdate) SetState(v ArtifactState) {
 	o.State = &v
 }
 
+// GetArtifactType returns the ArtifactType field value if set, zero value otherwise.
+func (o *DocArtifactUpdate) GetArtifactType() string {
+	if o == nil || IsNil(o.ArtifactType) {
+		var ret string
+		return ret
+	}
+	return *o.ArtifactType
+}
+
+// GetArtifactTypeOk returns a tuple with the ArtifactType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DocArtifactUpdate) GetArtifactTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.ArtifactType) {
+		return nil, false
+	}
+	return o.ArtifactType, true
+}
+
+// HasArtifactType returns a boolean if a field has been set.
+func (o *DocArtifactUpdate) HasArtifactType() bool {
+	if o != nil && !IsNil(o.ArtifactType) {
+		return true
+	}
+
+	return false
+}
+
+// SetArtifactType gets a reference to the given string and assigns it to the ArtifactType field.
+func (o *DocArtifactUpdate) SetArtifactType(v string) {
+	o.ArtifactType = &v
+}
+
 func (o DocArtifactUpdate) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -248,7 +258,6 @@ func (o DocArtifactUpdate) MarshalJSON() ([]byte, error) {
 
 func (o DocArtifactUpdate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["artifactType"] = o.ArtifactType
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -263,6 +272,9 @@ func (o DocArtifactUpdate) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.State) {
 		toSerialize["state"] = o.State
+	}
+	if !IsNil(o.ArtifactType) {
+		toSerialize["artifactType"] = o.ArtifactType
 	}
 	return toSerialize, nil
 }

--- a/pkg/openapi/model_model_artifact.go
+++ b/pkg/openapi/model_model_artifact.go
@@ -19,7 +19,6 @@ var _ MappedNullable = &ModelArtifact{}
 
 // ModelArtifact An ML model artifact.
 type ModelArtifact struct {
-	ArtifactType string `json:"artifactType"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -37,6 +36,7 @@ type ModelArtifact struct {
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`
 	// Output only. Last update time of the resource since epoch in millisecond since epoch.
 	LastUpdateTimeSinceEpoch *string `json:"lastUpdateTimeSinceEpoch,omitempty"`
+	ArtifactType             *string `json:"artifactType,omitempty"`
 	// Name of the model format.
 	ModelFormatName *string `json:"modelFormatName,omitempty"`
 	// Storage secret name.
@@ -53,10 +53,12 @@ type ModelArtifact struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewModelArtifact(artifactType string) *ModelArtifact {
+func NewModelArtifact() *ModelArtifact {
 	this := ModelArtifact{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "model-artifact"
+	this.ArtifactType = &artifactType
 	return &this
 }
 
@@ -65,35 +67,11 @@ func NewModelArtifact(artifactType string) *ModelArtifact {
 // but it doesn't guarantee that properties required by API are set
 func NewModelArtifactWithDefaults() *ModelArtifact {
 	this := ModelArtifact{}
-	var artifactType string = "model-artifact"
-	this.ArtifactType = artifactType
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "model-artifact"
+	this.ArtifactType = &artifactType
 	return &this
-}
-
-// GetArtifactType returns the ArtifactType field value
-func (o *ModelArtifact) GetArtifactType() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.ArtifactType
-}
-
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
-// and a boolean to check if the value has been set.
-func (o *ModelArtifact) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.ArtifactType, true
-}
-
-// SetArtifactType sets field value
-func (o *ModelArtifact) SetArtifactType(v string) {
-	o.ArtifactType = v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -384,6 +362,38 @@ func (o *ModelArtifact) SetLastUpdateTimeSinceEpoch(v string) {
 	o.LastUpdateTimeSinceEpoch = &v
 }
 
+// GetArtifactType returns the ArtifactType field value if set, zero value otherwise.
+func (o *ModelArtifact) GetArtifactType() string {
+	if o == nil || IsNil(o.ArtifactType) {
+		var ret string
+		return ret
+	}
+	return *o.ArtifactType
+}
+
+// GetArtifactTypeOk returns a tuple with the ArtifactType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ModelArtifact) GetArtifactTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.ArtifactType) {
+		return nil, false
+	}
+	return o.ArtifactType, true
+}
+
+// HasArtifactType returns a boolean if a field has been set.
+func (o *ModelArtifact) HasArtifactType() bool {
+	if o != nil && !IsNil(o.ArtifactType) {
+		return true
+	}
+
+	return false
+}
+
+// SetArtifactType gets a reference to the given string and assigns it to the ArtifactType field.
+func (o *ModelArtifact) SetArtifactType(v string) {
+	o.ArtifactType = &v
+}
+
 // GetModelFormatName returns the ModelFormatName field value if set, zero value otherwise.
 func (o *ModelArtifact) GetModelFormatName() string {
 	if o == nil || IsNil(o.ModelFormatName) {
@@ -554,7 +564,6 @@ func (o ModelArtifact) MarshalJSON() ([]byte, error) {
 
 func (o ModelArtifact) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["artifactType"] = o.ArtifactType
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -581,6 +590,9 @@ func (o ModelArtifact) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.LastUpdateTimeSinceEpoch) {
 		toSerialize["lastUpdateTimeSinceEpoch"] = o.LastUpdateTimeSinceEpoch
+	}
+	if !IsNil(o.ArtifactType) {
+		toSerialize["artifactType"] = o.ArtifactType
 	}
 	if !IsNil(o.ModelFormatName) {
 		toSerialize["modelFormatName"] = o.ModelFormatName

--- a/pkg/openapi/model_model_artifact_create.go
+++ b/pkg/openapi/model_model_artifact_create.go
@@ -19,7 +19,7 @@ var _ MappedNullable = &ModelArtifactCreate{}
 
 // ModelArtifactCreate An ML model artifact.
 type ModelArtifactCreate struct {
-	ArtifactType string `json:"artifactType"`
+	ArtifactType *string `json:"artifactType,omitempty"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -47,10 +47,12 @@ type ModelArtifactCreate struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewModelArtifactCreate(artifactType string) *ModelArtifactCreate {
+func NewModelArtifactCreate() *ModelArtifactCreate {
 	this := ModelArtifactCreate{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "model-artifact"
+	this.ArtifactType = &artifactType
 	return &this
 }
 
@@ -60,34 +62,42 @@ func NewModelArtifactCreate(artifactType string) *ModelArtifactCreate {
 func NewModelArtifactCreateWithDefaults() *ModelArtifactCreate {
 	this := ModelArtifactCreate{}
 	var artifactType string = "model-artifact"
-	this.ArtifactType = artifactType
+	this.ArtifactType = &artifactType
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
 	return &this
 }
 
-// GetArtifactType returns the ArtifactType field value
+// GetArtifactType returns the ArtifactType field value if set, zero value otherwise.
 func (o *ModelArtifactCreate) GetArtifactType() string {
-	if o == nil {
+	if o == nil || IsNil(o.ArtifactType) {
 		var ret string
 		return ret
 	}
-
-	return o.ArtifactType
+	return *o.ArtifactType
 }
 
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
+// GetArtifactTypeOk returns a tuple with the ArtifactType field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ModelArtifactCreate) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.ArtifactType) {
 		return nil, false
 	}
-	return &o.ArtifactType, true
+	return o.ArtifactType, true
 }
 
-// SetArtifactType sets field value
+// HasArtifactType returns a boolean if a field has been set.
+func (o *ModelArtifactCreate) HasArtifactType() bool {
+	if o != nil && !IsNil(o.ArtifactType) {
+		return true
+	}
+
+	return false
+}
+
+// SetArtifactType gets a reference to the given string and assigns it to the ArtifactType field.
 func (o *ModelArtifactCreate) SetArtifactType(v string) {
-	o.ArtifactType = v
+	o.ArtifactType = &v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -452,7 +462,9 @@ func (o ModelArtifactCreate) MarshalJSON() ([]byte, error) {
 
 func (o ModelArtifactCreate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["artifactType"] = o.ArtifactType
+	if !IsNil(o.ArtifactType) {
+		toSerialize["artifactType"] = o.ArtifactType
+	}
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}

--- a/pkg/openapi/model_model_artifact_update.go
+++ b/pkg/openapi/model_model_artifact_update.go
@@ -19,7 +19,6 @@ var _ MappedNullable = &ModelArtifactUpdate{}
 
 // ModelArtifactUpdate An ML model artifact to be updated.
 type ModelArtifactUpdate struct {
-	ArtifactType string `json:"artifactType"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
@@ -27,8 +26,9 @@ type ModelArtifactUpdate struct {
 	// The external id that come from the clients’ system. This field is optional. If set, it must be unique among all resources within a database instance.
 	ExternalId *string `json:"externalId,omitempty"`
 	// The uniform resource identifier of the physical artifact. May be empty if there is no physical artifact.
-	Uri   *string        `json:"uri,omitempty"`
-	State *ArtifactState `json:"state,omitempty"`
+	Uri          *string        `json:"uri,omitempty"`
+	State        *ArtifactState `json:"state,omitempty"`
+	ArtifactType *string        `json:"artifactType,omitempty"`
 	// Name of the model format.
 	ModelFormatName *string `json:"modelFormatName,omitempty"`
 	// Storage secret name.
@@ -45,10 +45,12 @@ type ModelArtifactUpdate struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewModelArtifactUpdate(artifactType string) *ModelArtifactUpdate {
+func NewModelArtifactUpdate() *ModelArtifactUpdate {
 	this := ModelArtifactUpdate{}
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "model-artifact"
+	this.ArtifactType = &artifactType
 	return &this
 }
 
@@ -57,35 +59,11 @@ func NewModelArtifactUpdate(artifactType string) *ModelArtifactUpdate {
 // but it doesn't guarantee that properties required by API are set
 func NewModelArtifactUpdateWithDefaults() *ModelArtifactUpdate {
 	this := ModelArtifactUpdate{}
-	var artifactType string = "model-artifact"
-	this.ArtifactType = artifactType
 	var state ArtifactState = ARTIFACTSTATE_UNKNOWN
 	this.State = &state
+	var artifactType string = "model-artifact"
+	this.ArtifactType = &artifactType
 	return &this
-}
-
-// GetArtifactType returns the ArtifactType field value
-func (o *ModelArtifactUpdate) GetArtifactType() string {
-	if o == nil {
-		var ret string
-		return ret
-	}
-
-	return o.ArtifactType
-}
-
-// GetArtifactTypeOk returns a tuple with the ArtifactType field value
-// and a boolean to check if the value has been set.
-func (o *ModelArtifactUpdate) GetArtifactTypeOk() (*string, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.ArtifactType, true
-}
-
-// SetArtifactType sets field value
-func (o *ModelArtifactUpdate) SetArtifactType(v string) {
-	o.ArtifactType = v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -246,6 +224,38 @@ func (o *ModelArtifactUpdate) HasState() bool {
 // SetState gets a reference to the given ArtifactState and assigns it to the State field.
 func (o *ModelArtifactUpdate) SetState(v ArtifactState) {
 	o.State = &v
+}
+
+// GetArtifactType returns the ArtifactType field value if set, zero value otherwise.
+func (o *ModelArtifactUpdate) GetArtifactType() string {
+	if o == nil || IsNil(o.ArtifactType) {
+		var ret string
+		return ret
+	}
+	return *o.ArtifactType
+}
+
+// GetArtifactTypeOk returns a tuple with the ArtifactType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ModelArtifactUpdate) GetArtifactTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.ArtifactType) {
+		return nil, false
+	}
+	return o.ArtifactType, true
+}
+
+// HasArtifactType returns a boolean if a field has been set.
+func (o *ModelArtifactUpdate) HasArtifactType() bool {
+	if o != nil && !IsNil(o.ArtifactType) {
+		return true
+	}
+
+	return false
+}
+
+// SetArtifactType gets a reference to the given string and assigns it to the ArtifactType field.
+func (o *ModelArtifactUpdate) SetArtifactType(v string) {
+	o.ArtifactType = &v
 }
 
 // GetModelFormatName returns the ModelFormatName field value if set, zero value otherwise.
@@ -418,7 +428,6 @@ func (o ModelArtifactUpdate) MarshalJSON() ([]byte, error) {
 
 func (o ModelArtifactUpdate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["artifactType"] = o.ArtifactType
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -433,6 +442,9 @@ func (o ModelArtifactUpdate) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.State) {
 		toSerialize["state"] = o.State
+	}
+	if !IsNil(o.ArtifactType) {
+		toSerialize["artifactType"] = o.ArtifactType
 	}
 	if !IsNil(o.ModelFormatName) {
 		toSerialize["modelFormatName"] = o.ModelFormatName


### PR DESCRIPTION
Fixes `artifactType` being required on `model_artifact` routes.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
