### PR TITLE
fix(frontend): sort namespaces by name for the namespace selector

### DIFF
--- a/clients/ui/frontend/src/shared/context/NamespaceSelectorContext.tsx
+++ b/clients/ui/frontend/src/shared/context/NamespaceSelectorContext.tsx
@@ -44,7 +44,11 @@ declare global {
 const EnabledNamespaceSelectorContextProvider: React.FC<NamespaceSelectorContextProviderProps> = ({
   children,
 }) => {
-  const [namespaces, isLoaded, error] = useNamespaces();
+  const [unsortedNamespaces, isLoaded, error] = useNamespaces();
+  const namespaces = React.useMemo(
+    () => unsortedNamespaces.toSorted((a, b) => a.name.localeCompare(b.name)),
+    [unsortedNamespaces],
+  );
   const [preferredNamespace, setPreferredNamespace] =
     React.useState<NamespaceSelectorContextType['preferredNamespace']>(undefined);
   const [initializationError, setInitializationError] = React.useState<Error>();

--- a/clients/ui/frontend/src/shared/context/__tests__/NamespaceSelectorContext.test.tsx
+++ b/clients/ui/frontend/src/shared/context/__tests__/NamespaceSelectorContext.test.tsx
@@ -12,7 +12,7 @@ import {
 jest.mock('~/shared/hooks/useNamespaces');
 jest.mock('~/shared/utilities/const');
 
-const mockNamespaces = [{ name: 'namespace-1' }, { name: 'namespace-2' }, { name: 'namespace-3' }];
+const mockNamespaces = [{ name: 'namespace-2' }, { name: 'namespace-3' }, { name: 'namespace-1' }];
 
 describe('NamespaceSelectorContext', () => {
   const TestConsumer = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Sorts the namespaces by name so that the namespace selector options are in alphabetical order.
This makes for a better experience when running the standalone app with a user who has access to many namespaces.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Modified unit test to return namespaces out of order. 
The existing tests assert alphabetical order already.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
