### PR TITLE
build: use also different K8s versions for E2E testing in GHA

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -71,17 +71,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.12", "3.11", "3.10", "3.9"]
-        kubernetes-version: ["v1.27.11"]
-        include: # on main merges (not PRs), use also different K8s versions for E2E testing
-          - python: "3.12"
-            kubernetes-version: ${{ github.event_name == 'push' && 'v1.28.7' }}
-          - python: "3.12"
-            kubernetes-version: ${{ github.event_name == 'push' && 'v1.29.2' }}
-          - python: "3.12"
-            kubernetes-version: ${{ github.event_name == 'push' && 'v1.30.6' }}
-        exclude:
-          - kubernetes-version: 'false'
+        python: ["3.12"] # see below for versions 3.9-3.11
+        kubernetes-version: ["v1.27.11", "v1.28.7", "v1.29.2", "v1.30.6"]
+        exclude: # on main merges (not PRs), use also different K8s versions for E2E testing
+          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.28.7' }}
+          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.29.2' }}
+          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.30.6' }}
+        include: # test Py versions only with a reference K8s version, designated currently to kubernetes-version: v1.27.11
+          - python: "3.11"
+            kubernetes-version: "v1.27.11"
+          - python: "3.10"
+            kubernetes-version: "v1.27.11"
+          - python: "3.9"
+            kubernetes-version: "v1.27.11"
     env:
       FORCE_COLOR: "1"
       IMG_ORG: kubeflow

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -73,11 +73,10 @@ jobs:
       matrix:
         python: ["3.12"] # see below for versions 3.9-3.11
         kubernetes-version: ["v1.27.11", "v1.28.7", "v1.29.2", "v1.30.6"]
-        # DEMO on PR how it would look on main-merges
-        # exclude: # on main merges (not PRs), use also different K8s versions for E2E testing
-        #   - kubernetes-version: ${{ github.event_name != 'push' && 'v1.28.7' }}
-        #   - kubernetes-version: ${{ github.event_name != 'push' && 'v1.29.2' }}
-        #   - kubernetes-version: ${{ github.event_name != 'push' && 'v1.30.6' }}
+        exclude: # on main merges (not PRs), use also different K8s versions for E2E testing
+          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.28.7' }}
+          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.29.2' }}
+          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.30.6' }}
         include: # test Py versions only with a reference K8s version, designated currently to kubernetes-version: v1.27.11
           - python: "3.11"
             kubernetes-version: "v1.27.11"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -66,12 +66,22 @@ jobs:
           fi
 
   test:
-    name: Test against Py ${{ matrix.python }}
+    name: Test against Py ${{ matrix.python }} and K8s ${{ matrix.kubernetes-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python: ["3.12", "3.11", "3.10", "3.9"]
+        kubernetes-version: ["v1.27.11"]
+        include: # on main merges (not PRs), use also different K8s versions for E2E testing
+          - python: "3.12"
+            kubernetes-version: ${{ github.event_name == 'push' && 'v1.28.7' }}
+          - python: "3.12"
+            kubernetes-version: ${{ github.event_name == 'push' && 'v1.29.2' }}
+          - python: "3.12"
+            kubernetes-version: ${{ github.event_name == 'push' && 'v1.30.6' }}
+        exclude:
+          - kubernetes-version: 'false'
     env:
       FORCE_COLOR: "1"
       IMG_ORG: kubeflow
@@ -124,8 +134,9 @@ jobs:
       - name: Start Kind Cluster
         uses: helm/kind-action@v1.11.0
         with:
-          node_image: "kindest/node:v1.27.11"
+          node_image: kindest/node:${{ matrix.kubernetes-version }}
           cluster_name: chart-testing-py-${{ matrix.python }}
+          kubectl_version: ${{ matrix.kubernetes-version }}
       - name: Load Local Registry Test Image
         env:
           IMG: "${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -72,11 +72,12 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12"] # see below for versions 3.9-3.11
-        kubernetes-version: ["v1.27.11", "v1.28.7", "v1.29.2", "v1.30.6"]
+        kubernetes-version: ["v1.27.11", "v1.28.7", "v1.29.2", "v1.30.6", "v1.31.0"]
         exclude: # on main merges (not PRs), use also different K8s versions for E2E testing
           - kubernetes-version: ${{ github.event_name != 'push' && 'v1.28.7' }}
           - kubernetes-version: ${{ github.event_name != 'push' && 'v1.29.2' }}
           - kubernetes-version: ${{ github.event_name != 'push' && 'v1.30.6' }}
+          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.31.0' }}
         include: # test Py versions only with a reference K8s version, designated currently to kubernetes-version: v1.27.11
           - python: "3.11"
             kubernetes-version: "v1.27.11"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -73,10 +73,11 @@ jobs:
       matrix:
         python: ["3.12"] # see below for versions 3.9-3.11
         kubernetes-version: ["v1.27.11", "v1.28.7", "v1.29.2", "v1.30.6"]
-        exclude: # on main merges (not PRs), use also different K8s versions for E2E testing
-          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.28.7' }}
-          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.29.2' }}
-          - kubernetes-version: ${{ github.event_name != 'push' && 'v1.30.6' }}
+        # DEMO on PR how it would look on main-merges
+        # exclude: # on main merges (not PRs), use also different K8s versions for E2E testing
+        #   - kubernetes-version: ${{ github.event_name != 'push' && 'v1.28.7' }}
+        #   - kubernetes-version: ${{ github.event_name != 'push' && 'v1.29.2' }}
+        #   - kubernetes-version: ${{ github.event_name != 'push' && 'v1.30.6' }}
         include: # test Py versions only with a reference K8s version, designated currently to kubernetes-version: v1.27.11
           - python: "3.11"
             kubernetes-version: "v1.27.11"


### PR DESCRIPTION
proposal for https://github.com/kubeflow/model-registry/issues/614

## Description
please note

> Note All include combinations are processed after exclude

from: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#excluding-matrix-configurations

## How Has This Been Tested?
see https://github.com/kubeflow/model-registry/pull/659#issuecomment-2546855431

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
