### PR TITLE
fix: update api.go link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For a high-level documentation of the Model Registry _logical model_, please che
 ## Model Registry Core
 
 The model registry core is the layer which implements the core/business logic by interacting with the underlying ml-metadata server.
-It provides a model registry domain-specific [api](internal/core/api.go) that is in charge to proxy all, appropriately transformed, requests to ml-metadata using gRPC calls.
+It provides a model registry domain-specific [api](pkg/api/api.go) that is in charge to proxy all, appropriately transformed, requests to ml-metadata using gRPC calls.
 
 ### Model registry library
 


### PR DESCRIPTION
`internal/core/api.go` was moved to `pkg/api/api.go`
(1a7a4138d88267602b4901946e0956b5f1a09d1b), so updating the link.

Fixes #675.

Signed-off-by: Paul Boyd <pboyd@redhat.com>
