### PR TITLE
core: make server generation use default factories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,7 @@ internal/server/openapi/api_model_registry_service.go: bin/openapi-generator-cli
 .PHONY: gen/openapi
 gen/openapi: bin/openapi-generator-cli openapi/validate pkg/openapi/client.go
 
-pkg/openapi/client.go: bin/openapi-generator-cli api/openapi/model-registry.yaml
-	rm -rf pkg/openapi
+pkg/openapi/client.go: bin/openapi-generator-cli api/openapi/model-registry.yaml clean-pkg-openapi
 	${OPENAPI_GENERATOR} generate \
 		-i api/openapi/model-registry.yaml -g go -o pkg/openapi --package-name openapi \
 		--ignore-file-override ./.openapi-generator-ignore --additional-properties=isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true
@@ -111,9 +110,12 @@ pkg/openapi/client.go: bin/openapi-generator-cli api/openapi/model-registry.yaml
 vet:
 	${GO} vet ./...
 
-.PHONY: clean
+.PHONY: clean-pkg-openapi
+	while IFS= read -r file; do rm -f "pkg/openapi/$file"; done < pkg/openapi/.openapi-generator/FILES
+
+.PHONY: clean clean-pkg-openapi
 clean:
-	rm -Rf ./model-registry internal/ml_metadata/proto/*.go internal/converter/generated/*.go pkg/openapi internal/server/openapi/api_model_registry_service.go
+	rm -Rf ./model-registry internal/ml_metadata/proto/*.go internal/converter/generated/*.go internal/server/openapi/api_model_registry_service.go
 
 .PHONY: clean/odh
 clean/odh:

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -188,7 +188,7 @@ async def test_patch_mm(client: ModelRegistry):
 
     payload = { "modelFormatName": "foo" }
     from .conftest import REGISTRY_HOST, REGISTRY_PORT
-    response = requests.patch(url=f"{REGISTRY_HOST}:{REGISTRY_PORT}/api/model_registry/v1alpha3/model_artifacts/{ma.id}", json=payload, headers={"Content-Type": "application/json"})
+    response = requests.patch(url=f"{REGISTRY_HOST}:{REGISTRY_PORT}/api/model_registry/v1alpha3/model_artifacts/{ma.id}", json=payload, timeout=10, headers={"Content-Type": "application/json"})
     assert response.status_code == 200
     ma = client.get_model_artifact(name, version)
     assert ma

--- a/internal/server/openapi/api_model_registry_service.go
+++ b/internal/server/openapi/api_model_registry_service.go
@@ -257,7 +257,7 @@ func (c *ModelRegistryServiceAPIController) Routes() Routes {
 
 // CreateArtifact - Create an Artifact
 func (c *ModelRegistryServiceAPIController) CreateArtifact(w http.ResponseWriter, r *http.Request) {
-	artifactCreateParam := model.ArtifactCreate{}
+	artifactCreateParam := *model.NewArtifactCreateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&artifactCreateParam); err != nil {
@@ -285,7 +285,7 @@ func (c *ModelRegistryServiceAPIController) CreateArtifact(w http.ResponseWriter
 // CreateEnvironmentInferenceService - Create a InferenceService in ServingEnvironment
 func (c *ModelRegistryServiceAPIController) CreateEnvironmentInferenceService(w http.ResponseWriter, r *http.Request) {
 	servingenvironmentIdParam := chi.URLParam(r, "servingenvironmentId")
-	inferenceServiceCreateParam := model.InferenceServiceCreate{}
+	inferenceServiceCreateParam := *model.NewInferenceServiceCreateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&inferenceServiceCreateParam); err != nil {
@@ -312,7 +312,7 @@ func (c *ModelRegistryServiceAPIController) CreateEnvironmentInferenceService(w 
 
 // CreateInferenceService - Create a InferenceService
 func (c *ModelRegistryServiceAPIController) CreateInferenceService(w http.ResponseWriter, r *http.Request) {
-	inferenceServiceCreateParam := model.InferenceServiceCreate{}
+	inferenceServiceCreateParam := *model.NewInferenceServiceCreateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&inferenceServiceCreateParam); err != nil {
@@ -340,7 +340,7 @@ func (c *ModelRegistryServiceAPIController) CreateInferenceService(w http.Respon
 // CreateInferenceServiceServe - Create a ServeModel action in a InferenceService
 func (c *ModelRegistryServiceAPIController) CreateInferenceServiceServe(w http.ResponseWriter, r *http.Request) {
 	inferenceserviceIdParam := chi.URLParam(r, "inferenceserviceId")
-	serveModelCreateParam := model.ServeModelCreate{}
+	serveModelCreateParam := *model.NewServeModelCreateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&serveModelCreateParam); err != nil {
@@ -367,7 +367,7 @@ func (c *ModelRegistryServiceAPIController) CreateInferenceServiceServe(w http.R
 
 // CreateModelArtifact - Create a ModelArtifact
 func (c *ModelRegistryServiceAPIController) CreateModelArtifact(w http.ResponseWriter, r *http.Request) {
-	modelArtifactCreateParam := model.ModelArtifactCreate{}
+	modelArtifactCreateParam := *model.NewModelArtifactCreateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&modelArtifactCreateParam); err != nil {
@@ -394,7 +394,7 @@ func (c *ModelRegistryServiceAPIController) CreateModelArtifact(w http.ResponseW
 
 // CreateModelVersion - Create a ModelVersion
 func (c *ModelRegistryServiceAPIController) CreateModelVersion(w http.ResponseWriter, r *http.Request) {
-	modelVersionCreateParam := model.ModelVersionCreate{}
+	modelVersionCreateParam := *model.NewModelVersionCreateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&modelVersionCreateParam); err != nil {
@@ -421,7 +421,7 @@ func (c *ModelRegistryServiceAPIController) CreateModelVersion(w http.ResponseWr
 
 // CreateRegisteredModel - Create a RegisteredModel
 func (c *ModelRegistryServiceAPIController) CreateRegisteredModel(w http.ResponseWriter, r *http.Request) {
-	registeredModelCreateParam := model.RegisteredModelCreate{}
+	registeredModelCreateParam := *model.NewRegisteredModelCreateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&registeredModelCreateParam); err != nil {
@@ -449,7 +449,7 @@ func (c *ModelRegistryServiceAPIController) CreateRegisteredModel(w http.Respons
 // CreateRegisteredModelVersion - Create a ModelVersion in RegisteredModel
 func (c *ModelRegistryServiceAPIController) CreateRegisteredModelVersion(w http.ResponseWriter, r *http.Request) {
 	registeredmodelIdParam := chi.URLParam(r, "registeredmodelId")
-	modelVersionParam := model.ModelVersion{}
+	modelVersionParam := *model.NewModelVersionWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&modelVersionParam); err != nil {
@@ -476,7 +476,7 @@ func (c *ModelRegistryServiceAPIController) CreateRegisteredModelVersion(w http.
 
 // CreateServingEnvironment - Create a ServingEnvironment
 func (c *ModelRegistryServiceAPIController) CreateServingEnvironment(w http.ResponseWriter, r *http.Request) {
-	servingEnvironmentCreateParam := model.ServingEnvironmentCreate{}
+	servingEnvironmentCreateParam := *model.NewServingEnvironmentCreateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&servingEnvironmentCreateParam); err != nil {
@@ -884,7 +884,7 @@ func (c *ModelRegistryServiceAPIController) GetServingEnvironments(w http.Respon
 // UpdateArtifact - Update an Artifact
 func (c *ModelRegistryServiceAPIController) UpdateArtifact(w http.ResponseWriter, r *http.Request) {
 	idParam := chi.URLParam(r, "id")
-	artifactUpdateParam := model.ArtifactUpdate{}
+	artifactUpdateParam := *model.NewArtifactUpdateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&artifactUpdateParam); err != nil {
@@ -912,7 +912,7 @@ func (c *ModelRegistryServiceAPIController) UpdateArtifact(w http.ResponseWriter
 // UpdateInferenceService - Update a InferenceService
 func (c *ModelRegistryServiceAPIController) UpdateInferenceService(w http.ResponseWriter, r *http.Request) {
 	inferenceserviceIdParam := chi.URLParam(r, "inferenceserviceId")
-	inferenceServiceUpdateParam := model.InferenceServiceUpdate{}
+	inferenceServiceUpdateParam := *model.NewInferenceServiceUpdateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&inferenceServiceUpdateParam); err != nil {
@@ -940,7 +940,7 @@ func (c *ModelRegistryServiceAPIController) UpdateInferenceService(w http.Respon
 // UpdateModelArtifact - Update a ModelArtifact
 func (c *ModelRegistryServiceAPIController) UpdateModelArtifact(w http.ResponseWriter, r *http.Request) {
 	modelartifactIdParam := chi.URLParam(r, "modelartifactId")
-	modelArtifactUpdateParam := model.ModelArtifactUpdate{}
+	modelArtifactUpdateParam := *model.NewModelArtifactUpdateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&modelArtifactUpdateParam); err != nil {
@@ -968,7 +968,7 @@ func (c *ModelRegistryServiceAPIController) UpdateModelArtifact(w http.ResponseW
 // UpdateModelVersion - Update a ModelVersion
 func (c *ModelRegistryServiceAPIController) UpdateModelVersion(w http.ResponseWriter, r *http.Request) {
 	modelversionIdParam := chi.URLParam(r, "modelversionId")
-	modelVersionUpdateParam := model.ModelVersionUpdate{}
+	modelVersionUpdateParam := *model.NewModelVersionUpdateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&modelVersionUpdateParam); err != nil {
@@ -996,7 +996,7 @@ func (c *ModelRegistryServiceAPIController) UpdateModelVersion(w http.ResponseWr
 // UpdateRegisteredModel - Update a RegisteredModel
 func (c *ModelRegistryServiceAPIController) UpdateRegisteredModel(w http.ResponseWriter, r *http.Request) {
 	registeredmodelIdParam := chi.URLParam(r, "registeredmodelId")
-	registeredModelUpdateParam := model.RegisteredModelUpdate{}
+	registeredModelUpdateParam := *model.NewRegisteredModelUpdateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&registeredModelUpdateParam); err != nil {
@@ -1024,7 +1024,7 @@ func (c *ModelRegistryServiceAPIController) UpdateRegisteredModel(w http.Respons
 // UpdateServingEnvironment - Update a ServingEnvironment
 func (c *ModelRegistryServiceAPIController) UpdateServingEnvironment(w http.ResponseWriter, r *http.Request) {
 	servingenvironmentIdParam := chi.URLParam(r, "servingenvironmentId")
-	servingEnvironmentUpdateParam := model.ServingEnvironmentUpdate{}
+	servingEnvironmentUpdateParam := *model.NewServingEnvironmentUpdateWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&servingEnvironmentUpdateParam); err != nil {
@@ -1052,7 +1052,7 @@ func (c *ModelRegistryServiceAPIController) UpdateServingEnvironment(w http.Resp
 // UpsertModelVersionArtifact - Upsert an Artifact in a ModelVersion
 func (c *ModelRegistryServiceAPIController) UpsertModelVersionArtifact(w http.ResponseWriter, r *http.Request) {
 	modelversionIdParam := chi.URLParam(r, "modelversionId")
-	artifactParam := model.Artifact{}
+	artifactParam := *model.NewArtifactWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&artifactParam); err != nil {

--- a/pkg/openapi/factories.go
+++ b/pkg/openapi/factories.go
@@ -1,0 +1,13 @@
+package openapi
+
+func NewArtifactCreateWithDefaults() *ArtifactCreate {
+	return &ArtifactCreate{}
+}
+
+func NewArtifactUpdateWithDefaults() *ArtifactUpdate {
+	return &ArtifactUpdate{}
+}
+
+func NewArtifactWithDefaults() *Artifact {
+	return &Artifact{}
+}

--- a/templates/go-server/controller-api.mustache
+++ b/templates/go-server/controller-api.mustache
@@ -406,7 +406,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{paramName}}Param := r.Header.Get("{{baseName}}")
 	{{/isHeaderParam}}
 	{{#isBodyParam}}
-	{{paramName}}Param := model.{{dataType}}{}
+	{{paramName}}Param := *model.New{{dataType}}WithDefaults()
 	d := json.NewDecoder(r.Body)
 	{{^isAdditionalPropertiesTrue}}
 	d.DisallowUnknownFields()


### PR DESCRIPTION
alternative of https://github.com/kubeflow/model-registry/pull/527

## Description
- 0cce633466311c34eef19661222f414de1cca9d5 show required changes in openapi codegeneration to align model
- 543cea11c3ccbfa77d454f42d718b5156e4c9596 codegeneration
- 3701535248fc4088328bfcd508b664783e02b0bf non regression testing in Python, using client to prepare the data, and UI code describing the issue

## How Has This Been Tested?
Locally with Go test, and `poetry run pytest --e2e -s -k test_patch_mm` after `make test-e2e`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
