### PR TITLE
fix: patch requests to artifact endpoint make mr panic

### DIFF
--- a/clients/python/tests/regression_test.py
+++ b/clients/python/tests/regression_test.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 from model_registry import ModelRegistry
 from model_registry.types.artifacts import ModelArtifact
@@ -99,3 +100,36 @@ async def test_create_standalone_model_artifact(client: ModelRegistry):
     assert mv.id
     mv_ma = await client._api.upsert_model_version_artifact(new_ma, mv.id)
     assert mv_ma.id == new_ma.id
+
+@pytest.mark.e2e
+async def test_patch_model_artifacts_artifact_type(client: ModelRegistry):
+    """Patching Artifacts makes the model registry server panic.
+
+    reported with https://issues.redhat.com/browse/RHOAIENG-16932
+    """
+    name = "test_model"
+    version = "1.0.0"
+    rm = client.register_model(
+        name,
+        "s3",
+        model_format_name="test_format",
+        model_format_version="test_version",
+        version=version,
+    )
+    assert rm.id
+    mv = client.get_model_version(name, version)
+    assert mv
+    assert mv.id
+    ma = client.get_model_artifact(name, version)
+    assert ma
+    assert ma.id
+
+    # payload = { "modelFormatName": "foo", "artifactType": "model-artifact" }
+    payload = { "modelFormatName": "foo"}
+    from .conftest import REGISTRY_HOST, REGISTRY_PORT
+    response = requests.patch(url=f"{REGISTRY_HOST}:{REGISTRY_PORT}/api/model_registry/v1alpha3/artifacts/{ma.id}", json=payload, timeout=10, headers={"Content-Type": "application/json"})
+    assert response.status_code == 200
+    ma = client.get_model_artifact(name, version)
+    assert ma
+    assert ma.id
+    assert ma.model_format_name == "foo"

--- a/clients/python/tests/regression_test.py
+++ b/clients/python/tests/regression_test.py
@@ -124,8 +124,7 @@ async def test_patch_model_artifacts_artifact_type(client: ModelRegistry):
     assert ma
     assert ma.id
 
-    # payload = { "modelFormatName": "foo", "artifactType": "model-artifact" }
-    payload = { "modelFormatName": "foo"}
+    payload = { "modelFormatName": "foo", "artifactType": "model-artifact" }
     from .conftest import REGISTRY_HOST, REGISTRY_PORT
     response = requests.patch(url=f"{REGISTRY_HOST}:{REGISTRY_PORT}/api/model_registry/v1alpha3/artifacts/{ma.id}", json=payload, timeout=10, headers={"Content-Type": "application/json"})
     assert response.status_code == 200

--- a/internal/converter/openapi_reconciler_util.go
+++ b/internal/converter/openapi_reconciler_util.go
@@ -6,18 +6,28 @@ import (
 
 func UpdateExistingArtifact(genc OpenAPIReconciler, source OpenapiUpdateWrapper[openapi.Artifact]) (openapi.Artifact, error) {
 	art := InitWithExisting(source)
+
 	if source.Update == nil {
 		return art, nil
 	}
-	ma, err := genc.UpdateExistingModelArtifact(OpenapiUpdateWrapper[openapi.ModelArtifact]{Existing: art.ModelArtifact, Update: source.Update.ModelArtifact})
-	if err != nil {
-		return art, err
+
+	if source.Update.ModelArtifact != nil {
+		ma, err := genc.UpdateExistingModelArtifact(OpenapiUpdateWrapper[openapi.ModelArtifact]{Existing: art.ModelArtifact, Update: source.Update.ModelArtifact})
+		if err != nil {
+			return art, err
+		}
+
+		art.ModelArtifact = &ma
 	}
-	da, err := genc.UpdateExistingDocArtifact(OpenapiUpdateWrapper[openapi.DocArtifact]{Existing: art.DocArtifact, Update: source.Update.DocArtifact})
-	if err != nil {
-		return art, err
+
+	if source.Update.DocArtifact != nil {
+		da, err := genc.UpdateExistingDocArtifact(OpenapiUpdateWrapper[openapi.DocArtifact]{Existing: art.DocArtifact, Update: source.Update.DocArtifact})
+		if err != nil {
+			return art, err
+		}
+
+		art.DocArtifact = &da
 	}
-	art.DocArtifact = &da
-	art.ModelArtifact = &ma
+
 	return art, nil
 }

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -492,7 +492,8 @@ func (s *ModelRegistryServiceAPIService) UpdateArtifact(ctx context.Context, art
 	}
 	if artifactUpdate.DocArtifactUpdate != nil {
 		entity.DocArtifact.Id = &artifactId
-	} else {
+	}
+	if artifactUpdate.ModelArtifactUpdate != nil {
 		entity.ModelArtifact.Id = &artifactId
 	}
 	existing, err := s.coreApi.GetArtifactById(artifactId)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Trying to do a PATCH request to v1alpha3/artifacts/{artifactId} made mr panic:

```shell
http: panic serving 0.0.0.0:8080: runtime error: invalid memory address or nil pointer dereference
goroutine 25997 [running]:
net/http.(*conn).serve.func1()
	/usr/lib/golang/src/net/http/server.go:1873 +0xb9
panic({0xb13ba0?, 0x13a8810?})
	/usr/lib/golang/src/runtime/panic.go:920 +0x270
github.com/kubeflow/model-registry/internal/server/openapi.(*ModelRegistryServiceAPIService).UpdateArtifact(0xc0003c7c20, {0xb351a0?, 0xc000042190?}, {0xc00029e0ad, 0x1}, {0x0, 0x0})
	/workspace/internal/server/openapi/api_model_registry_service_service.go:496 +0x12f
github.com/kubeflow/model-registry/internal/server/openapi.(*ModelRegistryServiceAPIController).UpdateArtifact(0xc000013c98, {0x7fb4fa6124b8, 0xc0001665c0}, 0xc0001d8e00)
	/workspace/internal/server/openapi/api_model_registry_service.go:902 +0x1cd
net/http.HandlerFunc.ServeHTTP(0xb0e3c0?, {0x7fb4fa6124b8?, 0xc0001665c0?}, 0xc00029e086?)
	/usr/lib/golang/src/net/http/server.go:2141 +0x29
github.com/go-chi/chi/v5.(*Mux).routeHTTP(0xc0003b8de0, {0x7fb4fa6124b8, 0xc0001665c0}, 0xc0001d8e00)
	/cachi2/output/deps/gomod/pkg/mod/github.com/go-chi/chi/v5@v5.1.0/mux.go:459 +0x2b4
net/http.HandlerFunc.ServeHTTP(0xc0000cc960?, {0x7fb4fa6124b8?, 0xc0001665c0?}, 0xc0001d8e00?)
	/usr/lib/golang/src/net/http/server.go:2141 +0x29
github.com/go-chi/cors.(*Cors).Handler-fm.(*Cors).Handler.func1({0x7fb4fa6124b8, 0xc0001665c0}, 0xc0001d8e00)
	/cachi2/output/deps/gomod/pkg/mod/github.com/go-chi/cors@v1.2.1/cors.go:228 +0x17e
net/http.HandlerFunc.ServeHTTP(0xc0001d8d00?, {0x7fb4fa6124b8?, 0xc0001665c0?}, 0x30?)
	/usr/lib/golang/src/net/http/server.go:2141 +0x29
github.com/go-chi/chi/v5/middleware.init.0.RequestLogger.func1.1({0xd08058, 0xc00019a540}, 0xc0001d8d00)
	/cachi2/output/deps/gomod/pkg/mod/github.com/go-chi/chi/v5@v5.1.0/middleware/logger.go:55 +0x16d
net/http.HandlerFunc.ServeHTTP(0xd09790?, {0xd08058?, 0xc00019a540?}, 0x13a92c0?)
	/usr/lib/golang/src/net/http/server.go:2141 +0x29
github.com/go-chi/chi/v5.(*Mux).ServeHTTP(0xc0003b8de0, {0xd08058, 0xc00019a540}, 0xc0001d8c00)
	/cachi2/output/deps/gomod/pkg/mod/github.com/go-chi/chi/v5@v5.1.0/mux.go:90 +0x330
net/http.serverHandler.ServeHTTP({0xd05f10?}, {0xd08058?, 0xc00019a540?}, 0x6?)
	/usr/lib/golang/src/net/http/server.go:2943 +0x8e
net/http.(*conn).serve(0xc0001b7560, {0xd09758, 0xc0003d62d0})
	/usr/lib/golang/src/net/http/server.go:2014 +0x5f4
created by net/http.(*Server).Serve in goroutine 1
	/usr/lib/golang/src/net/http/server.go:3091 +0x5cb 
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
curl -k -X 'POST' 'http://localhost:8080/api/model_registry/v1alpha3/artifacts' -d '{"description": "test","artifactType": "model-artifact"
```

```shell
curl -k -X 'PATCH' 'http://localhost:8080/api/model_registry/v1alpha3/artifacts/1' -d '{"description": "test-two","artifactType": "model-artifact"}'
```

plus

python client e2e tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
