### PR TITLE
feat(bff) crud for api/v1/model_registry/{model_registry_id}/artifacts

### DIFF
--- a/clients/ui/bff/README.md
+++ b/clients/ui/bff/README.md
@@ -1,13 +1,16 @@
 # Kubeflow Model Registry UI BFF
+
 The Kubeflow Model Registry UI BFF is the _backend for frontend_ (BFF) used by the Kubeflow Model Registry UI.
 
 ## Pre-requisites:
 
-### Dependencies 
+### Dependencies
+
 - Go >= 1.22.2
 
 ### Running model registry & ml-metadata
-To be operational, our BFF needs the Model Registry & Ml-metadata backend running. 
+
+To be operational, our BFF needs the Model Registry & Ml-metadata backend running.
 
 > **NOTE:** Docker compose must be installed in your environment.
 
@@ -24,36 +27,45 @@ When shutting down the docker compose, you might want to clean-up the SQLite db 
 # Development
 
 Run the following command to build the BFF:
+
 ```shell
 make build
 ```
+
 After building it, you can run our app with:
+
 ```shell
 make run
 ```
+
 If you want to use a different port, mock kubernetes client or model registry client - useful for front-end development, you can run:
+
 ```shell
 make run PORT=8000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true
 ```
+
 If you want to change the log level on deployment, add the LOG_LEVEL argument when running, supported levels are: ERROR, WARN, INFO, DEBUG. The default level is INFO.
+
 ```shell
 # Run with debug logging
-make run LOG_LEVEL=DEBUG  
+make run LOG_LEVEL=DEBUG
 ```
 
 # Building and Deploying
 
 Run the following command to build the BFF:
+
 ```shell
 make build
 ```
+
 The BFF binary will be inside `bin` directory
 
 You can also build BFF docker image with:
+
 ```shell
 make docker-build
 ```
-
 
 ## Getting started
 
@@ -66,33 +78,40 @@ See the [OpenAPI specification](../api/openapi/mod-arch.yaml) for a complete lis
 You will need to inject your requests with a `kubeflow-userid` header and namespace for authorization purposes.
 
 When running the service with the mocked Kubernetes client (MOCK_K8S_CLIENT=true), the user `user@example.com` is preconfigured with the necessary RBAC permissions to perform these actions.
+
 ```
 # GET /v1/healthcheck
 curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/healthcheck"
 ```
+
 ```
 # GET /v1/user
 curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/user"
 ```
+
 ```
 # GET /v1/namespaces (only works when DEV_MODE=true)
 curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/namespaces"
 ```
+
 ```
-# GET /v1/model_registry 
+# GET /v1/model_registry
 curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/model_registry?namespace=kubeflow"
 ```
+
 ```
 # GET /v1/model_registry using groups permissions
-curl -i \                                                                                                                                      
+curl -i \
   -H "kubeflow-userid: non-user@example.com" \
   -H "kubeflow-groups: dora-namespace-group ,group2,group3" \
   "http://localhost:4000/api/v1/model_registry?namespace=dora-namespace"
 ```
+
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models
 curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/model_registry/model-registry/registered_models?namespace=kubeflow"
 ```
+
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models using group permissions
 curl -i \
@@ -100,6 +119,7 @@ curl -i \
   -H "kubeflow-groups: dora-namespace-group ,dora-service-group,group3" \
   "http://localhost:4000/api/v1/model_registry/model-registry-dora/registered_models?namespace=dora-namespace"
 ```
+
 ```
 #POST /v1/model_registry/{model_registry_id}/registered_models
 curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models?namespace=kubeflow" \
@@ -118,10 +138,12 @@ curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/ap
   "state": "LIVE"
 }}'
 ```
+
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}
 curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/model_registry/model-registry/registered_models/1?namespace=kubeflow"
 ```
+
 ```
 # PATCH /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}
 curl -i -H "kubeflow-userid: user@example.com" -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1?namespace=kubeflow" \
@@ -130,14 +152,17 @@ curl -i -H "kubeflow-userid: user@example.com" -X PATCH "http://localhost:4000/a
   "description": "New description"
 }}'
 ```
+
 ```
 # GET /api/v1/model_registry/{model_registry_id}/model_versions
 curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/model_versions?namespace=kubeflow"
 ```
+
 ```
-# GET /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id} 
+# GET /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}
 curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1?namespace=kubeflow"
 ```
+
 ```
 # POST /api/v1/model_registry/{model_registry_id}/model_versions
 curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/api/v1/model_registry/model-registry/model_versions?namespace=kubeflow" \
@@ -157,6 +182,7 @@ curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/ap
   "registeredModelId": "1"
 }}'
 ```
+
 ```
 # PATCH /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}
 curl -i -H "kubeflow-userid: user@example.com" -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1?namespace=kubeflow" \
@@ -165,10 +191,12 @@ curl -i -H "kubeflow-userid: user@example.com" -X PATCH "http://localhost:4000/a
   "description": "New description 2"
 }}'
 ```
+
 ```
 # GET /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}/versions
 curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/model_registry/model-registry/registered_models/1/versions?namespace=kubeflow"
 ```
+
 ```
 # POST /v1/model_registry/{model_registry_id}/registered_models/{registered_model_id}/versions
 curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/api/v1/model_registry/model-registry/registered_models/1/versions?namespace=kubeflow" \
@@ -188,10 +216,12 @@ curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/ap
   "registeredModelId": "1"
 }}'
 ```
+
 ```
-# GET /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}/artifacts 
+# GET /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}/artifacts
 curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1/artifacts?namespace=kubeflow"
 ```
+
 ```
 # POST /api/v1/model_registry/{model_registry_id}/model_versions/{model_version_id}/artifacts
 curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/api/v1/model_registry/model-registry/model_versions/1/artifacts?namespace=kubeflow" \
@@ -211,26 +241,71 @@ curl -i -H "kubeflow-userid: user@example.com" -X POST "http://localhost:4000/ap
 }}'
 ```
 
+```
+# GET /api/v1/model_registry/{model_registry_id}/artifacts
+curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/artifacts?namespace=kubeflow"
+
+```
+
+```
+# GET /api/v1/model_registry/{model_registry_id}/artifacts/{artifact_id}
+curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/artifacts/{artifact_id}?namespace=kubeflow"
+
+```
+
+```
+# POST /api/v1/model_registry/{model_registry_id}/artifacts
+curl -i \
+  -H "kubeflow-userid: user@example.com" \
+  -X POST "http://localhost:4000/api/v1/model_registry/model-registry/artifacts?namespace=kubeflow" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "artifactType": "model-artifact",
+      "name": "dora-classifier-v2",
+      "description": "MNIST digit classification model trained on TensorFlow",
+      "uri": "gs://my-models/mnist-classifier/v2",
+      "externalId": "model-12345678",
+      "modelFormatName": "tensorflow",
+      "modelFormatVersion": "2.9.0",
+      "storageKey": "models/mnist/1.0.0",
+      "storagePath": "/models/mnist/1.0.0/model.savedmodel"
+    }
+  }'
+```
+
+```
+# PATCH /api/v1/model_registry/{model_registry_id}/artifacts/{artifact_id}
+curl -i -H "kubeflow-userid: user@example.com" -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/artifacts/1?namespace=kubeflow" \
+     -H "Content-Type: application/json" \
+-d '{ "data": {
+  "artifactType": "model-artifact",
+  "description": "New description 2"
+}}'
+```
+
 ### Pagination
+
 The following query parameters are supported by "Get All" style endpoints to control pagination.
 
 | Parameter Name | Description                                                                                               |
-|----------------|-----------------------------------------------------------------------------------------------------------|
+| -------------- | --------------------------------------------------------------------------------------------------------- |
 | pageSize       | Number of entities in each page                                                                           |
 | orderBy        | Specifies the order by criteria for listing entities. Available values: CREATE_TIME, LAST_UPDATE_TIME, ID |
 | sortOrder      | Specifies the sort order for listing entities. Available values: ASC, DESC. Default: ASC                  |
-| nextPageToken  | Token to use to retrieve next page of results.                                                            | 
+| nextPageToken  | Token to use to retrieve next page of results.                                                            |
 
 ### Sample local calls
+
 ```
 # Get with a page size of 5 getting a specific page.
 curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/registered_models?pageSize=5&nextPageToken=CAEQARoCCAE"
 ```
+
 ```
 # Get with a page size of 5, order by last update time in descending order.
 curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/registered_models?pageSize=5&orderBy=LAST_UPDATE_TIME&sortOrder=DESC"
 ```
-
 
 ### FAQ
 
@@ -239,6 +314,7 @@ curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/mod
 We filter Model Registry services by using the Kubernetes label `component: model-registry. This label helps distinguish Model Registry services from other services in the cluster.
 
 For example, in our service manifest, the `component label is defined as follows:
+
 ```yaml
 # ...
 labels:
@@ -246,6 +322,7 @@ labels:
   component: model-registry
 #...
 ```
+
 You can view the complete Model Registry service manifest [here](https://github.com/kubeflow/model-registry/blob/main/manifests/kustomize/base/model-registry-service.yaml#L10).
 
 #### 2. What is the structure of the mock Kubernetes environment?
@@ -253,23 +330,24 @@ You can view the complete Model Registry service manifest [here](https://github.
 The mock Kubernetes environment is activated when the environment variable `MOCK_K8S_CLIENT` is set to `true`. It is based on `env-test` and is designed to simulate a realistic Kubernetes setup for testing. The mock has the following characteristics:
 
 - **Namespaces**:
+
   - `kubeflow`
   - `dora-namespace`
   - `bella-namespace`
 
 - **Users**:
+
   - `user@example.com` (has `cluster-admin` privileges)
   - `doraNonAdmin@example.com` (restricted to the `dora-namespace`)
   - `bellaNonAdmin@example.com` (restricted to the `bella-namespace`)
 
 - **Groups**:
   - `dora-service-group` (has access to `model-registry-dora` inside `dora-namespace`)
-  - `dora-namespace-group` (has access to the `dora-namespace`) 
-  
+  - `dora-namespace-group` (has access to the `dora-namespace`)
 - **Services (Model Registries)**:
   - `model-registry`: resides in the `kubeflow` namespace with the label `component: model-registry`.
   - `model-registry-one`: resides in the `kubeflow` namespace with the label `component: model-registry`.
-  - `non-model-registry`: resides in the `kubeflow` namespace *without* the label `component: model-registry`.
+  - `non-model-registry`: resides in the `kubeflow` namespace _without_ the label `component: model-registry`.
   - `model-registry-dora`: resides in the `dora-namespace` namespace with the label `component: model-registry`.
 
 #### 3. How BFF authorization works for kubeflow-userid and kubeflow-groups?
@@ -279,22 +357,24 @@ Authorization is performed using Kubernetes SubjectAccessReview (SAR), which val
 - `kubeflow-userid`: Required header that specifies the user’s email. Access is checked directly for the user via SAR.
 - `kubeflow-groups`: Optional header with a comma-separated list of groups. If the user does not have access, SAR checks group permissions using OR logic. If any group has access, the request is authorized.
 
-
 Access to Model Registry List:
+
 - To list all model registries (/v1/model_registry), we perform a SAR check for get and list verbs on services within the specified namespace.
 - If the user or any group has permission to get and list services in the namespace, the request is authorized.
 
 Access to Specific Model Registry Endpoints:
+
 - For other endpoints (e.g., /v1/model_registry/{model_registry_id}/...), we perform a SAR check for get and list verbs on the specific service (identified by model_registry_id) within the namespace.
 - If the user or any group has permission to get or list the specific service, the request is authorized.
 
 #### 4. How do I allow CORS requests from other origins
 
-When serving the UI directly from the BFF there is no need for any CORS headers to be served, by default they are turned off for security reasons. 
+When serving the UI directly from the BFF there is no need for any CORS headers to be served, by default they are turned off for security reasons.
 
 If you need to enable CORS for any reasons you can add origins to the allow-list in several ways:
 
 ##### Via the make command
+
 Add the following parameter to your command: `ALLOWED_ORIGINS` this takes a comma separated list of origins to permit serving to, alterantively you can specify the value `*` to allow all origins, **Note this is not recommended in production deployments as it poses a security risk**
 
 Examples:
@@ -314,6 +394,7 @@ make run ALLOWED_ORIGINS=""
 ```
 
 #### Via environment variable
+
 Setting CORS via environment variable follows the same rules as using the Makefile, simply set the environment variable `ALLOWED_ORIGINS` with the same value as above.
 
 #### Via the command line arguments
@@ -321,7 +402,7 @@ Setting CORS via environment variable follows the same rules as using the Makefi
 Setting CORS via command line arguments follows the same rules as using the Makefile. Simply add the `--allowed-origins=` flag to your command.
 
 Examples:
+
 ```shell
 ./bff --allowed-origins="http://my-domain.com,http://my-other-domain.com"
 ```
-

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -3,12 +3,13 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/kubeflow/model-registry/ui/bff/internal/config"
-	"github.com/kubeflow/model-registry/ui/bff/internal/integrations"
-	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 	"log/slog"
 	"net/http"
 	"path"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/config"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
@@ -22,6 +23,7 @@ const (
 	RegisteredModelId            = "registered_model_id"
 	ModelVersionId               = "model_version_id"
 	ModelArtifactId              = "model_artifact_id"
+	ArtifactId                   = "artifact_id"
 	HealthCheckPath              = PathPrefix + "/healthcheck"
 	UserPath                     = PathPrefix + "/user"
 	ModelRegistryListPath        = PathPrefix + "/model_registry"
@@ -35,6 +37,9 @@ const (
 	ModelVersionArtifactListPath = ModelVersionPath + "/artifacts"
 	ModelArtifactListPath        = ModelRegistryPath + "/model_artifacts"
 	ModelArtifactPath            = ModelArtifactListPath + "/:" + ModelArtifactId
+
+	ArtifactListPath = ModelRegistryPath + "/artifacts"
+	ArtifactPath     = ArtifactListPath + "/:" + ArtifactId
 )
 
 type App struct {
@@ -105,13 +110,17 @@ func (app *App) Routes() http.Handler {
 	apiRouter.GET(ModelVersionListPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.GetAllModelVersionHandler))))
 	apiRouter.GET(ModelVersionPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.GetModelVersionHandler))))
 	apiRouter.PATCH(ModelVersionPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.UpdateModelVersionHandler))))
+	apiRouter.GET(ArtifactListPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.GetAllArtifactsHandler))))
+	apiRouter.GET(ArtifactPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.GetArtifactHandler))))
+	apiRouter.POST(ArtifactListPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.CreateArtifactHandler))))
+	apiRouter.PATCH(ArtifactPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.UpdateArtifactHandler))))
 	apiRouter.GET(ModelVersionArtifactListPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.GetAllModelArtifactsByModelVersionHandler))))
 	apiRouter.POST(ModelVersionArtifactListPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.CreateModelArtifactByModelVersionHandler))))
 	apiRouter.PATCH(ModelRegistryPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.UpdateModelVersionHandler))))
 
 	// Kubernetes routes
 	apiRouter.GET(UserPath, app.UserHandler)
-	// Perform SAR to Get List Services by Namspace
+	// Perform SAR to Get List Services by Namespace
 	apiRouter.GET(ModelRegistryListPath, app.AttachNamespace(app.PerformSARonGetListServicesByNamespace(app.ModelRegistryHandler)))
 	if app.config.StandaloneMode {
 		apiRouter.GET(NamespaceListPath, app.GetNamespacesHandler)

--- a/clients/ui/bff/internal/api/artifacts_handler.go
+++ b/clients/ui/bff/internal/api/artifacts_handler.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/model-registry/pkg/openapi"
+	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+)
+
+type ArtifactListEnvelope Envelope[*openapi.ArtifactList, None]
+type ArtifactEnvelope Envelope[*openapi.Artifact, None]
+type ArtifactUpdateEnvelope Envelope[*openapi.ArtifactUpdate, None]
+
+func (app *App) CreateArtifactHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelRegistryHttpClientKey).(integrations.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("REST client not found"))
+		return
+	}
+
+	var envelope ArtifactEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error decoding JSON:: %v", err.Error()))
+		return
+	}
+
+	data := *envelope.Data
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error marshaling model to JSON: %w", err))
+		return
+	}
+
+	createdArtifact, err := app.repositories.ModelRegistryClient.CreateArtifact(client, jsonData)
+	if err != nil {
+		var httpErr *integrations.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if createdArtifact == nil || (createdArtifact.DocArtifact == nil && createdArtifact.ModelArtifact == nil) {
+		app.serverErrorResponse(w, r, fmt.Errorf("created artifact is nil or does not contain valid data"))
+		return
+	}
+
+	response := ArtifactEnvelope{
+		Data: createdArtifact,
+	}
+
+	if createdArtifact.DocArtifact != nil && createdArtifact.DocArtifact.Id != nil {
+		w.Header().Set("Location", r.URL.JoinPath(*createdArtifact.DocArtifact.Id).String())
+	} else if createdArtifact.ModelArtifact != nil && createdArtifact.ModelArtifact.Id != nil {
+		w.Header().Set("Location", r.URL.JoinPath(*createdArtifact.ModelArtifact.Id).String())
+	} else {
+		app.serverErrorResponse(w, r, fmt.Errorf("artifact ID is missing"))
+		return
+	}
+
+	err = app.WriteJSON(w, http.StatusCreated, response, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetArtifactHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelRegistryHttpClientKey).(integrations.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("REST client not found"))
+		return
+	}
+
+	model, err := app.repositories.ModelRegistryClient.GetArtifact(client, ps.ByName(ArtifactId))
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	result := ArtifactEnvelope{
+		Data: model,
+	}
+
+	err = app.WriteJSON(w, http.StatusOK, result, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetAllArtifactsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelRegistryHttpClientKey).(integrations.HTTPClientInterface)
+
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("REST client not found"))
+		return
+	}
+
+	artifactList, err := app.repositories.ModelRegistryClient.GetAllArtifacts(client, r.URL.Query())
+
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	artifactsRes := ArtifactListEnvelope{
+		Data: artifactList,
+	}
+
+	err = app.WriteJSON(w, http.StatusOK, artifactsRes, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) UpdateArtifactHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelRegistryHttpClientKey).(integrations.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("REST client not found"))
+		return
+	}
+
+	var envelope ArtifactUpdateEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error decoding JSON:: %v", err.Error()))
+		return
+	}
+
+	data := *envelope.Data
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error marshaling model to JSON: %w", err))
+		return
+	}
+
+	patchedArtifact, err := app.repositories.ModelRegistryClient.UpdateArtifact(client, ps.ByName(ArtifactId), jsonData)
+	if err != nil {
+		var httpErr *integrations.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if patchedArtifact == nil || (patchedArtifact.DocArtifact == nil && patchedArtifact.ModelArtifact == nil) {
+		app.serverErrorResponse(w, r, fmt.Errorf("created artifact is nil or does not contain valid data"))
+		return
+	}
+
+	responseBody := ArtifactEnvelope{
+		Data: patchedArtifact,
+	}
+
+	err = app.WriteJSON(w, http.StatusOK, responseBody, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/clients/ui/bff/internal/api/artifacts_handler_test.go
+++ b/clients/ui/bff/internal/api/artifacts_handler_test.go
@@ -14,11 +14,11 @@ var _ = Describe("TestArtifactsHandler", func() {
 		Context("successful operations", func() {
 			It("should retrieve an artifact", func() {
 				By("fetching a specific artifact")
-				gofakeit.Seed(123)
+				_ = gofakeit.Seed(123)
 				data := mocks.GenerateMockArtifact()
 				expected := ArtifactEnvelope{Data: &data}
 
-				gofakeit.Seed(123)
+				_ = gofakeit.Seed(123)
 				actual, rs, err := setupApiTest[ArtifactEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/artifacts/1?namespace=kubeflow", nil, k8sClient, mocks.KubeflowUserIDHeaderValue, "kubeflow")
 				Expect(err).NotTo(HaveOccurred())
 
@@ -31,7 +31,7 @@ var _ = Describe("TestArtifactsHandler", func() {
 
 			It("should list all artifacts", func() {
 				By("fetching all artifacts")
-				gofakeit.Seed(123)
+				_ = gofakeit.Seed(123)
 
 				actual, rs, err := setupApiTest[ArtifactListEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/artifacts?namespace=kubeflow", nil, k8sClient, mocks.KubeflowUserIDHeaderValue, "kubeflow")
 				Expect(err).NotTo(HaveOccurred())

--- a/clients/ui/bff/internal/api/artifacts_handler_test.go
+++ b/clients/ui/bff/internal/api/artifacts_handler_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/brianvoe/gofakeit/v7"
+	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestArtifactsHandler", func() {
+	Context("testing artifacts", Ordered, func() {
+		Context("successful operations", func() {
+			It("should retrieve an artifact", func() {
+				By("fetching a specific artifact")
+				gofakeit.Seed(123)
+				data := mocks.GenerateMockArtifact()
+				expected := ArtifactEnvelope{Data: &data}
+
+				gofakeit.Seed(123)
+				actual, rs, err := setupApiTest[ArtifactEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/artifacts/1?namespace=kubeflow", nil, k8sClient, mocks.KubeflowUserIDHeaderValue, "kubeflow")
+				Expect(err).NotTo(HaveOccurred())
+
+				By("should match the expected artifact")
+				Expect(rs.StatusCode).To(Equal(http.StatusOK))
+				Expect(actual.Data.ModelArtifact.GetName()).To(Equal(expected.Data.ModelArtifact.GetName()))
+				Expect(actual.Data.ModelArtifact.GetArtifactType()).To(Equal(expected.Data.ModelArtifact.GetArtifactType()))
+				Expect(actual.Data.ModelArtifact.GetDescription()).To(Equal(expected.Data.ModelArtifact.GetDescription()))
+			})
+
+			It("should list all artifacts", func() {
+				By("fetching all artifacts")
+				gofakeit.Seed(123)
+
+				actual, rs, err := setupApiTest[ArtifactListEnvelope](http.MethodGet, "/api/v1/model_registry/model-registry/artifacts?namespace=kubeflow", nil, k8sClient, mocks.KubeflowUserIDHeaderValue, "kubeflow")
+				Expect(err).NotTo(HaveOccurred())
+
+				By("should return success status and valid data")
+				Expect(rs.StatusCode).To(Equal(http.StatusOK))
+				Expect(actual.Data).NotTo(BeNil())
+				Expect(actual.Data.Items).NotTo(BeEmpty())
+
+				By("should contain valid artifacts")
+				for _, item := range actual.Data.Items {
+					Expect(*item.ModelArtifact.Name).NotTo(BeEmpty())
+					Expect(item.ModelArtifact.ArtifactType).NotTo(BeEmpty())
+				}
+			})
+		})
+	})
+})

--- a/clients/ui/bff/internal/api/suite_test.go
+++ b/clients/ui/bff/internal/api/suite_test.go
@@ -2,17 +2,17 @@ package api
 
 import (
 	"context"
-	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
-	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
 	"log/slog"
 	"os"
+	"testing"
+
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
-)
 
-import (
 	. "github.com/onsi/ginkgo/v2"
+
 	. "github.com/onsi/gomega"
 )
 

--- a/clients/ui/bff/internal/api/test_utils.go
+++ b/clients/ui/bff/internal/api/test_utils.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
-	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
-	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
-	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
+	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 )
 
 func setupApiTest[T any](method string, url string, body interface{}, k8sClient k8s.KubernetesClientInterface, kubeflowUserIDHeaderValue string, namespace string) (T, *http.Response, error) {

--- a/clients/ui/bff/internal/mocks/k8s_mock.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock.go
@@ -3,16 +3,17 @@ package mocks
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+
 	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"log/slog"
-	"os"
-	"path/filepath"
-	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
@@ -274,9 +275,6 @@ func createService(k8sClient client.Client, ctx context.Context, name string, na
 		return fmt.Errorf("failed to list services: %w", err)
 	}
 
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/clients/ui/bff/internal/mocks/model_registry_client_mock.go
+++ b/clients/ui/bff/internal/mocks/model_registry_client_mock.go
@@ -85,3 +85,23 @@ func (m *ModelRegistryClientMock) CreateModelArtifactByModelVersion(_ integratio
 	mockData := GetModelArtifactMocks()[0]
 	return &mockData, nil
 }
+
+func (m *ModelRegistryClientMock) GetAllArtifacts(_ integrations.HTTPClientInterface, _ url.Values) (*openapi.ArtifactList, error) {
+	mockData := GenerateMockArtifactList()
+	return &mockData, nil
+}
+
+func (m *ModelRegistryClientMock) GetArtifact(_ integrations.HTTPClientInterface, _ string) (*openapi.Artifact, error) {
+	mockData := GenerateMockArtifact()
+	return &mockData, nil
+}
+
+func (m *ModelRegistryClientMock) CreateArtifact(_ integrations.HTTPClientInterface, _ []byte) (*openapi.Artifact, error) {
+	mockData := GenerateMockArtifact()
+	return &mockData, nil
+}
+
+func (m *ModelRegistryClientMock) UpdateArtifact(_ integrations.HTTPClientInterface, _ string, _ []byte) (*openapi.Artifact, error) {
+	mockData := GenerateMockArtifact()
+	return &mockData, nil
+}

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -2,11 +2,13 @@ package mocks
 
 import (
 	"context"
+	"log/slog"
+	"os"
+
+	"github.com/brianvoe/gofakeit/v7"
 	"github.com/google/uuid"
 	"github.com/kubeflow/model-registry/pkg/openapi"
 	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
-	"log/slog"
-	"os"
 )
 
 func GetRegisteredModelMocks() []openapi.RegisteredModel {
@@ -220,4 +222,28 @@ func NewMockSessionContext(parent context.Context) context.Context {
 
 func NewMockSessionContextNoParent() context.Context {
 	return NewMockSessionContext(context.TODO())
+}
+
+func GenerateMockArtifactList() openapi.ArtifactList {
+	var artifacts []openapi.Artifact
+	for i := 0; i < 2; i++ {
+		artifact := GenerateMockArtifact()
+		artifacts = append(artifacts, artifact)
+	}
+
+	return openapi.ArtifactList{
+		NextPageToken: gofakeit.UUID(),
+		PageSize:      int32(gofakeit.Number(1, 20)),
+		Size:          int32(len(artifacts)),
+		Items:         artifacts,
+	}
+}
+
+func GenerateMockArtifact() openapi.Artifact {
+	modelArtifact := GenerateMockModelArtifact()
+
+	mockData := openapi.Artifact{
+		ModelArtifact: &modelArtifact,
+	}
+	return mockData
 }

--- a/clients/ui/bff/internal/mocks/types_mock.go
+++ b/clients/ui/bff/internal/mocks/types_mock.go
@@ -2,10 +2,11 @@ package mocks
 
 import (
 	"fmt"
-	"github.com/brianvoe/gofakeit/v7"
-	"github.com/kubeflow/model-registry/pkg/openapi"
 	"net/url"
 	"strconv"
+
+	"github.com/brianvoe/gofakeit/v7"
+	"github.com/kubeflow/model-registry/pkg/openapi"
 )
 
 func GenerateMockRegisteredModelList() openapi.RegisteredModelList {
@@ -85,7 +86,7 @@ func GenerateMockModelVersionList() openapi.ModelVersionList {
 
 func GenerateMockModelArtifact() openapi.ModelArtifact {
 	artifact := openapi.ModelArtifact{
-		ArtifactType: gofakeit.Word(),
+		ArtifactType: "model-artifact",
 		CustomProperties: &map[string]openapi.MetadataValue{
 			"example_key": {
 				MetadataStringValue: &openapi.MetadataStringValue{

--- a/clients/ui/bff/internal/repositories/artifacts.go
+++ b/clients/ui/bff/internal/repositories/artifacts.go
@@ -1,0 +1,91 @@
+package repositories
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/kubeflow/model-registry/pkg/openapi"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations"
+)
+
+const artifactPath = "/artifacts"
+
+type ArtifactInterface interface {
+	GetAllArtifacts(client integrations.HTTPClientInterface, pageValues url.Values) (*openapi.ArtifactList, error)
+	GetArtifact(client integrations.HTTPClientInterface, id string) (*openapi.Artifact, error)
+	CreateArtifact(client integrations.HTTPClientInterface, jsonData []byte) (*openapi.Artifact, error)
+	UpdateArtifact(client integrations.HTTPClientInterface, id string, jsonData []byte) (*openapi.Artifact, error)
+}
+
+type Artifact struct {
+	ArtifactInterface
+}
+
+func (a Artifact) GetAllArtifacts(client integrations.HTTPClientInterface, pageValues url.Values) (*openapi.ArtifactList, error) {
+	responseData, err := client.GET(UrlWithPageParams(artifactPath, pageValues))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching artifacts: %w", err)
+	}
+
+	var artifacts openapi.ArtifactList
+	if err := json.Unmarshal(responseData, &artifacts); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &artifacts, nil
+}
+
+func (a Artifact) GetArtifact(client integrations.HTTPClientInterface, id string) (*openapi.Artifact, error) {
+	path, err := url.JoinPath(artifactPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	responseData, err := client.GET(path)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching artifacts: %w", err)
+	}
+
+	var artifact openapi.Artifact
+	if err := json.Unmarshal(responseData, &artifact); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &artifact, nil
+}
+
+func (a Artifact) CreateArtifact(client integrations.HTTPClientInterface, jsonData []byte) (*openapi.Artifact, error) {
+	responseData, err := client.POST(artifactPath, bytes.NewBuffer(jsonData))
+
+	if err != nil {
+		return nil, fmt.Errorf("error creating artifact: %w", err)
+	}
+
+	var artifact openapi.Artifact
+	if err := json.Unmarshal(responseData, &artifact); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &artifact, nil
+}
+
+func (a Artifact) UpdateArtifact(client integrations.HTTPClientInterface, id string, jsonData []byte) (*openapi.Artifact, error) {
+	path, err := url.JoinPath(artifactPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	responseData, err := client.PATCH(path, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("error patching registered model: %w", err)
+	}
+
+	var artifact openapi.Artifact
+	if err := json.Unmarshal(responseData, &artifact); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &artifact, nil
+}

--- a/clients/ui/bff/internal/repositories/model_registry_client.go
+++ b/clients/ui/bff/internal/repositories/model_registry_client.go
@@ -7,12 +7,14 @@ import (
 type ModelRegistryClientInterface interface {
 	RegisteredModelInterface
 	ModelVersionInterface
+	ArtifactInterface
 }
 
 type ModelRegistryClient struct {
 	logger *slog.Logger
 	RegisteredModel
 	ModelVersion
+	Artifact
 }
 
 func NewModelRegistryClient(logger *slog.Logger) (ModelRegistryClientInterface, error) {


### PR DESCRIPTION
## Description
This PR introduces the endpoints for GET, POST, and PATCH for artifacts.

In this PR:
- clients/ui/bff/README.md: some formating and adding the new API endpoints
- clients/ui/bff/internal/api/app.go: adding the new routes  GET ../artifacts ../artifacts/{id}, POST and PATCH
- clients/ui/bff/internal/api/artifacts_handler.go: handler for the following endpoints
- clients/ui/bff/internal/api/artifacts_handler_test.go: companion test
- clients/ui/bff/internal/api/suite_test.go and clients/ui/bff/internal/api/test_utils.go: code formating
- clients/ui/bff/internal/mocks/k8s_mock.go: redundant error handling
- clients/ui/bff/internal/mocks/model_registry_client_mock.go: simple mocks for when MOCK_MR_CLIENT=true
- clients/ui/bff/internal/mocks/static_data_mock.go: companion mocks
- clients/ui/bff/internal/mocks/types_mock.go: changed the ArtifactType for a hardcode value to avoid serialization issues
- clients/ui/bff/internal/mocks/types_mock.go: repository for artifacts
- clients/ui/bff/internal/repositories/model_registry_client.go: adding new repository for our ModelRegistryClient

## How Has This Been Tested?

Tested both with mocked and real model registry. With MOCK_MR_CLIENT=false:
```shell

# GET /api/v1/model_registry/{model_registry_id}/artifacts
curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/artifacts?namespace=kubeflow"
HTTP/1.1 200 OK
Content-Type: application/json
Date: Mon, 20 Jan 2025 21:03:27 GMT
Transfer-Encoding: chunked

{
	"data": {
		"items": [
			{
				"artifactType": "model-artifact",
				"createTimeSinceEpoch": "1729029766683",
				"customProperties": {},
				"description": "fsdfsd",
				"id": "1",
				"lastUpdateTimeSinceEpoch": "1729029766683",
				"name": "fsdfsd-fsdfsd-artifact",
				"state": "LIVE",
				"uri": "s3://fsd/fsdfsd?endpoint=fsd\u0026defaultRegion=fsd"
			},
			...
			{
				"artifactType": "model-artifact",
				"createTimeSinceEpoch": "1737406383829",
				"customProperties": {},
				"description": "MNIST digit classification model trained on TensorFlow",
				"externalId": "33fdsfdmzodel-12345678",
				"id": "16",
				"lastUpdateTimeSinceEpoch": "1737406383829",
				"modelFormatName": "tensorfl2ow",
				"modelFormatVersion": "2.339.30",
				"name": "dora-classififsdfsder-v3333432",
				"storageKey": "models/mnist/1.0.0",
				"storagePath": "/models/mnist/1.0.0/model.savedmodel",
				"uri": "gs://my-models/mnist33-classifier/v234"
			}
		],
		"nextPageToken": "",
		"pageSize": 0,
		"size": 16
	}
}
```

```shell
# GET /api/v1/model_registry/{model_registry_id}/artifacts/{artifact_id}
curl -i -H "kubeflow-userid: user@example.com" "http://localhost:4000/api/v1/model_registry/model-registry/artifacts/{artifact_id}?namespace=kubeflow"
HTTP/1.1 200 OK
Content-Type: application/json
Date: Mon, 20 Jan 2025 21:04:06 GMT
Content-Length: 545

{
	"data": {
		"artifactType": "model-artifact",
		"createTimeSinceEpoch": "1737394565358",
		"customProperties": {},
		"description": "MNIST digit classification model trained on TensorFlow",
		"externalId": "mzodel-12345678",
		"id": "14",
		"lastUpdateTimeSinceEpoch": "1737394565358",
		"modelFormatName": "tensorfl2ow",
		"modelFormatVersion": "2.9.30",
		"name": "dora-classifier-v33432",
		"storageKey": "models/mnist/1.0.0",
		"storagePath": "/models/mnist/1.0.0/model.savedmodel",
		"uri": "gs://my-models/mnist33-classifier/v234"
	}
}
```

```shell
# POST /api/v1/model_registry/{model_registry_id}/artifacts
# externalId and name should be unique
curl -i \                                                                                                                                           
  -H "kubeflow-userid: user@example.com" \
  -X POST "http://localhost:4000/api/v1/model_registry/model-registry/artifacts?namespace=kubeflow" \
  -H "Content-Type: application/json" \
  -d '{
    "data": {
      "artifactType": "model-artifact",
      "name": "dora-classifsdier-v2",
      "description": "MNIST digit classification model trained on TensorFlow",
      "uri": "gs://my-models/mnist-classifier/v2",
      "externalId": "mfsdfodel-12345678",
      "modelFormatName": "tensorflow",
      "modelFormatVersion": "2.9.0",
      "storageKey": "models/mnist/1.0.0",
      "storagePath": "/models/mnist/1.0.0/model.savedmodel"
    }
  }'
HTTP/1.1 201 Created
Content-Type: application/json
Location: /api/v1/model_registry/model-registry/artifacts/17?namespace=kubeflow
Date: Mon, 20 Jan 2025 21:04:34 GMT
Content-Length: 540

{
	"data": {
		"artifactType": "model-artifact",
		"createTimeSinceEpoch": "1737407074319",
		"customProperties": {},
		"description": "MNIST digit classification model trained on TensorFlow",
		"externalId": "mfsdfodel-12345678",
		"id": "17",
		"lastUpdateTimeSinceEpoch": "1737407074319",
		"modelFormatName": "tensorflow",
		"modelFormatVersion": "2.9.0",
		"name": "dora-classifsdier-v2",
		"storageKey": "models/mnist/1.0.0",
		"storagePath": "/models/mnist/1.0.0/model.savedmodel",
		"uri": "gs://my-models/mnist-classifier/v2"
	}
}
```

```shell
# PATCH /api/v1/model_registry/{model_registry_id}/artifacts/{artifact_id}
curl -i -H "kubeflow-userid: user@example.com" -X PATCH "http://localhost:4000/api/v1/model_registry/model-registry/artifacts/1?namespace=kubeflow" \
     -H "Content-Type: application/json" \
-d '{ "data": {
  "artifactType": "model-artifact",
  "description": "New description 2"
}}'

This is currently broken on MR side but it will be fixed by https://github.com/kubeflow/model-registry/pull/718


```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
 