### PR TITLE
[UI] update path for all cypress interceptApi calls

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -153,7 +153,12 @@ Cypress.Commands.add(
       });
     }
     return cy.intercept(
-      { method, pathname, query: options?.query, ...(options?.times && { times: options.times }) },
+      {
+        method,
+        pathname: `/model-registry/${pathname}`,
+        query: options?.query,
+        ...(options?.times && { times: options.times }),
+      },
       mockBFFResponse(response),
     );
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Recent changes to the standalone UI were made to update all API requests to `/model-registry/api`. However the cypress tests were still intercepting `/api`. This fix simple updates the `interceptApi` function to prepend the new prefix. 

Not sure why the original PR did not run the tests. That will be looked at separately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In the `clients/ui/frontend` dir:
- `npm run cypress:server:build`
- `npm run cypress:server`
- `npm run cypress:run:mock`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
