### PR TITLE
Add BFF dev mode for local K8s testing

### DIFF
--- a/clients/ui/bff/Makefile
+++ b/clients/ui/bff/Makefile
@@ -3,6 +3,8 @@ IMG ?= model-registry-bff:latest
 PORT ?= 4000
 MOCK_K8S_CLIENT ?= false
 MOCK_MR_CLIENT ?= false
+DEV_MODE ?= false
+DEV_MODE_PORT ?= 8080
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 
@@ -45,7 +47,7 @@ build: fmt vet test
 .PHONY: run
 run: fmt vet envtest
 	ENVTEST_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go run ./cmd/main.go  --port=$(PORT) --mock-k8s-client=$(MOCK_K8S_CLIENT) --mock-mr-client=$(MOCK_MR_CLIENT)
+	go run ./cmd/main.go  --port=$(PORT) --mock-k8s-client=$(MOCK_K8S_CLIENT) --mock-mr-client=$(MOCK_MR_CLIENT) --dev-mode=$(DEV_MODE) --dev-mode-port=$(DEV_MODE_PORT)
 
 .PHONY: docker-build
 docker-build:

--- a/clients/ui/bff/cmd/main.go
+++ b/clients/ui/bff/cmd/main.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/kubeflow/model-registry/ui/bff/internal/api"
-	"github.com/kubeflow/model-registry/ui/bff/internal/config"
 	"os/signal"
 	"syscall"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/api"
+	"github.com/kubeflow/model-registry/ui/bff/internal/config"
 
 	"log/slog"
 	"net/http"
@@ -21,6 +22,8 @@ func main() {
 	flag.IntVar(&cfg.Port, "port", getEnvAsInt("PORT", 4000), "API server port")
 	flag.BoolVar(&cfg.MockK8Client, "mock-k8s-client", false, "Use mock Kubernetes client")
 	flag.BoolVar(&cfg.MockMRClient, "mock-mr-client", false, "Use mock Model Registry client")
+	flag.BoolVar(&cfg.DevMode, "dev-mode", false, "Use development mode for access to local K8s cluster")
+	flag.IntVar(&cfg.DevModePort, "dev-mode-port", getEnvAsInt("DEV_MODE_PORT", 8080), "Use port when in development mode")
 	flag.Parse()
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))

--- a/clients/ui/bff/docs/dev-guide.md
+++ b/clients/ui/bff/docs/dev-guide.md
@@ -83,3 +83,14 @@ You should receive a 200 response if everything is working correctly, the body s
 ```json
 {"items":[],"nextPageToken":"","pageSize":0,"size":0}
 ```
+
+#### 6. Run BFF locally in Dev Mode
+To access your local kind cluster when running the BFF locally, you can use the `DEV_MODE` option. This is useful for when
+you want to test live changes on real cluster. To do so, simply run:
+```shell
+make run DEV_MODE=true
+```
+You can also specify the port you are forwarding to if it is something other than 8080:
+```shell
+make run DEV_MODE=true DEV_MODE_PORT=8081
+```

--- a/clients/ui/bff/internal/config/environment.go
+++ b/clients/ui/bff/internal/config/environment.go
@@ -4,4 +4,6 @@ type EnvConfig struct {
 	Port         int
 	MockK8Client bool
 	MockMRClient bool
+	DevMode      bool
+	DevModePort  int
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR allows developers to run a local MR cluster in kind and port forward their service to work with the BFF running locally.

<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Follow the [dev guide](https://github.com/kubeflow/model-registry/blob/main/clients/ui/bff/docs/dev-guide.md) all the way to step 4.

Port forward with:
```
kubectl port-forward svc/model-registry-service 8081:8080 -n kubeflow
```

Run the BFF with:
```
make run DEV_MODE=true DEV_MODE_PORT=8081
```
and the UI in a separate terminal.

You should see an empty MR that you can interact with (make models, versions, archive, restore, etc)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
