### PR TITLE
Limit use of mockBFFResponse in mock tests

### DIFF
--- a/clients/ui/frontend/src/__mocks__/mockBFFResponse.ts
+++ b/clients/ui/frontend/src/__mocks__/mockBFFResponse.ts
@@ -1,5 +1,0 @@
-import { ModelRegistryBody } from '~/app/types';
-
-export const mockBFFResponse = <T>(data: T): ModelRegistryBody<T> => ({
-  data,
-});

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -1,9 +1,9 @@
 import type { GenericStaticResponse, RouteHandlerController } from 'cypress/types/net-stubbing';
+import { mockBFFResponse } from '~/__mocks__/utils';
 import type {
   ModelArtifact,
   ModelArtifactList,
   ModelRegistry,
-  ModelRegistryBody,
   ModelVersion,
   ModelVersionList,
   RegisteredModel,
@@ -35,7 +35,7 @@ declare global {
       interceptApi: ((
         type: 'GET /api/:apiVersion/model_registry/:modelRegistryName/registered_models',
         options: { path: { modelRegistryName: string; apiVersion: string } },
-        response: ApiResponse<ModelRegistryBody<RegisteredModelList>>,
+        response: ApiResponse<RegisteredModelList>,
       ) => Cypress.Chainable<null>) &
         ((
           type: 'POST /api/:apiVersion/model_registry/:modelRegistryName/registered_models',
@@ -47,7 +47,7 @@ declare global {
           options: {
             path: { modelRegistryName: string; apiVersion: string; registeredModelId: number };
           },
-          response: ApiResponse<ModelRegistryBody<ModelVersionList>>,
+          response: ApiResponse<ModelVersionList>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'POST /api/:apiVersion/model_registry/:modelRegistryName/registered_models/:registeredModelId/versions',
@@ -61,28 +61,28 @@ declare global {
           options: {
             path: { modelRegistryName: string; apiVersion: string; registeredModelId: number };
           },
-          response: ApiResponse<ModelRegistryBody<RegisteredModel>>,
+          response: ApiResponse<RegisteredModel>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'PATCH /api/:apiVersion/model_registry/:modelRegistryName/registered_models/:registeredModelId',
           options: {
             path: { modelRegistryName: string; apiVersion: string; registeredModelId: number };
           },
-          response: ApiResponse<ModelRegistryBody<RegisteredModel>>,
+          response: ApiResponse<RegisteredModel>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/:apiVersion/model_registry/:modelRegistryName/model_versions/:modelVersionId',
           options: {
             path: { modelRegistryName: string; apiVersion: string; modelVersionId: number };
           },
-          response: ApiResponse<ModelRegistryBody<ModelVersion>>,
+          response: ApiResponse<ModelVersion>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/:apiVersion/model_registry/:modelRegistryName/model_versions/:modelVersionId/artifacts',
           options: {
             path: { modelRegistryName: string; apiVersion: string; modelVersionId: number };
           },
-          response: ApiResponse<ModelRegistryBody<ModelArtifactList>>,
+          response: ApiResponse<ModelArtifactList>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'POST /api/:apiVersion/model_registry/:modelRegistryName/model_versions/:modelVersionId/artifacts',
@@ -96,12 +96,12 @@ declare global {
           options: {
             path: { modelRegistryName: string; apiVersion: string; modelVersionId: number };
           },
-          response: ApiResponse<ModelRegistryBody<ModelVersion | undefined>>,
+          response: ApiResponse<ModelVersion | undefined>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/:apiVersion/model_registry',
           options: { path: { apiVersion: string } },
-          response: ApiResponse<ModelRegistryBody<ModelRegistry[]>>,
+          response: ApiResponse<ModelRegistry[]>,
         ) => Cypress.Chainable<null>);
     }
   }
@@ -136,7 +136,7 @@ Cypress.Commands.add(
     }
     return cy.intercept(
       { method, pathname, query: options?.query, ...(options?.times && { times: options.times }) },
-      response,
+      mockBFFResponse(response),
     );
   },
 );

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -5,7 +5,6 @@ import { mockModelVersionList } from '~/__mocks__/mockModelVersionList';
 import { mockRegisteredModel } from '~/__mocks__/mockRegisteredModel';
 import { mockRegisteredModelList } from '~/__mocks__/mockRegisteredModelsList';
 import { labelModal, modelRegistry } from '~/__tests__/cypress/cypress/pages/modelRegistry';
-import { mockBFFResponse } from '~/__mocks__/mockBFFResponse';
 import type { ModelRegistry, ModelVersion, RegisteredModel } from '~/app/types';
 import { be } from '~/__tests__/cypress/cypress/utils/should';
 import { MODEL_REGISTRY_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
@@ -69,7 +68,7 @@ const initIntercepts = ({
     {
       path: { apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(modelRegistries),
+    modelRegistries,
   );
 
   cy.interceptApi(
@@ -77,7 +76,7 @@ const initIntercepts = ({
     {
       path: { modelRegistryName: 'modelregistry-sample', apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(mockRegisteredModelList({ items: registeredModels })),
+    mockRegisteredModelList({ items: registeredModels }),
   );
 
   cy.interceptApi(
@@ -89,7 +88,7 @@ const initIntercepts = ({
         registeredModelId: 1,
       },
     },
-    mockBFFResponse(mockModelVersionList({ items: modelVersions })),
+    mockModelVersionList({ items: modelVersions }),
   );
 };
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -1,6 +1,5 @@
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
 import type { ModelRegistry } from '~/app/types';
-import { mockBFFResponse } from '~/__mocks__/mockBFFResponse';
 import { modelRegistrySettings } from '~/__tests__/cypress/cypress/pages/modelRegistrySettings';
 
 type HandlersProps = {
@@ -28,7 +27,7 @@ const initIntercepts = ({
     {
       path: { apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(modelRegistries),
+    modelRegistries,
   );
 };
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelVersionArchive.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelVersionArchive.cy.ts
@@ -63,7 +63,7 @@ const initIntercepts = ({
     {
       path: { apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(modelRegistries),
+    modelRegistries,
   );
 
   cy.interceptApi(
@@ -71,7 +71,7 @@ const initIntercepts = ({
     {
       path: { modelRegistryName: 'modelregistry-sample', apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(mockRegisteredModelList({ size: registeredModelsSize })),
+    mockRegisteredModelList({ size: registeredModelsSize }),
   );
 
   cy.interceptApi(
@@ -83,11 +83,9 @@ const initIntercepts = ({
         registeredModelId: 1,
       },
     },
-    mockBFFResponse(
-      mockModelVersionList({
-        items: modelVersions,
-      }),
-    ),
+    mockModelVersionList({
+      items: modelVersions,
+    }),
   );
 
   cy.interceptApi(
@@ -99,7 +97,7 @@ const initIntercepts = ({
         registeredModelId: 1,
       },
     },
-    mockBFFResponse(mockRegisteredModel({ name: 'test-1' })),
+    mockRegisteredModel({ name: 'test-1' }),
   );
 
   cy.interceptApi(
@@ -111,9 +109,7 @@ const initIntercepts = ({
         modelVersionId: 2,
       },
     },
-    mockBFFResponse(
-      mockModelVersion({ id: '2', name: 'model version 2', state: ModelState.ARCHIVED }),
-    ),
+    mockModelVersion({ id: '2', name: 'model version 2', state: ModelState.ARCHIVED }),
   );
 
   cy.interceptApi(
@@ -125,7 +121,7 @@ const initIntercepts = ({
         modelVersionId: 3,
       },
     },
-    mockBFFResponse(mockModelVersion({ id: '3', name: 'model version 3', state: ModelState.LIVE })),
+    mockModelVersion({ id: '3', name: 'model version 3', state: ModelState.LIVE }),
   );
 };
 
@@ -199,7 +195,7 @@ describe('Restoring archive version', () => {
           modelVersionId: 2,
         },
       },
-      mockBFFResponse(mockModelVersion({})),
+      mockModelVersion({}),
     ).as('versionRestored');
 
     initIntercepts({});
@@ -228,7 +224,7 @@ describe('Restoring archive version', () => {
           modelVersionId: 2,
         },
       },
-      mockBFFResponse(mockModelVersion({})),
+      mockModelVersion({}),
     ).as('versionRestored');
 
     initIntercepts({});
@@ -257,7 +253,7 @@ describe('Archiving version', () => {
           modelVersionId: 3,
         },
       },
-      mockBFFResponse(mockModelVersion({})),
+      mockModelVersion({}),
     ).as('versionArchived');
 
     initIntercepts({});
@@ -287,7 +283,7 @@ describe('Archiving version', () => {
           modelVersionId: 3,
         },
       },
-      mockBFFResponse(mockModelVersion({})),
+      mockModelVersion({}),
     ).as('versionArchived');
 
     initIntercepts({});

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelVersionDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelVersionDetails.cy.ts
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
-import { mockBFFResponse } from '~/__mocks__/utils';
 import { mockRegisteredModel } from '~/__mocks__/mockRegisteredModel';
 import { mockModelVersionList } from '~/__mocks__/mockModelVersionList';
 import { mockModelVersion } from '~/__mocks__/mockModelVersion';
@@ -34,7 +33,7 @@ const initIntercepts = ({
     {
       path: { apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(modelRegistries),
+    modelRegistries,
   );
 
   cy.interceptApi(
@@ -46,7 +45,7 @@ const initIntercepts = ({
         registeredModelId: 1,
       },
     },
-    mockBFFResponse(mockRegisteredModel({})),
+    mockRegisteredModel({}),
   );
 
   cy.interceptApi(
@@ -58,19 +57,17 @@ const initIntercepts = ({
         registeredModelId: 1,
       },
     },
-    mockBFFResponse(
-      mockModelVersionList({
-        items: [
-          mockModelVersion({ name: 'Version 1', author: 'Author 1', registeredModelId: '1' }),
-          mockModelVersion({
-            author: 'Author 2',
-            registeredModelId: '1',
-            id: '2',
-            name: 'Version 2',
-          }),
-        ],
-      }),
-    ),
+    mockModelVersionList({
+      items: [
+        mockModelVersion({ name: 'Version 1', author: 'Author 1', registeredModelId: '1' }),
+        mockModelVersion({
+          author: 'Author 2',
+          registeredModelId: '1',
+          id: '2',
+          name: 'Version 2',
+        }),
+      ],
+    }),
   );
 
   cy.interceptApi(
@@ -82,23 +79,21 @@ const initIntercepts = ({
         modelVersionId: 1,
       },
     },
-    mockBFFResponse(
-      mockModelVersion({
-        id: '1',
-        name: 'Version 1',
-        labels: [
-          'Testing label',
-          'Financial data',
-          'Fraud detection',
-          'Long label data to be truncated abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc',
-          'Machine learning',
-          'Next data to be overflow',
-          'Label x',
-          'Label y',
-          'Label z',
-        ],
-      }),
-    ),
+    mockModelVersion({
+      id: '1',
+      name: 'Version 1',
+      labels: [
+        'Testing label',
+        'Financial data',
+        'Fraud detection',
+        'Long label data to be truncated abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc',
+        'Machine learning',
+        'Next data to be overflow',
+        'Label x',
+        'Label y',
+        'Label z',
+      ],
+    }),
   );
 
   cy.interceptApi(
@@ -110,7 +105,7 @@ const initIntercepts = ({
         modelVersionId: 2,
       },
     },
-    mockBFFResponse(mockModelVersion({ id: '2', name: 'Version 2' })),
+    mockModelVersion({ id: '2', name: 'Version 2' }),
   );
 
   cy.interceptApi(
@@ -122,18 +117,16 @@ const initIntercepts = ({
         modelVersionId: 1,
       },
     },
-    mockBFFResponse(
-      mockModelArtifactList({
-        items: [
-          mockModelArtifact({}),
-          mockModelArtifact({
-            author: 'Author 2',
-            id: '2',
-            name: 'Artifact 2',
-          }),
-        ],
-      }),
-    ),
+    mockModelArtifactList({
+      items: [
+        mockModelArtifact({}),
+        mockModelArtifact({
+          author: 'Author 2',
+          id: '2',
+          name: 'Artifact 2',
+        }),
+      ],
+    }),
   );
 };
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelVersions.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelVersions.cy.ts
@@ -8,7 +8,6 @@ import type { ModelRegistry, ModelVersion } from '~/app/types';
 import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
 import { mockModelVersion } from '~/__mocks__/mockModelVersion';
-import { mockBFFResponse } from '~/__mocks__/utils';
 import { MODEL_REGISTRY_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 
 type HandlersProps = {
@@ -54,7 +53,7 @@ const initIntercepts = ({
     {
       path: { apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(modelRegistries),
+    modelRegistries,
   );
 
   cy.interceptApi(
@@ -62,7 +61,7 @@ const initIntercepts = ({
     {
       path: { modelRegistryName: 'modelregistry-sample', apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(mockRegisteredModelList({ size: registeredModelsSize })),
+    mockRegisteredModelList({ size: registeredModelsSize }),
   );
 
   cy.interceptApi(
@@ -74,7 +73,7 @@ const initIntercepts = ({
         registeredModelId: 1,
       },
     },
-    mockBFFResponse(mockModelVersionList({ items: modelVersions })),
+    mockModelVersionList({ items: modelVersions }),
   );
 
   cy.interceptApi(
@@ -86,7 +85,7 @@ const initIntercepts = ({
         registeredModelId: 1,
       },
     },
-    mockBFFResponse(mockRegisteredModel({})),
+    mockRegisteredModel({}),
   );
 
   cy.interceptApi(
@@ -98,7 +97,7 @@ const initIntercepts = ({
         modelVersionId: 1,
       },
     },
-    mockBFFResponse(mockModelVersion({ id: '1', name: 'model version' })),
+    mockModelVersion({ id: '1', name: 'model version' }),
   );
 };
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/registeredModelArchive.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/registeredModelArchive.cy.ts
@@ -67,7 +67,7 @@ const initIntercepts = ({
     {
       path: { apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(modelRegistries),
+    modelRegistries,
   );
 
   cy.interceptApi(
@@ -75,7 +75,7 @@ const initIntercepts = ({
     {
       path: { modelRegistryName: 'modelregistry-sample', apiVersion: MODEL_REGISTRY_API_VERSION },
     },
-    mockBFFResponse(mockRegisteredModelList({ items: registeredModels })),
+    mockRegisteredModelList({ items: registeredModels }),
   );
 
   cy.interceptApi(
@@ -87,7 +87,7 @@ const initIntercepts = ({
         modelVersionId: 1,
       },
     },
-    mockBFFResponse(mockModelVersion({ id: '1', name: 'Version 2' })),
+    mockModelVersion({ id: '1', name: 'Version 2' }),
   );
 
   cy.interceptApi(
@@ -99,7 +99,7 @@ const initIntercepts = ({
         registeredModelId: 2,
       },
     },
-    mockBFFResponse(mockModelVersionList({ items: modelVersions })),
+    mockModelVersionList({ items: modelVersions }),
   );
 
   cy.interceptApi(
@@ -111,7 +111,7 @@ const initIntercepts = ({
         registeredModelId: 2,
       },
     },
-    mockBFFResponse(mockRegisteredModel({ id: '2', name: 'model 2', state: ModelState.ARCHIVED })),
+    mockRegisteredModel({ id: '2', name: 'model 2', state: ModelState.ARCHIVED }),
   );
 
   cy.interceptApi(
@@ -123,7 +123,7 @@ const initIntercepts = ({
         registeredModelId: 3,
       },
     },
-    mockBFFResponse(mockRegisteredModel({ id: '3', name: 'model 3' })),
+    mockRegisteredModel({ id: '3', name: 'model 3' }),
   );
 };
 
@@ -249,7 +249,7 @@ describe('Restoring archive model', () => {
           registeredModelId: 2,
         },
       },
-      mockBFFResponse(mockRegisteredModel({ id: '2', name: 'model 2', state: ModelState.LIVE })),
+      mockRegisteredModel({ id: '2', name: 'model 2', state: ModelState.LIVE }),
     ).as('modelRestored');
 
     initIntercepts({});
@@ -278,7 +278,7 @@ describe('Restoring archive model', () => {
           registeredModelId: 2,
         },
       },
-      mockBFFResponse(mockRegisteredModel({ id: '2', name: 'model 2', state: ModelState.LIVE })),
+      mockRegisteredModel({ id: '2', name: 'model 2', state: ModelState.LIVE }),
     ).as('modelRestored');
 
     initIntercepts({});
@@ -307,9 +307,7 @@ describe('Archiving model', () => {
           registeredModelId: 3,
         },
       },
-      mockBFFResponse(
-        mockRegisteredModel({ id: '3', name: 'model 3', state: ModelState.ARCHIVED }),
-      ),
+      mockRegisteredModel({ id: '3', name: 'model 3', state: ModelState.ARCHIVED }),
     ).as('modelArchived');
 
     initIntercepts({});
@@ -339,9 +337,7 @@ describe('Archiving model', () => {
           registeredModelId: 3,
         },
       },
-      mockBFFResponse(
-        mockRegisteredModel({ id: '3', name: 'model 3', state: ModelState.ARCHIVED }),
-      ),
+      mockRegisteredModel({ id: '3', name: 'model 3', state: ModelState.ARCHIVED }),
     ).as('modelArchived');
 
     initIntercepts({});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This changes what our `interceptApi` Cypress command returns, so that we don't have to wrap all of our mock calls with `mockBFFResponse`. I also duplicated a file that was a duplicate (`mockBFFResponse.ts` the function in this file was already in utils which makes more sense)
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Just a test enhancement, so as long as tests pass we are good.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
