### PR TITLE
fix(python): client autogen to include verify_ssl param

### DIFF
--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -4,7 +4,7 @@ IMG_VERSION ?= latest
 
 .PHONY: install
 install:
-	../../bin/openapi-generator-cli generate -i ../../api/openapi/model-registry.yaml -g python -o src/ --package-name mr_openapi --additional-properties=library=asyncio,generateSourceCodeOnly=true,useOneOfDiscriminatorLookup=true
+	../../bin/openapi-generator-cli generate -i ../../api/openapi/model-registry.yaml -g python -o src/ --package-name mr_openapi --additional-properties=library=asyncio,generateSourceCodeOnly=true,useOneOfDiscriminatorLookup=true --template-dir templates/
 	mv src/mr_openapi{_,/}README.md
 	git apply patches/*
 	poetry install

--- a/clients/python/templates/configuration.mustache
+++ b/clients/python/templates/configuration.mustache
@@ -1,0 +1,621 @@
+# coding: utf-8
+
+{{>partial_header}}
+
+import copy
+import logging
+from logging import FileHandler
+{{^asyncio}}
+import multiprocessing
+{{/asyncio}}
+import sys
+from typing import Optional
+import urllib3
+
+import http.client as httplib
+
+JSON_SCHEMA_VALIDATION_KEYWORDS = {
+    'multipleOf', 'maximum', 'exclusiveMaximum',
+    'minimum', 'exclusiveMinimum', 'maxLength',
+    'minLength', 'pattern', 'maxItems', 'minItems'
+}
+
+class Configuration:
+    """This class contains various settings of the API client.
+
+    :param host: Base url.
+    :param api_key: Dict to store API key(s).
+      Each entry in the dict specifies an API key.
+      The dict key is the name of the security scheme in the OAS specification.
+      The dict value is the API key secret.
+    :param api_key_prefix: Dict to store API prefix (e.g. Bearer).
+      The dict key is the name of the security scheme in the OAS specification.
+      The dict value is an API key prefix when generating the auth data.
+    :param username: Username for HTTP basic authentication.
+    :param password: Password for HTTP basic authentication.
+    :param access_token: Access token.
+{{#hasHttpSignatureMethods}}
+    :param signing_info: Configuration parameters for the HTTP signature security scheme.
+        Must be an instance of {{{packageName}}}.signing.HttpSigningConfiguration
+{{/hasHttpSignatureMethods}}
+    :param server_index: Index to servers configuration.
+    :param server_variables: Mapping with string values to replace variables in
+      templated server configuration. The validation of enums is performed for
+      variables with defined enum values before.
+    :param server_operation_index: Mapping from operation ID to an index to server
+      configuration.
+    :param server_operation_variables: Mapping from operation ID to a mapping with
+      string values to replace variables in templated server configuration.
+      The validation of enums is performed for variables with defined enum
+      values before.
+    :param ssl_ca_cert: str - The path to a file of concatenated CA certificates
+      in PEM format.
+    :param verify_ssl: bool - Whether to verify the SSL certificate when making API
+      requests to an HTTPS server.
+      Set to False to disable verification, default=True.
+
+{{#hasAuthMethods}}
+    :Example:
+{{#hasApiKeyMethods}}
+
+    API Key Authentication Example.
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          cookieAuth:         # name for the security scheme
+            type: apiKey
+            in: cookie
+            name: JSESSIONID  # cookie name
+
+    You can programmatically set the cookie:
+
+conf = {{{packageName}}}.Configuration(
+    api_key={'cookieAuth': 'abc123'}
+    api_key_prefix={'cookieAuth': 'JSESSIONID'}
+)
+
+    The following cookie will be added to the HTTP request:
+       Cookie: JSESSIONID abc123
+{{/hasApiKeyMethods}}
+{{#hasHttpBasicMethods}}
+
+    HTTP Basic Authentication Example.
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          http_basic_auth:
+            type: http
+            scheme: basic
+
+    Configure API client with HTTP basic authentication:
+
+conf = {{{packageName}}}.Configuration(
+    username='the-user',
+    password='the-password',
+)
+
+{{/hasHttpBasicMethods}}
+{{#hasHttpSignatureMethods}}
+
+    HTTP Signature Authentication Example.
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          http_basic_auth:
+            type: http
+            scheme: signature
+
+    Configure API client with HTTP signature authentication. Use the 'hs2019' signature scheme,
+    sign the HTTP requests with the RSA-SSA-PSS signature algorithm, and set the expiration time
+    of the signature to 5 minutes after the signature has been created.
+    Note you can use the constants defined in the {{{packageName}}}.signing module, and you can
+    also specify arbitrary HTTP headers to be included in the HTTP signature, except for the
+    'Authorization' header, which is used to carry the signature.
+
+    One may be tempted to sign all headers by default, but in practice it rarely works.
+    This is because explicit proxies, transparent proxies, TLS termination endpoints or
+    load balancers may add/modify/remove headers. Include the HTTP headers that you know
+    are not going to be modified in transit.
+
+conf = {{{packageName}}}.Configuration(
+    signing_info = {{{packageName}}}.signing.HttpSigningConfiguration(
+        key_id =                 'my-key-id',
+        private_key_path =       'rsa.pem',
+        signing_scheme =         {{{packageName}}}.signing.SCHEME_HS2019,
+        signing_algorithm =      {{{packageName}}}.signing.ALGORITHM_RSASSA_PSS,
+        signed_headers =         [{{{packageName}}}.signing.HEADER_REQUEST_TARGET,
+                                    {{{packageName}}}.signing.HEADER_CREATED,
+                                    {{{packageName}}}.signing.HEADER_EXPIRES,
+                                    {{{packageName}}}.signing.HEADER_HOST,
+                                    {{{packageName}}}.signing.HEADER_DATE,
+                                    {{{packageName}}}.signing.HEADER_DIGEST,
+                                    'Content-Type',
+                                    'User-Agent'
+                                    ],
+        signature_max_validity = datetime.timedelta(minutes=5)
+    )
+)
+{{/hasHttpSignatureMethods}}
+{{/hasAuthMethods}}
+    """
+
+    _default = None
+
+    def __init__(self, host=None,
+                 api_key=None, api_key_prefix=None,
+                 username=None, password=None,
+                 access_token=None,
+{{#hasHttpSignatureMethods}}
+                 signing_info=None,
+{{/hasHttpSignatureMethods}}
+                 server_index=None, server_variables=None,
+                 server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
+                 verify_ssl=True,
+                 ) -> None:
+        """Constructor
+        """
+        self._base_path = "{{{basePath}}}" if host is None else host
+        """Default Base url
+        """
+        self.server_index = 0 if server_index is None and host is None else server_index
+        self.server_operation_index = server_operation_index or {}
+        """Default server index
+        """
+        self.server_variables = server_variables or {}
+        self.server_operation_variables = server_operation_variables or {}
+        """Default server variables
+        """
+        self.temp_folder_path = None
+        """Temp file folder for downloading files
+        """
+        # Authentication Settings
+        self.api_key = {}
+        if api_key:
+            self.api_key = api_key
+        """dict to store API key(s)
+        """
+        self.api_key_prefix = {}
+        if api_key_prefix:
+            self.api_key_prefix = api_key_prefix
+        """dict to store API prefix (e.g. Bearer)
+        """
+        self.refresh_api_key_hook = None
+        """function hook to refresh API key if expired
+        """
+        self.username = username
+        """Username for HTTP basic authentication
+        """
+        self.password = password
+        """Password for HTTP basic authentication
+        """
+        self.access_token = access_token
+        """Access token
+        """
+{{#hasHttpSignatureMethods}}
+        if signing_info is not None:
+            signing_info.host = host
+        self.signing_info = signing_info
+        """The HTTP signing configuration
+        """
+{{/hasHttpSignatureMethods}}
+        self.logger = {}
+        """Logging Settings
+        """
+        self.logger["package_logger"] = logging.getLogger("{{packageName}}")
+        self.logger["urllib3_logger"] = logging.getLogger("urllib3")
+        self.logger_format = '%(asctime)s %(levelname)s %(message)s'
+        """Log format
+        """
+        self.logger_stream_handler = None
+        """Log stream handler
+        """
+        self.logger_file_handler: Optional[FileHandler] = None
+        """Log file handler
+        """
+        self.logger_file = None
+        """Debug file location
+        """
+        self.debug = False
+        """Debug switch
+        """
+
+        self.verify_ssl = verify_ssl
+        """SSL/TLS verification
+           Set this to false to skip verifying SSL certificate when calling API
+           from https server.
+        """
+        self.ssl_ca_cert = ssl_ca_cert
+        """Set this to customize the certificate file to verify the peer.
+        """
+        self.cert_file = None
+        """client certificate file
+        """
+        self.key_file = None
+        """client key file
+        """
+        self.assert_hostname = None
+        """Set this to True/False to enable/disable SSL hostname verification.
+        """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
+
+        {{#asyncio}}
+        self.connection_pool_maxsize = 100
+        """This value is passed to the aiohttp to limit simultaneous connections.
+           Default values is 100, None means no-limit.
+        """
+        {{/asyncio}}
+        {{^asyncio}}
+        self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+        """urllib3 connection pool's maximum number of connections saved
+           per pool. urllib3 uses 1 connection as default value, but this is
+           not the best value when you are making a lot of possibly parallel
+           requests to the same host, which is often the case here.
+           cpu_count * 5 is used as default value to increase performance.
+        """
+        {{/asyncio}}
+
+        self.proxy: Optional[str] = None
+        """Proxy URL
+        """
+        self.proxy_headers = None
+        """Proxy headers
+        """
+        self.safe_chars_for_path_param = ''
+        """Safe chars for path_param
+        """
+        self.retries = None
+        """Adding retries to override urllib3 default value 3
+        """
+        # Enable client side validation
+        self.client_side_validation = True
+
+        self.socket_options = None
+        """Options to pass down to the underlying urllib3 socket
+        """
+
+        self.datetime_format = "{{{datetimeFormat}}}"
+        """datetime format
+        """
+
+        self.date_format = "{{{dateFormat}}}"
+        """date format
+        """
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k not in ('logger', 'logger_file_handler'):
+                setattr(result, k, copy.deepcopy(v, memo))
+        # shallow copy of loggers
+        result.logger = copy.copy(self.logger)
+        # use setters to configure loggers
+        result.logger_file = self.logger_file
+        result.debug = self.debug
+        return result
+
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+{{#hasHttpSignatureMethods}}
+        if name == "signing_info" and value is not None:
+            # Ensure the host parameter from signing info is the same as
+            # Configuration.host.
+            value.host = self.host
+{{/hasHttpSignatureMethods}}
+
+    @classmethod
+    def set_default(cls, default):
+        """Set default instance of configuration.
+
+        It stores default configuration, which can be
+        returned by get_default_copy method.
+
+        :param default: object of Configuration
+        """
+        cls._default = default
+
+    @classmethod
+    def get_default_copy(cls):
+        """Deprecated. Please use `get_default` instead.
+
+        Deprecated. Please use `get_default` instead.
+
+        :return: The configuration object.
+        """
+        return cls.get_default()
+
+    @classmethod
+    def get_default(cls):
+        """Return the default configuration.
+
+        This method returns newly created, based on default constructor,
+        object of Configuration class or returns a copy of default
+        configuration.
+
+        :return: The configuration object.
+        """
+        if cls._default is None:
+            cls._default = Configuration()
+        return cls._default
+
+    @property
+    def logger_file(self):
+        """The logger file.
+
+        If the logger_file is None, then add stream handler and remove file
+        handler. Otherwise, add file handler and remove stream handler.
+
+        :param value: The logger_file path.
+        :type: str
+        """
+        return self.__logger_file
+
+    @logger_file.setter
+    def logger_file(self, value):
+        """The logger file.
+
+        If the logger_file is None, then add stream handler and remove file
+        handler. Otherwise, add file handler and remove stream handler.
+
+        :param value: The logger_file path.
+        :type: str
+        """
+        self.__logger_file = value
+        if self.__logger_file:
+            # If set logging file,
+            # then add file handler and remove stream handler.
+            self.logger_file_handler = logging.FileHandler(self.__logger_file)
+            self.logger_file_handler.setFormatter(self.logger_formatter)
+            for _, logger in self.logger.items():
+                logger.addHandler(self.logger_file_handler)
+
+    @property
+    def debug(self):
+        """Debug status
+
+        :param value: The debug status, True or False.
+        :type: bool
+        """
+        return self.__debug
+
+    @debug.setter
+    def debug(self, value):
+        """Debug status
+
+        :param value: The debug status, True or False.
+        :type: bool
+        """
+        self.__debug = value
+        if self.__debug:
+            # if debug status is True, turn on debug logging
+            for _, logger in self.logger.items():
+                logger.setLevel(logging.DEBUG)
+            # turn on httplib debug
+            httplib.HTTPConnection.debuglevel = 1
+        else:
+            # if debug status is False, turn off debug logging,
+            # setting log level to default `logging.WARNING`
+            for _, logger in self.logger.items():
+                logger.setLevel(logging.WARNING)
+            # turn off httplib debug
+            httplib.HTTPConnection.debuglevel = 0
+
+    @property
+    def logger_format(self):
+        """The logger format.
+
+        The logger_formatter will be updated when sets logger_format.
+
+        :param value: The format string.
+        :type: str
+        """
+        return self.__logger_format
+
+    @logger_format.setter
+    def logger_format(self, value):
+        """The logger format.
+
+        The logger_formatter will be updated when sets logger_format.
+
+        :param value: The format string.
+        :type: str
+        """
+        self.__logger_format = value
+        self.logger_formatter = logging.Formatter(self.__logger_format)
+
+    def get_api_key_with_prefix(self, identifier, alias=None):
+        """Gets API key (with prefix if set).
+
+        :param identifier: The identifier of apiKey.
+        :param alias: The alternative identifier of apiKey.
+        :return: The token for api key authentication.
+        """
+        if self.refresh_api_key_hook is not None:
+            self.refresh_api_key_hook(self)
+        key = self.api_key.get(identifier, self.api_key.get(alias) if alias is not None else None)
+        if key:
+            prefix = self.api_key_prefix.get(identifier)
+            if prefix:
+                return "%s %s" % (prefix, key)
+            else:
+                return key
+
+    def get_basic_auth_token(self):
+        """Gets HTTP basic authentication header (string).
+
+        :return: The token for basic HTTP authentication.
+        """
+        username = ""
+        if self.username is not None:
+            username = self.username
+        password = ""
+        if self.password is not None:
+            password = self.password
+        return urllib3.util.make_headers(
+            basic_auth=username + ':' + password
+        ).get('authorization')
+
+    def auth_settings(self):
+        """Gets Auth Settings dict for api client.
+
+        :return: The Auth Settings information dict.
+        """
+        auth = {}
+{{#authMethods}}
+{{#isApiKey}}
+        if '{{name}}' in self.api_key{{#vendorExtensions.x-auth-id-alias}} or '{{.}}' in self.api_key{{/vendorExtensions.x-auth-id-alias}}:
+            auth['{{name}}'] = {
+                'type': 'api_key',
+                'in': {{#isKeyInCookie}}'cookie'{{/isKeyInCookie}}{{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}},
+                'key': '{{keyParamName}}',
+                'value': self.get_api_key_with_prefix(
+                    '{{name}}',{{#vendorExtensions.x-auth-id-alias}}
+                    alias='{{.}}',{{/vendorExtensions.x-auth-id-alias}}
+                ),
+            }
+{{/isApiKey}}
+{{#isBasic}}
+  {{#isBasicBasic}}
+        if self.username is not None and self.password is not None:
+            auth['{{name}}'] = {
+                'type': 'basic',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': self.get_basic_auth_token()
+            }
+  {{/isBasicBasic}}
+  {{#isBasicBearer}}
+        if self.access_token is not None:
+            auth['{{name}}'] = {
+                'type': 'bearer',
+                'in': 'header',
+                {{#bearerFormat}}
+                'format': '{{{.}}}',
+                {{/bearerFormat}}
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
+  {{/isBasicBearer}}
+  {{#isHttpSignature}}
+        if self.signing_info is not None:
+            auth['{{name}}'] = {
+                'type': 'http-signature',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': None  # Signature headers are calculated for every HTTP request
+            }
+  {{/isHttpSignature}}
+{{/isBasic}}
+{{#isOAuth}}
+        if self.access_token is not None:
+            auth['{{name}}'] = {
+                'type': 'oauth2',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
+{{/isOAuth}}
+{{/authMethods}}
+        return auth
+
+    def to_debug_report(self):
+        """Gets the essential information for debugging.
+
+        :return: The report for debugging.
+        """
+        return "Python SDK Debug Report:\n"\
+               "OS: {env}\n"\
+               "Python Version: {pyversion}\n"\
+               "Version of the API: {{version}}\n"\
+               "SDK Package Version: {{packageVersion}}".\
+               format(env=sys.platform, pyversion=sys.version)
+
+    def get_host_settings(self):
+        """Gets an array of host settings
+
+        :return: An array of host settings
+        """
+        return [
+            {{#servers}}
+            {
+                'url': "{{{url}}}",
+                'description': "{{{description}}}{{^description}}No description provided{{/description}}",
+                {{#variables}}
+                {{#-first}}
+                'variables': {
+                {{/-first}}
+                    '{{{name}}}': {
+                        'description': "{{{description}}}{{^description}}No description provided{{/description}}",
+                        'default_value': "{{{defaultValue}}}",
+                        {{#enumValues}}
+                        {{#-first}}
+                        'enum_values': [
+                        {{/-first}}
+                            "{{{.}}}"{{^-last}},{{/-last}}
+                        {{#-last}}
+                        ]
+                        {{/-last}}
+                        {{/enumValues}}
+                        }{{^-last}},{{/-last}}
+                {{#-last}}
+                    }
+                {{/-last}}
+                {{/variables}}
+            }{{^-last}},{{/-last}}
+            {{/servers}}
+        ]
+
+    def get_host_from_settings(self, index, variables=None, servers=None):
+        """Gets host URL based on the index and variables
+        :param index: array index of the host settings
+        :param variables: hash of variable and the corresponding value
+        :param servers: an array of host settings or None
+        :return: URL based on host settings
+        """
+        if index is None:
+            return self._base_path
+
+        variables = {} if variables is None else variables
+        servers = self.get_host_settings() if servers is None else servers
+
+        try:
+            server = servers[index]
+        except IndexError:
+            raise ValueError(
+                "Invalid index {0} when selecting the host settings. "
+                "Must be less than {1}".format(index, len(servers)))
+
+        url = server['url']
+
+        # go through variables and replace placeholders
+        for variable_name, variable in server.get('variables', {}).items():
+            used_value = variables.get(
+                variable_name, variable['default_value'])
+
+            if 'enum_values' in variable \
+                    and used_value not in variable['enum_values']:
+                raise ValueError(
+                    "The variable `{0}` in the host URL has invalid value "
+                    "{1}. Must be {2}.".format(
+                        variable_name, variables[variable_name],
+                        variable['enum_values']))
+
+            url = url.replace("{" + variable_name + "}", used_value)
+
+        return url
+
+    @property
+    def host(self):
+        """Return generated host."""
+        return self.get_host_from_settings(self.server_index, variables=self.server_variables)
+
+    @host.setter
+    def host(self, value):
+        """Fix base path."""
+        self._base_path = value
+        self.server_index = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Given that the verify_ssl code change was made on generated code, if local users try to run make build, the change gets overwritten and the client fails with this error:

```
TypeError: Configuration.__init__() got an unexpected keyword argument 'verify_ssl'
```

This PR aims to add the change to the configuration file template so that it gets into the autogenerated code.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tested locally both manually and with e2e python tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

