### PR TITLE
chore: upgrade to Go 1.23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the model-registry binary
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.22 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.odh
+++ b/Dockerfile.odh
@@ -1,5 +1,5 @@
 # Build the model-registry binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Model registry provides a central repository for model developers to store and m
 8. [UI](.clients/ui/README.md)
 
 ## Pre-requisites:
-- go >= 1.22
+- go >= 1.23
 - protoc v24.3 - [Protocol Buffers v24.3 Release](https://github.com/protocolbuffers/protobuf/releases/tag/v24.3)
 - npm >= 10.2.0 - [Installing Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - Java >= 11.0

--- a/cmd/csi/Dockerfile.csi
+++ b/cmd/csi/Dockerfile.csi
@@ -1,5 +1,5 @@
 # Build the model-registry CSI binary
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.22 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/mr_go_library.md
+++ b/docs/mr_go_library.md
@@ -15,7 +15,7 @@ This includes models, model versions, artifacts, serving environments, inference
 ### Prerequisites
 
 * [MLMD server](https://github.com/google/ml-metadata/blob/f0fef74eae2bdf6650a79ba976b36bea0b777c2e/g3doc/get_started.md#use-mlmd-with-a-remote-grpc-server)
-* Go >= 1.22
+* Go >= 1.23
 
 Install it using:
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kubeflow/model-registry
 
-go 1.22
-
-toolchain go1.22.11
+go 1.23
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1


### PR DESCRIPTION
## Description

Upgrade to Go 1.23 now that [ubi8/go-toolset](https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1) image is available.

## How Has This Been Tested?
Verified that the code compiled.

## Merge criteria:
- [x] All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
