### PR TITLE
fix(frontend): Update padding to fix upstream spacing

### DIFF
--- a/clients/ui/frontend/src/shared/style/MUI-theme.scss
+++ b/clients/ui/frontend/src/shared/style/MUI-theme.scss
@@ -143,10 +143,6 @@
   padding: var(--pf-t--global--spacer--md);
 }
 
-.mui-theme .pf-v6-c-page__main-breadcrumb {
-  --pf-v6-c-page__main-breadcrumb--PaddingInlineStart: none;
-}
-
 .mui-theme .pf-v6-c-button {
   --pf-v6-c-button--FontWeight: var(--mui-button-font-weight);
   --pf-v6-c-button--PaddingBlockStart: var(--mui-button--PaddingBlockStart);
@@ -851,9 +847,16 @@
   }
 }
 
-.mui-theme .pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__main-container,
-.mui-theme .pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__drawer {
+.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__main-container,
+.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__drawer,
+.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__main-breadcrumb {
   --pf-v6-c-page__main-container--MarginInlineStart: calc(-2 * var(--mui-spacing-16px));
   --pf-v6-c-page__main-section--PaddingInlineStart: none;
   --pf-v6-c-page__main-section--PaddingInlineEnd: none;
+  --pf-v6-c-page__main-breadcrumb--PaddingInlineStart: none;
+}
+
+.pf-v6-c-page__sidebar.pf-m-collapsed+.pf-v6-c-page__main-container {
+  --pf-v6-c-page__main-container--MarginInlineStart: calc(-1 * var(--mui-spacing-8px));
+  --pf-v6-c-page__main-container--MarginInlineEnd: calc(-1 * var(--mui-spacing-8px));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Removes additional padding that is currently rendered with integrated mode. Also fixes breadcrumb issue in standalone mode. 

Padding (Integrated Mode):

Before:
<img width="1580" alt="Screenshot 2025-02-24 at 2 56 10 PM" src="https://github.com/user-attachments/assets/432af083-dfda-40d8-ba16-3610a95cd6f2" />

After:
<img width="1585" alt="Screenshot 2025-02-24 at 2 56 23 PM" src="https://github.com/user-attachments/assets/52edc347-0a6d-42bf-bb65-ae3c2f6a5211" />

Breadcrumb (Standalone mode):

Before:
<img width="342" alt="Screenshot 2025-02-24 at 3 01 08 PM" src="https://github.com/user-attachments/assets/62d5d21a-e3d3-47ce-baf9-3a7b2070c7e3" />
After:
<img width="357" alt="Screenshot 2025-02-24 at 3 00 59 PM" src="https://github.com/user-attachments/assets/6844a75e-8cff-48a8-be0a-e308a639c704" />




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test updated padding in Integrated mode:

1. In App.tsx replaces lines 113 - 126 with:
```
        masthead={
          // isStandalone() ? (
          //   <NavBar
          //     username={username}
          //     onLogout={() => {
          //       logout().then(() => window.location.reload());
          //     }}
          //   />
          // ) : (
          ''
          // )
        }
        // isManagedSidebar={isStandalone()}
        // sidebar={isStandalone() ? <NavSidebar /> : sidebar}
        sidebar={sidebar}
```
2.  Verify additional padding has been removed. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

