### PR TITLE
Update verify_ssl behaviour in Configuration class

### DIFF
--- a/clients/python/src/model_registry/core.py
+++ b/clients/python/src/model_registry/core.py
@@ -78,7 +78,7 @@ class ModelRegistryAPIClient:
             user_token: The PEM-encoded user token as a string.
         """
         return cls(
-            Configuration(host=f"{server_address}:{port}", access_token=user_token)
+            Configuration(host=f"{server_address}:{port}", access_token=user_token, verify_ssl=False)
         )
 
     @asynccontextmanager

--- a/clients/python/src/mr_openapi/configuration.py
+++ b/clients/python/src/mr_openapi/configuration.py
@@ -53,8 +53,11 @@ class Configuration:
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum
       values before.
-    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
+    :param ssl_ca_cert: str - The path to a file of concatenated CA certificates
       in PEM format.
+    :param verify_ssl: bool - Whether to verify the SSL certificate when making API 
+      requests to an HTTPS server.
+      Set to False to disable verification, default=True.
 
     :Example:
     """

--- a/clients/python/src/mr_openapi/configuration.py
+++ b/clients/python/src/mr_openapi/configuration.py
@@ -74,6 +74,7 @@ class Configuration:
         server_operation_index=None,
         server_operation_variables=None,
         ssl_ca_cert=None,
+        verify_ssl=True,
     ) -> None:
         """Constructor."""
         self._base_path = "https://localhost:8080" if host is None else host
@@ -133,7 +134,7 @@ class Configuration:
         """Debug switch
         """
 
-        self.verify_ssl = True
+        self.verify_ssl = verify_ssl
         """SSL/TLS verification
            Set this to false to skip verifying SSL certificate when calling API
            from https server.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Exposes the verify_ssl attribute in the Configuration class to be modified when instantiating the class. Set it to "True" by default but update the client's behaviour to override it to False when an insecure connection is attempted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The same change has been applied locally in order to test https://github.com/opendatahub-io/opendatahub-tests/pull/100 and the insecure connection now works correctly. Without this change, even though the ModelRegistry instance is created with the attribute "is_secure" set to False would fail to connect to the remote endpoint.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
