### PR TITLE
feat(bff): user info endpoint

### DIFF
--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -79,7 +79,7 @@ You will need to inject your requests with a kubeflow-userid header for authoriz
 curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/healthcheck
 ```
 ```
-# GET /v1/healthcheck
+# GET /v1/user
 curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/user
 ```
 ```

--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -57,6 +57,7 @@ make docker-build
 | URL Pattern                                                                                  | Handler                                      | Action                                                      |
 |----------------------------------------------------------------------------------------------|----------------------------------------------|-------------------------------------------------------------|
 | GET /v1/healthcheck                                                                          | HealthcheckHandler                           | Show application information.                               |
+| GET /v1/user                                                                                 | UserHandler                                  | Show "kubeflow-user-id" from header information.            |
 | GET /v1/model_registry                                                                       | ModelRegistryHandler                         | Get all model registries,                                   |
 | GET /v1/model_registry/{model_registry_id}/registered_models                                 | GetAllRegisteredModelsHandler                | Gets a list of all RegisteredModel entities.                |
 | POST /v1/model_registry/{model_registry_id}/registered_models                                | CreateRegisteredModelHandler                 | Create a RegisteredModel entity.                            |
@@ -76,6 +77,10 @@ You will need to inject your requests with a kubeflow-userid header for authoriz
 ```
 # GET /v1/healthcheck
 curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/healthcheck
+```
+```
+# GET /v1/healthcheck
+curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/user
 ```
 ```
 # GET /v1/model_registry 

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -21,6 +21,7 @@ const (
 	ModelVersionId               = "model_version_id"
 	ModelArtifactId              = "model_artifact_id"
 	HealthCheckPath              = PathPrefix + "/healthcheck"
+	UserPath                     = PathPrefix + "/user"
 	ModelRegistryListPath        = PathPrefix + "/model_registry"
 	ModelRegistryPath            = ModelRegistryListPath + "/:" + ModelRegistryId
 	RegisteredModelListPath      = ModelRegistryPath + "/registered_models"
@@ -103,6 +104,7 @@ func (app *App) Routes() http.Handler {
 	router.POST(ModelVersionArtifactListPath, app.AttachRESTClient(app.CreateModelArtifactByModelVersionHandler))
 
 	// Kubernetes client routes
+	router.GET(UserPath, app.UserHandler)
 	router.GET(ModelRegistryListPath, app.ModelRegistryHandler)
 	router.PATCH(ModelRegistryPath, app.AttachRESTClient(app.UpdateModelVersionHandler))
 

--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -83,6 +83,12 @@ func (app *App) RequireAccessControl(next http.Handler) http.Handler {
 			return
 		}
 
+		// Skip SAR for user info
+		if r.URL.Path == UserPath {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		user := r.Header.Get(kubeflowUserId)
 		if user == "" {
 			app.forbiddenResponse(w, r, "missing kubeflow-userid header")

--- a/clients/ui/bff/internal/api/user_handler.go
+++ b/clients/ui/bff/internal/api/user_handler.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"errors"
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+	"net/http"
+)
+
+type UserEnvelope Envelope[*models.User, None]
+
+func (app *App) UserHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+
+	userHeader := r.Header.Get(kubeflowUserId)
+	if userHeader == "" {
+		app.serverErrorResponse(w, r, errors.New("kubeflow-userid not present on header"))
+		return
+	}
+
+	user, err := app.repositories.User.GetUser(app.kubernetesClient, userHeader)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	userRes := UserEnvelope{
+		Data: user,
+	}
+
+	err = app.WriteJSON(w, http.StatusOK, userRes, nil)
+
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+
+}

--- a/clients/ui/bff/internal/api/user_handler_test.go
+++ b/clients/ui/bff/internal/api/user_handler_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	KubeflowUserIDHeaderValue = "user@example.com"
+	DoraNonAdminUser          = "doraNonAdmin@example.com"
+)
+
+var _ = Describe("TestUserHandler", func() {
+	Context("fetching user details", Ordered, func() {
+		var testApp App
+
+		BeforeAll(func() {
+			By("creating the test app")
+			testApp = App{
+				kubernetesClient: k8sClient,
+				repositories:     repositories.NewRepositories(mockMRClient),
+				logger:           logger,
+			}
+		})
+
+		It("should show that KubeflowUserIDHeaderValue (user@example.com) is a cluster-admin", func() {
+			By("creating the http request")
+			req, err := http.NewRequest(http.MethodGet, UserPath, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			req.Header.Set(kubeflowUserId, KubeflowUserIDHeaderValue)
+
+			By("creating the http test infrastructure")
+			rr := httptest.NewRecorder()
+
+			By("invoking the UserHandler")
+			testApp.UserHandler(rr, req, nil)
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the user response")
+			var actual UserEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			By("checking that the user is cluster-admin")
+			Expect(actual.Data.UserID).To(Equal(KubeflowUserIDHeaderValue))
+			Expect(actual.Data.ClusterAdmin).To(BeTrue(), "Expected this user to be cluster-admin")
+		})
+
+		It("should show that DoraNonAdminUser (doraNonAdmin@example.com) is not a cluster-admin", func() {
+			By("creating the http request")
+			req, err := http.NewRequest(http.MethodGet, UserPath, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			req.Header.Set(kubeflowUserId, DoraNonAdminUser)
+
+			By("creating the http test infrastructure")
+			rr := httptest.NewRecorder()
+
+			By("invoking the UserHandler")
+			testApp.UserHandler(rr, req, nil)
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the user response")
+			var actual UserEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			By("checking that the user is not cluster-admin")
+			Expect(actual.Data.UserID).To(Equal(DoraNonAdminUser))
+			Expect(actual.Data.ClusterAdmin).To(BeFalse(), "Expected this user to not be cluster-admin")
+		})
+
+		It("should show that a random non-existent user is not a cluster-admin", func() {
+			randomUser := "bellaUser@example.com"
+
+			By("creating the http request")
+			req, err := http.NewRequest(http.MethodGet, UserPath, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			req.Header.Set(kubeflowUserId, randomUser)
+
+			By("creating the http test infrastructure")
+			rr := httptest.NewRecorder()
+
+			By("invoking the UserHandler")
+			testApp.UserHandler(rr, req, nil)
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the user response")
+			var actual UserEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			By("checking that the user is not cluster-admin")
+			Expect(actual.Data.UserID).To(Equal(randomUser))
+			Expect(actual.Data.ClusterAdmin).To(BeFalse(), "Expected this user to not be cluster-admin")
+		})
+	})
+
+})

--- a/clients/ui/bff/internal/mocks/k8s_mock_test.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock_test.go
@@ -53,9 +53,8 @@ var _ = Describe("Kubernetes ControllerRuntimeClient Test", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create HTTP request")
 
 			By("checking that service details are correct")
-			Expect(services[0]).To(Equal("model-registry"))
-			Expect(services[1]).To(Equal("model-registry-bella"))
-			Expect(services[2]).To(Equal("model-registry-dora"))
+			Expect(services).To(ConsistOf("model-registry", "model-registry-bella", "model-registry-dora"))
+
 		})
 	})
 
@@ -78,5 +77,25 @@ var _ = Describe("KubernetesNativeClient SAR Test", func() {
 			Expect(allowed).To(BeFalse(), "Expected unauthorized-dora@example.com to be denied access")
 		})
 
+	})
+})
+
+var _ = Describe("KubernetesClient isClusterAdmin Test", func() {
+	Context("checking cluster admin status", func() {
+		It("should confirm that user@example.com(KubeflowUserIDHeaderValue) is a cluster-admin", func() {
+			isAdmin, err := k8sClient.IsClusterAdmin(KubeflowUserIDHeaderValue)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isAdmin).To(BeTrue())
+		})
+		It("should confirm that doraNonAdmin@example.com(DoraNonAdminUser) is a not cluster-admin", func() {
+			isAdmin, err := k8sClient.IsClusterAdmin(DoraNonAdminUser)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isAdmin).To(BeFalse())
+		})
+		It("should confirm that non existent user is not a cluster-admin", func() {
+			isAdmin, err := k8sClient.IsClusterAdmin("bella@non-existent.com")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isAdmin).To(BeFalse())
+		})
 	})
 })

--- a/clients/ui/bff/internal/models/user.go
+++ b/clients/ui/bff/internal/models/user.go
@@ -1,0 +1,6 @@
+package models
+
+type User struct {
+	UserID       string `json:"user-id"`
+	ClusterAdmin bool   `json:"cluster-admin"`
+}

--- a/clients/ui/bff/internal/repositories/repositories.go
+++ b/clients/ui/bff/internal/repositories/repositories.go
@@ -5,6 +5,7 @@ type Repositories struct {
 	HealthCheck         *HealthCheckRepository
 	ModelRegistry       *ModelRegistryRepository
 	ModelRegistryClient ModelRegistryClientInterface
+	User                *UserRepository
 }
 
 func NewRepositories(modelRegistryClient ModelRegistryClientInterface) *Repositories {
@@ -12,5 +13,6 @@ func NewRepositories(modelRegistryClient ModelRegistryClientInterface) *Reposito
 		HealthCheck:         NewHealthCheckRepository(),
 		ModelRegistry:       NewModelRegistryRepository(),
 		ModelRegistryClient: modelRegistryClient,
+		User:                NewUserRepository(),
 	}
 }

--- a/clients/ui/bff/internal/repositories/user.go
+++ b/clients/ui/bff/internal/repositories/user.go
@@ -1,0 +1,28 @@
+package repositories
+
+import (
+	"fmt"
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+)
+
+type UserRepository struct{}
+
+func NewUserRepository() *UserRepository {
+	return &UserRepository{}
+}
+
+func (r *UserRepository) GetUser(client k8s.KubernetesClientInterface, user string) (*models.User, error) {
+
+	isAdmin, err := client.IsClusterAdmin(user)
+	if err != nil {
+		return nil, fmt.Errorf("error getting user info: %w", err)
+	}
+
+	var res = models.User{
+		UserID:       user,
+		ClusterAdmin: isAdmin,
+	}
+
+	return &res, nil
+}


### PR DESCRIPTION
Create a new user endpoint to allow frontend to see if kubeflow-userid header is a cluster admin. 

## Description
This PR is a FUP of [discussion](https://github.com/kubeflow/model-registry/pull/599#issuecomment-2515156274), and it allows the frontend to enable and disable the namespace selector on the UI.

In this PR:
- clients/ui/bff/internal/api/app.go: added the GET /v1/user endpoint;
- clients/ui/bff/internal/api/middleware.go: skip the SAR on this endpoint. This operation is, in my point of view safe because it just provide the logged user email address and a boolean telling if it's a cluster admin or not;
- clients/ui/bff/internal/api/user_handler.go and clients/ui/bff/internal/api/user_handler_test.go: respective handler and it's tests;
- clients/ui/bff/internal/integrations/k8s.go: add the functionality to see if a user is a cluster admin. I want you to know that I didn't check intentionally if the user is part of a group of cluster admins (for performance reasons). If necessary, we can include this complimentary check in the future;
- clients/ui/bff/internal/mocks/k8s_mock.go: I've added in our mocks:
user@example.com as cluster admin;
doraNonAdmin@example.com as a regular user;
created dora-namespace (to add services for this scope)
- clients/ui/bff/internal/mocks/k8s_mock_test.go: tests;
- clients/ui/bff/internal/models/user.go : user model
- clients/ui/bff/internal/repositories/user.go: user repository

## How Has This Been Tested?

```
curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/user                                                         (kind-kubeflow/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Mon, 09 Dec 2024 15:21:39 GMT
Content-Length: 75

{
	"data": {
		"user-id": "user@example.com",
		"cluster-admin": true
	}
}
```

```
curl -i -H "bad-header: doraNonAdmin@example.com" localhost:4000/api/v1/user                                                      (kind-kubeflow/default)
HTTP/1.1 500 Internal Server Error
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Mon, 09 Dec 2024 15:23:14 GMT
Content-Length: 119

{
	"error": {
		"code": "500",
		"message": "the server encountered a problem and could not process your request"
	}
}
```

```
curl -i -H "kubeflow-userid: doraNonAdmin@example.com" localhost:4000/api/v1/user                                                 (kind-kubeflow/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Mon, 09 Dec 2024 15:22:32 GMT
Content-Length: 84

{
	"data": {
		"user-id": "doraNonAdmin@example.com",
		"cluster-admin": false
	}
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
