### PR TITLE
kind: fix script var scope

### DIFF
--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -4,13 +4,13 @@ set -e
 
 DIR="$(dirname "$0")"
 MR_NAMESPACE="${MR_NAMESPACE:-kubeflow}"
+IMG="${IMG:-kubeflow/model-registry:latest}"
 
 source ./${DIR}/utils.sh
 
 # modularity to allow re-use this script against a remote k8s cluster
 if [[ -n "$LOCAL" ]]; then
     CLUSTER_NAME="${CLUSTER_NAME:-kind}"
-    IMG="${IMG:-kubeflow/model-registry:latest}"
 
     echo 'Creating local Kind cluster and loading image'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
since the IMG var is _also_ used without going through the if/branch in the main scripts few lines below

https://github.com/kubeflow/model-registry/blob/a12fd00d67b0e8c002cd5e021d8697a3fdb168da/scripts/deploy_on_kind.sh#L40-L41

fix variable scope by providing the default globally. 

## How Has This Been Tested?

```
 ./scripts/deploy_on_kind.sh
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

wdyt @Al-Pragliola ?