### PR TITLE
Add --load flag to Docker build command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ endif
 # build docker image
 .PHONY: image/build
 image/build:
-	${DOCKER} build ${BUILD_PATH} -f ${DOCKERFILE} -t ${IMG}:$(IMG_VERSION)
+	${DOCKER} build ${BUILD_PATH} -f ${DOCKERFILE} -t ${IMG}:$(IMG_VERSION) $(ARGS)
 
 # build docker image using buildx
 # PLATFORMS defines the target platforms for the model registry image be built to provide support to multiple

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -15,7 +15,7 @@ clean:
 
 .PHONY: deploy-latest-mr
 deploy-latest-mr:
-	cd ../../ && IMG_VERSION=${IMG_VERSION} make image/build && LOCAL=1 ./scripts/deploy_on_kind.sh
+	cd ../../ && IMG_VERSION=${IMG_VERSION} make image/build ARGS=--load && LOCAL=1 ./scripts/deploy_on_kind.sh
 	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 &
 
 .PHONY: deploy-test-minio


### PR DESCRIPTION
## Description
This merge request updates the image/build target in the Makefile to include the --load flag when building Docker images. This change ensures compatibility with Podman (desktop) and allows locally built images to be loaded into the Docker image store, enabling seamless deployment to Kind clusters during local development.

Issue description: https://github.com/kubeflow/model-registry/issues/766

## How Has This Been Tested?
Local Testing with Docker:
- Ran make image/build to verify that the image builds successfully and is loaded into the local Docker image store.
- Verified the built image using docker images.
- Deployed the image to a Kind cluster using make deploy-latest-mr.
- 
![image](https://github.com/user-attachments/assets/b9ab541e-823f-4cd3-8962-ff9301335dca)


## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)


- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [x] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes
NA
