### PR TITLE
build: fix Makefile following GHCR image rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,13 @@ else
 endif
 
 # Change Dockerfile path depending on IMG_REPO
-ifeq ($(IMG_REPO),model-registry-ui)
+ifeq ($(IMG_REPO),model-registry/ui)
     DOCKERFILE := $(UI_PATH)/Dockerfile
 	BUILD_PATH := $(UI_PATH)
 endif
 
 # The BUILD_PATH is still the root
-ifeq ($(IMG_REPO),model-registry-storage-initializer)
+ifeq ($(IMG_REPO),model-registry/storage-initializer)
     DOCKERFILE := $(CSI_PATH)/Dockerfile.csi
 endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
following up to https://github.com/kubeflow/model-registry/pull/899 we need this Makefile change thanks @Al-Pragliola for the findings

## How Has This Been Tested?
testing via GHA as this is a target invoked by GHA

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
