### PR TITLE
chore: Fix build after 246f41d

### DIFF
--- a/clients/ui/Dockerfile
+++ b/clients/ui/Dockerfile
@@ -42,10 +42,11 @@ RUN go mod download
 
 # Copy the go source files
 COPY ${BFF_SOURCE_CODE}/cmd/main.go cmd/main.go
+COPY ${BFF_SOURCE_CODE}/cmd/helpers.go cmd/helpers.go
 COPY ${BFF_SOURCE_CODE}/internal/ internal/
 
 # Build the Go application
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bff ./cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bff ./cmd/*.go
 
 # Final stage
 # Use distroless as minimal base image to package the application binary


### PR DESCRIPTION
## Description
https://github.com/kubeflow/model-registry/commit/246f41d62126f4be0cccbb5edcf725346d752f51 missed to import the Dockerfile.

In an FUP PR, we should introduce an action to build the image locally to avoid this failure.

## How Has This Been Tested?

Before this PR locally:
```code
 => CANCELED [ui-builder 5/6] RUN npm ci --omit=optional                                                                                                                 2.7s
------
 > [bff-builder 7/7] RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o bff ./cmd/main.go:
14.59 # command-line-arguments
14.59 cmd/main.go:21:33: undefined: getEnvAsInt
14.59 cmd/main.go:25:49: undefined: getEnvAsInt
14.59 cmd/main.go:28:43: undefined: parseLevel
14.59 cmd/main.go:28:54: undefined: getEnvAsString
14.59 cmd/main.go:29:148: undefined: newOriginParser
14.59 cmd/main.go:29:185: undefined: getEnvAsString
------

 1 warning found (use docker --debug to expand):
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "MOCK_AUTH") (line 15)
Dockerfile:48
--------------------
  46 |
  47 |     # Build the Go application
  48 | >>> RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bff ./cmd/main.go
  49 |
  50 |     # Final stage
--------------------
ERROR: failed to solve: p
```

After the PR, I got a successful Docker build.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

 
