### PR TITLE
feat(bff): update bff service filtering to match model registry services by component: model-registry label

### DIFF
--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -216,3 +216,38 @@ curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/mod
 # Get with a page size of 5, order by last update time in descending order.
 curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/registered_models?pageSize=5&orderBy=LAST_UPDATE_TIME&sortOrder=DESC"
 ```
+
+
+### FAQ
+
+#### 1. How do we filter model registry services from other Kubernetes services?
+
+We filter Model Registry services by using the Kubernetes label `component: model-registry. This label helps distinguish Model Registry services from other services in the cluster.
+
+For example, in our service manifest, the `component label is defined as follows:
+```yaml
+# ...
+labels:
+  # ...
+  component: model-registry
+#...
+```
+You can view the complete Model Registry service manifest [here](https://github.com/kubeflow/model-registry/blob/main/manifests/kustomize/base/model-registry-service.yaml#L10).
+
+#### 2. What is the structure of the mock Kubernetes environment?
+
+The mock Kubernetes environment is activated when the environment variable `MOCK_K8S_CLIENT` is set to `true`. It is based on `env-test` and is designed to simulate a realistic Kubernetes setup for testing. The mock has the following characteristics:
+
+- **Namespaces**:
+  - `kubeflow`
+  - `dora-namespace`
+
+- **Users**:
+  - `user@example.com` (has `cluster-admin` privileges)
+  - `doraNonAdmin@example.com` (restricted to the `dora-namespace`)
+
+- **Services (Model Registries)**:
+  - `model-registry`: resides in the `kubeflow` namespace with the label `component: model-registry`.
+  - `model-registry-dora`: resides in the `dora-namespace` namespace with the label `component: model-registry`.
+  - `model-registry-bella`: resides in the `kubeflow` namespace with the label `component: model-registry`.
+  - `non-model-registry`: resides in the `kubeflow` namespace *without* the label `component: model-registry`.


### PR DESCRIPTION

## Description
This PR sits on top of https://github.com/kubeflow/model-registry/pull/630 and update bff service filtering to match model registry services by component: model-registry label.

In this specific PR: ([commit](https://github.com/kubeflow/model-registry/commit/b8be495613111d00b187c0865815dc570e70f431))
- clients/ui/bff/README.md : add a FAQ section detailing what is setup on env test mock and also how we do model registry service filtering
On clients/ui/bff/internal/integrations/k8s.go
- Removed some duplicated logic on GetServiceNames()
- On GetServiceDetails, removed component filtering in favor of label filtering (much more efficient)
- I've also make all context with similar values (30seconds)
- clients/ui/bff/internal/mocks/k8s_mock.go: added label for our 3 services and created a new one without the label.

As illustration, I've I remove the label filtering:
````
curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/model_registry                                                                         (kind-kubeflow/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Tue, 10 Dec 2024 15:10:16 GMT
Content-Length: 556

{
	"data": [
		{
			"name": "model-registry-dora",
			"displayName": "Model Registry Dora",
			"description": "Model Registry Dora description"
		},
		{
			"name": "model-registry",
			"displayName": "Model Registry",
			"description": "Model Registry Description"
		},
		{
			"name": "model-registry-bella",
			"displayName": "Model Registry Bella",
			"description": "Model Registry Bella description"
		},
		{
			"name": "non-model-registry", <----- WRONG
			"displayName": "Not a Model Registry",
			"description": "Not a Model Registry Bella description"
		}
	]
}
````

With filtering:

````
curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/model_registry                                                                         (kind-kubeflow/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Tue, 10 Dec 2024 15:31:35 GMT
Content-Length: 413

{
	"data": [
		{
			"name": "model-registry-dora",
			"displayName": "Model Registry Dora",
			"description": "Model Registry Dora description"
		},
		{
			"name": "model-registry",
			"displayName": "Model Registry",
			"description": "Model Registry Description"
		},
		{
			"name": "model-registry-bella",
			"displayName": "Model Registry Bella",
			"description": "Model Registry Bella description"
		}
	]
}
```

## How Has This Been Tested? 
Basic sanity check of the app

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
 
