### PR TITLE
fix(devenv): switch overridden images to ghcr.io

### DIFF
--- a/devenv/Tiltfile
+++ b/devenv/Tiltfile
@@ -76,7 +76,7 @@ local_resource(
 )
 
 docker_build_with_restart(
-    "kubeflow/model-registry:latest",
+    "ghcr.io/kubeflow/model-registry/server:latest",
     context="../",
     dockerfile="../tilt.dockerfile",
     entrypoint=["/model-registry", "proxy"],

--- a/devenv/configs/tiltfiles/frontend.tiltfile
+++ b/devenv/configs/tiltfiles/frontend.tiltfile
@@ -103,7 +103,7 @@ local_resource(
 )
 
 docker_build_with_restart(
-    "docker.io/kubeflow/model-registry-ui:latest",
+    "ghcr.io/kubeflow/model-registry/ui:latest",
     context="../../../",
     dockerfile="../../../tilt-ui.dockerfile",
     entrypoint=["/bff"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR aims to fix the devenv container images override by updating the existing ones to ghcr.io

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

run devenv locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
