### PR TITLE
feat(bff): Stub endpoints for CRUD Model Registries

### DIFF
--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -3,10 +3,11 @@ package api
 import (
 	"context"
 	"fmt"
-	helper "github.com/kubeflow/model-registry/ui/bff/internal/helpers"
 	"log/slog"
 	"net/http"
 	"path"
+
+	helper "github.com/kubeflow/model-registry/ui/bff/internal/helpers"
 
 	"github.com/kubeflow/model-registry/ui/bff/internal/config"
 	"github.com/kubeflow/model-registry/ui/bff/internal/integrations"
@@ -19,26 +20,29 @@ import (
 const (
 	Version = "1.0.0"
 
-	PathPrefix                   = "/model-registry"
-	ApiPathPrefix                = "/api/v1"
-	ModelRegistryId              = "model_registry_id"
-	RegisteredModelId            = "registered_model_id"
-	ModelVersionId               = "model_version_id"
-	ModelArtifactId              = "model_artifact_id"
-	ArtifactId                   = "artifact_id"
-	HealthCheckPath              = ApiPathPrefix + "/healthcheck"
-	UserPath                     = ApiPathPrefix + "/user"
-	ModelRegistryListPath        = ApiPathPrefix + "/model_registry"
-	NamespaceListPath            = ApiPathPrefix + "/namespaces"
-	ModelRegistryPath            = ModelRegistryListPath + "/:" + ModelRegistryId
-	RegisteredModelListPath      = ModelRegistryPath + "/registered_models"
-	RegisteredModelPath          = RegisteredModelListPath + "/:" + RegisteredModelId
-	RegisteredModelVersionsPath  = RegisteredModelPath + "/versions"
-	ModelVersionListPath         = ModelRegistryPath + "/model_versions"
-	ModelVersionPath             = ModelVersionListPath + "/:" + ModelVersionId
-	ModelVersionArtifactListPath = ModelVersionPath + "/artifacts"
-	ModelArtifactListPath        = ModelRegistryPath + "/model_artifacts"
-	ModelArtifactPath            = ModelArtifactListPath + "/:" + ModelArtifactId
+	PathPrefix                    = "/model-registry"
+	ApiPathPrefix                 = "/api/v1"
+	ModelRegistryId               = "model_registry_id"
+	RegisteredModelId             = "registered_model_id"
+	ModelVersionId                = "model_version_id"
+	ModelArtifactId               = "model_artifact_id"
+	ArtifactId                    = "artifact_id"
+	HealthCheckPath               = ApiPathPrefix + "/healthcheck"
+	UserPath                      = ApiPathPrefix + "/user"
+	ModelRegistryListPath         = ApiPathPrefix + "/model_registry"
+	ModelRegistryPath             = ModelRegistryListPath + "/:" + ModelRegistryId
+	NamespaceListPath             = ApiPathPrefix + "/namespaces"
+	SettingsPath                  = ApiPathPrefix + "/settings"
+	ModelRegistrySettingsListPath = SettingsPath + "/model_registry"
+	ModelRegistrySettingsPath     = ModelRegistrySettingsListPath + "/:" + ModelRegistryId
+	RegisteredModelListPath       = ModelRegistryPath + "/registered_models"
+	RegisteredModelPath           = RegisteredModelListPath + "/:" + RegisteredModelId
+	RegisteredModelVersionsPath   = RegisteredModelPath + "/versions"
+	ModelVersionListPath          = ModelRegistryPath + "/model_versions"
+	ModelVersionPath              = ModelVersionListPath + "/:" + ModelVersionId
+	ModelVersionArtifactListPath  = ModelVersionPath + "/artifacts"
+	ModelArtifactListPath         = ModelRegistryPath + "/model_artifacts"
+	ModelArtifactPath             = ModelArtifactListPath + "/:" + ModelArtifactId
 
 	ArtifactListPath = ModelRegistryPath + "/artifacts"
 	ArtifactPath     = ArtifactListPath + "/:" + ArtifactId
@@ -119,14 +123,18 @@ func (app *App) Routes() http.Handler {
 	apiRouter.PATCH(ArtifactPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.UpdateArtifactHandler))))
 	apiRouter.GET(ModelVersionArtifactListPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.GetAllModelArtifactsByModelVersionHandler))))
 	apiRouter.POST(ModelVersionArtifactListPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.CreateModelArtifactByModelVersionHandler))))
-	apiRouter.PATCH(ModelRegistryPath, app.AttachNamespace(app.PerformSARonSpecificService(app.AttachRESTClient(app.UpdateModelVersionHandler))))
 
 	// Kubernetes routes
 	apiRouter.GET(UserPath, app.UserHandler)
-	// Perform SAR to Get List Services by Namespace
-	apiRouter.GET(ModelRegistryListPath, app.AttachNamespace(app.PerformSARonGetListServicesByNamespace(app.ModelRegistryHandler)))
+	apiRouter.GET(ModelRegistryListPath, app.AttachNamespace(app.PerformSARonGetListServicesByNamespace(app.GetAllModelRegistriesHandler)))
 	if app.config.StandaloneMode {
 		apiRouter.GET(NamespaceListPath, app.GetNamespacesHandler)
+		//Those endpoints are not implement yet. This is a STUB API to unblock frontend development
+		apiRouter.GET(ModelRegistrySettingsListPath, app.AttachNamespace(app.GetAllModelRegistriesSettingsHandler))
+		apiRouter.POST(ModelRegistrySettingsListPath, app.AttachNamespace(app.CreateModelRegistrySettingsHandler))
+		apiRouter.GET(ModelRegistrySettingsPath, app.AttachNamespace(app.GetModelRegistrySettingsHandler))
+		apiRouter.PATCH(ModelRegistrySettingsPath, app.AttachNamespace(app.UpdateModelRegistrySettingsHandler))
+		apiRouter.DELETE(ModelRegistrySettingsPath, app.AttachNamespace(app.DeleteModelRegistrySettingsHandler))
 	}
 
 	// App Router

--- a/clients/ui/bff/internal/api/model_registry_handler.go
+++ b/clients/ui/bff/internal/api/model_registry_handler.go
@@ -2,15 +2,17 @@ package api
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
 	"github.com/kubeflow/model-registry/ui/bff/internal/models"
-	"net/http"
 )
 
 type ModelRegistryListEnvelope Envelope[[]models.ModelRegistryModel, None]
+type ModelRegistryEnvelope Envelope[models.ModelRegistryModel, None]
 
-func (app *App) ModelRegistryHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (app *App) GetAllModelRegistriesHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 
 	namespace, ok := r.Context().Value(constants.NamespaceHeaderParameterKey).(string)
 	if !ok || namespace == "" {

--- a/clients/ui/bff/internal/api/model_registry_handler_test.go
+++ b/clients/ui/bff/internal/api/model_registry_handler_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
 	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
 	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
 	"github.com/kubeflow/model-registry/ui/bff/internal/models"
 	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"io"
-	"net/http"
-	"net/http/httptest"
 )
 
 var _ = Describe("TestModelRegistryHandler", func() {
@@ -38,7 +39,7 @@ var _ = Describe("TestModelRegistryHandler", func() {
 			rr := httptest.NewRecorder()
 
 			By("creating the http request for the handler")
-			testApp.ModelRegistryHandler(rr, req, nil)
+			testApp.GetAllModelRegistriesHandler(rr, req, nil)
 			rs := rr.Result()
 			defer rs.Body.Close()
 			body, err := io.ReadAll(rs.Body)
@@ -52,8 +53,8 @@ var _ = Describe("TestModelRegistryHandler", func() {
 
 			By("should match the expected model registries")
 			var expected = []models.ModelRegistryModel{
-				{Name: "model-registry", Description: "Model Registry Description", DisplayName: "Model Registry"},
-				{Name: "model-registry-one", Description: "Model Registry One description", DisplayName: "Model Registry One"},
+				{Name: "model-registry", Description: "Model Registry Description", DisplayName: "Model Registry", ServerAddress: "http://127.0.0.1:8080/api/model_registry/v1alpha3"},
+				{Name: "model-registry-one", Description: "Model Registry One description", DisplayName: "Model Registry One", ServerAddress: "http://127.0.0.1:8080/api/model_registry/v1alpha3"},
 			}
 			Expect(actual.Data).To(ConsistOf(expected))
 		})

--- a/clients/ui/bff/internal/api/model_registry_settings_handler.go
+++ b/clients/ui/bff/internal/api/model_registry_settings_handler.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
+	helper "github.com/kubeflow/model-registry/ui/bff/internal/helpers"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+)
+
+type ModelRegistrySettingsListEnvelope Envelope[[]models.ModelRegistryKind, None]
+type ModelRegistrySettingsEnvelope Envelope[models.ModelRegistryKind, None]
+
+func (app *App) GetAllModelRegistriesSettingsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctxLogger := helper.GetContextLoggerFromReq(r)
+	ctxLogger.Info("This functionality is not implement yet. This is a STUB API to unblock frontend development")
+
+	namespace, ok := r.Context().Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in the context"))
+	}
+
+	registries := []models.ModelRegistryKind{createSampleModelRegistry("model-registry", namespace),
+		createSampleModelRegistry("model-registry-dora", namespace),
+		createSampleModelRegistry("model-registry-bella", namespace)}
+
+	modelRegistryRes := ModelRegistrySettingsListEnvelope{
+		Data: registries,
+	}
+
+	err := app.WriteJSON(w, http.StatusOK, modelRegistryRes, nil)
+
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+
+}
+
+func (app *App) GetModelRegistrySettingsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctxLogger := helper.GetContextLoggerFromReq(r)
+	ctxLogger.Info("This functionality is not implement yet. This is a STUB API to unblock frontend development")
+
+	namespace, ok := r.Context().Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in the context"))
+	}
+
+	modelId := ps.ByName(ModelRegistryId)
+	registry := createSampleModelRegistry(modelId, namespace)
+
+	modelRegistryRes := ModelRegistrySettingsEnvelope{
+		Data: registry,
+	}
+
+	err := app.WriteJSON(w, http.StatusOK, modelRegistryRes, nil)
+
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) CreateModelRegistrySettingsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctxLogger := helper.GetContextLoggerFromReq(r)
+	ctxLogger.Info("This functionality is not implement yet. This is a STUB API to unblock frontend development")
+
+	namespace, ok := r.Context().Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in the context"))
+	}
+
+	registry := createSampleModelRegistry("new-model-registry", namespace)
+
+	modelRegistryRes := ModelRegistrySettingsEnvelope{
+		Data: registry,
+	}
+
+	w.Header().Set("Location", r.URL.JoinPath(modelRegistryRes.Data.Metadata.Name).String())
+	err := app.WriteJSON(w, http.StatusCreated, modelRegistryRes, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error writing JSON"))
+		return
+	}
+
+}
+
+func (app *App) UpdateModelRegistrySettingsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctxLogger := helper.GetContextLoggerFromReq(r)
+	ctxLogger.Info("This functionality is not implement yet. This is a STUB API to unblock frontend development")
+
+	namespace, ok := r.Context().Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in the context"))
+	}
+
+	modelId := ps.ByName(ModelRegistryId)
+	registry := createSampleModelRegistry(modelId, namespace)
+
+	modelRegistryRes := ModelRegistrySettingsEnvelope{
+		Data: registry,
+	}
+
+	err := app.WriteJSON(w, http.StatusOK, modelRegistryRes, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error writing JSON"))
+		return
+	}
+}
+
+func (app *App) DeleteModelRegistrySettingsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctxLogger := helper.GetContextLoggerFromReq(r)
+	ctxLogger.Info("This functionality is not implement yet. This is a STUB API to unblock frontend development")
+
+	namespace, ok := r.Context().Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in the context"))
+	}
+
+	w.WriteHeader(200)
+}
+
+// This function is a temporary function to create a sample model registry kind until we have a real implementation
+func createSampleModelRegistry(name string, namespace string) models.ModelRegistryKind {
+
+	creationTime, _ := time.Parse(time.RFC3339, "2024-03-14T08:01:42Z")
+	lastTransitionTime, _ := time.Parse(time.RFC3339, "2024-03-22T09:30:02Z")
+
+	return models.ModelRegistryKind{
+		APIVersion: "modelregistry.io/v1alpha1",
+		Kind:       "ModelRegistry",
+		Metadata: models.Metadata{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: creationTime,
+			Annotations:       map[string]string{},
+		},
+		Spec: models.ModelRegistrySpec{
+			GRPC: models.EmptyObject{},
+			REST: models.EmptyObject{},
+			Istio: models.IstioConfig{
+				Gateway: models.GatewayConfig{
+					GRPC: models.GRPCConfig{
+						TLS: models.EmptyObject{},
+					},
+					REST: models.RESTConfig{
+						TLS: models.EmptyObject{},
+					},
+				},
+			},
+			DatabaseConfig: models.DatabaseConfig{
+				DatabaseType: models.MySQL,
+				Database:     "model-registry",
+				Host:         "model-registry-db",
+				//intentionally not set
+				// PasswordSecret: models.PasswordSecret{
+				// 	Key:  "database-password",
+				// 	Name: "model-registry-db",
+				// },
+				Port:                        5432,
+				SkipDBCreation:              false,
+				Username:                    "mlmduser",
+				SSLRootCertificateConfigMap: "ssl-config-map",
+				SSLRootCertificateSecret:    "ssl-secret",
+			},
+		},
+		Status: models.Status{
+			Conditions: []models.Condition{
+				{
+					LastTransitionTime: lastTransitionTime,
+					Message:            "Deployment for custom resource " + name + " was successfully created",
+					Reason:             "CreatedDeployment",
+					Status:             "True",
+					Type:               "Progressing",
+				},
+			},
+		},
+	}
+}

--- a/clients/ui/bff/internal/mocks/k8s_mock.go
+++ b/clients/ui/bff/internal/mocks/k8s_mock.go
@@ -192,6 +192,8 @@ func (m *KubernetesClientMock) GetServiceDetails(sessionCtx context.Context, nam
 		return nil, fmt.Errorf("failed to get service details: %w", err)
 	}
 
+	//in the mock we are changing the cluster ip to localhost
+	//to be able to connect with local model registry
 	for i := range originalServices {
 		originalServices[i].ClusterIP = "127.0.0.1"
 		originalServices[i].HTTPPort = 8080
@@ -205,7 +207,8 @@ func (m *KubernetesClientMock) GetServiceDetailsByName(sessionCtx context.Contex
 	if err != nil {
 		return k8s.ServiceDetails{}, fmt.Errorf("failed to get service details: %w", err)
 	}
-	//changing from cluster service ip to localhost
+	//in the mock we are changing the cluster ip to localhost
+	//to be able to connect with local model registry
 	originalService.ClusterIP = "127.0.0.1"
 	originalService.HTTPPort = 8080
 

--- a/clients/ui/bff/internal/models/model_registry.go
+++ b/clients/ui/bff/internal/models/model_registry.go
@@ -1,7 +1,8 @@
 package models
 
 type ModelRegistryModel struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
+	Name          string `json:"name"`
+	DisplayName   string `json:"displayName"`
+	Description   string `json:"description"`
+	ServerAddress string `json:"serverAddress"`
 }

--- a/clients/ui/bff/internal/models/model_registry_kind.go
+++ b/clients/ui/bff/internal/models/model_registry_kind.go
@@ -1,0 +1,83 @@
+package models
+
+import (
+	"time"
+)
+
+type ModelRegistryKind struct {
+	APIVersion string            `json:"apiVersion"`
+	Kind       string            `json:"kind"`
+	Metadata   Metadata          `json:"metadata"`
+	Spec       ModelRegistrySpec `json:"spec"`
+	Status     Status            `json:"status"`
+}
+
+type Metadata struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
+}
+
+// EmptyObject represents an empty object at create time, properties here aren't used by the UI
+type EmptyObject struct{}
+
+type ModelRegistrySpec struct {
+	GRPC           EmptyObject    `json:"grpc"` // Empty object at create time, properties here aren't used by the UI
+	REST           EmptyObject    `json:"rest"` // Empty object at create time, properties here aren't used by the UI
+	Istio          IstioConfig    `json:"istio"`
+	DatabaseConfig DatabaseConfig `json:"databaseConfig"`
+}
+
+type IstioConfig struct {
+	Gateway GatewayConfig `json:"gateway"`
+}
+
+type GatewayConfig struct {
+	GRPC GRPCConfig `json:"grpc"`
+	REST RESTConfig `json:"rest"`
+}
+
+type GRPCConfig struct {
+	TLS EmptyObject `json:"tls"` // Empty object at create time, properties here aren't used by the UI
+}
+
+type RESTConfig struct {
+	TLS EmptyObject `json:"tls"` // Empty object at create time, properties here aren't used by the UI
+}
+
+type DatabaseType string
+
+const (
+	MySQL    DatabaseType = "mysql"
+	Postgres DatabaseType = "postgres"
+)
+
+type DatabaseConfig struct {
+	DatabaseType                DatabaseType   `json:"databaseType"`
+	Database                    string         `json:"database"`
+	Host                        string         `json:"host"`
+	PasswordSecret              PasswordSecret `json:"passwordSecret,omitempty"`
+	Port                        int            `json:"port"`
+	SkipDBCreation              bool           `json:"skipDBCreation"`
+	Username                    string         `json:"username"`
+	SSLRootCertificateConfigMap string         `json:"sslRootCertificateConfigMap"`
+	SSLRootCertificateSecret    string         `json:"sslRootCertificateSecret"`
+}
+
+type PasswordSecret struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+type Status struct {
+	Conditions []Condition `json:"conditions"`
+}
+
+type Condition struct {
+	LastTransitionTime time.Time `json:"lastTransitionTime"`
+	Message            string    `json:"message"`
+	Reason             string    `json:"reason"`
+	Status             string    `json:"status"`
+	Type               string    `json:"type"`
+}

--- a/clients/ui/bff/internal/repositories/model_registry_test.go
+++ b/clients/ui/bff/internal/repositories/model_registry_test.go
@@ -19,8 +19,8 @@ var _ = Describe("TestFetchAllModelRegistry", func() {
 
 			By("should match the expected model registries")
 			expectedRegistries := []models.ModelRegistryModel{
-				{Name: "model-registry", Description: "Model Registry Description", DisplayName: "Model Registry"},
-				{Name: "model-registry-one", Description: "Model Registry One description", DisplayName: "Model Registry One"},
+				{Name: "model-registry", Description: "Model Registry Description", DisplayName: "Model Registry", ServerAddress: "http://127.0.0.1:8080/api/model_registry/v1alpha3"},
+				{Name: "model-registry-one", Description: "Model Registry One description", DisplayName: "Model Registry One", ServerAddress: "http://127.0.0.1:8080/api/model_registry/v1alpha3"},
 			}
 			Expect(registries).To(ConsistOf(expectedRegistries))
 		})
@@ -34,7 +34,7 @@ var _ = Describe("TestFetchAllModelRegistry", func() {
 
 			By("should match the expected model registries")
 			expectedRegistries := []models.ModelRegistryModel{
-				{Name: "model-registry-dora", Description: "Model Registry Dora description", DisplayName: "Model Registry Dora"},
+				{Name: "model-registry-dora", Description: "Model Registry Dora description", DisplayName: "Model Registry Dora", ServerAddress: "http://127.0.0.1:8080/api/model_registry/v1alpha3"},
 			}
 			Expect(registries).To(ConsistOf(expectedRegistries))
 		})


### PR DESCRIPTION
## Description
This PR creates a stub implementation of APIs for CRUD on Model Registries settings. The endpoints are only exposed if app.config.StandaloneMode=true.

### In this PR:

### APIs introduced/changed:

#### GET /api/v1/settings/model_registry
```code
curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/settings/model_registry?namespace=kubeflow"

HTTP/1.1 200 OK
Content-Type: application/json
Date: Mon, 10 Mar 2025 19:42:57 GMT
Transfer-Encoding: chunked

{
	"data": [
		{
			"apiVersion": "modelregistry.io/v1alpha1",
			"kind": "ModelRegistry",
			"metadata": {
				"name": "model-registry",
				"namespace": "kubeflow",
				"creationTimestamp": "2024-03-14T08:01:42Z"
			},
			...
		},
		{
			"apiVersion": "modelregistry.io/v1alpha1",
			"kind": "ModelRegistry",
			"metadata": {
				"name": "model-registry-dora",
				"namespace": "kubeflow",
				"creationTimestamp": "2024-03-14T08:01:42Z"
			},
			"spec": {
			...
		},
		{
			"apiVersion": "modelregistry.io/v1alpha1",
			"kind": "ModelRegistry",
			"metadata": {
				"name": "model-registry-bella",
	                   ...
		}
	]
}

```
#### GET /api/v1/settings/model_registry/{id}
```code

curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/settings/model_registry/test?namespace=kubeflow"
HTTP/1.1 200 OK
Content-Type: application/json
Date: Mon, 10 Mar 2025 19:42:04 GMT
Content-Length: 1003

{
	"data": {
		"apiVersion": "modelregistry.io/v1alpha1",
		"kind": "ModelRegistry",
		"metadata": {
			"name": "test",
			"namespace": "kubeflow",
			"creationTimestamp": "2024-03-14T08:01:42Z"
		},
		"spec": {
			"grpc": {},
			"rest": {},
			"istio": {
				"gateway": {
					"grpc": {
						"tls": {}
					},
					"rest": {
						"tls": {}
					}
				}
			},
			"databaseConfig": {
				"databaseType": "mysql",
				"database": "model-registry",
				"host": "model-registry-db",
				"passwordSecret": {
					"key": "",
					"name": ""
				},
				"port": 5432,
				"skipDBCreation": false,
				"username": "mlmduser",
				"sslRootCertificateConfigMap": "ssl-config-map",
				"sslRootCertificateSecret": "ssl-secret"
			}
		},
		"status": {
			"conditions": [
				{
					"lastTransitionTime": "2024-03-22T09:30:02Z",
					"message": "Deployment for custom resource test was successfully created",
					"reason": "CreatedDeployment",
					"status": "True",
					"type": "Progressing"
				}
			]
		}
	}
}
```

#### PATCH /api/v1/settings/model_registry/{id}
```code
curl -i -X PATCH \                                                
  -H "kubeflow-userid: user@example.com" \
  -H "Content-Type: application/json" \
  "localhost:4000/api/v1/settings/model_registry/test?namespace=kubeflow" \
  -d '{
    "spec": {
      "databaseConfig": {
        "databaseType": "postgres",
        "database": "new-model-registry",
        "host": "new-model-registry-db",
        "port": 5433,
        "username": "newuser"
      }
    }
  }'
HTTP/1.1 200 OK
Content-Type: application/json
Date: Mon, 10 Mar 2025 19:47:20 GMT
Content-Length: 1003

{
	"data": {
		...
	}
}

```

#### POST /api/v1/settings/model_registry
```code
curl -i -X POST \                                            
  -H "kubeflow-userid: user@example.com" \
  -H "Content-Type: application/json" \
  "localhost:4000/api/v1/settings/model_registry?namespace=kubeflow" \
  -d '{
    "apiVersion": "modelregistry.io/v1alpha1",
    "kind": "ModelRegistry",
    "metadata": {
      "name": "new-registry",
      "namespace": "kubeflow"
    },
    "spec": {
      "grpc": {},
      "rest": {},
      "istio": {
        "gateway": {
          "grpc": {
            "tls": {}
          },
          "rest": {
            "tls": {}
          }
        }
      },
      "databaseConfig": {
        "databaseType": "mysql",
        "database": "model-registry",
        "host": "model-registry-db",
        "port": 5432,
        "username": "mlmduser",
        "sslRootCertificateConfigMap": "ssl-config-map",
        "sslRootCertificateSecret": "ssl-secret"
      }
    }
  }'
HTTP/1.1 201 Created
Content-Type: application/json
Location: /api/v1/settings/model_registry/new-model-registry?namespace=kubeflow
Date: Mon, 10 Mar 2025 19:52:34 GMT
Content-Length: 1031

{
	"data": {
		...
	}
}
```

#### POST /api/v1/settings/model_registry
```code
curl -i -X DELETE \                                               
  -H "kubeflow-userid: user@example.com" \
  "localhost:4000/api/v1/settings/model_registry/test?namespace=kubeflow"
HTTP/1.1 200 OK
Date: Mon, 10 Mar 2025 19:50:47 GMT
Content-Length: 0
```

### Code changes
- clients/ui/bff/internal/api/app.go: 
        - Added new settings path;
        - Removed a 'bug' on L122;
        - Added settings endpoints just for standalone mode;
- clients/ui/bff/internal/api/middleware.go
        - Moved the logic to resolve model registry URL to the repository 
- clients/ui/bff/internal/api/model_registry_handler.go
        - Minor refactoring
- clients/ui/bff/internal/api/model_registry_handler_test.go
        - Minor refactoring
- clients/ui/bff/internal/api/model_registry_settings_handler.go 
        -  GET POST PATCH DELETE Model Registry Settings handler
- clients/ui/bff/internal/mocks/k8s_mock.go
        - Minor refactoring
- clients/ui/bff/internal/models/model_registry.go
        - Added ServerAddress as @lucferbux suggested on spec
- clients/ui/bff/internal/models/model_registry_kind.go
        - Go type to reflect Model Registry Settings ('ModelRegistryKind')
- clients/ui/bff/internal/repositories/model_registry.go
        - Moved server address string build from middleware to repository
        - Created GetModelRegistry Method
        - Add Server Address to the payload
- clients/ui/bff/internal/repositories/model_registry_test.go
          - Minor refactoring
## How Has This Been Tested?
I ran a quick sanity checks on the UI.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [X] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
 