### PR TITLE
test: E2E pytest for ModelVersion.name length

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -97,7 +97,7 @@ def test_register_version_long_name(client: ModelRegistry):
     assert ma.uri == "https://acme.org/something"
     assert ma.model_format_name == "test_format_name"
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception): # noqa the focus of this test is the failure case, not to fix on the exception being raised
         client.register_model(name="test_model",
                         uri="https://acme.org/something",
                         model_format_name="test_format_name",

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -80,6 +80,32 @@ def test_register_existing_version(client: ModelRegistry):
 
 
 @pytest.mark.e2e
+def test_register_version_long_name(client: ModelRegistry):
+    """ModelVersion.name can generally account for up to 250chars, assuming up to 10K RegisteredModels.
+    This is because ModelVersion being a MLMD.Context owned entity, its name is prefixed with `RegisteredModel.id:` in the backend
+    to preserve uniqueness for MLMD schema constraints
+    """
+    lorem = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium."
+    assert len(lorem) == 250
+
+    client.register_model(name="test_model",
+                          uri="https://acme.org/something",
+                          model_format_name="test_format_name",
+                          model_format_version="test_format_version",
+                          version=lorem)
+    ma = client.get_model_artifact(name="test_model", version=lorem)
+    assert ma.uri == "https://acme.org/something"
+    assert ma.model_format_name == "test_format_name"
+
+    with pytest.raises(Exception):
+        client.register_model(name="test_model",
+                        uri="https://acme.org/something",
+                        model_format_name="test_format_name",
+                        model_format_version="test_format_version",
+                        version=lorem+"12345") # version of 255 chars is above limit because does not account for owned entity prefix, ie `1:...`
+
+
+@pytest.mark.e2e
 async def test_update_models(client: ModelRegistry):
     name = "test_model"
     version = "1.0.0"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
ModelVersion.name can generally account for up to 250chars, assuming up to 10K RegisteredModels. This is because ModelVersion being a MLMD.Context owned entity, its name is prefixed with `RegisteredModel.id:` in the backend to preserve uniqueness for MLMD schema constraints

## How Has This Been Tested?
`make test-e2e`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [no changes, just tests] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
