### PR TITLE
fix(proxy): compatibility with 1.24 bump golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ bin/envtest:
 
 GOLANGCI_LINT ?= ${PROJECT_BIN}/golangci-lint
 bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_BIN) v1.61.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_BIN) v2.0.2
 
 GOVERTER ?= ${PROJECT_BIN}/goverter
 bin/goverter:
@@ -232,12 +232,12 @@ gen: deps gen/grpc gen/openapi gen/openapi-server gen/converter
 	${GO} generate ./...
 
 .PHONY: lint
-lint:
+lint: bin/golangci-lint
 	${GOLANGCI_LINT} run main.go  --timeout 3m
 	${GOLANGCI_LINT} run cmd/... internal/... ./pkg/...  --timeout 3m
 
 .PHONY: lint/csi
-lint/csi:
+lint/csi: bin/golangci-lint
 	${GOLANGCI_LINT} run ${CSI_PATH}/main.go
 	${GOLANGCI_LINT} run internal/csi/...
 

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -119,7 +119,9 @@ func runProxyServer(cmd *cobra.Command, args []string) error {
 		if conn != nil {
 			glog.Info("closing connection to MLMD server")
 
-			conn.Close()
+			if err := conn.Close(); err != nil {
+				errChan <- fmt.Errorf("error while closing connection to MLMD server")
+			}
 		}
 	}()
 

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -119,9 +119,8 @@ func runProxyServer(cmd *cobra.Command, args []string) error {
 		if conn != nil {
 			glog.Info("closing connection to MLMD server")
 
-			if err := conn.Close(); err != nil {
-				errChan <- fmt.Errorf("error while closing connection to MLMD server")
-			}
+			//nolint:errcheck
+			conn.Close()
 		}
 	}()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/spf13/pflag"
 	"os"
 	"strings"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -94,7 +95,7 @@ func initConfig(cmd *cobra.Command) error {
 		var configFileNotFoundError viper.ConfigFileNotFoundError
 		ok := errors.As(err, &configFileNotFoundError)
 		// ignore if it's a file not found error for default config file
-		if !(cfgFile == "" && ok) {
+		if cfgFile != "" || !ok {
 			return fmt.Errorf("reading config %s: %v", viper.ConfigFileUsed(), err)
 		}
 	}

--- a/internal/server/openapi/routers.go
+++ b/internal/server/openapi/routers.go
@@ -123,7 +123,11 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 		return nil, err
 	}
 
-	defer formFile.Close()
+	defer func() {
+		if err := formFile.Close(); err != nil {
+			glog.Errorf("error while closing formFile: %w", err)
+		}
+	}()
 
 	fileBytes, err := io.ReadAll(formFile)
 	if err != nil {
@@ -135,7 +139,11 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 		return nil, err
 	}
 
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			glog.Errorf("error while closing file: %w", err)
+		}
+	}()
 
 	// FIXME: return values are ignored!!!
 	_, _ = file.Write(fileBytes)

--- a/internal/server/openapi/routers.go
+++ b/internal/server/openapi/routers.go
@@ -123,11 +123,8 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 		return nil, err
 	}
 
-	defer func() {
-		if err := formFile.Close(); err != nil {
-			glog.Errorf("error while closing formFile: %w", err)
-		}
-	}()
+	//nolint:errcheck
+	defer formFile.Close()
 
 	fileBytes, err := io.ReadAll(formFile)
 	if err != nil {
@@ -139,11 +136,8 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 		return nil, err
 	}
 
-	defer func() {
-		if err := file.Close(); err != nil {
-			glog.Errorf("error while closing file: %w", err)
-		}
-	}()
+	//nolint:errcheck
+	defer file.Close()
 
 	// FIXME: return values are ignored!!!
 	_, _ = file.Write(fileBytes)

--- a/pkg/inferenceservice-controller/suite_test.go
+++ b/pkg/inferenceservice-controller/suite_test.go
@@ -281,22 +281,16 @@ func DownloadFile(url string, path string) error {
 		return err
 	}
 
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			ctrl.Log.WithName("controllers").WithName("ModelRegistry-InferenceService-Controller").Error(err, "error while closing response body")
-		}
-	}()
+	//nolint:errcheck
+	defer resp.Body.Close()
 
 	file, err := os.Create(path)
 	if err != nil {
 		return err
 	}
 
-	defer func() {
-		if err := file.Close(); err != nil {
-			ctrl.Log.WithName("controllers").WithName("ModelRegistry-InferenceService-Controller").Error(err, "error while closing file body")
-		}
-	}()
+	//nolint:errcheck
+	defer file.Close()
 
 	_, err = io.Copy(file, resp.Body)
 	if err != nil {

--- a/pkg/inferenceservice-controller/suite_test.go
+++ b/pkg/inferenceservice-controller/suite_test.go
@@ -281,14 +281,22 @@ func DownloadFile(url string, path string) error {
 		return err
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			ctrl.Log.WithName("controllers").WithName("ModelRegistry-InferenceService-Controller").Error(err, "error while closing response body")
+		}
+	}()
 
 	file, err := os.Create(path)
 	if err != nil {
 		return err
 	}
 
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			ctrl.Log.WithName("controllers").WithName("ModelRegistry-InferenceService-Controller").Error(err, "error while closing file body")
+		}
+	}()
 
 	_, err = io.Copy(file, resp.Body)
 	if err != nil {

--- a/templates/go-server/routers.mustache
+++ b/templates/go-server/routers.mustache
@@ -163,11 +163,8 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 		return nil, err
 	}
 
-	defer func() {
-		if err := formFile.Close(); err != nil {
-			glog.Errorf("error while closing formFile: %w", err)
-		}
-	}()
+	//nolint:errcheck
+	defer formFile.Close()
 
 	fileBytes, err := io.ReadAll(formFile)
 	if err != nil {
@@ -179,11 +176,8 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 		return nil, err
 	}
 
-	defer func() {
-		if err := file.Close(); err != nil {
-			glog.Errorf("error while closing file: %w", err)
-		}
-	}()
+	//nolint:errcheck
+	defer file.Close()
 
 	// FIXME: return values are ignored!!!
 	_, _ = file.Write(fileBytes)

--- a/templates/go-server/routers.mustache
+++ b/templates/go-server/routers.mustache
@@ -163,7 +163,11 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 		return nil, err
 	}
 
-	defer formFile.Close()
+	defer func() {
+		if err := formFile.Close(); err != nil {
+			glog.Errorf("error while closing formFile: %w", err)
+		}
+	}()
 
 	fileBytes, err := io.ReadAll(formFile)
 	if err != nil {
@@ -175,7 +179,11 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 		return nil, err
 	}
 
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			glog.Errorf("error while closing file: %w", err)
+		}
+	}()
 
 	// FIXME: return values are ignored!!!
 	_, _ = file.Write(fileBytes)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

`make build` is not working at the moment with go 1.24

![image](https://github.com/user-attachments/assets/59978733-1d6f-4702-9807-f2421071e441)

I fixed this error by bumping our golangci-lint version to 2.0.2 and fixing subsequent lint issues

![image](https://github.com/user-attachments/assets/d2131f74-364b-4822-b799-6c7693540e99)

**NOTE**: to try this PR locally remember to clean your bin folder

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

run `make build` locally after bumping local golang version to v1.24.2

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
