### PR TITLE
handle GET reqs with invalid query params as 400

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -16,11 +16,13 @@ var (
 func ErrToStatus(err error) int {
 	// If the error is a gRPC error, we can extract the status code.
 	if status, ok := status.FromError(err); ok {
-		if status.Code() == codes.Unavailable {
-			return http.StatusServiceUnavailable
-		}
-		if status.Code() == codes.AlreadyExists {
+		switch status.Code() {
+		case codes.InvalidArgument:
+			return http.StatusBadRequest
+		case codes.AlreadyExists:
 			return http.StatusConflict
+		case codes.Unavailable:
+			return http.StatusServiceUnavailable
 		}
 	}
 

--- a/pkg/core/artifact_test.go
+++ b/pkg/core/artifact_test.go
@@ -494,6 +494,21 @@ func (suite *CoreTestSuite) TestGetArtifactByParams() {
 	suite.Equal(*da, *daByExtId, "artifacts returned during creation and on get by ext id should be equal")
 }
 
+func (suite *CoreTestSuite) TestGetArtifactByParamsInvalid() {
+	// trigger a 400 bad request to test unallowed query params
+	// create mode registry service
+	service := suite.setupModelRegistryService()
+
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
+
+	invalidName := "\xFF"
+
+	_, err := service.GetArtifactByParams(&invalidName, &modelVersionId, nil)
+	statusResp := api.ErrToStatus(err)
+	suite.NotNilf(err, "invalid parameter used to retreive artifact")
+	suite.Equal(400, statusResp, "invalid parameter used to retreive artifact")
+}
+
 func (suite *CoreTestSuite) TestGetArtifacts() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()

--- a/pkg/core/inference_service_test.go
+++ b/pkg/core/inference_service_test.go
@@ -499,6 +499,38 @@ func (suite *CoreTestSuite) TestGetInferenceServiceByParamsName() {
 	suite.Equal(ctx.CustomProperties["custom_string_prop"].GetStringValue(), (*getByName.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, "saved custom_string_prop custom property should match the provided one")
 }
 
+func (suite *CoreTestSuite) TestGetInferenceServiceByParamInvalid() {
+	// create mode registry service
+	service := suite.setupModelRegistryService()
+
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
+
+	eut := &openapi.InferenceService{
+		Name:                 &entityName,
+		ExternalId:           &entityExternalId2,
+		Description:          &entityDescription,
+		ServingEnvironmentId: parentResourceId,
+		RegisteredModelId:    registeredModelId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"custom_string_prop": {
+				MetadataStringValue: converter.NewMetadataStringValue(customString),
+			},
+		},
+	}
+
+	// must register an inference service first, otherwise the http error will be a 404
+	_, err := service.UpsertInferenceService(eut)
+	suite.Nilf(err, "error creating new eut for %s", parentResourceId)
+
+	invalidName := "\xFF"
+
+	_, err = service.GetInferenceServiceByParams(&invalidName, &parentResourceId, nil)
+	statusResp := api.ErrToStatus(err)
+	suite.NotNilf(err, "invalid parameter used to retreive inference service")
+	suite.Equal(400, statusResp, "invalid parameter used to retreive inference service")
+}
+
 func (suite *CoreTestSuite) TestGetInfernenceServiceByParamsExternalId() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()

--- a/pkg/core/registered_model_test.go
+++ b/pkg/core/registered_model_test.go
@@ -244,6 +244,28 @@ func (suite *CoreTestSuite) TestGetRegisteredModelByParamsName() {
 	suite.Equalf(*createdModel.Id, *byName.Id, "the returned model id should match the retrieved by name")
 }
 
+func (suite *CoreTestSuite) TestGetRegisteredModelByParamsInvalid() {
+	// trigger a 400 bad request to test unallowed query params
+	// create mode registry service
+	service := suite.setupModelRegistryService()
+
+	registeredModel := &openapi.RegisteredModel{
+		Name:       modelName,
+		ExternalId: &modelExternalId,
+	}
+
+	// must register a model first, otherwise the http error will be a 404
+	_, err := service.UpsertRegisteredModel(registeredModel)
+	suite.Nilf(err, "error creating registered model: %v", err)
+
+	invalidName := "\xFF"
+
+	_, err = service.GetRegisteredModelByParams(&invalidName, nil)
+	statusResp := api.ErrToStatus(err)
+	suite.NotNilf(err, "invalid parameter used to retreive registered model")
+	suite.Equal(400, statusResp, "invalid parameter used to retreive registered model")
+}
+
 func (suite *CoreTestSuite) TestGetRegisteredModelByParamsExternalId() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()

--- a/pkg/core/serving_environment_test.go
+++ b/pkg/core/serving_environment_test.go
@@ -223,6 +223,27 @@ func (suite *CoreTestSuite) TestGetServingEnvironmentByParamsName() {
 	suite.Equalf(*createdEntity.Id, *byName.Id, "the returned entity id should match the retrieved by name")
 }
 
+func (suite *CoreTestSuite) TestGetServingEnvironmentByParamsInvalid() {
+	// create mode registry service
+	service := suite.setupModelRegistryService()
+
+	eut := &openapi.ServingEnvironment{
+		Name:       &entityName,
+		ExternalId: &entityExternalId,
+	}
+
+	// must register a serving environment first, otherwise the http error will be a 404
+	_, err := service.UpsertServingEnvironment(eut)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
+
+	invalidName := "\xFF"
+
+	_, err = service.GetServingEnvironmentByParams(&invalidName, nil)
+	statusResp := api.ErrToStatus(err)
+	suite.NotNilf(err, "invalid parameter used to retreive serving environemnt")
+	suite.Equal(400, statusResp, "invalid parameter used to retreive serving environemnt")
+}
+
 func (suite *CoreTestSuite) TestGetServingEnvironmentByParamsExternalId() {
 	// create mode registry service
 	service := suite.setupModelRegistryService()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, when an user inputs a request with a query param that has an invalid syntax issue, it gets processed as a 500 internal service error. We should be processing these as a 400 bad request instead.

Link to original Jira with more details: https://issues.redhat.com/browse/RHOAIENG-19195 

## How Has This Been Tested?

This has been locally tested by creating new registered models and model artifacts, and then sending GET requests with bad query params for name and externalId in order to trigger the "Illegal syntax" error. For example: 
`GET /api/model_registry/v1alpha3/registered_model?%C3%B5%F1%A5%BC%A2x%1D%1C&externalId=1l%26%F3%AF%81%9Fd%F0%96%B0%AD%5C-%10%C3%AD%09%C3%BD%F3%BF%B9%B0%C2%98%C3%8B%C3%A7%F0%BF%BD%A4%3D%C2%BB%C2%B0%C3%AF`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x ] The developer has manually tested the changes and verified that the changes work.
- [ x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

<img width="1034" alt="Screenshot 2025-02-27 at 8 56 09 AM" src="https://github.com/user-attachments/assets/205e6dc2-8e66-47f9-94c0-5bbab5e93993" />

