### PR TITLE
feat(bff): use 'kubeflow-userid' header to authorize BFF endpoints

### DIFF
--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -71,21 +71,23 @@ make docker-build
 | POST /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}/artifacts  | CreateModelArtifactByModelVersion            | Create a ModelArtifact entity for a specific ModelVersion   |
 
 ### Sample local calls
+
+You will need to inject your requests with a kubeflow-userid header for authorization purposes. When running the service with the mocked Kubernetes client (MOCK_K8S_CLIENT=true), the user user@example.com is preconfigured with the necessary RBAC permissions to perform these actions.
 ```
 # GET /v1/healthcheck
-curl -i localhost:4000/api/v1/healthcheck
+curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/healthcheck
 ```
 ```
 # GET /v1/model_registry 
-curl -i localhost:4000/api/v1/model_registry
+curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/model_registry
 ```
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models
-curl -i localhost:4000/api/v1/model_registry/model-registry/registered_models
+curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/model_registry/model-registry/registered_models
 ```
 ```
 #POST /v1/model_registry/{model_registry_id}/registered_models
-curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models" \
+curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models" \
      -H "Content-Type: application/json" \
      -d '{ "data": {
   "customProperties": {
@@ -103,11 +105,11 @@ curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/regi
 ```
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}
-curl -i localhost:4000/api/v1/model_registry/model-registry/registered_models/1
+curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/model_registry/model-registry/registered_models/1
 ```
 ```
 # PATCH /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}
-curl -i -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1" \
+curl -i -H "kubeflow-userid: user@example.com" -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1" \
 -H "Content-Type: application/json" \
 -d '{ "data": {
   "description": "New description"
@@ -115,11 +117,11 @@ curl -i -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/reg
 ```
 ```
 # GET /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id} 
-curl -i http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1
+curl -i -H "kubeflow-userid: user@example.com" http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1
 ```
 ```
 # POST /api/v1/model_registry/{model_registry_id}/model_versions
-curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/model_versions" \
+curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/api/v1/model_registry/model-registry/model_versions" \
      -H "Content-Type: application/json" \
      -d '{ "data": {
   "customProperties": {
@@ -138,7 +140,7 @@ curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/mode
 ```
 ```
 # PATCH /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}
-curl -i -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1" \
+curl -i -H "kubeflow-userid: user@example.com" -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1" \
      -H "Content-Type: application/json" \
 -d '{ "data": {
   "description": "New description 2"
@@ -146,11 +148,11 @@ curl -i -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/mod
 ```
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}/versions
-curl -i localhost:4000/api/v1/model_registry/model-registry/registered_models/1/versions
+curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/model_registry/model-registry/registered_models/1/versions
 ```
 ```
 # POST /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}/versions
-curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1/versions" \
+curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1/versions" \
      -H "Content-Type: application/json" \
      -d '{ "data": {
   "customProperties": {
@@ -163,17 +165,17 @@ curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/regi
   "externalId": "9928",
   "name": "ModelVersion One",
   "state": "LIVE",
-  "author": "alex"
+  "author": "alex",
   "registeredModelId: "1"
 }}'
 ```
 ```
 # GET /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}/artifacts
-curl -i http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1/artifacts
+curl -i -H "kubeflow-userid: user@example.com" http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1/artifacts
 ```
 ```
 # POST /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}/artifacts
-curl -i -X POST "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1/artifacts" \
+curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1/artifacts" \
      -H "Content-Type: application/json" \
      -d '{ "data": {
   "customProperties": {
@@ -203,9 +205,9 @@ The following query parameters are supported by "Get All" style endpoints to con
 ### Sample local calls
 ```
 # Get with a page size of 5 getting a specific page.
-curl -i "http://localhost:4000/api/v1/model_registry/model-registry/registered_models?pageSize=5&nextPageToken=CAEQARoCCAE"
+curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/registered_models?pageSize=5&nextPageToken=CAEQARoCCAE"
 ```
 ```
 # Get with a page size of 5, order by last update time in descending order.
-curl -i "http://localhost:4000/api/v1/model_registry/model-registry/registered_models?pageSize=5&orderBy=LAST_UPDATE_TIME&sortOrder=DESC"
+curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/registered_models?pageSize=5&orderBy=LAST_UPDATE_TIME&sortOrder=DESC"
 ```

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -106,5 +106,5 @@ func (app *App) Routes() http.Handler {
 	router.GET(ModelRegistryListPath, app.ModelRegistryHandler)
 	router.PATCH(ModelRegistryPath, app.AttachRESTClient(app.UpdateModelVersionHandler))
 
-	return app.RecoverPanic(app.enableCORS(router))
+	return app.RecoverPanic(app.enableCORS(app.RequireAccessControl(router)))
 }

--- a/clients/ui/bff/internal/api/errors.go
+++ b/clients/ui/bff/internal/api/errors.go
@@ -43,6 +43,17 @@ func (app *App) badRequestResponse(w http.ResponseWriter, r *http.Request, err e
 	app.errorResponse(w, r, httpError)
 }
 
+func (app *App) forbiddenResponse(w http.ResponseWriter, r *http.Request, message string) {
+	httpError := &integrations.HTTPError{
+		StatusCode: http.StatusForbidden,
+		ErrorResponse: integrations.ErrorResponse{
+			Code:    strconv.Itoa(http.StatusForbidden),
+			Message: message,
+		},
+	}
+	app.errorResponse(w, r, httpError)
+}
+
 func (app *App) errorResponse(w http.ResponseWriter, r *http.Request, error *integrations.HTTPError) {
 
 	env := ErrorEnvelope{Error: error}

--- a/clients/ui/bff/internal/api/healthcheck__handler_test.go
+++ b/clients/ui/bff/internal/api/healthcheck__handler_test.go
@@ -27,6 +27,8 @@ func TestHealthCheckHandler(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, HealthCheckPath, nil)
 	assert.NoError(t, err)
 
+	req.Header.Set(kubeflowUserId, mocks.KubeflowUserIDHeaderValue)
+
 	app.HealthcheckHandler(rr, req, nil)
 	rs := rr.Result()
 
@@ -46,6 +48,7 @@ func TestHealthCheckHandler(t *testing.T) {
 		SystemInfo: models.SystemInfo{
 			Version: Version,
 		},
+		UserID: mocks.KubeflowUserIDHeaderValue,
 	}
 
 	assert.Equal(t, expected, healthCheckRes)

--- a/clients/ui/bff/internal/api/healthcheck_handler.go
+++ b/clients/ui/bff/internal/api/healthcheck_handler.go
@@ -7,7 +7,9 @@ import (
 
 func (app *App) HealthcheckHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
-	healthCheck, err := app.repositories.HealthCheck.HealthCheck(Version)
+	userID := r.Header.Get(kubeflowUserId)
+
+	healthCheck, err := app.repositories.HealthCheck.HealthCheck(Version, userID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -14,6 +14,7 @@ type contextKey string
 
 const httpClientKey contextKey = "httpClientKey"
 const userAccessToken = "x-forwarded-access-token"
+const kubeflowUserId = "kubeflow-userid"
 
 func (app *App) RecoverPanic(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -48,14 +49,8 @@ func (app *App) AttachRESTClient(handler func(http.ResponseWriter, *http.Request
 			app.serverErrorResponse(w, r, fmt.Errorf("failed to resolve model registry base URL): %v", err))
 			return
 		}
-		var bearerToken string
-		bearerToken, err = resolveBearerToken(app.kubernetesClient, r.Header)
-		if err != nil {
-			app.serverErrorResponse(w, r, fmt.Errorf("failed to resolve BearerToken): %v", err))
-			return
-		}
 
-		client, err := integrations.NewHTTPClient(modelRegistryBaseURL, bearerToken)
+		client, err := integrations.NewHTTPClient(modelRegistryBaseURL)
 		if err != nil {
 			app.serverErrorResponse(w, r, fmt.Errorf("failed to create Kubernetes client: %v", err))
 			return
@@ -63,26 +58,6 @@ func (app *App) AttachRESTClient(handler func(http.ResponseWriter, *http.Request
 		ctx := context.WithValue(r.Context(), httpClientKey, client)
 		handler(w, r.WithContext(ctx), ps)
 	}
-}
-
-func resolveBearerToken(k8s integrations.KubernetesClientInterface, header http.Header) (string, error) {
-	var bearerToken string
-	//check if I'm inside cluster
-	if k8s.IsInCluster() {
-		//in cluster
-		bearerToken = header.Get(userAccessToken)
-		if bearerToken == "" {
-			return "", fmt.Errorf("failed to create Rest client (not able to get bearerToken on cluster)")
-		}
-	} else {
-		//off cluster (development)
-		var err error
-		bearerToken, err = k8s.BearerToken()
-		if err != nil {
-			return "", fmt.Errorf("failed to fetch BearerToken in development mode: %v", err)
-		}
-	}
-	return bearerToken, nil
 }
 
 func resolveModelRegistryURL(id string, client integrations.KubernetesClientInterface, config config.EnvConfig) (string, error) {
@@ -98,4 +73,33 @@ func resolveModelRegistryURL(id string, client integrations.KubernetesClientInte
 
 	url := fmt.Sprintf("http://%s:%d/api/model_registry/v1alpha3", serviceDetails.ClusterIP, serviceDetails.HTTPPort)
 	return url, nil
+}
+
+func (app *App) RequireAccessControl(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Skip SAR for health check
+		if r.URL.Path == HealthCheckPath {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		user := r.Header.Get(kubeflowUserId)
+		if user == "" {
+			app.forbiddenResponse(w, r, "missing kubeflow-userid header")
+			return
+		}
+
+		allowed, err := app.kubernetesClient.PerformSAR(user)
+		if err != nil {
+			app.forbiddenResponse(w, r, "failed to perform SAR: %v")
+			return
+		}
+		if !allowed {
+			app.forbiddenResponse(w, r, "access denied")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }

--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -13,7 +13,6 @@ import (
 type contextKey string
 
 const httpClientKey contextKey = "httpClientKey"
-const userAccessToken = "x-forwarded-access-token"
 const kubeflowUserId = "kubeflow-userid"
 
 func (app *App) RecoverPanic(next http.Handler) http.Handler {

--- a/clients/ui/bff/internal/api/test_utils.go
+++ b/clients/ui/bff/internal/api/test_utils.go
@@ -12,7 +12,7 @@ import (
 	"net/http/httptest"
 )
 
-func setupApiTest[T any](method string, url string, body interface{}, k8sClient k8s.KubernetesClientInterface) (T, *http.Response, error) {
+func setupApiTest[T any](method string, url string, body interface{}, k8sClient k8s.KubernetesClientInterface, kubeflowUserIDHeader string) (T, *http.Response, error) {
 	mockMRClient, err := mocks.NewModelRegistryClient(nil)
 	if err != nil {
 		return *new(T), nil, err
@@ -42,6 +42,9 @@ func setupApiTest[T any](method string, url string, body interface{}, k8sClient 
 			return *new(T), nil, err
 		}
 	}
+
+	// Set the kubeflow-userid header
+	req.Header.Set(kubeflowUserId, kubeflowUserIDHeader)
 
 	ctx := context.WithValue(req.Context(), httpClientKey, mockClient)
 	req = req.WithContext(ctx)

--- a/clients/ui/bff/internal/integrations/http.go
+++ b/clients/ui/bff/internal/integrations/http.go
@@ -16,9 +16,8 @@ type HTTPClientInterface interface {
 }
 
 type HTTPClient struct {
-	client      *http.Client
-	baseURL     string
-	bearerToken string
+	client  *http.Client
+	baseURL string
 }
 
 type ErrorResponse struct {
@@ -35,14 +34,13 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP %d: %s - %s", e.StatusCode, e.Code, e.Message)
 }
 
-func NewHTTPClient(baseURL string, bearerToken string) (HTTPClientInterface, error) {
+func NewHTTPClient(baseURL string) (HTTPClientInterface, error) {
 
 	return &HTTPClient{
 		client: &http.Client{Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}},
-		baseURL:     baseURL,
-		bearerToken: bearerToken,
+		baseURL: baseURL,
 	}, nil
 }
 
@@ -53,7 +51,6 @@ func (c *HTTPClient) GET(url string) ([]byte, error) {
 		return nil, err
 	}
 
-	req.Header.Add("Authorization", "Bearer "+c.bearerToken)
 	response, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -76,7 +73,6 @@ func (c *HTTPClient) POST(url string, body io.Reader) ([]byte, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+c.bearerToken)
 
 	response, err := c.client.Do(req)
 	if err != nil {
@@ -118,7 +114,6 @@ func (c *HTTPClient) PATCH(url string, body io.Reader) ([]byte, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+c.bearerToken)
 
 	response, err := c.client.Do(req)
 	if err != nil {

--- a/clients/ui/bff/internal/mocks/k8s_mock_test.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Kubernetes Client Test", func() {
+var _ = Describe("Kubernetes ControllerRuntimeClient Test", func() {
 	Context("with existing services", Ordered, func() {
 
 		It("should retrieve the get all service successfully", func() {
@@ -59,4 +59,24 @@ var _ = Describe("Kubernetes Client Test", func() {
 		})
 	})
 
+})
+
+var _ = Describe("KubernetesNativeClient SAR Test", func() {
+	Context("Subject Access Review", func() {
+
+		It("should allow allowed user to access services", func() {
+			By("performing SAR for Kubeflow User ID")
+			allowed, err := k8sClient.PerformSAR(KubeflowUserIDHeaderValue)
+			Expect(err).NotTo(HaveOccurred(), "Failed to perform SAR for Kubeflow User ID\"")
+			Expect(allowed).To(BeTrue(), "Expected Kubeflow User ID to have access")
+		})
+
+		It("should deny access for another user", func() {
+			By("performing SAR for another user")
+			allowed, err := k8sClient.PerformSAR("unauthorized-dora@example.com")
+			Expect(err).NotTo(HaveOccurred(), "Failed to perform SAR for unauthorized-dora@example.com")
+			Expect(allowed).To(BeFalse(), "Expected unauthorized-dora@example.com to be denied access")
+		})
+
+	})
 })

--- a/clients/ui/bff/internal/models/health_check.go
+++ b/clients/ui/bff/internal/models/health_check.go
@@ -7,4 +7,5 @@ type SystemInfo struct {
 type HealthCheckModel struct {
 	Status     string     `json:"status"`
 	SystemInfo SystemInfo `json:"system_info"`
+	UserID     string     `json:"user-id"`
 }

--- a/clients/ui/bff/internal/repositories/health_check.go
+++ b/clients/ui/bff/internal/repositories/health_check.go
@@ -8,13 +8,14 @@ func NewHealthCheckRepository() *HealthCheckRepository {
 	return &HealthCheckRepository{}
 }
 
-func (r *HealthCheckRepository) HealthCheck(version string) (models.HealthCheckModel, error) {
+func (r *HealthCheckRepository) HealthCheck(version string, userID string) (models.HealthCheckModel, error) {
 
 	var res = models.HealthCheckModel{
 		Status: "available",
 		SystemInfo: models.SystemInfo{
 			Version: version,
 		},
+		UserID: userID,
 	}
 
 	return res, nil

--- a/clients/ui/frontend/docs/dev-setup.md
+++ b/clients/ui/frontend/docs/dev-setup.md
@@ -32,6 +32,8 @@ npm run build
 
 This is the default context for running a local UI.  Make sure you build the project using the instructions above prior to running the command below.
 
+You will need to inject your requests with a kubeflow-userid header for authorization purposes. For example, you can use the [Header Editor](https://chromewebstore.google.com/detail/eningockdidmgiojffjmkdblpjocbhgh) extension in Chrome to set the kubeflow-userid header to user@example.com.
+
 ```bash
 npm run start:dev
 ```

--- a/clients/ui/manifests/user-rbac/kubeflow-dashboard-rbac.yaml
+++ b/clients/ui/manifests/user-rbac/kubeflow-dashboard-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: service-access-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: service-access-cluster-binding
+subjects:
+  - kind: User
+    name: user@example.com
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: service-access-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/clients/ui/manifests/user-rbac/kustomization.yaml
+++ b/clients/ui/manifests/user-rbac/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - admin-rbac.yaml
+  - kubeflow-dashboard-rbac.yaml

--- a/clients/ui/scripts/deploy_kind_cluster.sh
+++ b/clients/ui/scripts/deploy_kind_cluster.sh
@@ -52,10 +52,10 @@ echo "Applying admin user service account and rolebinding..."
 kubectl apply -k .
 
 # Step 6: Generate token for admin user and display it
-echo "Generating token for admin user, copy the following token in the local storage with key 'x-forwarded-access-token'..."
-echo -e "\033[32m$(kubectl -n kube-system create token admin-user)\033[0m"
+echo "In your browser, you will need to inject your requests with a kubeflow-userid header for authorization purposes."
+echo "For example, you can use the Header Editor - https://chromewebstore.google.com/detail/eningockdidmgiojffjmkdblpjocbhgh extension in Chrome to set the kubeflow-userid header to user@example.com."
 
 # Step 5: Port-forward the service
-echo "Port-fowarding Model Registry UI..."
+echo "Port-forwarding Model Registry UI..."
 echo -e "\033[32mDashboard available in http://localhost:8080\033[0m"
 kubectl port-forward svc/model-registry-ui-service -n kubeflow 8080:8080


### PR DESCRIPTION
## Description

In Kubeflow's Central Dashboard, the kubeflow-userid header carries the user's email address for authentication purposes. When a user accesses applications through the dashboard, each request includes this header, allowing the application to identify the user.

On the BFF, we are using kubeflow-userid header to do Authorization via SubjectAccessReview on all endpoints. For all endpoints we only authorize requests from users that can "get", "list" services via ClusterRole.

One thing that we need to double-check with other people from community (@tarilabs please chime in), is that instead of a ClusterRole, we should not do SubjectAccessReview for a given namespace. I've implemented in a 'cluster level' access because my understanding is that model registries access are not restricted by namespace.

So in short, the BFF authorize every user that has get/list for services authorization cluster-wide.

Another important aspect is that for ALL kubernetes APIs calls (including SubjectAccessReview), the BFF is using the service account token for it (after SubjectAccessReview check). 

As Kubeflow don't have any bearerToken information, I've removed this piece for codebase. I'm always happy to reintroduce it as soon as have this need, i.e. if any distribution needs to do authentication differently. 

In this PR:

- clients/ui/bff/README.md: added header info and some clarifications on readme;
- clients/ui/bff/internal/api/app.go: added a middleware that is executed on ALL endpoints to SubjectAccessReview checks;
- clients/ui/bff/internal/api/errors.go: utility function to deal with forbiddenResponse
- clients/ui/bff/internal/api/healthcheck_handler.go, clients/ui/bff/internal/models/health_check.go and clients/ui/bff/internal/repositories/health_check.go: added kubeflow-userid  info to the healthcheck. This is the only entrypoint that don't do SubjectAccessReview
- clients/ui/bff/internal/api/middleware.go: removed all code related to bearerToken and also implemented the middleware for access control
- clients/ui/bff/internal/integrations/http.go: removed bearerToken header that we pass for model registry apis
- clients/ui/bff/internal/integrations/k8s.go: we now have two clients here, one ControllerRuntimeClient(cached) and KubernetesNativeClient(for operations like  SubjectAccessReview). I've also created the PerformSAR method that is the core piece of this PR
- clients/ui/bff/internal/mocks/k8s_mock.go: on the mock, I've created the default rbac on envtest for user@example.com
- clients/ui/manifests/user-rbac/kubeflow-dashboard-rbac.yaml: the RBAC of our make kind-deployment test functionality
- clients/ui/scripts/deploy_kind_cluster.sh: removed the kuberentes token in favor of warning user of the required headers 


## How Has This Been Tested?
```
curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/healthcheck                                           (kind-kubeflow-ui/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Wed, 27 Nov 2024 22:18:50 GMT
Content-Length: 102

{
	"status": "available",
	"system_info": {
		"version": "1.0.0"
	},
	"user-id": "user@example.com"
}
```
```
curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/model_registry                                        (kind-kubeflow-ui/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Wed, 27 Nov 2024 22:19:26 GMT
Content-Length: 413

{
	"data": [
		{
			"name": "model-registry",
			"displayName": "Model Registry",
			"description": "Model Registry Description"
		},
		{
			"name": "model-registry-bella",
			"displayName": "Model Registry Bella",
			"description": "Model Registry Bella description"
		},
		{
			"name": "model-registry-dora",
			"displayName": "Model Registry Dora",
			"description": "Model Registry Dora description"
		}
	]
}
```
```
curl -i -H "kubeflow-userid: shouldnotwork" localhost:4000/api/v1/model_registry                                           (kind-kubeflow-ui/default)
HTTP/1.1 403 Forbidden
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Wed, 27 Nov 2024 22:19:45 GMT
Content-Length: 65

{
	"error": {
		"code": "403",
		"message": "access denied"
	}
}
```
Using the Header Editor Chrome Extension:

With wrong user name:
<img width="1531" alt="Screenshot 2024-11-27 at 4 29 54 PM" src="https://github.com/user-attachments/assets/3f4cf3f5-ef73-4ab7-87d2-7e577ecfb364">

With right user name:
<img width="1528" alt="Screenshot 2024-11-27 at 4 30 31 PM" src="https://github.com/user-attachments/assets/2374b528-35e5-45c2-b4b8-2cd5741300f5">


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [X] The developer has added tests or explained why testing cannot be added.
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
