### PR TITLE
Fixing slog.Logger.Error arg err should be a string or a slog.Attr (possible missing key or value)

### DIFF
--- a/clients/ui/bff/internal/mocks/k8s_mock.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock.go
@@ -3,14 +3,15 @@ package mocks
 import (
 	"context"
 	"fmt"
-	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
@@ -50,21 +51,21 @@ func NewKubernetesClient(logger *slog.Logger, ctx context.Context, cancel contex
 	}
 	cfg, err := testEnv.Start()
 	if err != nil {
-		logger.Error("failed to start test environment", err)
+		logger.Error("failed to start test environment", slog.String("error", err.Error()))
 		cancel()
 		os.Exit(1)
 	}
 
 	mockK8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
-		logger.Error("failed to create Kubernetes client", err)
+		logger.Error("failed to create Kubernetes client", slog.String("error", err.Error()))
 		cancel()
 		os.Exit(1)
 	}
 
 	err = setupMock(mockK8sClient, ctx)
 	if err != nil {
-		logger.Error("failed on mock setup", err)
+		logger.Error("failed on mock setup", slog.String("error", err.Error()))
 		cancel()
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Description
On go 23, this error occurs:

internal/mocks/k8s_mock.go:53:52: slog.Logger.Error arg "err" should be a string or a slog.Attr (possible missing key or value)
internal/mocks/k8s_mock.go:60:54: slog.Logger.Error arg "err" should be a string or a slog.Attr (possible missing key or value)
internal/mocks/k8s_mock.go:67:40: slog.Logger.Error arg "err" should be a string or a slog.Attr (possible missing key or value)


## How Has This Been Tested?
Ran the BFF and ran the FE.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
