### PR TITLE
py: non-regression of user-feedback flow

### DIFF
--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -20,7 +20,7 @@ deploy-latest-mr:
 
 .PHONY: test-e2e
 test-e2e: deploy-latest-mr
-	poetry run pytest --e2e -s
+	poetry run pytest --e2e -s -rA
 
 .PHONY: test
 test:

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -24,7 +24,7 @@ test-e2e: deploy-latest-mr
 
 .PHONY: test
 test:
-	poetry run pytest -s
+	poetry run pytest -s -rA
 
 .PHONY: lint
 lint:

--- a/clients/python/noxfile.py
+++ b/clients/python/noxfile.py
@@ -61,6 +61,7 @@ def tests(session: Session) -> None:
     )
     session.run(
         "pytest",
+        "-rA",
         *session.posargs,
     )
 
@@ -81,6 +82,7 @@ def e2e_tests(session: Session) -> None:
         session.run(
             "pytest",
             "--e2e",
+            "-rA",
             "--cov",
             "--cov-config=pyproject.toml",
             *session.posargs,

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -231,7 +231,7 @@ async def test_update_preserves_model_info(client: ModelRegistry):
 
 
 @pytest.mark.e2e
-async def test_update_model_artifact_uri_reuse(client: ModelRegistry):
+async def test_update_existing_model_artifact(client: ModelRegistry):
     """Updating uri (or other properties) by re-using and call to update
 
     reported via slack

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -231,6 +231,39 @@ async def test_update_preserves_model_info(client: ModelRegistry):
 
 
 @pytest.mark.e2e
+async def test_update_model_artifact_uri_reuse(client: ModelRegistry):
+    """Updating uri (or other properties) by re-using and call to update
+
+    reported via slack
+    """
+    name = "test_model"
+    version = "1.0.0"
+    rm = client.register_model(
+        name,
+        "s3",
+        model_format_name="test_format",
+        model_format_version="test_version",
+        version=version,
+    )
+    assert rm.id
+    mv = client.get_model_version(name, version)
+    assert mv
+    assert mv.id
+    ma = client.get_model_artifact(name, version)
+    assert ma
+    assert ma.id
+
+    something_else = "https://something.else/model.onnx"
+    ma.uri = something_else
+    response = client.update(ma)
+    assert response
+    assert response.uri == something_else
+
+    ma = client.get_model_artifact(name, version)
+    assert ma.uri == something_else
+
+
+@pytest.mark.e2e
 async def test_get(client: ModelRegistry):
     name = "test_model"
     version = "1.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
edit: this add a non-regression test based on user feedback

## How Has This Been Tested?
`make test-e2e`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
