### PR TITLE
Adds BFF support for CORS

### DIFF
--- a/clients/ui/bff/Makefile
+++ b/clients/ui/bff/Makefile
@@ -9,6 +9,7 @@ STATIC_ASSETS_DIR ?= ./static
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 LOG_LEVEL ?= info
+ALLOWED_ORIGINS ?= ""
 
 .PHONY: all
 all: build
@@ -49,7 +50,7 @@ build: fmt vet test ## Builds the project to produce a binary executable.
 .PHONY: run
 run: fmt vet envtest ## Runs the project.
 	ENVTEST_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go run ./cmd/main.go  --port=$(PORT) --static-assets-dir=$(STATIC_ASSETS_DIR) --mock-k8s-client=$(MOCK_K8S_CLIENT) --mock-mr-client=$(MOCK_MR_CLIENT) --dev-mode=$(DEV_MODE) --dev-mode-port=$(DEV_MODE_PORT)  --standalone-mode=$(STANDALONE_MODE) --log-level=$(LOG_LEVEL)
+	go run ./cmd/main.go  --port=$(PORT) --static-assets-dir=$(STATIC_ASSETS_DIR) --mock-k8s-client=$(MOCK_K8S_CLIENT) --mock-mr-client=$(MOCK_MR_CLIENT) --dev-mode=$(DEV_MODE) --dev-mode-port=$(DEV_MODE_PORT)  --standalone-mode=$(STANDALONE_MODE) --log-level=$(LOG_LEVEL) --allowed-origins=$(ALLOWED_ORIGINS)
 
 ##@ Dependencies
 

--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -287,3 +287,41 @@ Access to Model Registry List:
 Access to Specific Model Registry Endpoints:
 - For other endpoints (e.g., /v1/model_registry/{model_registry_id}/...), we perform a SAR check for get and list verbs on the specific service (identified by model_registry_id) within the namespace.
 - If the user or any group has permission to get or list the specific service, the request is authorized.
+
+#### 4. How do I allow CORS requests from other origins
+
+When serving the UI directly from the BFF there is no need for any CORS headers to be served, by default they are turned off for security reasons. 
+
+If you need to enable CORS for any reasons you can add origins to the allow-list in several ways:
+
+##### Via the make command
+Add the following parameter to your command: `ALLOWED_ORIGINS` this takes a comma separated list of origins to permit serving to, alterantively you can specify the value `*` to allow all origins, **Note this is not recommended in production deployments as it poses a security risk**
+
+Examples:
+
+```shell
+# Allow only the origin http://example.com:8081
+make run ALLOWED_ORIGINS="http://example.com:8081"
+
+# Allow the origins http://example.com and http://very-nice.com
+make run ALLOWED_ORIGINS="http://example.com,http://very-nice.com"
+
+# Allow all origins
+make run ALLOWED_ORIGINS="*"
+
+# Explicitly disable CORS (default behaviour)
+make run ALLOWED_ORIGINS=""
+```
+
+#### Via environment variable
+Setting CORS via environment variable follows the same rules as using the Makefile, simply set the environment variable `ALLOWED_ORIGINS` with the same value as above.
+
+#### Via the command line arguments
+
+Setting CORS via command line arguments follows the same rules as using the Makefile. Simply add the `--allowed-origins=` flag to your command.
+
+Examples:
+```shell
+./bff --allowed-origins="http://my-domain.com,http://my-other-domain.com"
+```
+

--- a/clients/ui/bff/cmd/main.go
+++ b/clients/ui/bff/cmd/main.go
@@ -28,6 +28,7 @@ func main() {
 	flag.BoolVar(&cfg.StandaloneMode, "standalone-mode", false, "Use standalone mode for enabling endpoints in standalone mode")
 	flag.StringVar(&cfg.StaticAssetsDir, "static-assets-dir", "./static", "Configure frontend static assets root directory")
 	flag.StringVar(&cfg.LogLevel, "log-level", getEnvAsString("LOG_LEVEL", "info"), "Sets server log level, possible values: debug, info, warn, error, fatal")
+	flag.StringVar(&cfg.AllowedOrigins, "allowed-origins", getEnvAsString("ALLOWED_ORIGINS", ""), "Sets allowed origins for CORS purposes, accepts a comma separated list of origins or * to allow all, default none")
 	flag.Parse()
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/clients/ui/bff/go.mod
+++ b/clients/ui/bff/go.mod
@@ -4,10 +4,12 @@ go 1.22.2
 
 require (
 	github.com/brianvoe/gofakeit/v7 v7.1.2
+	github.com/google/uuid v1.6.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kubeflow/model-registry v0.2.9
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
+	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.31.2
 	k8s.io/apimachinery v0.31.4
@@ -36,7 +38,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/clients/ui/bff/go.sum
+++ b/clients/ui/bff/go.sum
@@ -97,6 +97,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -138,5 +138,5 @@ func (app *App) Routes() http.Handler {
 		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
 	})
 
-	return app.RecoverPanic(app.EnableTelemetry(app.enableCORS(app.InjectUserHeaders(appMux))))
+	return app.RecoverPanic(app.EnableTelemetry(app.EnableCORS(app.InjectUserHeaders(appMux))))
 }

--- a/clients/ui/bff/internal/api/helpers.go
+++ b/clients/ui/bff/internal/api/helpers.go
@@ -106,3 +106,15 @@ func ParseURLTemplate(tmpl string, params map[string]string) string {
 
 	return r.Replace(tmpl)
 }
+
+func ParseOriginList(origins string) ([]string, bool) {
+	if origins == "" {
+		return []string{}, false
+	}
+
+	if origins == "*" {
+		return []string{"*"}, true
+	}
+	originsTrimmed := strings.ReplaceAll(origins, " ", "")
+	return strings.Split(originsTrimmed, ","), true
+}

--- a/clients/ui/bff/internal/api/helpers_test.go
+++ b/clients/ui/bff/internal/api/helpers_test.go
@@ -19,3 +19,42 @@ func TestParseURLTemplateWhenEmpty(t *testing.T) {
 	actual := ParseURLTemplate("", nil)
 	assert.Empty(t, actual)
 }
+
+func TestParseOriginListAllowAll(t *testing.T) {
+	expected := []string{"*"}
+
+	actual, ok := ParseOriginList("*")
+
+	assert.True(t, ok)
+	assert.Equal(t, expected, actual)
+}
+
+func TestParseOriginListEmpty(t *testing.T) {
+	actual, ok := ParseOriginList("")
+
+	assert.False(t, ok)
+	assert.Empty(t, actual)
+}
+
+func TestParseOriginListSingle(t *testing.T) {
+	expected := []string{"http://test.com"}
+
+	actual, ok := ParseOriginList("http://test.com")
+
+	assert.True(t, ok)
+	assert.Equal(t, expected, actual)
+}
+
+func TestParseOriginListMultiple(t *testing.T) {
+	expected := []string{"http://test.com", "http://test2.com"}
+	actual, ok := ParseOriginList("http://test.com,http://test2.com")
+	assert.True(t, ok)
+	assert.Equal(t, expected, actual)
+}
+
+func TestParseOriginListMultipleAndSpaces(t *testing.T) {
+	expected := []string{"http://test.com", "http://test2.com"}
+	actual, ok := ParseOriginList("http://test.com, http://test2.com")
+	assert.True(t, ok)
+	assert.Equal(t, expected, actual)
+}

--- a/clients/ui/bff/internal/config/environment.go
+++ b/clients/ui/bff/internal/config/environment.go
@@ -9,4 +9,5 @@ type EnvConfig struct {
 	DevModePort     int
 	StaticAssetsDir string
 	LogLevel        string
+	AllowedOrigins  string
 }

--- a/clients/ui/bff/internal/constants/keys.go
+++ b/clients/ui/bff/internal/constants/keys.go
@@ -2,6 +2,8 @@ package constants
 
 type contextKey string
 
+// NOTE: If you are adding any HTTP headers, they need to also be added to the EnableCORS middleware
+// to ensure requests are not blocked when using CORS.
 const (
 	ModelRegistryHttpClientKey  contextKey = "ModelRegistryHttpClientKey"
 	NamespaceHeaderParameterKey contextKey = "namespace"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
NOTE: This PR is stacked on top of my logging PR, that will need to be merged first.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds W3C standards compliant support for CORS for the BFF

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This can be tested by running the BFF in full mock mode as the headers are generated by a middleware that will run in all scenarios. The tests involve merely querying the health check endpoint with a different combination of headers. 

This to note: 
* CORS is only enforced by browsers, so all requests should be successful, the headers returned will vary and the browser will either accept or deny the request based on this.
* When the frontend is served by the BFF, CORS will not be required as it will be served from the same origin - as such the default behaviour is to not return any CORS headers, this disallows cross origin requests and is the most secure.

Scenario 1: Testing with CORS disabled
Start the server:
```
 make run PORT=4000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true
```

Run a curl against the health check endpoint:
```
curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/healthcheck"
```

Expected outcome: The endpoint should function as normal and there should be no CORS headers in the response.

Scenario 2: Test with a single allowed origin
Start the server:
```
 make run PORT=4000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true ALLOWED_ORIGINS="http://example.com"
```

2.1 Make a request with an allowed origin header
```
curl -i -H "Origin: http://example.com" -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/healthcheck"
```

Expected outcome: Successful request with the following CORS specific headers:
```
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://example.com
Vary: Origin
```

2.2 Make a request with a disallowed origin header
```
curl -i -H "Origin: http://shady-as-duck.com" -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/healthcheck"
```
Expected outcome: The request should be successful, but the only CORS header in the response should be:
```
Vary: Origin
```
If there are any other Access-Control-* headers present the test has failed!

2.3 Simulate a CORS pre-flight request for an allowed origin:
```
curl -i -X OPTIONS -H "Origin: http://example.com" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: kubeflow-userid" "localhost:4000/api/v1/healthcheck"
```
Expected outcome: A response like below - note the CORS headers.
```
HTTP/1.1 204 No Content
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: kubeflow-userid
Access-Control-Allow-Methods: POST
Access-Control-Allow-Origin: http://example.com
Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
Date: Fri, 17 Jan 2025 18:12:13 GMT
```

2.4 Simulate a CORS pre-flight request for a disallowed origin
```
curl -i -X OPTIONS -H "Origin: http://shady-as-duck.com" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: kubeflow-userid" "localhost:4000/api/v1/healthcheck"
```

Expected outcome: A response like below - note the lack of CORS headers aside from the `Vary` header
```
HTTP/1.1 204 No Content
Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
Date: Fri, 17 Jan 2025 18:15:10 GMT
```

Additional tests:
You can repeat the above tests using an allow list of multiple origins, simply add comma separated ones to the make command e.g.

```
 make run PORT=4000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true ALLOWED_ORIGINS="http://example1.com,http://example2.com"
```
NOTE: Only a single origin is allowed in the `Access-Control-Allow-Origin` header, so the BFF will return only a single origin if the `Origin` request header matches the allow list.

Also you can test that allowing all origins (wildcard) works as expected:
```
 make run PORT=4000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true ALLOWED_ORIGINS="*"
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
