### PR TITLE
fix(frontend): fixes URI field alignment

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/RegistrationCommonFormSections.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/RegistrationCommonFormSections.tsx
@@ -232,19 +232,16 @@ const RegistrationCommonFormSections = <D extends RegistrationCommonFormData>({
         title="Model location"
         description="Specify the model location by providing either the object storage details or the URI."
       >
-        <Split>
-          <SplitItem isFilled>
-            <Radio
-              isChecked={modelLocationType === ModelLocationType.ObjectStorage}
-              name="location-type-object-storage"
-              onChange={() => {
-                setData('modelLocationType', ModelLocationType.ObjectStorage);
-              }}
-              label="Object storage"
-              id="location-type-object-storage"
-            />
-          </SplitItem>
-          {/* {modelLocationType === ModelLocationType.ObjectStorage && (
+        <Radio
+          isChecked={modelLocationType === ModelLocationType.ObjectStorage}
+          name="location-type-object-storage"
+          onChange={() => {
+            setData('modelLocationType', ModelLocationType.ObjectStorage);
+          }}
+          label="Object storage"
+          id="location-type-object-storage"
+        />
+        {/* {modelLocationType === ModelLocationType.ObjectStorage && (
             <SplitItem>
               <Button
                 data-testid="object-storage-autofill-button"
@@ -257,7 +254,6 @@ const RegistrationCommonFormSections = <D extends RegistrationCommonFormData>({
               </Button>
             </SplitItem>
           )} */}
-        </Split>
         {modelLocationType === ModelLocationType.ObjectStorage && (
           <>
             <FormGroup
@@ -303,16 +299,14 @@ const RegistrationCommonFormSections = <D extends RegistrationCommonFormData>({
           }}
           label="URI"
           id="location-type-uri"
-          body={
-            modelLocationType === ModelLocationType.URI && (
-              <>
-                <FormGroup label="URI" isRequired fieldId="location-uri">
-                  {isMUITheme() ? <FormFieldset component={uriInput} field="URI" /> : uriInput}
-                </FormGroup>
-              </>
-            )
-          }
         />
+        {modelLocationType === ModelLocationType.URI && (
+          <>
+            <FormGroup className={spacing.mlLg} label="URI" isRequired fieldId="location-uri">
+              {isMUITheme() ? <FormFieldset component={uriInput} field="URI" /> : uriInput}
+            </FormGroup>
+          </>
+        )}
       </FormSection>
       {/* {isAutofillModalOpen ? (
         <ConnectionModal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes URI input field which was misaligned with the radio button, it should be in a new line and should span the full width. This happens in model registration modal.

Before
<img width="500" alt="Screenshot 2025-01-30 at 5 00 56 PM" src="https://github.com/user-attachments/assets/3577b4d0-b0db-47d9-8fed-5aaf9755828b" />

After
<img width="500" alt="Screenshot 2025-01-30 at 5 00 41 PM" src="https://github.com/user-attachments/assets/89b0eb0b-4247-4326-a773-ed571a159eff" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Click "Register Model" in Model Registry list view, and scroll down to "URI" field in the "Modal Location" section. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
