### PR TITLE
chore(go): bump golang version to 1.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Model registry provides a central repository for model developers to store and m
 8. [UI](.clients/ui/README.md)
 
 ## Pre-requisites:
-- go >= 1.21
+- go >= 1.22
 - protoc v24.3 - [Protocol Buffers v24.3 Release](https://github.com/protocolbuffers/protobuf/releases/tag/v24.3)
 - npm >= 10.2.0 - [Installing Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - Java >= 11.0
@@ -173,7 +173,7 @@ To delete something, simply update its status.
 ## Tips
 ### Pull image rate limiting
 
-Ocassionally you may encounter an 'ImagePullBackOff' error when deploying the Model Registry manifests. See example below for the `model-registry-db` container. 
+Ocassionally you may encounter an 'ImagePullBackOff' error when deploying the Model Registry manifests. See example below for the `model-registry-db` container.
 
 ```
 Failed to pull image “mysql:8.3.0”: rpc error: code = Unknown desc = fetching target platform image selected from image index: reading manifest sha256:f9097d95a4ba5451fff79f4110ea6d750ac17ca08840f1190a73320b84ca4c62 in docker.io/library/mysql: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit

--- a/docs/mr_go_library.md
+++ b/docs/mr_go_library.md
@@ -15,7 +15,7 @@ This includes models, model versions, artifacts, serving environments, inference
 ### Prerequisites
 
 * [MLMD server](https://github.com/google/ml-metadata/blob/f0fef74eae2bdf6650a79ba976b36bea0b777c2e/g3doc/get_started.md#use-mlmd-with-a-remote-grpc-server)
-* Go >= 1.21
+* Go >= 1.22
 
 Install it using:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/model-registry
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

According to the golang [release policy](https://go.dev/doc/devel/release#policy),
golang 1.21 had the last security fixes released in go1.21.13 (2024-08-06), so I propose to bump golang's version to the next supported major (1.22) to improve security coverage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make test`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

