### PR TITLE
feat(controller): added reconciliation of inferenceservice url

### DIFF
--- a/pkg/inferenceservice-controller/controller.go
+++ b/pkg/inferenceservice-controller/controller.go
@@ -169,8 +169,8 @@ func (r *InferenceServiceController) Reconcile(ctx context.Context, req ctrl.Req
 
 		mrCurrentIvcUrl := ""
 
-		if mrIs.CustomProperties != nil && (*mrIs.CustomProperties)["url"].MetadataStringValue != nil {
-			mrCurrentIvcUrl = (*mrIs.CustomProperties)["url"].MetadataStringValue.StringValue
+		if mrIs.CustomProperties != nil {
+			mrCurrentIvcUrl = (*mrIs.CustomProperties)["url"].MetadataStringValue.GetStringValue()
 		}
 
 		urlAreDiff := r.checkURLDiff(isvc, mrCurrentIvcUrl)

--- a/pkg/inferenceservice-controller/controller.go
+++ b/pkg/inferenceservice-controller/controller.go
@@ -377,7 +377,11 @@ func (r *InferenceServiceController) createMRInferenceService(
 		}
 
 		if isvc.Status.URL != nil {
-			(*isCreate.CustomProperties)["url"].MetadataStringValue.StringValue = isvc.Status.URL.String()
+			isCreate.CustomProperties = &map[string]openapi.MetadataValue{}
+
+			(*isCreate.CustomProperties)["url"] = openapi.MetadataValue{
+				MetadataStringValue: openapi.NewMetadataStringValue(isvc.Status.URL.String(), "MetadataStringValue"),
+			}
 		}
 
 		is, _, err = mr.ModelRegistryServiceAPI.CreateInferenceService(ctx).InferenceServiceCreate(isCreate).Execute()

--- a/pkg/inferenceservice-controller/controller.go
+++ b/pkg/inferenceservice-controller/controller.go
@@ -166,6 +166,27 @@ func (r *InferenceServiceController) Reconcile(ctx context.Context, req ctrl.Req
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to find InferenceService with id %s in model registry: %w", mrIsvcId, err)
 		}
+
+		mrCurrentIvcUrl := ""
+
+		if mrIs.CustomProperties != nil && (*mrIs.CustomProperties)["url"].MetadataStringValue != nil {
+			mrCurrentIvcUrl = (*mrIs.CustomProperties)["url"].MetadataStringValue.StringValue
+		}
+
+		urlAreDiff := r.checkURLDiff(isvc, mrCurrentIvcUrl)
+		if urlAreDiff {
+			err := r.updateMRInferenceService(
+				mrApiCtx,
+				log,
+				mrApi,
+				isvc,
+				mrIs,
+			)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
 	} else if okRegisteredModelId {
 		// No corresponding InferenceService in model registry, create new one
 		mrIs, err = r.createMRInferenceService(mrApiCtx, log, mrApi, isvc, *servingEnvironment.Id, registeredModelId, modelVersionId)
@@ -223,6 +244,18 @@ func (r *InferenceServiceController) SetupWithManager(mgr ctrl.Manager) error {
 		For(&kservev1beta1.InferenceService{})
 
 	return builder.Complete(r)
+}
+
+func (r *InferenceServiceController) checkURLDiff(isvc *kservev1beta1.InferenceService, mrIsvcUrl string) bool {
+	if mrIsvcUrl == "" && isvc.Status.URL == nil {
+		return false
+	}
+
+	if isvc.Status.URL == nil {
+		return true
+	}
+
+	return mrIsvcUrl != isvc.Status.URL.String()
 }
 
 func (r *InferenceServiceController) initModelRegistryService(ctx context.Context, log logr.Logger, name, namespace, url string) (*openapi.APIClient, error) {
@@ -334,17 +367,53 @@ func (r *InferenceServiceController) createMRInferenceService(
 	if err != nil {
 		log.Info("Creating new model registry InferenceService", "name", isName, "registeredModelId", registeredModelId, "modelVersionId", modelVersionId)
 
-		is, _, err = mr.ModelRegistryServiceAPI.CreateInferenceService(ctx).InferenceServiceCreate(openapi.InferenceServiceCreate{
+		isCreate := openapi.InferenceServiceCreate{
 			DesiredState:         openapi.INFERENCESERVICESTATE_DEPLOYED.Ptr(),
 			ModelVersionId:       modelVersionIdPtr,
 			Name:                 &isName,
 			RegisteredModelId:    registeredModelId,
 			Runtime:              isvc.Spec.Predictor.Model.Runtime,
 			ServingEnvironmentId: servingEnvironmentId,
-		}).Execute()
+		}
+
+		if isvc.Status.URL != nil {
+			(*isCreate.CustomProperties)["url"].MetadataStringValue.StringValue = isvc.Status.URL.String()
+		}
+
+		is, _, err = mr.ModelRegistryServiceAPI.CreateInferenceService(ctx).InferenceServiceCreate(isCreate).Execute()
 	}
 
 	return is, err
+}
+
+func (r *InferenceServiceController) updateMRInferenceService(
+	ctx context.Context,
+	log logr.Logger,
+	mr *openapi.APIClient,
+	isvc *kservev1beta1.InferenceService,
+	mrIsvc *openapi.InferenceService,
+) error {
+	log.Info("Updating model registry InferenceService..")
+
+	url := ""
+
+	if isvc.Status.URL != nil {
+		url = isvc.Status.URL.String()
+	}
+
+	if mrIsvc.CustomProperties == nil {
+		mrIsvc.CustomProperties = &map[string]openapi.MetadataValue{}
+	}
+
+	(*mrIsvc.CustomProperties)["url"] = openapi.MetadataValue{
+		MetadataStringValue: openapi.NewMetadataStringValue(url, "MetadataStringValue"),
+	}
+
+	_, _, err := mr.ModelRegistryServiceAPI.UpdateInferenceService(ctx, *mrIsvc.Id).InferenceServiceUpdate(openapi.InferenceServiceUpdate{
+		CustomProperties: mrIsvc.CustomProperties,
+	}).Execute()
+
+	return err
 }
 
 func (r *InferenceServiceController) getOrCreateServingEnvironment(ctx context.Context, log logr.Logger, mr *openapi.APIClient, namespace string) (*openapi.ServingEnvironment, error) {

--- a/pkg/inferenceservice-controller/controller_test.go
+++ b/pkg/inferenceservice-controller/controller_test.go
@@ -338,8 +338,230 @@ var _ = Describe("InferenceService Controller", func() {
 					return fmt.Errorf("InferenceService URL is not set")
 				}
 
-				if (*restIsvc.CustomProperties)["url"].MetadataStringValue.StringValue != url.String() {
-					return fmt.Errorf("InferenceService URL is not set correctly, got %s, want %s", (*restIsvc.CustomProperties)["url"].MetadataStringValue.StringValue, url.String())
+				if (*restIsvc.CustomProperties)["url"].MetadataStringValue.GetStringValue() != url.String() {
+					return fmt.Errorf("InferenceService URL is not set correctly, got %s, want %s", (*restIsvc.CustomProperties)["url"].MetadataStringValue.GetStringValue(), url.String())
+				}
+
+				return nil
+			}, 20*time.Second, 1*time.Second).Should(Succeed())
+		})
+
+		It("Should not set the model registry InferenceService url if the status.url is nil", func() {
+			const InferenceServiceMissingNamePath = "./testdata/inferenceservices/inference-service-missing-name.yaml"
+			const ModelRegistrySVCPath = "./testdata/deploy/model-registry-svc.yaml"
+			const namespace = "url-reconcile-empty-status-url"
+			const mrUrl = "http://model-registry.svc.cluster.local:8080"
+
+			ns := &corev1.Namespace{}
+
+			ns.SetName(namespace)
+
+			if err := cli.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			mrSvc := &corev1.Service{}
+			Expect(ConvertFileToStructuredResource(ModelRegistrySVCPath, mrSvc)).To(Succeed())
+
+			mrSvc.SetNamespace(namespace)
+
+			if err := cli.Create(ctx, mrSvc); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			inferenceService := &kservev1beta1.InferenceService{}
+			Expect(ConvertFileToStructuredResource(InferenceServiceMissingNamePath, inferenceService)).To(Succeed())
+
+			inferenceService.SetNamespace(namespace)
+
+			inferenceService.Labels[namespaceLabel] = namespace
+
+			if err := cli.Create(ctx, inferenceService); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			Eventually(func() error {
+				isvc := &kservev1beta1.InferenceService{}
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      inferenceService.Name,
+					Namespace: inferenceService.Namespace,
+				}, isvc)
+				if err != nil {
+					return err
+				}
+
+				if isvc.Labels[inferenceServiceIDLabel] != "1" {
+					return fmt.Errorf("Label for InferenceServiceID is not set, got %s", isvc.Labels[inferenceServiceIDLabel])
+				}
+
+				return nil
+			}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+			restIsvc := &openapi.InferenceService{}
+
+			err := cli.Get(ctx, types.NamespacedName{Name: inferenceService.Name, Namespace: inferenceService.Namespace}, inferenceService)
+			Expect(err).To(BeNil())
+
+			inferenceService.Status.URL = nil
+
+			if err := cli.Status().Update(ctx, inferenceService); err != nil {
+				Fail(err.Error())
+			}
+
+			Eventually(func() error {
+				resp, err := mrMockServer.Client().Get(mrUrl + "/api/model_registry/v1alpha3/inference_services/1")
+				Expect(err).To(BeNil())
+
+				//nolint:errcheck
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				Expect(err).To(BeNil())
+
+				err = json.Unmarshal(body, &restIsvc)
+				Expect(err).To(BeNil())
+
+				if restIsvc.CustomProperties != nil {
+					return fmt.Errorf("InferenceService URL should not be set")
+				}
+
+				return nil
+			}, 20*time.Second, 1*time.Second).Should(Succeed())
+		})
+
+		It("Should update the model registry InferenceService url if the status.url is updated", func() {
+			const InferenceServiceMissingNamePath = "./testdata/inferenceservices/inference-service-missing-name.yaml"
+			const ModelRegistrySVCPath = "./testdata/deploy/model-registry-svc.yaml"
+			const namespace = "url-reconcile-update-status-url"
+			const mrUrl = "http://model-registry.svc.cluster.local:8080"
+
+			ns := &corev1.Namespace{}
+
+			ns.SetName(namespace)
+
+			if err := cli.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			mrSvc := &corev1.Service{}
+			Expect(ConvertFileToStructuredResource(ModelRegistrySVCPath, mrSvc)).To(Succeed())
+
+			mrSvc.SetNamespace(namespace)
+
+			if err := cli.Create(ctx, mrSvc); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			inferenceService := &kservev1beta1.InferenceService{}
+			Expect(ConvertFileToStructuredResource(InferenceServiceMissingNamePath, inferenceService)).To(Succeed())
+
+			inferenceService.SetNamespace(namespace)
+
+			inferenceService.Labels[namespaceLabel] = namespace
+
+			if err := cli.Create(ctx, inferenceService); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			Eventually(func() error {
+				isvc := &kservev1beta1.InferenceService{}
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      inferenceService.Name,
+					Namespace: inferenceService.Namespace,
+				}, isvc)
+				if err != nil {
+					return err
+				}
+
+				if isvc.Labels[inferenceServiceIDLabel] != "1" {
+					return fmt.Errorf("Label for InferenceServiceID is not set, got %s", isvc.Labels[inferenceServiceIDLabel])
+				}
+
+				return nil
+			}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+			restIsvc := &openapi.InferenceService{}
+
+			resp, err := mrMockServer.Client().Get(mrUrl + "/api/model_registry/v1alpha3/inference_services/1")
+			Expect(err).To(BeNil())
+
+			//nolint:errcheck
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).To(BeNil())
+
+			err = json.Unmarshal(body, &restIsvc)
+			Expect(err).To(BeNil())
+			Expect(restIsvc.CustomProperties).To(BeNil())
+
+			url, err := apis.ParseURL("https://example.com")
+			Expect(err).To(BeNil())
+
+			err = cli.Get(ctx, types.NamespacedName{Name: inferenceService.Name, Namespace: inferenceService.Namespace}, inferenceService)
+			Expect(err).To(BeNil())
+
+			inferenceService.Status.URL = url
+
+			if err := cli.Status().Update(ctx, inferenceService); err != nil {
+				Fail(err.Error())
+			}
+
+			Eventually(func() error {
+				resp, err := mrMockServer.Client().Get(mrUrl + "/api/model_registry/v1alpha3/inference_services/1")
+				Expect(err).To(BeNil())
+
+				//nolint:errcheck
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				Expect(err).To(BeNil())
+
+				err = json.Unmarshal(body, &restIsvc)
+				Expect(err).To(BeNil())
+
+				if restIsvc.CustomProperties == nil {
+					return fmt.Errorf("InferenceService URL is not set")
+				}
+
+				if (*restIsvc.CustomProperties)["url"].MetadataStringValue.GetStringValue() != url.String() {
+					return fmt.Errorf("InferenceService URL is not set correctly, got %s, want %s", (*restIsvc.CustomProperties)["url"].MetadataStringValue.GetStringValue(), url.String())
+				}
+
+				return nil
+			}, 20*time.Second, 1*time.Second).Should(Succeed())
+
+			url, err = apis.ParseURL("https://example-updated.com")
+			Expect(err).To(BeNil())
+
+			err = cli.Get(ctx, types.NamespacedName{Name: inferenceService.Name, Namespace: inferenceService.Namespace}, inferenceService)
+			Expect(err).To(BeNil())
+
+			inferenceService.Status.URL = url
+
+			if err := cli.Status().Update(ctx, inferenceService); err != nil {
+				Fail(err.Error())
+			}
+
+			Eventually(func() error {
+				resp, err := mrMockServer.Client().Get(mrUrl + "/api/model_registry/v1alpha3/inference_services/1")
+				Expect(err).To(BeNil())
+
+				//nolint:errcheck
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				Expect(err).To(BeNil())
+
+				err = json.Unmarshal(body, &restIsvc)
+				Expect(err).To(BeNil())
+
+				if restIsvc.CustomProperties == nil {
+					return fmt.Errorf("InferenceService URL is not set")
+				}
+
+				if (*restIsvc.CustomProperties)["url"].MetadataStringValue.GetStringValue() != url.String() {
+					return fmt.Errorf("InferenceService URL is not set correctly, got %s, want %s", (*restIsvc.CustomProperties)["url"].MetadataStringValue.GetStringValue(), url.String())
 				}
 
 				return nil

--- a/pkg/inferenceservice-controller/controller_test.go
+++ b/pkg/inferenceservice-controller/controller_test.go
@@ -1,12 +1,16 @@
 package inferenceservicecontroller_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kubeflow/model-registry/pkg/openapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"knative.dev/pkg/apis"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -235,6 +239,109 @@ var _ = Describe("InferenceService Controller", func() {
 
 				return nil
 			}, 10*time.Second, 1*time.Second).Should(Succeed())
+		})
+	})
+
+	When("An InferenceService have a status.url defined", func() {
+		FIt("Should get reconciled in the model registry InferenceService resource", func() {
+			const InferenceServiceMissingNamePath = "./testdata/inferenceservices/inference-service-missing-name.yaml"
+			const ModelRegistrySVCPath = "./testdata/deploy/model-registry-svc.yaml"
+			const namespace = "url-reconcile"
+			const mrUrl = "http://model-registry.svc.cluster.local:8080"
+
+			ns := &corev1.Namespace{}
+
+			ns.SetName(namespace)
+
+			if err := cli.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			mrSvc := &corev1.Service{}
+			Expect(ConvertFileToStructuredResource(ModelRegistrySVCPath, mrSvc)).To(Succeed())
+
+			mrSvc.SetNamespace(namespace)
+
+			if err := cli.Create(ctx, mrSvc); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			inferenceService := &kservev1beta1.InferenceService{}
+			Expect(ConvertFileToStructuredResource(InferenceServiceMissingNamePath, inferenceService)).To(Succeed())
+
+			inferenceService.SetNamespace(namespace)
+
+			inferenceService.Labels[namespaceLabel] = namespace
+
+			if err := cli.Create(ctx, inferenceService); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			Eventually(func() error {
+				isvc := &kservev1beta1.InferenceService{}
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      inferenceService.Name,
+					Namespace: inferenceService.Namespace,
+				}, isvc)
+				if err != nil {
+					return err
+				}
+
+				if isvc.Labels[inferenceServiceIDLabel] != "1" {
+					return fmt.Errorf("Label for InferenceServiceID is not set, got %s", isvc.Labels[inferenceServiceIDLabel])
+				}
+
+				return nil
+			}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+			restIsvc := &openapi.InferenceService{}
+
+			resp, err := mrMockServer.Client().Get(mrUrl + "/api/model_registry/v1alpha3/inference_services/1")
+			Expect(err).To(BeNil())
+
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).To(BeNil())
+
+			err = json.Unmarshal(body, &restIsvc)
+			Expect(err).To(BeNil())
+			Expect(restIsvc.CustomProperties).To(BeNil())
+
+			url, err := apis.ParseURL("https://example.com")
+			Expect(err).To(BeNil())
+
+			err = cli.Get(ctx, types.NamespacedName{Name: inferenceService.Name, Namespace: inferenceService.Namespace}, inferenceService)
+			Expect(err).To(BeNil())
+
+			inferenceService.Status.URL = url
+
+			if err := cli.Status().Update(ctx, inferenceService); err != nil {
+				Fail(err.Error())
+			}
+
+			Eventually(func() error {
+				resp, err := mrMockServer.Client().Get(mrUrl + "/api/model_registry/v1alpha3/inference_services/1")
+				Expect(err).To(BeNil())
+
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				Expect(err).To(BeNil())
+
+				err = json.Unmarshal(body, &restIsvc)
+				Expect(err).To(BeNil())
+
+				if restIsvc.CustomProperties == nil {
+					return fmt.Errorf("InferenceService URL is not set")
+				}
+
+				if (*restIsvc.CustomProperties)["url"].MetadataStringValue.StringValue != url.String() {
+					return fmt.Errorf("InferenceService URL is not set correctly, got %s, want %s", (*restIsvc.CustomProperties)["url"].MetadataStringValue.StringValue, url.String())
+				}
+
+				return nil
+			}, 20*time.Second, 1*time.Second).Should(Succeed())
 		})
 	})
 })

--- a/pkg/inferenceservice-controller/controller_test.go
+++ b/pkg/inferenceservice-controller/controller_test.go
@@ -299,6 +299,7 @@ var _ = Describe("InferenceService Controller", func() {
 			resp, err := mrMockServer.Client().Get(mrUrl + "/api/model_registry/v1alpha3/inference_services/1")
 			Expect(err).To(BeNil())
 
+			//nolint:errcheck
 			defer resp.Body.Close()
 
 			body, err := io.ReadAll(resp.Body)
@@ -324,6 +325,7 @@ var _ = Describe("InferenceService Controller", func() {
 				resp, err := mrMockServer.Client().Get(mrUrl + "/api/model_registry/v1alpha3/inference_services/1")
 				Expect(err).To(BeNil())
 
+				//nolint:errcheck
 				defer resp.Body.Close()
 
 				body, err := io.ReadAll(resp.Body)

--- a/pkg/inferenceservice-controller/controller_test.go
+++ b/pkg/inferenceservice-controller/controller_test.go
@@ -243,7 +243,7 @@ var _ = Describe("InferenceService Controller", func() {
 	})
 
 	When("An InferenceService have a status.url defined", func() {
-		FIt("Should get reconciled in the model registry InferenceService resource", func() {
+		It("Should get reconciled in the model registry InferenceService resource", func() {
 			const InferenceServiceMissingNamePath = "./testdata/inferenceservices/inference-service-missing-name.yaml"
 			const ModelRegistrySVCPath = "./testdata/deploy/model-registry-svc.yaml"
 			const namespace = "url-reconcile"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

needs #917 

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

In this PR, I have added a new field to the InferenceService customProperties, which is the 'url' field.
This field is used to reconcile the url from the status of the cluster InferenceService, and update the url in the customProperties.
Also, I have also added new unit tests to test the new functionality.

*Why a customProperty and not a first class field?*

Because the url is part of the InferenceService status, and not the spec so it is ephemeral and should be treated as such in my opinion.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
make test
```

And also, I have created a mock controller that periodically updates the URL in the InferenceService status, and the URL in the customProperties is updated accordingly.

```go
package controllers

import (
	"context"
	"fmt"
	"time"

	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
	"k8s.io/apimachinery/pkg/api/errors"
	"k8s.io/apimachinery/pkg/runtime"
	"knative.dev/pkg/apis"
	ctrl "sigs.k8s.io/controller-runtime"
	"sigs.k8s.io/controller-runtime/pkg/client"
	"sigs.k8s.io/controller-runtime/pkg/log"
)

type InferenceServiceMockReconciler struct {
	client.Client
	Scheme *runtime.Scheme
}

// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;update;patch
// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/status,verbs=get;list;watch;update;patch
// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;list;watch;update;create;patch;delete
// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch

func (r *InferenceServiceMockReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
	_ = log.FromContext(ctx)

	isvc := &kservev1beta1.InferenceService{}
	err := r.Get(ctx, req.NamespacedName, isvc)
	if err != nil {
		if errors.IsNotFound(err) {
			// Resource not found, nothing to do
			return ctrl.Result{}, nil
		}
		// Error fetching resource
		return ctrl.Result{}, err
	}

	// Update the status.url field
	newUrl, err := apis.ParseURL(fmt.Sprintf("https://example.com/%d", time.Now().Unix()))
	if err != nil {
		return ctrl.Result{}, err
	}

	isvc.Status.URL = newUrl
	err = r.Status().Update(ctx, isvc)
	if err != nil {
		return ctrl.Result{}, err
	}

	// Requeue the reconcile loop after 30 seconds
	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
}

func (r *InferenceServiceMockReconciler) SetupWithManager(mgr ctrl.Manager) error {
	return ctrl.NewControllerManagedBy(mgr).
		For(&kservev1beta1.InferenceService{}).
		Named("mockinferenceservice").
		Complete(r)
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.