### PR TITLE
feat(bff): proper support for SPA routes 

### DIFF
--- a/clients/ui/bff/internal/api/app_test.go
+++ b/clients/ui/bff/internal/api/app_test.go
@@ -62,12 +62,17 @@ var _ = Describe("Static File serving Test", func() {
 			Expect(string(body)).To(ContainSubstring("BFF Stub Subfolder Page"))
 		})
 
-		It("should return 404 for a non-existent static file", func() {
+		It("should return index.html for a non-existent static file", func() {
 			resp, err := client.Get(server.URL + "/non-existent.html")
 			Expect(err).NotTo(HaveOccurred())
 			defer resp.Body.Close()
 
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			//BFF Stub page is the context of index.html
+			Expect(string(body)).To(ContainSubstring("BFF Stub Page"))
 		})
 
 	})


### PR DESCRIPTION
## Description
This PR sits on top https://github.com/kubeflow/model-registry/pull/699 and does proper handling of SPA Routes.


In this PR: (specific commit https://github.com/kubeflow/model-registry/commit/a7448dd24dcef51a457127ef141582ad88c992ee)

- app.go: add a fallback if a path does not exist to app.config.StaticAssetsDir/index.html
- app_test.go: test the fallback (we should not get a 404 like before).


## How Has This Been Tested?

In the video, every time the UI blinks, I reload it. Also, pay attention that on /api/v1/something I still keep using our default api 404 page.
 
https://github.com/user-attachments/assets/de58e81c-13a1-4eac-8e3d-b4c8bcb0bbd0


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)
- 
**Please merge https://github.com/kubeflow/model-registry/pull/699 first!!!!**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

 
