### PR TITLE
feat(bff): serving static assets on bff

### DIFF
--- a/clients/ui/bff/Dockerfile
+++ b/clients/ui/bff/Dockerfile
@@ -15,7 +15,8 @@ RUN go mod download
 COPY cmd/main.go cmd/main.go
 COPY internal/ internal/
 
-
+# Copy the static assets
+COPY static/ static/
 
 # Build the Go application
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bff ./cmd/main.go
@@ -29,4 +30,4 @@ USER 65532:65532
 # Expose port 4000
 EXPOSE 4000
 
-ENTRYPOINT ["/bff"]
+ENTRYPOINT ["/bff", "--static-assets-dir=/static"]

--- a/clients/ui/bff/Dockerfile
+++ b/clients/ui/bff/Dockerfile
@@ -16,7 +16,7 @@ COPY cmd/main.go cmd/main.go
 COPY internal/ internal/
 
 # Copy the static assets
-COPY static/ static/
+COPY $STATIC_ASSETS_DIR static/
 
 # Build the Go application
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bff ./cmd/main.go

--- a/clients/ui/bff/Makefile
+++ b/clients/ui/bff/Makefile
@@ -6,6 +6,8 @@ MOCK_MR_CLIENT ?= false
 DEV_MODE ?= false
 DEV_MODE_PORT ?= 8080
 STANDALONE_MODE ?= true
+#frontend static assets root directory
+STATIC_ASSETS_DIR ?= ./static
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 
@@ -48,7 +50,7 @@ build: fmt vet test ## Builds the project to produce a binary executable.
 .PHONY: run
 run: fmt vet envtest ## Runs the project.
 	ENVTEST_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go run ./cmd/main.go  --port=$(PORT) --mock-k8s-client=$(MOCK_K8S_CLIENT) --mock-mr-client=$(MOCK_MR_CLIENT) --dev-mode=$(DEV_MODE) --dev-mode-port=$(DEV_MODE_PORT)  --standalone-mode=$(STANDALONE_MODE)
+	go run ./cmd/main.go  --port=$(PORT) --static-assets-dir=$(STATIC_ASSETS_DIR) --mock-k8s-client=$(MOCK_K8S_CLIENT) --mock-mr-client=$(MOCK_MR_CLIENT) --dev-mode=$(DEV_MODE) --dev-mode-port=$(DEV_MODE_PORT)  --standalone-mode=$(STANDALONE_MODE)
 
 .PHONY: docker-build
 docker-build: ## Builds a container for the project.

--- a/clients/ui/bff/cmd/main.go
+++ b/clients/ui/bff/cmd/main.go
@@ -25,6 +25,7 @@ func main() {
 	flag.BoolVar(&cfg.DevMode, "dev-mode", false, "Use development mode for access to local K8s cluster")
 	flag.IntVar(&cfg.DevModePort, "dev-mode-port", getEnvAsInt("DEV_MODE_PORT", 8080), "Use port when in development mode")
 	flag.BoolVar(&cfg.StandaloneMode, "standalone-mode", false, "Use standalone mode for enabling endpoints in standalone mode")
+	flag.StringVar(&cfg.StaticAssetsDir, "static-assets-dir", "./static", "Configure frontend static assets root directory")
 	flag.Parse()
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))

--- a/clients/ui/bff/internal/api/app_test.go
+++ b/clients/ui/bff/internal/api/app_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"github.com/kubeflow/model-registry/ui/bff/internal/config"
+	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"io"
+	"net/http"
+	httptest "net/http/httptest"
+)
+
+var _ = Describe("Static File serving Test", func() {
+	var (
+		server *httptest.Server
+		client *http.Client
+	)
+
+	Context("serving static files at /", Ordered, func() {
+
+		BeforeAll(func() {
+			envConfig := config.EnvConfig{
+				StaticAssetsDir: resolveStaticAssetsDirOnTests(),
+			}
+			app := &App{
+				kubernetesClient: k8sClient,
+				repositories:     repositories.NewRepositories(mockMRClient),
+				logger:           logger,
+				config:           envConfig,
+			}
+
+			server = httptest.NewServer(app.Routes())
+			client = server.Client()
+		})
+
+		AfterAll(func() {
+			server.Close()
+		})
+
+		It("should serve index.html from the root path", func() {
+			resp, err := client.Get(server.URL + "/")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(body)).To(ContainSubstring("BFF Stub Page"))
+		})
+
+		It("should serve subfolders from the root path", func() {
+			resp, err := client.Get(server.URL + "/sub/test.html")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(body)).To(ContainSubstring("BFF Stub Subfolder Page"))
+		})
+
+		It("should return 404 for a non-existent static file", func() {
+			resp, err := client.Get(server.URL + "/non-existent.html")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+	})
+})

--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -43,6 +43,12 @@ func (app *App) RecoverPanic(next http.Handler) http.Handler {
 func (app *App) InjectUserHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
+		//skip use headers check if we are not on /api/v1
+		if !strings.HasPrefix(r.URL.Path, PathPrefix) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		userIdHeader := r.Header.Get(KubeflowUserIDHeader)
 		userGroupsHeader := r.Header.Get(KubeflowUserGroupsIdHeader)
 		//`kubeflow-userid`: Contains the user's email address.

--- a/clients/ui/bff/internal/config/environment.go
+++ b/clients/ui/bff/internal/config/environment.go
@@ -1,10 +1,11 @@
 package config
 
 type EnvConfig struct {
-	Port           int
-	MockK8Client   bool
-	MockMRClient   bool
-	DevMode        bool
-	StandaloneMode bool
-	DevModePort    int
+	Port            int
+	MockK8Client    bool
+	MockMRClient    bool
+	DevMode         bool
+	StandaloneMode  bool
+	DevModePort     int
+	StaticAssetsDir string
 }

--- a/clients/ui/bff/static/index.html
+++ b/clients/ui/bff/static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>BFF Stub Page</title>
+</head>
+<body>
+<h1>Welcome to the BFF Stub Page</h1>
+<p>This is a placeholder page for the serving frontend.</p>
+</body>
+</html>

--- a/clients/ui/bff/static/sub/test.html
+++ b/clients/ui/bff/static/sub/test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>BFF Stub Subfolder Page</title>
+</head>
+<body>
+    <h1>Welcome to the BFF Stub Subfolder Page</h1>
+    <p>This is a placeholder page for the serving frontend.</p>
+</body>
+</html>


### PR DESCRIPTION
## Description
This PR is a preparation for the BFF and FE being served in production on the same container.

At "/" we are now serving static files:

<img width="879" alt="Screenshot 2025-01-08 at 5 23 57 PM" src="https://github.com/user-attachments/assets/b7f68192-3e53-4ccd-8454-e81ab38db887" />

As we used to do, we keep serving the BFF API on "/api/v1/*".

It is important also to highlight that on production (when using binaries), we need to copy the assets to the target containers. I've decided not to pack the static assets in the binary and serve them in the filesystem. I believe this makes it more coherent with our architecture (but I'm open to discussion and suggestions). If you would like more details on this, please look at MakeFile and Docker file changes.
 
Changes on this PR:

- Dockerfile: copying the static assets during build process and passing the target asset dir as parameter to binary
- Makefile: also added the STATIC_ASSETS_DIR property, pointing to root static folder
- main.go: added the new configuraton for static assets
- app.go: in order to avoid class, I've to split the router in two. One for the /api and another (server mux) to also handle "/" for static assets.
- app_Test.go: test file to make sure that we don't break this
- middleware.go: I've ignored the enforecer to use headers when we are using static files
- clients/ui/bff/internal/api/test_utils.go: as we can run the tests on the ide, it's annoying to hardcode the parameters of every test location to find the static folder. So I write this small traversal to find assets dir based on go.mod, not matter where the tests are located. THIS IS NOT INTEND FOR PRODUCTION BECAUSE WE SHOULD USE PARAMETERS there.
- clients/ui/bff/internal/config/environment.go: new configurations
- clients/ui/bff/static/index.html and clients/ui/bff/static/sub/test.html STUB files

## How Has This Been Tested?
 
- Loading the static assets: 
<img width="879" alt="Screenshot 2025-01-08 at 5 23 57 PM" src="https://github.com/user-attachments/assets/6f265630-9232-4619-afea-bf0c9421cc2b" />

- Loading the API to make sure that keep working
<img width="591" alt="Screenshot 2025-01-08 at 5 24 51 PM" src="https://github.com/user-attachments/assets/e22f1047-fb51-4b30-83f8-0ded86ff2d25" />

```shell
making sure that if I pass a bad header keep blocking requests
curl -i -H "fsdfsdfs-userid: user@example.com" "localhost:4000/api/v1/healthcheck"                      (kind-up-running/default)
HTTP/1.1 400 Bad Request
Access-Control-Allow-Origin: *
Content-Type: application/json
Date: Wed, 08 Jan 2025 22:32:38 GMT
Content-Length: 92

{
	"error": {
		"code": "400",
		"message": "missing required header: kubeflow-userid"
	}
}
```

I've also started to test this with our production assets of frontend.

<img width="1274" alt="Screenshot 2025-01-08 at 4 59 28 PM" src="https://github.com/user-attachments/assets/5ba30d87-65ca-47f1-ba42-a19b136d9594" />

Kind of work, but I was not able to figure out how to fix the routing. I've asked for FE guys help to debug the proxy calls..

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
