### PR TITLE
fix(frontend): adding missing key for SimpleSelect

### DIFF
--- a/clients/ui/frontend/src/shared/components/SimpleSelect.tsx
+++ b/clients/ui/frontend/src/shared/components/SimpleSelect.tsx
@@ -139,9 +139,9 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
         popperProps={{ maxWidth: 'trigger', ...popperProps }}
       >
         {groupedOptions?.map((group, index) => (
-          <>
+          <React.Fragment key={group.key}>
             {index > 0 ? <Divider /> : null}
-            <SelectGroup key={group.key} label={group.label}>
+            <SelectGroup label={group.label}>
               <SelectList>
                 {group.options.map(
                   ({
@@ -167,7 +167,7 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
                 )}
               </SelectList>
             </SelectGroup>
-          </>
+          </React.Fragment>
         )) ?? null}
         {options?.length ? (
           <SelectList>


### PR DESCRIPTION
## Description
I got a missing key warning in Dev Mode, so I replaced the <> shorthand for fragments with an explicit <React.Fragment> and a key.

<img width="1256" alt="Screenshot 2025-01-22 at 5 18 35 PM" src="https://github.com/user-attachments/assets/9e193f9d-9257-4cd5-ac3e-b945e44f9161" />


## How Has This Been Tested?
Run the web app in dev mode and also in production mode.

<img width="1268" alt="Screenshot 2025-01-22 at 5 18 51 PM" src="https://github.com/user-attachments/assets/2f9f2eb7-c884-4617-9187-4bcf032dfc81" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [X] The developer has added tests or explained why testing cannot be added.
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
