### PR TITLE
feat(manifests): add securityContext to deployments

### DIFF
--- a/manifests/kustomize/base/model-registry-deployment.yaml
+++ b/manifests/kustomize/base/model-registry-deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         component: model-registry-server
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       containers:
         - name: rest-container
           args:
@@ -44,6 +48,11 @@ spec:
             tcpSocket:
               port: http-api
             timeoutSeconds: 2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
         - name: grpc-container
           # ! Sync to the same MLMD version:
           # * backend/metadata_writer/requirements.in and requirements.txt
@@ -102,4 +111,11 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       serviceAccountName: model-registry-server

--- a/manifests/kustomize/options/ui/base/model-registry-ui-deployment.yaml
+++ b/manifests/kustomize/options/ui/base/model-registry-ui-deployment.yaml
@@ -15,6 +15,10 @@ spec:
         app: model-registry-ui
     spec: 
       serviceAccountName: model-registry-ui
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       containers:
       - name: model-registry-ui
         image: model-registry-ui-image
@@ -51,3 +55,8 @@ spec:
           - containerPort: 8080
         args:
           - "--port=8080"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL

--- a/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
@@ -19,6 +19,10 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       containers:
       - name: db-container
         image: mysql:8.3.0
@@ -46,6 +50,13 @@ spec:
         volumeMounts:
         - name: metadata-mysql
           mountPath: /var/lib/mysql
+        securityContext:
+          runAsUser: 999
+          runAsGroup: 999
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       volumes:
       - name: metadata-mysql
         persistentVolumeClaim:

--- a/manifests/kustomize/overlays/postgres/kustomization.yaml
+++ b/manifests/kustomize/overlays/postgres/kustomization.yaml
@@ -39,7 +39,7 @@ vars:
 - name: POSTGRES_PORT
   objref:
     kind: ConfigMap
-    name: model-registry-db-parameters
+    name: metadata-postgres-db-parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.POSTGRES_PORT

--- a/manifests/kustomize/overlays/postgres/kustomization.yaml
+++ b/manifests/kustomize/overlays/postgres/kustomization.yaml
@@ -13,11 +13,11 @@ patchesStrategicMerge:
 - patches/model-registry-deployment.yaml
 
 configMapGenerator:
-- name: metadata-postgres-db-parameters
+- name: metadata-registry-db-parameters
   envs:
   - params.env
 secretGenerator:
-- name: metadata-postgres-db-secrets
+- name: metadata-registry-db-secrets
   envs:
   - secrets.env
 generatorOptions:
@@ -39,7 +39,7 @@ vars:
 - name: POSTGRES_PORT
   objref:
     kind: ConfigMap
-    name: metadata-postgres-db-parameters
+    name: metadata-registry-db-parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.POSTGRES_PORT

--- a/manifests/kustomize/overlays/postgres/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/postgres/model-registry-db-deployment.yaml
@@ -31,9 +31,9 @@ spec:
             value: /var/lib/postgresql/data/pgdata
         envFrom:
         - configMapRef:
-            name: metadata-postgres-db-parameters
+            name: metadata-registry-db-parameters
         - secretRef:
-            name: metadata-postgres-db-secrets
+            name: metadata-registry-db-secrets
         ports:
         - name: postgres
           containerPort: 5432

--- a/manifests/kustomize/overlays/postgres/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/postgres/model-registry-db-deployment.yaml
@@ -19,6 +19,10 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       containers:
       - name: db-container
         image: postgres
@@ -36,8 +40,14 @@ spec:
         volumeMounts:
         - name: metadata-postgres
           mountPath: /var/lib/postgresql/data
+        securityContext:
+          runAsUser: 70
+          runAsGroup: 70
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       volumes:
       - name: metadata-postgres
         persistentVolumeClaim:
           claimName: metadata-postgres
-

--- a/manifests/kustomize/overlays/postgres/patches/model-registry-deployment.yaml
+++ b/manifests/kustomize/overlays/postgres/patches/model-registry-deployment.yaml
@@ -16,9 +16,9 @@ spec:
           - $patch: replace
           envFrom:
           - configMapRef:
-              name: metadata-postgres-db-parameters
+              name: metadata-registry-db-parameters
           - secretRef:
-              name: metadata-postgres-db-secrets
+              name: metadata-registry-db-secrets
           - configMapRef:
               name: model-registry-configmap
           args: ["--grpc_port=$(MODEL_REGISTRY_GRPC_SERVICE_PORT)",


### PR DESCRIPTION
## Description

Set `seccompProfile`, forbid containers to run as root, and disable
unnecessary system calls. This applies to:

- Model registry itself
- Example database (MySQL and PostgreSQL)
- Model registry UI

Fixes #760 

## How Has This Been Tested?
Applying the manifests in a local cluster.

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
