### PR TITLE
process: add Al-Pragliola as top level Reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,4 @@ approvers:
   - zijianjoy
 reviewers:
   - andreyvelich
+  - Al-Pragliola


### PR DESCRIPTION
I'm happy to sponsor @Al-Pragliola into Reviewer role, following the current [Kubeflow community process](https://github.com/kubeflow/website/blob/816df01d87f31b462c13aabec4cc235e18f660bf/content/en/docs/about/membership.md?plain=1#L81).

- [x] member for at least 3 months
  - Alessio [achieved membership on Nov 26th](https://github.com/kubeflow/internal-acls/pull/722#event-15437602206), today is Feb 26th, 3 months ✅ 
- [x] Primary reviewer for at least 5 PRs to the codebase
  - https://github.com/kubeflow/model-registry/pull/796#pullrequestreview-2612259993
  - https://github.com/kubeflow/model-registry/pull/790#pullrequestreview-2611917842
  - https://github.com/kubeflow/model-registry/pull/769#pullrequestreview-2599812855
  - https://github.com/kubeflow/model-registry/pull/741#issuecomment-2619891138
  - https://github.com/kubeflow/model-registry/pull/731#pullrequestreview-2572433196
  - these are 5 representative, but there are even more ✅ 
- [x] Reviewed or merged at least 15 substantial PRs to the codebase
  - at [this query](https://github.com/kubeflow/model-registry/pulls?q=is%3Apr+involves%3AAl-Pragliola+is%3Aclosed+-author%3AAl-Pragliola), at the time of writing I count 39 PRs which @Al-Pragliola reviewed and participated in, and counting ✅ 
- [x] Knowledgeable about the codebase
  - this is confirmed by the work above and for another example about this couple other proposals: https://github.com/kubeflow/model-registry/issues/398 https://github.com/kubeflow/model-registry/issues/577 ✅ 
- [x] Active engagement with the commmunity by answering user questions in GitHub issues and Slack
  - this is confirmed by [this query](https://github.com/kubeflow/model-registry/issues?q=is%3Aissue%20%20involves%3AAl-Pragliola%20) (count: 11 separate issue instances) and below screenshot ✅  : 
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/f8e2f1fc-99cd-459d-8842-e9e8851fe297" /> 

- [x] Sponsored by a subproject approver
  - [x] With no objections from other approvers
  - [x] Done through PR to update the OWNERS file
- [x] May either self-nominate or be nominated by an approver in this subproject
  - this PR itself.

I'm going to keep this PR open for any comments, but I expect mostly will be congratulatory messages 😏 🎉 