### PR TITLE
feat(bff): load x-forwarded-access-token in cluster setup

### DIFF
--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"github.com/julienschmidt/httprouter"
 	"github.com/kubeflow/model-registry/ui/bff/internal/integrations"
-	"k8s.io/client-go/rest"
 	"net/http"
 )
 
 type contextKey string
 
 const httpClientKey contextKey = "httpClientKey"
+const userAccessToken = "x-forwarded-access-token"
 
 func (app *App) RecoverPanic(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +47,7 @@ func (app *App) AttachRESTClient(handler func(http.ResponseWriter, *http.Request
 			return
 		}
 		var bearerToken string
-		bearerToken, err = resolveBearerToken(app.kubernetesClient)
+		bearerToken, err = resolveBearerToken(app.kubernetesClient, r.Header)
 		if err != nil {
 			app.serverErrorResponse(w, r, fmt.Errorf("failed to resolve BearerToken): %v", err))
 			return
@@ -63,21 +63,24 @@ func (app *App) AttachRESTClient(handler func(http.ResponseWriter, *http.Request
 	}
 }
 
-func resolveBearerToken(k8s integrations.KubernetesClientInterface) (string, error) {
+func resolveBearerToken(k8s integrations.KubernetesClientInterface, header http.Header) (string, error) {
 	var bearerToken string
-	_, err := rest.InClusterConfig()
-	if err == nil {
+	//check if I'm inside cluster
+	if k8s.IsInCluster() {
 		//in cluster
-		//TODO (eder) load bearerToken probably from x-forwarded-access-bearerToken
-		return "", fmt.Errorf("failed to create Rest client (not implemented yet - inside cluster): %v", err)
+		bearerToken = header.Get(userAccessToken)
+		if bearerToken == "" {
+			return "", fmt.Errorf("failed to create Rest client (not able to get bearerToken on cluster)")
+		}
 	} else {
 		//off cluster (development)
+		var err error
 		bearerToken, err = k8s.BearerToken()
 		if err != nil {
 			return "", fmt.Errorf("failed to fetch BearerToken in development mode: %v", err)
 		}
 	}
-	return bearerToken, err
+	return bearerToken, nil
 }
 
 func resolveModelRegistryURL(id string, client integrations.KubernetesClientInterface) (string, error) {

--- a/clients/ui/bff/internal/integrations/k8s.go
+++ b/clients/ui/bff/internal/integrations/k8s.go
@@ -3,6 +3,7 @@ package integrations
 import (
 	"context"
 	"fmt"
+	"k8s.io/client-go/rest"
 	"log/slog"
 	"os"
 	"time"
@@ -22,6 +23,7 @@ type KubernetesClientInterface interface {
 	GetServiceDetails() ([]ServiceDetails, error)
 	BearerToken() (string, error)
 	Shutdown(ctx context.Context, logger *slog.Logger) error
+	IsInCluster() bool
 }
 
 type ServiceDetails struct {
@@ -124,6 +126,11 @@ func (kc *KubernetesClient) Shutdown(ctx context.Context, logger *slog.Logger) e
 		logger.Error("timeout while waiting for Kubernetes manager to stop")
 		return fmt.Errorf("timeout while waiting for Kubernetes manager to stop")
 	}
+}
+
+func (kc *KubernetesClient) IsInCluster() bool {
+	_, err := rest.InClusterConfig()
+	return err == nil
 }
 
 func (kc *KubernetesClient) BearerToken() (string, error) {

--- a/clients/ui/frontend/src/shared/api/apiUtils.ts
+++ b/clients/ui/frontend/src/shared/api/apiUtils.ts
@@ -76,7 +76,10 @@ const callRestJSON = <T>(
 
   return fetch(`${host}${path}${searchParams ? `?${searchParams}` : ''}`, {
     ...otherOptions,
-    ...(contentType && { headers: { 'Content-Type': contentType } }),
+    headers: {
+      ...otherOptions.headers,
+      ...(contentType && { 'Content-Type': contentType }),
+    },
     method,
     body: formData ?? requestData,
   }).then((response) =>


### PR DESCRIPTION
## load x-forwarded-access-token in cluster setup
## Description
In this PR:
- middleware.go: load the bearerToken from x-forwarded-access-token and did a small refactoring to avoid leaking k8s client api;
- k8s.go: move the rest.inclusterConfig logic here for better encapsulation
- apiUtils.go: add the token parameter to the header also in calls where content type is set,
 
## How Has This Been Tested?
1. Built UI and BFF images locally and pushed to kind.
2. Used new 'make kind-deployment' to create and deploy everything to kind.

<img width="1272" alt="Screenshot 2024-11-11 at 11 32 44 AM" src="https://github.com/user-attachments/assets/99f9c48e-bfac-41db-a0a0-4d2fdc4a7215">

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
 
