### PR TITLE
feat(bff): list user namespaces in dev mode

### DIFF
--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -58,6 +58,7 @@ make docker-build
 |----------------------------------------------------------------------------------------------|----------------------------------------------|-------------------------------------------------------------|
 | GET /v1/healthcheck                                                                          | HealthcheckHandler                           | Show application information.                               |
 | GET /v1/user                                                                                 | UserHandler                                  | Show "kubeflow-user-id" from header information.            |
+| GET /v1/namespaces                                                                           | NamespacesHandler                            | Get all user namespaces.                                    |
 | GET /v1/model_registry                                                                       | ModelRegistryHandler                         | Get all model registries,                                   |
 | GET /v1/model_registry/{model_registry_id}/registered_models                                 | GetAllRegisteredModelsHandler                | Gets a list of all RegisteredModel entities.                |
 | POST /v1/model_registry/{model_registry_id}/registered_models                                | CreateRegisteredModelHandler                 | Create a RegisteredModel entity.                            |
@@ -81,6 +82,10 @@ curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/healthcheck
 ```
 # GET /v1/user
 curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/user
+```
+```
+# GET /v1/namespaces
+curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/namespaces
 ```
 ```
 # GET /v1/model_registry 

--- a/clients/ui/bff/internal/api/healthcheck__handler_test.go
+++ b/clients/ui/bff/internal/api/healthcheck__handler_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/kubeflow/model-registry/ui/bff/internal/config"
 	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
@@ -25,11 +26,12 @@ func TestHealthCheckHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest(http.MethodGet, HealthCheckPath, nil)
+	ctx := context.WithValue(req.Context(), KubeflowUserIdKey, mocks.KubeflowUserIDHeaderValue)
+	req = req.WithContext(ctx)
 	assert.NoError(t, err)
 
-	req.Header.Set(kubeflowUserId, mocks.KubeflowUserIDHeaderValue)
-
 	app.HealthcheckHandler(rr, req, nil)
+
 	rs := rr.Result()
 
 	defer rs.Body.Close()

--- a/clients/ui/bff/internal/api/healthcheck_handler.go
+++ b/clients/ui/bff/internal/api/healthcheck_handler.go
@@ -1,15 +1,20 @@
 package api
 
 import (
+	"errors"
 	"github.com/julienschmidt/httprouter"
 	"net/http"
 )
 
 func (app *App) HealthcheckHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
-	userID := r.Header.Get(kubeflowUserId)
+	userId, ok := r.Context().Value(KubeflowUserIdKey).(string)
+	if !ok || userId == "" {
+		app.serverErrorResponse(w, r, errors.New("failed to retrieve kubeflow-userid from context"))
+		return
+	}
 
-	healthCheck, err := app.repositories.HealthCheck.HealthCheck(Version, userID)
+	healthCheck, err := app.repositories.HealthCheck.HealthCheck(Version, userId)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/clients/ui/bff/internal/api/namespaces_handler.go
+++ b/clients/ui/bff/internal/api/namespaces_handler.go
@@ -2,14 +2,15 @@ package api
 
 import (
 	"errors"
-	"github.com/julienschmidt/httprouter"
 	"github.com/kubeflow/model-registry/ui/bff/internal/models"
 	"net/http"
+
+	"github.com/julienschmidt/httprouter"
 )
 
-type UserEnvelope Envelope[*models.User, None]
+type NamespacesEnvelope Envelope[[]models.NamespaceModel, None]
 
-func (app *App) UserHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (app *App) GetNamespacesHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 
 	userId, ok := r.Context().Value(KubeflowUserIdKey).(string)
 	if !ok || userId == "" {
@@ -17,20 +18,19 @@ func (app *App) UserHandler(w http.ResponseWriter, r *http.Request, _ httprouter
 		return
 	}
 
-	user, err := app.repositories.User.GetUser(app.kubernetesClient, userId)
+	namespaces, err := app.repositories.Namespace.GetNamespaces(app.kubernetesClient, userId)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
 
-	userRes := UserEnvelope{
-		Data: user,
+	namespacesEnvelope := NamespacesEnvelope{
+		Data: namespaces,
 	}
 
-	err = app.WriteJSON(w, http.StatusOK, userRes, nil)
+	err = app.WriteJSON(w, http.StatusOK, namespacesEnvelope, nil)
 
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 	}
-
 }

--- a/clients/ui/bff/internal/api/namespaces_handler_test.go
+++ b/clients/ui/bff/internal/api/namespaces_handler_test.go
@@ -84,7 +84,7 @@ var _ = Describe("TestNamespacesHandler", func() {
 			Expect(actual.Data).To(ContainElements(expected))
 		})
 
-		It("should return all namespaces for non-existent user", func() {
+		It("should return no namespaces for non-existent user", func() {
 			By("creating the HTTP request with a non-existent kubeflow-userid")
 			req, err := http.NewRequest(http.MethodGet, NamespaceListPath, nil)
 			ctx := context.WithValue(req.Context(), KubeflowUserIdKey, "nonexistent@example.com")

--- a/clients/ui/bff/internal/api/namespaces_handler_test.go
+++ b/clients/ui/bff/internal/api/namespaces_handler_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/kubeflow/model-registry/ui/bff/internal/config"
+	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"io"
+	"net/http"
+	"net/http/httptest"
+)
+
+var _ = Describe("TestNamespacesHandler", func() {
+	Context("when running in dev mode", Ordered, func() {
+		var testApp App
+
+		BeforeAll(func() {
+			By("setting up the test app in dev mode")
+			testApp = App{
+				config:           config.EnvConfig{DevMode: true},
+				kubernetesClient: k8sClient,
+				repositories:     repositories.NewRepositories(mockMRClient),
+				logger:           logger,
+			}
+		})
+
+		It("should return only dora-namespace for doraNonAdmin@example.com", func() {
+			By("creating the HTTP request with the kubeflow-userid header")
+			req, err := http.NewRequest(http.MethodGet, NamespaceListPath, nil)
+			ctx := context.WithValue(req.Context(), KubeflowUserIdKey, mocks.DoraNonAdminUser)
+			req = req.WithContext(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			rr := httptest.NewRecorder()
+
+			By("calling the GetNamespacesHandler")
+			testApp.GetNamespacesHandler(rr, req, nil)
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the response")
+			var actual NamespacesEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			By("validating the response contains only dora-namespace")
+			expected := []models.NamespaceModel{{Name: "dora-namespace"}}
+			Expect(actual.Data).To(ConsistOf(expected))
+		})
+
+		It("should return all namespaces for user@example.com", func() {
+			By("creating the HTTP request with the kubeflow-userid header")
+			req, err := http.NewRequest(http.MethodGet, NamespaceListPath, nil)
+			ctx := context.WithValue(req.Context(), KubeflowUserIdKey, mocks.KubeflowUserIDHeaderValue)
+			req = req.WithContext(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("kubeflow-userid", "user@example.com")
+			rr := httptest.NewRecorder()
+
+			By("calling the GetNamespacesHandler")
+			testApp.GetNamespacesHandler(rr, req, nil)
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the response")
+			var actual NamespacesEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			By("validating the response contains all namespaces")
+			expected := []models.NamespaceModel{
+				{Name: "kubeflow"},
+				{Name: "dora-namespace"},
+			}
+			Expect(actual.Data).To(ContainElements(expected))
+		})
+
+		It("should return all namespaces for non-existent user", func() {
+			By("creating the HTTP request with a non-existent kubeflow-userid")
+			req, err := http.NewRequest(http.MethodGet, NamespaceListPath, nil)
+			ctx := context.WithValue(req.Context(), KubeflowUserIdKey, "nonexistent@example.com")
+			req = req.WithContext(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			rr := httptest.NewRecorder()
+
+			By("calling the GetNamespacesHandler")
+			testApp.GetNamespacesHandler(rr, req, nil)
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("unmarshalling the response")
+			var actual NamespacesEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			By("validating the response contains no namespaces")
+			Expect(actual.Data).To(BeEmpty())
+		})
+	})
+
+})

--- a/clients/ui/bff/internal/api/test_utils.go
+++ b/clients/ui/bff/internal/api/test_utils.go
@@ -12,7 +12,7 @@ import (
 	"net/http/httptest"
 )
 
-func setupApiTest[T any](method string, url string, body interface{}, k8sClient k8s.KubernetesClientInterface, kubeflowUserIDHeader string) (T, *http.Response, error) {
+func setupApiTest[T any](method string, url string, body interface{}, k8sClient k8s.KubernetesClientInterface, kubeflowUserIDHeaderValue string) (T, *http.Response, error) {
 	mockMRClient, err := mocks.NewModelRegistryClient(nil)
 	if err != nil {
 		return *new(T), nil, err
@@ -44,7 +44,7 @@ func setupApiTest[T any](method string, url string, body interface{}, k8sClient 
 	}
 
 	// Set the kubeflow-userid header
-	req.Header.Set(kubeflowUserId, kubeflowUserIDHeader)
+	req.Header.Set(KubeflowUserIDHeader, kubeflowUserIDHeaderValue)
 
 	ctx := context.WithValue(req.Context(), httpClientKey, mockClient)
 	req = req.WithContext(ctx)

--- a/clients/ui/bff/internal/api/user_handler_test.go
+++ b/clients/ui/bff/internal/api/user_handler_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -32,9 +34,9 @@ var _ = Describe("TestUserHandler", func() {
 		It("should show that KubeflowUserIDHeaderValue (user@example.com) is a cluster-admin", func() {
 			By("creating the http request")
 			req, err := http.NewRequest(http.MethodGet, UserPath, nil)
+			ctx := context.WithValue(req.Context(), KubeflowUserIdKey, mocks.KubeflowUserIDHeaderValue)
+			req = req.WithContext(ctx)
 			Expect(err).NotTo(HaveOccurred())
-
-			req.Header.Set(kubeflowUserId, KubeflowUserIDHeaderValue)
 
 			By("creating the http test infrastructure")
 			rr := httptest.NewRecorder()
@@ -60,9 +62,9 @@ var _ = Describe("TestUserHandler", func() {
 		It("should show that DoraNonAdminUser (doraNonAdmin@example.com) is not a cluster-admin", func() {
 			By("creating the http request")
 			req, err := http.NewRequest(http.MethodGet, UserPath, nil)
+			ctx := context.WithValue(req.Context(), KubeflowUserIdKey, DoraNonAdminUser)
+			req = req.WithContext(ctx)
 			Expect(err).NotTo(HaveOccurred())
-
-			req.Header.Set(kubeflowUserId, DoraNonAdminUser)
 
 			By("creating the http test infrastructure")
 			rr := httptest.NewRecorder()
@@ -90,9 +92,9 @@ var _ = Describe("TestUserHandler", func() {
 
 			By("creating the http request")
 			req, err := http.NewRequest(http.MethodGet, UserPath, nil)
+			ctx := context.WithValue(req.Context(), KubeflowUserIdKey, randomUser)
+			req = req.WithContext(ctx)
 			Expect(err).NotTo(HaveOccurred())
-
-			req.Header.Set(kubeflowUserId, randomUser)
 
 			By("creating the http test infrastructure")
 			rr := httptest.NewRecorder()

--- a/clients/ui/bff/internal/mocks/k8s_mock.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock.go
@@ -303,7 +303,7 @@ func createNamespaceRestrictedRBAC(k8sClient client.Client, ctx context.Context,
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"services"},
+				Resources: []string{"services", "namespaces"},
 				Verbs:     []string{"get", "list"},
 			},
 		},

--- a/clients/ui/bff/internal/models/namespace.go
+++ b/clients/ui/bff/internal/models/namespace.go
@@ -1,0 +1,11 @@
+package models
+
+type NamespaceModel struct {
+	Name string `json:"name"`
+}
+
+func NewNamespaceModelFromNamespace(name string) NamespaceModel {
+	return NamespaceModel{
+		Name: name,
+	}
+}

--- a/clients/ui/bff/internal/repositories/namespace.go
+++ b/clients/ui/bff/internal/repositories/namespace.go
@@ -1,0 +1,28 @@
+package repositories
+
+import (
+	"fmt"
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+)
+
+type NamespaceRepository struct{}
+
+func NewNamespaceRepository() *NamespaceRepository {
+	return &NamespaceRepository{}
+}
+
+func (r *NamespaceRepository) GetNamespaces(client k8s.KubernetesClientInterface, user string) ([]models.NamespaceModel, error) {
+
+	namespaces, err := client.GetNamespaces(user)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching namespaces: %w", err)
+	}
+
+	var namespaceModels = []models.NamespaceModel{}
+	for _, ns := range namespaces {
+		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name))
+	}
+
+	return namespaceModels, nil
+}

--- a/clients/ui/bff/internal/repositories/repositories.go
+++ b/clients/ui/bff/internal/repositories/repositories.go
@@ -6,6 +6,7 @@ type Repositories struct {
 	ModelRegistry       *ModelRegistryRepository
 	ModelRegistryClient ModelRegistryClientInterface
 	User                *UserRepository
+	Namespace           *NamespaceRepository
 }
 
 func NewRepositories(modelRegistryClient ModelRegistryClientInterface) *Repositories {
@@ -14,5 +15,6 @@ func NewRepositories(modelRegistryClient ModelRegistryClientInterface) *Reposito
 		ModelRegistry:       NewModelRegistryRepository(),
 		ModelRegistryClient: modelRegistryClient,
 		User:                NewUserRepository(),
+		Namespace:           NewNamespaceRepository(),
 	}
 }


### PR DESCRIPTION
This PR introduces a new endpoint (GET /v1/namespaces) in dev mode (standalone app) to populate the namespaces dropdown.

It's important to highlight that this new endpoint is only available in BFF dev mode (DEV_MODE=true)

```shell
make run MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true DEV_MODE=true
```

## Description

In this PR:
- clients/ui/bff/internal/api/middleware.go: 
1. Created context keys;
2. Created kubeflow group headers (preparing for a following PR)
3. Inject kubeflow-userid and kubeflow-groups header in the request context
4. Refactoring on exempt paths for RequireAccessControl to receive a list of paths to skip SAR

- clients/ui/bff/internal/api/namespaces_handler.go: core handler of this PR
- clients/ui/bff/internal/api/namespaces_handler_test.go: tests of the handler of this PR
- clients/ui/bff/internal/api/app.go: only register the handler in dev mode and also add the new middleware method to extract the readers and add to the context
- clients/ui/bff/internal/integrations/k8s.go: method to list namespaces and do a SAR based on user to see which namespaces user can access
- clients/ui/bff/internal/api/test_utils.go: Refactoring to use the right keys
- clients/ui/bff/internal/mocks/k8s_mock.go: added the right rbac for non admin user in mock
- clients/ui/bff/internal/models/namespace.go: namespace model
- clients/ui/bff/internal/repositories/namespace.go: namespace repository
- clients/ui/bff/internal/repositories/repositories.go: changes in repository interface
- clients/ui/bff/internal/API/healthcheck_handler.go: refactoring to use context instead of handlers directly
- clients/ui/bff/internal/api/healthcheck__handler_test.go: refactoring to use context instead of handlers directly
- clients/ui/bff/internal/api/user_handler.go: refactoring to use context instead of handlers directly
- clients/ui/bff/internal/api/user_handler_test.go: refactoring to use context instead of handlers directly
- clients/ui/bff/README.md: adding endpoint info

## How Has This Been Tested?

- I did a basic sanity check in the UI

```shell
 make run MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true DEV_MODE=false
 
curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/namespaces                                     (kind-kubeflow/default)
HTTP/1.1 404 Not Found
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Fri, 13 Dec 2024 21:21:43 GMT
Content-Length: 93

{
	"error": {
		"code": "404",
		"message": "the requested resource could not be found"
	}
}
```

```
k8s mocked with env test
make run MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true DEV_MODE=true

curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/namespaces                                     (kind-kubeflow/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Fri, 13 Dec 2024 21:22:43 GMT
Content-Length: 221

{
	"data": [
		{
			"name": "default"
		},
		{
			"name": "dora-namespace"
		},
		{
			"name": "kube-node-lease"
		},
		{
			"name": "kube-public"
		},
		{
			"name": "kube-system"
		},
		{
			"name": "kubeflow"
		}
	]
}

curl -i -H "kubeflow-userid: doraNonAdmin@example.com" localhost:4000/api/v1/namespaces                             (kind-kubeflow/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Fri, 13 Dec 2024 21:23:05 GMT
Content-Length: 54

{
	"data": [
		{
			"name": "dora-namespace"
		}
	]
}


 curl -i -H "kubeflow-userid: dordasdasm" localhost:4000/api/v1/namespaces                                           (kind-kubeflow/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Fri, 13 Dec 2024 21:23:21 GMT
Content-Length: 16

{
	"data": []
}


curl -i -H "bad header: dordasdasm" localhost:4000/api/v1/namespaces                                                (kind-kubeflow/default)
HTTP/1.1 400 Bad Request: invalid header name
Content-Type: text/plain; charset=utf-8
Connection: close

400 Bad Request: invalid header name%

```


```
Connected to kubeflow cluster

make run MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=true DEV_MODE=true
curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/namespaces                                     (kind-kubeflow/default)
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Fri, 13 Dec 2024 21:24:40 GMT
Content-Length: 65

{
	"data": [
		{
			"name": "kubeflow-user-example-com"
		}
	]
}

```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X ] The developer has manually tested the changes and verified that the changes work.
- [X ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
 
