### PR TITLE
fix: mysql version fix 8.0.3 -> 8.3.0

### DIFF
--- a/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: db-container
-        image: mysql:8.0.3
+        image: mysql:8.3.0
         args:
         - --datadir
         - /var/lib/mysql/datadir


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

It Looks like the mysql:8.0.3 image version may have been a mistake, and it really should be mysql:8.3.0. I updated the mysql image version from 8.0.3 to 8.3.0 in the manifest file. This resolves three issues:
1. The README suggest version 8.3.0 is being used in some notes near the bottom (see https://github.com/dandawg/model-registry#pull-image-rate-limiting), which is inconsistent with what is in the manifest (8.0.3) as is.
2. The mysql:8.0.3 image results in ImagePullBackoff errors on Kind (at least on Mac). This can also be verified with `docker pull mysql:8.0.3`. 
3. The mysql:8.0.x versions are older (7 years old!) and have more vulnerabilities, so it will be better to use 8.3.0.

Note: this should fix issue #266 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Limited testing on Kind on Mac M2. Once I updated the version, the deployment was able to succeed. The rest of the model registry pods/services/deployments also came up without issue. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
