### PR TITLE
change uname check in scripts/install_protoc.sh for compatibility with macos

### DIFF
--- a/scripts/install_protoc.sh
+++ b/scripts/install_protoc.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 OSTYPE=$(uname -s)
 OS="linux"
-if [[ ${OSTYPE,,} =~ darwin ]]; then
+if [[ $OSTYPE =~ [Dd]arwin ]]; then
     OS="osx"
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The current version of the install_protoc.sh fails when running `make build` on MacOS due to a "bad substitution" error
```
./scripts/install_protoc.sh: line 6: ${OSTYPE,,}: bad substitution
make: *** [bin/protoc] Error 1
```
The change gets the value of `$OSTYPE` directly.

Furthermore, `uname -s` returns `Darwin`, which does not match against `=~ darwin`, causing the linux executable to be downloaded instead. 
The change looks for both capitalized and non-capitalized versions of the name (`[Dd]arwin`).

The proposed changes have been tested both in MacOS as well as Fedora

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran `make build`, correct version of protoc downloaded to bin folder

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
