### PR TITLE
fix(bff): correctly forward errors from MR API on Get operations

### DIFF
--- a/clients/ui/bff/internal/integrations/http.go
+++ b/clients/ui/bff/internal/integrations/http.go
@@ -77,6 +77,25 @@ func (c *HTTPClient) GET(url string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
+
+	if response.StatusCode != http.StatusOK {
+		var errorResponse ErrorResponse
+		if err := json.Unmarshal(body, &errorResponse); err != nil {
+			return nil, fmt.Errorf("error unmarshalling error response: %w", err)
+		}
+		httpError := &HTTPError{
+			StatusCode:    response.StatusCode,
+			ErrorResponse: errorResponse,
+		}
+		//Sometimes the code comes empty from model registry API
+		//also not all error codes are correctly implemented
+		//see https://github.com/kubeflow/model-registry/issues/95
+		if httpError.ErrorResponse.Code == "" {
+			httpError.ErrorResponse.Code = strconv.Itoa(response.StatusCode)
+		}
+		return nil, httpError
+	}
+
 	return body, nil
 }
 
@@ -84,7 +103,6 @@ func (c *HTTPClient) POST(url string, body io.Reader) ([]byte, error) {
 	requestId := uuid.NewString()
 
 	fullURL := c.baseURL + url
-	fmt.Println(fullURL)
 	req, err := http.NewRequest("POST", fullURL, body)
 	if err != nil {
 		return nil, err

--- a/clients/ui/bff/internal/integrations/http_test.go
+++ b/clients/ui/bff/internal/integrations/http_test.go
@@ -1,0 +1,281 @@
+package integrations
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+func TestHTTPClient_GET_Success(t *testing.T) {
+	// Setup test server
+	expectedResponse := map[string]interface{}{
+		"dora": "bella",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/test", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		err := json.NewEncoder(w).Encode(expectedResponse)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create http client pointing to test server
+	logger := setupTestLogger()
+	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	require.NoError(t, err)
+
+	// Make the request
+	response, err := client.GET("/test")
+
+	// Verify successful response
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	var actualResponse map[string]interface{}
+	err = json.Unmarshal(response, &actualResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, actualResponse)
+}
+
+func TestHTTPClient_GET_Error(t *testing.T) {
+	// Setup test server that returns an error
+	errorResponse := ErrorResponse{
+		Code:    "500",
+		Message: "the server encountered a problem and could not process your request",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+
+		err := json.NewEncoder(w).Encode(errorResponse)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create http client pointing to test server
+	logger := setupTestLogger()
+	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	require.NoError(t, err)
+
+	// Make the request
+	response, err := client.GET("/test")
+
+	// Verify error
+	assert.Error(t, err)
+	assert.Nil(t, response)
+
+	httpErr, ok := err.(*HTTPError)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.Equal(t, errorResponse.Code, httpErr.Code)
+	assert.Equal(t, errorResponse.Message, httpErr.Message)
+}
+
+func TestHTTPClient_POST_Success(t *testing.T) {
+	// Setup test server
+	requestBody := map[string]string{"dora": "test-model"}
+	expectedResponse := map[string]interface{}{
+		"id":   "123",
+		"name": "dora-model",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/test", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		var receivedBody map[string]string
+		err = json.Unmarshal(body, &receivedBody)
+		assert.NoError(t, err)
+		assert.Equal(t, requestBody, receivedBody)
+
+		// Send response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		err = json.NewEncoder(w).Encode(expectedResponse)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create http client pointing to test server
+	logger := setupTestLogger()
+	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	require.NoError(t, err)
+
+	// Prepare request body
+	bodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	// Make the request
+	response, err := client.POST("/test", bytes.NewReader(bodyBytes))
+
+	// Verify response
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	var actualResponse map[string]interface{}
+	err = json.Unmarshal(response, &actualResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, actualResponse)
+}
+
+func TestHTTPClient_POST_Error(t *testing.T) {
+	// Setup test server that returns an error
+	requestBody := map[string]string{"name": "test-model"}
+	errorResponse := ErrorResponse{
+		Code:    "400",
+		Message: "Bad Request parameters",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+
+		err := json.NewEncoder(w).Encode(errorResponse)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create http client pointing to test server
+	logger := setupTestLogger()
+	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	require.NoError(t, err)
+
+	// Prepare request body
+	bodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	// Make the request
+	response, err := client.POST("/test", bytes.NewReader(bodyBytes))
+
+	// Verify error
+	assert.Error(t, err)
+	assert.Nil(t, response)
+
+	httpErr, ok := err.(*HTTPError)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+	assert.Equal(t, errorResponse.Code, httpErr.Code)
+	assert.Equal(t, errorResponse.Message, httpErr.Message)
+}
+
+func TestHTTPClient_PATCH_Success(t *testing.T) {
+	// Setup test server
+	requestBody := map[string]string{"name": "updated-model"}
+	expectedResponse := map[string]interface{}{
+		"id":   "123",
+		"name": "updated--bella-model",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/test/123", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		var receivedBody map[string]string
+		err = json.Unmarshal(body, &receivedBody)
+		assert.NoError(t, err)
+		assert.Equal(t, requestBody, receivedBody)
+
+		// Send response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		err = json.NewEncoder(w).Encode(expectedResponse)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create http client pointing to test server
+	logger := setupTestLogger()
+	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	require.NoError(t, err)
+
+	// Prepare request body
+	bodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	// Make the request
+	response, err := client.PATCH("/test/123", bytes.NewReader(bodyBytes))
+
+	// Verify response
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	var actualResponse map[string]interface{}
+	err = json.Unmarshal(response, &actualResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, actualResponse)
+}
+
+func TestHTTPClient_PATCH_Error(t *testing.T) {
+	// Setup test server that returns an error
+	requestBody := map[string]string{"name": "updated-model"}
+	errorResponse := ErrorResponse{
+		Code:    "404",
+		Message: "Resource not found",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		err := json.NewEncoder(w).Encode(errorResponse)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create client pointing to test server
+	logger := setupTestLogger()
+	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	require.NoError(t, err)
+
+	// Prepare request body
+	bodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	// Make the request
+	response, err := client.PATCH("/test/123", bytes.NewReader(bodyBytes))
+
+	// Verify error
+	assert.Error(t, err)
+	assert.Nil(t, response)
+
+	httpErr, ok := err.(*HTTPError)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Equal(t, errorResponse.Code, httpErr.Code)
+	assert.Equal(t, errorResponse.Message, httpErr.Message)
+}


### PR DESCRIPTION
## Description
HTTP Get operations from BFF were not forwarding errors correctly.

In this PR:
- clients/ui/bff/internal/integrations/http.go: generated proper error object when there is an error with get operation
- clients/ui/bff/internal/integrations/http_test.go: test coverage for http.go

## How Has This Been Tested?
1-) Run model registry with docker compose -f docker-compose.yaml up
2-) Run BFF with make run MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=false
3-) After this PR, we should:
```code
curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/model_registry/model-registry-bella/registered_models?namespace=bella-namespace"

HTTP/1.1 200 OK
Content-Type: application/json
Date: Wed, 26 Feb 2025 22:20:18 GMT
Transfer-Encoding: chunked 
````
If we manually stop mlmd-server from Model Registry (forcing them return a error):

```code
HTTP/1.1 500 Internal Server Error
Content-Type: application/json
Date: Wed, 26 Feb 2025 22:20:59 GMT
Content-Length: 119

{
	"error": {
		"code": "500",
		"message": "the server encountered a problem and could not process your request"
	}
}
``` 

I've also done a small sanity check on the UI
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
 