### PR TITLE
Warn instead of fail when cannot resolve bearer token on cluster

### DIFF
--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -49,8 +49,7 @@ func (app *App) AttachRESTClient(handler func(http.ResponseWriter, *http.Request
 		var bearerToken string
 		bearerToken, err = resolveBearerToken(app.kubernetesClient)
 		if err != nil {
-			app.serverErrorResponse(w, r, fmt.Errorf("failed to resolve BearerToken): %v", err))
-			return
+			app.logger.Warn("failed to resolve bearer token", "error", err)
 		}
 
 		client, err := integrations.NewHTTPClient(modelRegistryBaseURL, bearerToken)
@@ -69,7 +68,7 @@ func resolveBearerToken(k8s integrations.KubernetesClientInterface) (string, err
 	if err == nil {
 		//in cluster
 		//TODO (eder) load bearerToken probably from x-forwarded-access-bearerToken
-		return "", fmt.Errorf("failed to create Rest client (not implemented yet - inside cluster): %v", err)
+		return "", fmt.Errorf("failed to fetch bearer token: %v", err)
 	} else {
 		//off cluster (development)
 		bearerToken, err = k8s.BearerToken()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
