### PR TITLE
500 custom prop type

### DIFF
--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubeflow/model-registry/internal/defaults"
 	"github.com/kubeflow/model-registry/internal/ml_metadata/proto"
+	"github.com/kubeflow/model-registry/pkg/api"
 	"github.com/kubeflow/model-registry/pkg/openapi"
 )
 
@@ -76,7 +77,7 @@ func MapMLMDCustomProperties(source map[string]*proto.Value) (map[string]openapi
 			b64 := base64.StdEncoding.EncodeToString(asJSON)
 			customValue.MetadataStructValue = NewMetadataStructValue(b64)
 		default:
-			return nil, fmt.Errorf("type mapping not found for %s:%v", key, v)
+			return nil, fmt.Errorf("%w: type mapping not found for %s:%v", api.ErrBadRequest, key, v)
 		}
 
 		data[key] = customValue

--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -77,7 +77,7 @@ func MapMLMDCustomProperties(source map[string]*proto.Value) (map[string]openapi
 			b64 := base64.StdEncoding.EncodeToString(asJSON)
 			customValue.MetadataStructValue = NewMetadataStructValue(b64)
 		default:
-			return nil, fmt.Errorf("%w: type mapping not found for %s:%v", api.ErrBadRequest, key, v)
+			return nil, fmt.Errorf("%w: type mapping not found for %s: %v", api.ErrBadRequest, key, v)
 		}
 
 		data[key] = customValue

--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -77,7 +77,7 @@ func MapMLMDCustomProperties(source map[string]*proto.Value) (map[string]openapi
 			b64 := base64.StdEncoding.EncodeToString(asJSON)
 			customValue.MetadataStructValue = NewMetadataStructValue(b64)
 		default:
-			return nil, fmt.Errorf("%w: type mapping not found for %s: %v", api.ErrBadRequest, key, v)
+			return nil, fmt.Errorf("%w: metadataType not found for %s: %v", api.ErrBadRequest, key, v)
 		}
 
 		data[key] = customValue

--- a/internal/converter/openapi_mlmd_converter_util.go
+++ b/internal/converter/openapi_mlmd_converter_util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kubeflow/model-registry/internal/defaults"
 	"github.com/kubeflow/model-registry/internal/ml_metadata/proto"
+	"github.com/kubeflow/model-registry/pkg/api"
 	"github.com/kubeflow/model-registry/pkg/openapi"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -93,7 +94,7 @@ func MapOpenAPICustomProperties(source *map[string]openapi.MetadataValue) (map[s
 					StructValue: asStruct,
 				}
 			default:
-				return nil, fmt.Errorf("type mapping not found for %s:%v", key, v)
+				return nil, fmt.Errorf("%w: type mapping not found for %s:%v", api.ErrBadRequest, key, v)
 			}
 
 			props[key] = &value

--- a/internal/converter/openapi_mlmd_converter_util.go
+++ b/internal/converter/openapi_mlmd_converter_util.go
@@ -94,7 +94,7 @@ func MapOpenAPICustomProperties(source *map[string]openapi.MetadataValue) (map[s
 					StructValue: asStruct,
 				}
 			default:
-				return nil, fmt.Errorf("%w: type mapping not found for %s:%v", api.ErrBadRequest, key, v)
+				return nil, fmt.Errorf("%w: metadataType not found for %s: %v", api.ErrBadRequest, key, v)
 			}
 
 			props[key] = &value

--- a/internal/converter/openapi_mlmd_converter_util.go
+++ b/internal/converter/openapi_mlmd_converter_util.go
@@ -66,7 +66,7 @@ func MapOpenAPICustomProperties(source *map[string]openapi.MetadataValue) (map[s
 			case v.MetadataIntValue != nil:
 				intValue, err := StringToInt64(&v.MetadataIntValue.IntValue)
 				if err != nil {
-					return nil, fmt.Errorf("unable to decode as int64 %w for key %s", err, key)
+					return nil, fmt.Errorf("%w: unable to decode as int64 %w for key %s", api.ErrBadRequest, err, key)
 				}
 				value.Value = &proto.Value_IntValue{IntValue: *intValue}
 			// double value
@@ -79,16 +79,16 @@ func MapOpenAPICustomProperties(source *map[string]openapi.MetadataValue) (map[s
 			case v.MetadataStructValue != nil:
 				data, err := base64.StdEncoding.DecodeString(v.MetadataStructValue.StructValue)
 				if err != nil {
-					return nil, fmt.Errorf("unable to decode %w for key %s", err, key)
+					return nil, fmt.Errorf("%w: unable to decode %w for key %s", api.ErrBadRequest, err, key)
 				}
 				var asMap map[string]interface{}
 				err = json.Unmarshal(data, &asMap)
 				if err != nil {
-					return nil, fmt.Errorf("unable to decode %w for key %s", err, key)
+					return nil, fmt.Errorf("%w: unable to decode %w for key %s", api.ErrBadRequest, err, key)
 				}
 				asStruct, err := structpb.NewStruct(asMap)
 				if err != nil {
-					return nil, fmt.Errorf("unable to decode %w for key %s", err, key)
+					return nil, fmt.Errorf("%w: unable to decode %w for key %s", api.ErrBadRequest, err, key)
 				}
 				value.Value = &proto.Value_StructValue{
 					StructValue: asStruct,

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -26,12 +26,13 @@ func ErrToStatus(err error) int {
 		}
 	}
 
-	switch errors.Unwrap(err) {
-	case ErrBadRequest:
+	if errors.Is(err, ErrBadRequest) {
 		return http.StatusBadRequest
-	case ErrNotFound:
-		return http.StatusNotFound
-	default:
-		return http.StatusInternalServerError
 	}
+	if errors.Is(err, ErrNotFound) {
+		return http.StatusNotFound
+	}
+
+	// Default error to return
+	return http.StatusInternalServerError
 }

--- a/pkg/core/registered_model_test.go
+++ b/pkg/core/registered_model_test.go
@@ -464,3 +464,24 @@ func (suite *CoreTestSuite) TestGetRegisteredModelsWithPageSize() {
 	suite.Equal(*secondModel.Id, *truncatedList.Items[0].Id)
 	suite.Equal(*thirdModel.Id, *truncatedList.Items[1].Id)
 }
+
+func (suite *CoreTestSuite) TestCreateRegisteredModelWithCustomPropFailure() {
+	// create mode registry service
+	service := suite.setupModelRegistryService()
+
+	// register a new model with incomplete customProperty fields
+	registeredModel := &openapi.RegisteredModel{
+		Name: modelName,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"myCustomProp1": {},
+		},
+	}
+
+	// test
+	_, err := service.UpsertRegisteredModel(registeredModel)
+
+	// checks
+	statusResp := api.ErrToStatus(err)
+	suite.NotNilf(err, "error creating registered model: %v", err)
+	suite.Equal(400, statusResp, "customProperties must include metadataType")
+}


### PR DESCRIPTION
## Description
We currently return a 500 error if a user requests to register a model with a customProperties field that does not include a metadataType parameter. This is required **conditionally** since customProperties is an optional field. 

We need to return a 400 bad request if a user attempts to pass a malformed customProperties parameter and give a more informed error message. 

Linked Jira: https://issues.redhat.com/browse/RHOAIENG-19192

## How Has This Been Tested?
Locally tested using the following request:

`curl -v -X POST \
-H 'Authorization: [Filtered]' \
-H 'Content-Type: application/json' -d \
'{"name": "Name4","customProperties": {"additionalProp1": {"metadataType": "MetadataStringValue", "string_value": "teststr"}}}' \
--insecure http://localhost:8080/api/model_registry/v1alpha3/registered_models`

<img width="815" alt="Screenshot 2025-03-26 at 3 55 26 PM" src="https://github.com/user-attachments/assets/dacd020e-4ede-4f83-8d93-34fb8c93fa75" />



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x ] The developer has manually tested the changes and verified that the changes work.
- [x ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

