### PR TITLE
feat(frontend): MUI Theme for Create Model Registry Form

### DIFF
--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistryCreateModal.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistryCreateModal.tsx
@@ -10,10 +10,12 @@ import {
 import { Modal } from '@patternfly/react-core/deprecated';
 import { useNavigate } from 'react-router';
 import ModelRegistryCreateModalFooter from '~/app/pages/settings/ModelRegistryCreateModalFooter';
+import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import FormSection from '~/shared/components/pf-overrides/FormSection';
 
 import ModelRegistryDatabasePassword from '~/app/pages/settings/ModelRegistryDatabasePassword';
 import K8sNameDescriptionField from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import { isMUITheme } from '~/shared/utilities/const';
 
 type CreateModalProps = {
   onClose: () => void;
@@ -81,6 +83,179 @@ const CreateModal: React.FC<CreateModalProps> = ({
     onClose();
   };
 
+  const hostInput = (
+    <TextInput
+      isRequired
+      type="text"
+      id="mr-host"
+      name="mr-host"
+      value={host}
+      onBlur={() => setIsHostTouched(true)}
+      onChange={(_e, value) => setHost(value)}
+      validated={isHostTouched && !hasContent(host) ? 'error' : 'default'}
+    />
+  );
+
+  const hostHelperText = isHostTouched && !hasContent(host) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-host-error">
+        Host cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const hostFormGroup = (
+    <>
+      <FormGroup
+        className={hostHelperText ? 'pf-m-error' : ''}
+        label="Host"
+        isRequired
+        fieldId="mr-host"
+      >
+        <FormFieldset component={hostInput} field="Host" />
+      </FormGroup>
+      {hostHelperText}
+    </>
+  );
+
+  const portInput = (
+    <TextInput
+      isRequired
+      type="text"
+      id="mr-port"
+      name="mr-port"
+      value={port}
+      onBlur={() => setIsPortTouched(true)}
+      onChange={(_e, value) => setPort(value)}
+      validated={isPortTouched && !hasContent(port) ? 'error' : 'default'}
+    />
+  );
+
+  const portHelperText = isPortTouched && !hasContent(port) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-port-error">
+        Port cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const portFormGroup = (
+    <>
+      <FormGroup
+        className={portHelperText ? 'pf-m-error' : ''}
+        label="Port"
+        isRequired
+        fieldId="mr-port"
+      >
+        <FormFieldset component={portInput} field="Port" />
+      </FormGroup>
+      {portHelperText}
+    </>
+  );
+
+  const userNameInput = (
+    <TextInput
+      isRequired
+      type="text"
+      id="mr-username"
+      name="mr-username"
+      value={username}
+      onBlur={() => setIsUsernameTouched(true)}
+      onChange={(_e, value) => setUsername(value)}
+      validated={isUsernameTouched && !hasContent(username) ? 'error' : 'default'}
+    />
+  );
+
+  const usernameHelperText = isUsernameTouched && !hasContent(username) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-username-error">
+        Username cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const usernameFormGroup = (
+    <>
+      <FormGroup
+        className={usernameHelperText ? 'pf-m-error' : ''}
+        label="Username"
+        isRequired
+        fieldId="mr-username"
+      >
+        <FormFieldset component={userNameInput} field="Host" />
+      </FormGroup>
+      {usernameHelperText}
+    </>
+  );
+
+  const passwordInput = (
+    <ModelRegistryDatabasePassword
+      password={password || ''}
+      setPassword={setPassword}
+      isPasswordTouched={isPasswordTouched}
+      setIsPasswordTouched={setIsPasswordTouched}
+      showPassword={showPassword}
+      //   editRegistry={mr}
+    />
+  );
+
+  const passwordHelperText = isPasswordTouched && !hasContent(password) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-password-error">
+        Password cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const passwordFormGroup = (
+    <>
+      <FormGroup
+        className={passwordHelperText ? 'pf-m-error' : ''}
+        label="Password"
+        isRequired
+        fieldId="mr-password"
+      >
+        <FormFieldset component={passwordInput} field="Password" />
+      </FormGroup>
+      {passwordHelperText}
+    </>
+  );
+
+  const databaseInput = (
+    <TextInput
+      isRequired
+      type="text"
+      id="mr-database"
+      name="mr-database"
+      value={database}
+      onBlur={() => setIsDatabaseTouched(true)}
+      onChange={(_e, value) => setDatabase(value)}
+      validated={isDatabaseTouched && !hasContent(database) ? 'error' : 'default'}
+    />
+  );
+
+  const databaseHelperText = isDatabaseTouched && !hasContent(database) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-database-error">
+        Database cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const databaseFormGroup = (
+    <>
+      <FormGroup
+        className={databaseHelperText ? 'pf-m-error' : ''}
+        label="Database"
+        isRequired
+        fieldId="mr-database"
+      >
+        <FormFieldset component={databaseInput} field="Database" />
+      </FormGroup>
+      {databaseHelperText}
+    </>
+  );
+
   return (
     <Modal
       isOpen
@@ -117,92 +292,56 @@ const CreateModal: React.FC<CreateModalProps> = ({
           title="Connect to external MySQL database"
           description="This external database is where model data is stored."
         >
-          <FormGroup label="Host" isRequired fieldId="mr-host">
-            <TextInput
-              isRequired
-              type="text"
-              id="mr-host"
-              name="mr-host"
-              value={host}
-              onBlur={() => setIsHostTouched(true)}
-              onChange={(_e, value) => setHost(value)}
-              validated={isHostTouched && !hasContent(host) ? 'error' : 'default'}
-            />
-            {isHostTouched && !hasContent(host) && (
-              <HelperText>
-                <HelperTextItem variant="error" data-testid="mr-host-error">
-                  Host cannot be empty
-                </HelperTextItem>
-              </HelperText>
-            )}
-          </FormGroup>
-          <FormGroup label="Port" isRequired fieldId="mr-port">
-            <TextInput
-              isRequired
-              type="text"
-              id="mr-port"
-              name="mr-port"
-              value={port}
-              onBlur={() => setIsPortTouched(true)}
-              onChange={(_e, value) => setPort(value)}
-              validated={isPortTouched && !hasContent(port) ? 'error' : 'default'}
-            />
-            {isPortTouched && !hasContent(port) && (
-              <HelperText>
-                <HelperTextItem variant="error" data-testid="mr-port-error">
-                  Port cannot be empty
-                </HelperTextItem>
-              </HelperText>
-            )}
-          </FormGroup>
-          <FormGroup label="Username" isRequired fieldId="mr-username">
-            <TextInput
-              isRequired
-              type="text"
-              id="mr-username"
-              name="mr-username"
-              value={username}
-              onBlur={() => setIsUsernameTouched(true)}
-              onChange={(_e, value) => setUsername(value)}
-              validated={isUsernameTouched && !hasContent(username) ? 'error' : 'default'}
-            />
-            {isUsernameTouched && !hasContent(username) && (
-              <HelperText>
-                <HelperTextItem variant="error" data-testid="mr-username-error">
-                  Username cannot be empty
-                </HelperTextItem>
-              </HelperText>
-            )}
-          </FormGroup>
-          <FormGroup label="Password" isRequired fieldId="mr-password">
-            <ModelRegistryDatabasePassword
-              password={password || ''}
-              setPassword={setPassword}
-              isPasswordTouched={isPasswordTouched}
-              setIsPasswordTouched={setIsPasswordTouched}
-              showPassword={showPassword}
-              //   editRegistry={mr}
-            />
-          </FormGroup>
-          <FormGroup label="Database" isRequired fieldId="mr-database">
-            <TextInput
-              isRequired
-              type="text"
-              id="mr-database"
-              name="mr-database"
-              value={database}
-              onBlur={() => setIsDatabaseTouched(true)}
-              onChange={(_e, value) => setDatabase(value)}
-              validated={isDatabaseTouched && !hasContent(database) ? 'error' : 'default'}
-            />
-            {isDatabaseTouched && !hasContent(database) && (
-              <HelperText>
-                <HelperTextItem variant="error" data-testid="mr-database-error">
-                  Database cannot be empty
-                </HelperTextItem>
-              </HelperText>
-            )}
-          </FormGroup>
+          {isMUITheme() ? (
+            hostFormGroup
+          ) : (
+            <>
+              <FormGroup label="Host" isRequired fieldId="mr-host">
+                {hostInput}
+                {hostHelperText}
+              </FormGroup>
+            </>
+          )}
+          {isMUITheme() ? (
+            portFormGroup
+          ) : (
+            <>
+              <FormGroup label="Port" isRequired fieldId="mr-port">
+                {portInput}
+                {portHelperText}
+              </FormGroup>
+            </>
+          )}
+          {isMUITheme() ? (
+            usernameFormGroup
+          ) : (
+            <>
+              <FormGroup label="Username" isRequired fieldId="mr-username">
+                {userNameInput}
+                {usernameHelperText}
+              </FormGroup>
+            </>
+          )}
+          {isMUITheme() ? (
+            passwordFormGroup
+          ) : (
+            <>
+              <FormGroup label="Password" isRequired fieldId="mr-password">
+                {passwordInput}
+                {passwordHelperText}
+              </FormGroup>
+            </>
+          )}
+          {isMUITheme() ? (
+            databaseFormGroup
+          ) : (
+            <>
+              <FormGroup label="Database" isRequired fieldId="mr-database">
+                {databaseInput}
+                {databaseFormGroup}
+              </FormGroup>
+            </>
+          )}
           {/* {secureDbEnabled && (
             <>
               <FormGroup>

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistryDatabasePassword.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistryDatabasePassword.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import PasswordInput from '~/app/pages/settings/PasswordInput';
 
 type ModelRegistryDatabasePasswordProps = {
@@ -67,13 +66,6 @@ const ModelRegistryDatabasePassword: React.FC<ModelRegistryDatabasePasswordProps
         onChange={(_e, value) => setPassword(value)}
         validated={isPasswordTouched && !hasContent(password) ? 'error' : 'default'}
       />
-      {isPasswordTouched && !hasContent(password) && (
-        <HelperText>
-          <HelperTextItem variant="error" data-testid="mr-password-error">
-            Password cannot be empty
-          </HelperTextItem>
-        </HelperText>
-      )}
     </>
   );
 };

--- a/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
+++ b/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
@@ -8,6 +8,8 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import ResourceNameDefinitionTooltip from '~/concepts/k8s/ResourceNameDefinitionTootip';
+import { isMUITheme } from '~/shared/utilities/const';
+import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import ResourceNameField from './ResourceNameField';
 
 // TODO: replace with the actual call once we have the endpoint
@@ -55,69 +57,114 @@ const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
   const [showK8sField, setShowK8sField] = React.useState(false);
 
   //   const { name, description, k8sName } = data;
+  const nameInput = (
+    <TextInput
+      //   aria-readonly={!onDataChange}
+      data-testid={`${dataTestId}-name`}
+      id={`${dataTestId}-name`}
+      name={`${dataTestId}-name`}
+      autoFocus={autoFocusName}
+      isRequired
+      //   value={name}
+      //   onChange={(event, value) => onDataChange?.('name', value)}
+    />
+  );
+
+  const nameFormGroup = (
+    <>
+      <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
+        <FormFieldset component={nameInput} field="Name" />
+      </FormGroup>
+      {nameHelperText || !showK8sField ? (
+        //  &&
+        // !k8sName.state.immutable
+        <HelperText>
+          {nameHelperText && <HelperTextItem>{nameHelperText}</HelperTextItem>}
+          {!showK8sField && (
+            // !k8sName.state.immutable
+            // &&
+            <>
+              {/* {k8sName.value && (
+                <HelperTextItem>
+                  The resource name will be <b>{k8sName.value}</b>.
+                </HelperTextItem>
+              )} */}
+              <HelperTextItem>
+                <Button
+                  data-testid={`${dataTestId}-editResourceLink`}
+                  variant="link"
+                  isInline
+                  onClick={() => setShowK8sField(true)}
+                >
+                  Edit resource name
+                </Button>{' '}
+                <ResourceNameDefinitionTooltip />
+              </HelperTextItem>
+            </>
+          )}
+        </HelperText>
+      ) : null}
+    </>
+  );
+
+  const descriptionTextInput = (
+    <TextInput
+      // aria-readonly={!onDataChange}
+      data-testid={`${dataTestId}-description`}
+      id={`${dataTestId}-description`}
+      name={`${dataTestId}-description`}
+      type="text"
+      // value={description}
+      // onChange={(event, value) => onDataChange?.('description', value)}
+    />
+  );
+
+  const descriptionTextArea = (
+    <TextArea
+      // aria-readonly={!onDataChange}
+      data-testid={`${dataTestId}-description`}
+      id={`${dataTestId}-description`}
+      name={`${dataTestId}-description`}
+      type="text"
+      // value={description}
+      // onChange={(event, value) => onDataChange?.('description', value)}
+      resizeOrientation="vertical"
+    />
+  );
+
+  const descriptionFormGroup = (
+    <FormGroup label={descriptionLabel} fieldId={`${dataTestId}-description`}>
+      <FormFieldset component={descriptionTextInput} field="Description" />
+    </FormGroup>
+  );
 
   return (
     <>
-      <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
-        <TextInput
-          //   aria-readonly={!onDataChange}
-          data-testid={`${dataTestId}-name`}
-          id={`${dataTestId}-name`}
-          name={`${dataTestId}-name`}
-          autoFocus={autoFocusName}
-          isRequired
-          //   value={name}
-          //   onChange={(event, value) => onDataChange?.('name', value)}
-        />
-        {nameHelperText || !showK8sField ? (
-          //  &&
-          // !k8sName.state.immutable
-          <HelperText>
-            {nameHelperText && <HelperTextItem>{nameHelperText}</HelperTextItem>}
-            {!showK8sField && (
-              // !k8sName.state.immutable
-              // &&
-              <>
-                {/* {k8sName.value && (
-                  <HelperTextItem>
-                    The resource name will be <b>{k8sName.value}</b>.
-                  </HelperTextItem>
-                )} */}
-                <HelperTextItem>
-                  <Button
-                    data-testid={`${dataTestId}-editResourceLink`}
-                    variant="link"
-                    isInline
-                    onClick={() => setShowK8sField(true)}
-                  >
-                    Edit resource name
-                  </Button>{' '}
-                  <ResourceNameDefinitionTooltip />
-                </HelperTextItem>
-              </>
-            )}
-          </HelperText>
-        ) : null}
-      </FormGroup>
+      {isMUITheme() ? (
+        nameFormGroup
+      ) : (
+        <>
+          <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
+            {nameInput}
+            {nameHelperText}
+          </FormGroup>
+        </>
+      )}
+
       <ResourceNameField
         allowEdit={showK8sField}
         dataTestId={dataTestId}
         // k8sName={k8sName}
         // onDataChange={onDataChange}
       />
-      {!hideDescription ? (
+
+      {!hideDescription && isMUITheme() ? (
+        descriptionFormGroup
+      ) : (
         <FormGroup label={descriptionLabel} fieldId={`${dataTestId}-description`}>
-          <TextArea
-            // aria-readonly={!onDataChange}
-            data-testid={`${dataTestId}-description`}
-            id={`${dataTestId}-description`}
-            name={`${dataTestId}-description`}
-            // value={description}
-            // onChange={(event, value) => onDataChange?.('description', value)}
-            resizeOrientation="vertical"
-          />
+          {descriptionTextArea}
         </FormGroup>
-      ) : null}
+      )}
     </>
   );
 };

--- a/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
+++ b/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { FormGroup, HelperText, TextInput } from '@patternfly/react-core';
-import ResourceNameDefinitionTooltip from '~/concepts/k8s/ResourceNameDefinitionTootip';
+import { FormGroup, HelperText, HelperTextItem, TextInput } from '@patternfly/react-core';
+import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
+import { isMUITheme } from '~/shared/utilities/const';
 
 type ResourceNameFieldProps = {
   allowEdit: boolean;
@@ -16,12 +17,6 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
   //   k8sName,
   //   onDataChange,
 }) => {
-  const formGroupProps: React.ComponentProps<typeof FormGroup> = {
-    label: 'Resource name',
-    labelHelp: <ResourceNameDefinitionTooltip />,
-    fieldId: `${dataTestId}-resourceName`,
-  };
-
   // TODO: Implement this once we have the endpoint.
 
   //   if (k8sName.state.immutable) {
@@ -47,6 +42,7 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
       id={`${dataTestId}-resourceName`}
       data-testid={`${dataTestId}-resourceName`}
       name={`${dataTestId}-resourceName`}
+      type="text"
       isRequired
       //   value={
       //     usePrefix && k8sName.state.safePrefix
@@ -62,22 +58,47 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
       //   validated={validated}
     />
   );
-  return (
-    <FormGroup {...formGroupProps} isRequired>
-      {/* {usePrefix ? (
-        <InputGroup>
-          <InputGroupText>{k8sName.state.safePrefix}</InputGroupText>
-          <InputGroupItem isFill>{textInput}</InputGroupItem>
-        </InputGroup>
-      ) : ( */}
-      {textInput}
-      {/* )} */}
+
+  const resourceNameFormGroup = (
+    <>
+      <FormGroup
+        label="Resource name"
+        className="resource-name"
+        isRequired
+        fieldId={`${dataTestId}-resource-name`}
+      >
+        <FormFieldset component={textInput} field="Host" />
+      </FormGroup>
       <HelperText>
+        <HelperTextItem>
+          The resource name is used to identify your resource, and is generated based on the name
+          you enter. The resource name cannot be edited after creation.
+        </HelperTextItem>
         {/* <HelperTextItemMaxLength k8sName={k8sName} />
-        <HelperTextItemValidCharacters k8sName={k8sName} /> */}
+         <HelperTextItemValidCharacters k8sName={k8sName} /> */}
       </HelperText>
-    </FormGroup>
+    </>
   );
+
+  // TODO: Implement this once we have the endpoint.
+  // return (
+  //   <FormGroup {...formGroupProps} isRequired>
+  //     {usePrefix ? (
+  //       <InputGroup>
+  //         <InputGroupText>{k8sName.state.safePrefix}</InputGroupText>
+  //         <InputGroupItem isFill>{textInput}</InputGroupItem>
+  //       </InputGroup>
+  //     ) : (
+  //       { textInput }
+  //     )}
+  //     <HelperText>
+  //       <HelperTextItemMaxLength k8sName={k8sName} />
+  //       <HelperTextItemValidCharacters k8sName={k8sName} />
+  //     </HelperText>
+  //   </FormGroup>
+  // );
+
+  return isMUITheme() ? resourceNameFormGroup : textInput;
 };
 
 export default ResourceNameField;

--- a/clients/ui/frontend/src/shared/style/MUI-theme.scss
+++ b/clients/ui/frontend/src/shared/style/MUI-theme.scss
@@ -2,7 +2,7 @@
   // Alert
   --mui-alert--BoxShadow: none;
   --mui-alert-warning-text: #663c00;
-  --mui-alert-warning-font-weight: 400;
+  --mui-alert-warning-FontWeight: 400;
   --mui-alert--PaddingBlockStart: 6px;
   --mui-alert--PaddingBlockEnd: 6px;
   --mui-alert--PaddingInlineStart: 16px;
@@ -14,7 +14,7 @@
   --mui-alert__icon--FontSize: 22px;
 
   // Button
-  --mui-button-font-weight: 500;
+  --mui-button-FontWeight: 500;
   --mui-button--hover--BorderWidth: 1px;
   --mui-button--PaddingBlockStart: 6px;
   --mui-button--PaddingBlockEnd: 6px;
@@ -22,6 +22,9 @@
   --mui-button--PaddingInlineEnd: 16px;
   --mui-button--LineHeight: 1.75;
   --mui-link-underlineColor: rgba(33, 150, 243, 0.4);
+
+  // Helper text
+  --mui-helper-text__item--FontWeight: 400;
 
   // Menu item
   --mui-menu__item--PaddingBlockStart: 6px;
@@ -121,7 +124,7 @@
     --pf-t--global--text--color--status--warning--default
   );
   --pf-v6-c-alert__icon--MarginInlineEnd: var(--mui-alert__icon--MarginInlineEnd);
-  --pf-v6-c-alert__title--FontWeight: var(--mui-alert-warning-font-weight);
+  --pf-v6-c-alert__title--FontWeight: var(--mui-alert-warning-FontWeight);
   --pf-v6-c-alert__icon--MarginBlockStart: var(--mui-alert__icon--MarginBlockStart);
   --pf-v6-c-alert__icon--FontSize: var(--mui-alert__icon--FontSize);
   --pf-v6-c-alert--BoxShadow: var(--mui-alert--BoxShadow);
@@ -144,7 +147,7 @@
 }
 
 .mui-theme .pf-v6-c-button {
-  --pf-v6-c-button--FontWeight: var(--mui-button-font-weight);
+  --pf-v6-c-button--FontWeight: var(--mui-button-FontWeight);
   --pf-v6-c-button--PaddingBlockStart: var(--mui-button--PaddingBlockStart);
   --pf-v6-c-button--PaddingBlockEnd: var(--mui-button--PaddingBlockEnd);
   --pf-v6-c-button--PaddingInlineStart: var(--mui-button--PaddingInlineStart);
@@ -179,6 +182,10 @@
   align-content: center;
 }
 
+.mui-theme .pf-v6-c-form {
+  --pf-v6-c-form--GridGap: none;
+}
+
 .mui-theme .pf-v6-c-form__group {
   position: relative;
 }
@@ -193,8 +200,16 @@
   color: var(--mui-palette-text-disabled);
 }
 
+.mui-theme .pf-v6-c-form__group.form-group-error .pf-v6-c-form__label {
+  color: var(--mui-palette-error-main);
+}
+
 .mui-theme .pf-v6-c-form__helper-text.path-helper-text {
   margin-inline-start: var(--pf-t--global--spacer--lg);
+}
+
+.mui-theme .pf-v6-c-helper-text .pf-v6-c-helper-text__item-icon {
+  display: none;
 }
 
 .mui-theme .pf-v6-c-form__section-title {
@@ -227,6 +242,8 @@
 .mui-theme .pf-v6-c-form-control {
   --pf-v6-c-form-control--m-disabled--BackgroundColor: var(--mui-palette-common-white);
   --pf-v6-c-form-control--m-disabled--Color: var(--mui-palette-text-disabled);
+  --pf-v6-c-form-control--m-error--after--BorderColor: var(--mui-palette-error-main);
+  --pf-v6-c-form-control--m-error--hover--after--BorderColor: var(--mui-palette-error-main);
 }
 
 .mui-theme .pf-v6-c-form-control {
@@ -311,8 +328,24 @@
   border-color: black;
 }
 
-.form-fieldset-wrapper:hover span.pf-v6-c-form-control.pf-m-disabled ~ .form-fieldset {
+.form-fieldset-wrapper:focus-within span.pf-v6-c-form-control.pf-m-disabled ~ .form-fieldset {
   border-color: rgba(0, 0, 0, 0.23);
+}
+
+.form-fieldset-wrapper span.pf-v6-c-form-control.pf-m-error ~ .form-fieldset {
+  border-color: var(--mui-palette-error-main);
+}
+
+.form-fieldset-wrapper .pf-v6-c-input-group span.pf-v6-c-form-control .pf-m-error ~ .form-fieldset {
+  border-color: var(--mui-palette-error-main);
+}
+
+.form-fieldset-wrapper .pf-v6-c-input-group__item button {
+  // Aligns EyeIcon in password input
+  --pf-v6-c-button--PaddingBlockStart: var(--mui-spacing-16px);
+  --pf-v6-c-button--PaddingBlockEnd: var(--mui-spacing-16px);
+  --pf-v6-c-button--BorderColor: var(--mui-palette-common-white);
+  --pf-v6-c-button--BorderRadius: 50%;
 }
 
 .form-fieldset-wrapper:focus-within .form-fieldset {
@@ -410,10 +443,34 @@
 
 .pf-v6-c-form__group:focus-within .pf-v6-c-form-control {
   --pf-v6-c-form-control--after--BorderWidth: 2px;
-  --pf-v6-c-form-control--after--BorderColor: var(--mui-palette-primary-main);
 }
 
-.pf-v6-c-form__group:focus-within .pf-v6-c-form__label {
+.pf-v6-c-form-control.pf-m-error {
+  --pf-v6-c-form-control--after--BorderColor: var(--mui-palette-error-main);
+}
+
+.mui-theme .pf-v6-c-form-control__utilities {
+  display: none;
+}
+
+.pf-v6-c-helper-text__item.pf-m-error {
+  --pf-v6-c-helper-text__item-text--Color: var(--mui-palette-error-main);
+  --pf-v6-c-helper-text__item-text--FontWeight: var(--mui-helper-text__item--FontWeight);
+  margin-left: 14px;
+  margin-top: 3px;
+}
+
+.pf-v6-c-form__group.pf-m-error .pf-v6-c-form__label {
+  // Using CSS property here since --pf-v6-c-form__label--Color does not exist.
+
+  color: var(--mui-palette-error-main);
+}
+
+.mui-theme .pf-v6-c-form__group.pf-m-error fieldset.form-fieldset {
+  border-color: var(--mui-palette-error-main);
+}
+
+.pf-v6-c-form__group:not(.pf-m-error):focus-within .pf-v6-c-form__label {
   // Using CSS property here since --pf-v6-c-form__label--Color does not exist.
 
   /* Change color of the label when the input is focused */
@@ -462,13 +519,13 @@
 
   border-radius: var(--mui-shape-borderRadius);
   text-transform: var(--mui-text-transform);
-  font-weight: var(--mui-button-font-weight);
+  font-weight: var(--mui-button-FontWeight);
   letter-spacing: 0.02857em;
 }
 
 .mui-theme .pf-v6-c-menu-toggle__button {
   text-transform: var(--mui-text-transform);
-  font-weight: var(--mui-button-font-weight);
+  font-weight: var(--mui-button-FontWeight);
   letter-spacing: 0.02857em;
   align-self: stretch;
 }
@@ -639,7 +696,7 @@
   --pf-v6-c-table--cell--first-last-child--PaddingInline: var(
     --mui-table--cell--first-last-child--PaddingInline
   );
-  --pf-v6-c-table__thead--cell--FontWeight: var(--mui-button-font-weight);
+  --pf-v6-c-table__thead--cell--FontWeight: var(--mui-button-FontWeight);
   --pf-v6-c-table__thead--cell--FontSize: var(--mui-table__thead--cell--FontSize);
   --pf-v6-c-table__tr--BorderBlockEndColor: var(--mui-palette-grey-300);
   --pf-v6-c-table__sort-indicator--MarginInlineStart: var(
@@ -716,7 +773,7 @@
 
 .mui-theme .pf-v6-c-tabs__link {
   text-transform: var(--mui-text-transform);
-  font-weight: var(--mui-button-font-weight);
+  font-weight: var(--mui-button-FontWeight);
   line-height: var(--mui-button-line-height);
   letter-spacing: 0.02857em;
 }
@@ -829,7 +886,6 @@
   /* Position sidebar above the masthead */
 }
 
-
 /* Hide Masthead Toggle by default */
 .mui-theme .pf-v6-c-masthead__toggle {
   display: none;
@@ -847,9 +903,9 @@
   }
 }
 
-.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__main-container,
-.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__drawer,
-.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__main-breadcrumb {
+.mui-theme .pf-v6-c-page__sidebar:not(.pf-m-collapsed) + .pf-v6-c-page__main-container,
+.mui-theme .pf-v6-c-page__sidebar:not(.pf-m-collapsed) + .pf-v6-c-page__drawer,
+.mui-theme .pf-v6-c-page__sidebar:not(.pf-m-collapsed) + .pf-v6-c-page__main-breadcrumb {
   --pf-v6-c-page__main-container--MarginInlineStart: calc(-2 * var(--mui-spacing-16px));
   --pf-v6-c-page__main-section--PaddingInlineStart: none;
   --pf-v6-c-page__main-section--PaddingInlineEnd: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR themes the validated form inputs in the "Create Model Registry" form in order to align with the validated form inputs from MUI. Some DOM structure changes and refactoring are required to adhere to previous theming conventions with the form fields.

Before - Create MR modal:
<img width="500" alt="Screenshot 2025-03-10 at 5 14 51 PM" src="https://github.com/user-attachments/assets/4abe06a1-1f05-4a7e-b02a-5f5fa7728c5d" />

Before - click "Edit resource name": 
<img width="500" alt="Screenshot 2025-03-10 at 5 13 44 PM" src="https://github.com/user-attachments/assets/f34846b5-01fd-4320-bfd5-158d0793cf03" />


After - Create MR modal:
<img width="500" alt="Screenshot 2025-03-10 at 5 03 30 PM" src="https://github.com/user-attachments/assets/2ab0b1ed-5a86-42fe-aab3-27739935a3a3" />

After - click "Edit resource name": 
<img width="500" alt="Screenshot 2025-03-10 at 5 12 44 PM" src="https://github.com/user-attachments/assets/5d27fef1-a95d-409a-a77a-a7c09342b11c" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to Model registry settings -> Click "Create model registry" button. 
2. Verify modal is themed correctly and text inputs have the correct styling for default and error states. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [x] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
