### PR TITLE
change resp status from 500 to 409 for dup POST reqs

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -317,6 +317,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":
@@ -443,6 +445,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":
@@ -552,6 +556,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":
@@ -753,6 +759,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":
@@ -825,6 +833,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":
@@ -994,6 +1004,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":
@@ -1755,6 +1767,12 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
       description: Unauthorized
+    Conflict:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Conflict with current state of target resource
     InternalServerError:
       content:
         application/json:

--- a/clients/python/src/mr_openapi/api/model_registry_service_api.py
+++ b/clients/python/src/mr_openapi/api/model_registry_service_api.py
@@ -627,6 +627,7 @@ class ModelRegistryServiceApi:
             "200": "InferenceService",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -692,6 +693,7 @@ class ModelRegistryServiceApi:
             "200": "InferenceService",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -757,6 +759,7 @@ class ModelRegistryServiceApi:
             "200": "InferenceService",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -880,6 +883,7 @@ class ModelRegistryServiceApi:
             "400": "Error",
             "401": "Error",
             "404": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -950,6 +954,7 @@ class ModelRegistryServiceApi:
             "400": "Error",
             "401": "Error",
             "404": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -1020,6 +1025,7 @@ class ModelRegistryServiceApi:
             "400": "Error",
             "401": "Error",
             "404": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -1387,6 +1393,7 @@ class ModelRegistryServiceApi:
             "201": "ModelVersion",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -1450,6 +1457,7 @@ class ModelRegistryServiceApi:
             "201": "ModelVersion",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -1513,6 +1521,7 @@ class ModelRegistryServiceApi:
             "201": "ModelVersion",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -1631,6 +1640,7 @@ class ModelRegistryServiceApi:
             "201": "RegisteredModel",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -1696,6 +1706,7 @@ class ModelRegistryServiceApi:
             "201": "RegisteredModel",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -1761,6 +1772,7 @@ class ModelRegistryServiceApi:
             "201": "RegisteredModel",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -2139,6 +2151,7 @@ class ModelRegistryServiceApi:
             "201": "ServingEnvironment",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -2204,6 +2217,7 @@ class ModelRegistryServiceApi:
             "201": "ServingEnvironment",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -2269,6 +2283,7 @@ class ModelRegistryServiceApi:
             "201": "ServingEnvironment",
             "400": "Error",
             "401": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -10717,6 +10732,7 @@ class ModelRegistryServiceApi:
             "400": "Error",
             "401": "Error",
             "404": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -10788,6 +10804,7 @@ class ModelRegistryServiceApi:
             "400": "Error",
             "401": "Error",
             "404": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }
@@ -10859,6 +10876,7 @@ class ModelRegistryServiceApi:
             "400": "Error",
             "401": "Error",
             "404": "Error",
+            "409": "Error",
             "500": "Error",
             "503": "Error",
         }

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -19,6 +19,9 @@ func ErrToStatus(err error) int {
 		if status.Code() == codes.Unavailable {
 			return http.StatusServiceUnavailable
 		}
+		if status.Code() == codes.AlreadyExists {
+			return http.StatusBadRequest
+		}
 	}
 
 	switch errors.Unwrap(err) {

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -20,7 +20,7 @@ func ErrToStatus(err error) int {
 			return http.StatusServiceUnavailable
 		}
 		if status.Code() == codes.AlreadyExists {
-			return http.StatusBadRequest
+			return http.StatusConflict
 		}
 	}
 

--- a/pkg/core/artifact_test.go
+++ b/pkg/core/artifact_test.go
@@ -46,6 +46,35 @@ func (suite *CoreTestSuite) TestCreateModelVersionArtifact() {
 	suite.Equal(customString, (*docArtifact.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
 }
 
+func (suite *CoreTestSuite) TestCreateDuplicateModelVersionArtifactFailure() {
+	// create mode registry service
+	service := suite.setupModelRegistryService()
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
+
+	artifact := &openapi.Artifact{
+		DocArtifact: &openapi.DocArtifact{
+			Name:        &artifactName,
+			State:       (*openapi.ArtifactState)(&artifactState),
+			Uri:         &artifactUri,
+			Description: &artifactDescription,
+			CustomProperties: &map[string]openapi.MetadataValue{
+				"custom_string_prop": {
+					MetadataStringValue: converter.NewMetadataStringValue(customString),
+				},
+			},
+		},
+	}
+
+	_, err := service.UpsertModelVersionArtifact(artifact, modelVersionId)
+	suite.Nilf(err, "error creating new artifact: %v", err)
+
+	// attempt to create dupliate version artifact
+	_, err = service.UpsertModelVersionArtifact(artifact, modelVersionId)
+	statusResp := api.ErrToStatus(err)
+	suite.NotNilf(err, "cannot register a duplicate version artifact")
+	suite.Equal(409, statusResp, "duplicate version artifacts not allowed")
+}
+
 func (suite *CoreTestSuite) TestCreateModelVersionArtifactFailure() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()

--- a/pkg/core/registered_model_test.go
+++ b/pkg/core/registered_model_test.go
@@ -59,7 +59,7 @@ func (suite *CoreTestSuite) TestCreateRegisteredModel() {
 	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 }
 
-func (suite *CoreTestSuite) TestCreateDuplicateRegisteredModel() {
+func (suite *CoreTestSuite) TestCreateDuplicateRegisteredModelFailure() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()
 

--- a/pkg/core/registered_model_test.go
+++ b/pkg/core/registered_model_test.go
@@ -59,6 +59,36 @@ func (suite *CoreTestSuite) TestCreateRegisteredModel() {
 	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 }
 
+func (suite *CoreTestSuite) TestCreateDuplicateRegisteredModel() {
+	// create mode registry service
+	service := suite.setupModelRegistryService()
+
+	state := openapi.REGISTEREDMODELSTATE_ARCHIVED
+	// register a new model
+	registeredModel := &openapi.RegisteredModel{
+		Name:        modelName,
+		ExternalId:  &modelExternalId,
+		Description: &modelDescription,
+		Owner:       &modelOwner,
+		State:       &state,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
+			},
+		},
+	}
+
+	// create the first model
+	_, err := service.UpsertRegisteredModel(registeredModel)
+	suite.Nilf(err, "error creating registered model: %v", err)
+
+	// attempt to create dupliate model
+	_, err = service.UpsertRegisteredModel(registeredModel)
+	statusResp := api.ErrToStatus(err)
+	suite.NotNilf(err, "cannot register a model with duplicate names")
+	suite.Equal(409, statusResp, "duplicate model names not allowed")
+}
+
 func (suite *CoreTestSuite) TestUpdateRegisteredModel() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()

--- a/pkg/core/serving_environment_test.go
+++ b/pkg/core/serving_environment_test.go
@@ -54,6 +54,34 @@ func (suite *CoreTestSuite) TestCreateServingEnvironment() {
 	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 }
 
+func (suite *CoreTestSuite) TestCreateDuplicateServingEnvironmentFailure() {
+	// create mode registry service
+	service := suite.setupModelRegistryService()
+
+	// register a new ServingEnvironment
+	eut := &openapi.ServingEnvironment{
+		Name:        &entityName,
+		ExternalId:  &entityExternalId,
+		Description: &entityDescription,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"myCustomProp": {
+				MetadataStringValue: converter.NewMetadataStringValue(myCustomProp),
+			},
+		},
+	}
+
+	// create first serving environment
+	createdEntity, err := service.UpsertServingEnvironment(eut)
+	suite.Nilf(err, "error creating uut: %v", err)
+	suite.NotNilf(createdEntity.Id, "created uut should not have nil Id")
+
+	// attempt to create dupliate serving environment
+	_, err = service.UpsertServingEnvironment(eut)
+	statusResp := api.ErrToStatus(err)
+	suite.NotNilf(err, "cannot register a duplicate serving environment")
+	suite.Equal(409, statusResp, "duplicate serving environments not allowed")
+}
+
 func (suite *CoreTestSuite) TestUpdateServingEnvironment() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()

--- a/pkg/openapi/api_model_registry_service.go
+++ b/pkg/openapi/api_model_registry_service.go
@@ -466,6 +466,17 @@ func (a *ModelRegistryServiceAPIService) CreateInferenceServiceExecute(r ApiCrea
 			newErr.model = v
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		if localVarHTTPResponse.StatusCode == 409 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -626,6 +637,17 @@ func (a *ModelRegistryServiceAPIService) CreateInferenceServiceServeExecute(r Ap
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
@@ -946,6 +968,17 @@ func (a *ModelRegistryServiceAPIService) CreateModelVersionExecute(r ApiCreateMo
 			newErr.model = v
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		if localVarHTTPResponse.StatusCode == 409 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -1091,6 +1124,17 @@ func (a *ModelRegistryServiceAPIService) CreateRegisteredModelExecute(r ApiCreat
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
@@ -1416,6 +1460,17 @@ func (a *ModelRegistryServiceAPIService) CreateServingEnvironmentExecute(r ApiCr
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
@@ -6768,6 +6823,17 @@ func (a *ModelRegistryServiceAPIService) UpsertModelVersionArtifactExecute(r Api
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Small change to return a 400 error if a user attempts to add a duplicate value. Previously, this was defaulting to a 500 internal service error which is not appropriate. 

## How Has This Been Tested?
https://issues.redhat.com/browse/RHOAIENG-19196
Locally reproduced this error to confirm that the resp status is 400 instead of 500.

## Merge criteria:
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
