### PR TITLE
Fix Istio sidecar injection by moving from annotations to labels

### DIFF
--- a/manifests/kustomize/base/model-registry-deployment.yaml
+++ b/manifests/kustomize/base/model-registry-deployment.yaml
@@ -11,9 +11,8 @@ spec:
       component: model-registry-server
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "true"
       labels:
+        sidecar.istio.io/inject: "true"
         component: model-registry-server
     spec:
       securityContext:

--- a/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
@@ -16,7 +16,6 @@ spec:
       name: db
       labels:
         component: db
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       securityContext:

--- a/manifests/kustomize/overlays/postgres/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/postgres/model-registry-db-deployment.yaml
@@ -16,7 +16,6 @@ spec:
       name: db
       labels:
         component: db
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       securityContext:


### PR DESCRIPTION
## Description
This PR fixes Istio sidecar injection configuration in the Model Registry component by replacing deprecated annotations with the recommended labels approach. According to Istio documentation, controlling sidecar injection via annotations is no longer the preferred method.

The changes move `sidecar.istio.io/inject` from annotations to labels in:
- Base model-registry deployment
- DB overlay deployment
- Postgres overlay deployment

## How Has This Been Tested?
The changes maintain the same injection behavior but use the correct approach. These changes have been validated by deploying in a local Kubeflow environment with Istio and confirming proper sidecar injection behavior.

## Issues and Related PR
Issue: https://github.com/kubeflow/manifests/issues/2798
Part of PR: https://github.com/kubeflow/manifests/pull/3044

## Merge criteria:
- [x] All the commits have been [_[signed-off](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body.
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [[kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/)](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [[Reviewers](https://claude.ai/OWNERS)](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.