### PR TITLE
Add STUB endpoints for settings RBAC

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -113,17 +113,11 @@ paths:
       description: Gets a list of all Model Registry settings.
     post:
       requestBody:
-        description: A new Model Registry settings to be created.
+        description: A new Model Registry settings to be created, potentially including credentials.
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                metadata:
-                  type: object
-                  description: Metadata about the response
-                data:
-                  $ref: "#/components/schemas/ModelRegistryKind"
+              $ref: "#/components/schemas/ModelRegistrySettingsPayload" # New schema for create payload
         required: true
       tags:
         - K8SOperation
@@ -141,29 +135,44 @@ paths:
       operationId: createModelRegistrySettings
       summary: Create Model Registry Settings
       description: Creates a new instance of Model Registry settings.
-  /api/v1/settings/model_registry/{modelregistryId}:
+  /api/v1/settings/model_registry/{modelRegistryId}:
     summary: Path used to manage Model Registry resources.
     description: >-
-      The REST endpoint/path used to list, create, update and delete Model Registry resources.
+      The REST endpoint/path used to get, update and delete a single Model Registry resource.
+    # Add GET operation
+    get:
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: '#/components/parameters/modelRegistryId' # Use the correct parameter name
+      responses:
+        "200":
+          # Define a response that might include credentials
+          $ref: "#/components/responses/ModelRegistryKindResponse" 
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getModelRegistrySetting # Renamed for clarity
+      summary: Get Model Registry Settings
+      description: Gets the details of a single Model Registry settings, potentially including related credentials.
     patch:
       requestBody:
         description: Updated Model Registry settings information.
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                metadata:
-                  type: object
-                  description: Metadata about the response
-                data:
-                  $ref: "#/components/schemas/ModelRegistryKind"
+              # Use the new payload schema to allow optional credentials
+              $ref: "#/components/schemas/ModelRegistrySettingsPayload" # New schema for update payload
         required: true
       tags:
         - K8SOperation
       parameters:
         - $ref: "#/components/parameters/kubeflowUserId"
-        - $ref: '#/components/parameters/registeredmodelId'
+        - $ref: "#/components/parameters/modelRegistryId"
       responses:
         "200":
           $ref: "#/components/responses/ModelRegistryKindResponse"
@@ -183,7 +192,7 @@ paths:
         - K8SOperation
       parameters:
         - $ref: "#/components/parameters/kubeflowUserId"
-        - $ref: '#/components/parameters/registeredmodelId'
+        - $ref: '#/components/parameters/modelRegistryId'
       responses:
         "204":
           description: Successfully deleted
@@ -198,6 +207,99 @@ paths:
       operationId: deleteModelRegistrySettings
       summary: Delete Model Registry Settings
       description: Deletes an existing Model Registry settings.
+  # New path for certificates
+  /api/v1/settings/certificates:
+    summary: Path used to list available certificates (Secrets and ConfigMaps).
+    description: >-
+      The REST endpoint/path used to list Secrets and ConfigMaps that can be used for TLS/SSL configuration in Model Registries.
+    get:
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+      responses:
+        "200":
+          $ref: "#/components/responses/CertificateListResponse" # New response type needed
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getCertificates
+      summary: List Available Certificates
+      description: Gets lists of Secrets and ConfigMaps suitable for certificate usage.
+
+  # New path for role bindings
+  /api/v1/settings/role_bindings:
+    summary: Path used to manage Role Bindings for Model Registries.
+    description: >-
+      The REST endpoint/path used to list and create Role Bindings associated with Model Registries.
+    get:
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+      responses:
+        "200":
+          $ref: "#/components/responses/RoleBindingListResponse" # New response type needed
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getRoleBindings
+      summary: List Model Registry Role Bindings
+      description: Gets a list of Role Bindings associated with Model Registries.
+    post:
+      requestBody:
+        description: A new Role Binding to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleBinding" # New schema needed
+        required: true
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+      responses:
+        "201":
+          $ref: "#/components/responses/RoleBindingResponse" # New response type needed
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/ConflictResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: createRoleBinding
+      summary: Create Model Registry Role Binding
+      description: Creates a new Role Binding associated with Model Registries.
+
+  # New path for specific role binding
+  /api/v1/settings/role_bindings/{roleBindingName}:
+    summary: Path used to manage a single Role Binding for Model Registries.
+    description: >-
+      The REST endpoint/path used to delete a specific Role Binding associated with Model Registries.
+    delete:
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: '#/components/parameters/roleBindingName' # New parameter needed
+      responses:
+        "204":
+          description: Successfully deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: deleteRoleBinding
+      summary: Delete Model Registry Role Binding
+      description: Deletes an existing Role Binding associated with Model Registries.
+    parameters: # Add parameters at the path level
+      - $ref: '#/components/parameters/roleBindingName' # Ensure this path parameter is defined
   /api/v1/model_registry/{modelRegistryName}/model_versions/{modelversionId}:
     summary: Path used to manage a single ModelVersion.
     description: >-
@@ -208,6 +310,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/modelRegistryName"
         - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: "#/components/parameters/modelversionId"
       responses:
         "200":
           $ref: "#/components/responses/ModelVersionResponse"
@@ -253,12 +356,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/modelRegistryName"
       - $ref: "#/components/parameters/kubeflowUserId"
-      - name: modelversionId
-        description: A unique identifier for a `ModelVersion`.
-        schema:
-          type: string
-        in: path
-        required: true
+      - $ref: "#/components/parameters/modelversionId"
   /api/v1/model_registry/{modelRegistryName}/registered_models:
     summary: Path used to manage the list of registeredmodels.
     description: >-
@@ -386,6 +484,7 @@ paths:
         - $ref: "#/components/parameters/sortOrder"
         - $ref: "#/components/parameters/nextPageToken"
         - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: "#/components/parameters/modelversionId"
       responses:
         "200":
           $ref: "#/components/responses/ArtifactListResponse"
@@ -433,12 +532,7 @@ paths:
       summary: Create an Artifact in a ModelVersion
       description: Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
     parameters:
-      - name: modelversionId
-        description: A unique identifier for a `ModelVersion`.
-        schema:
-          type: string
-        in: path
-        required: true
+      - $ref: "#/components/parameters/modelversionId"
   "/api/v1/model_registry/{modelRegistryName}/registered_models/{registeredmodelId}/versions":
     summary: Path used to manage the list of modelversions for a registeredmodel.
     description: >-
@@ -500,7 +594,7 @@ paths:
       - $ref: "#/components/parameters/modelRegistryName"
       - $ref: "#/components/parameters/kubeflowUserId"
       - $ref: '#/components/parameters/registeredmodelId'
-  /api/v1/model_registry/{modelRegistryName}/model_artifact/{modelartifactId}:
+  /api/v1/model_registry/{modelRegistryName}/model_artifact/{modelArtifactId}:
     summary: Path used to patch Model Artifacts
     description: >-
       The REST endpoint/path used patch single instances of an `ModelArtifact`. This path contains`PATCH` operation used to perform the patch tasks.
@@ -537,6 +631,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/modelRegistryName"
       - $ref: "#/components/parameters/kubeflowUserId"
+      - $ref: "#/components/parameters/modelArtifactId"
 components:
   schemas:
     Config:
@@ -1269,6 +1364,111 @@ components:
             servingEnvironmentId:
               description: ID of the parent `ServingEnvironment` for this `InferenceService` entity.
               type: string
+    # New schema for Certificate list item
+    CertificateItem:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the Secret or ConfigMap.
+        keys:
+          type: array
+          items:
+            type: string
+          description: List of keys within the Secret/ConfigMap containing certificate data.
+
+    # New schema for Certificate list response data
+    CertificateListData:
+      type: object
+      properties:
+        secrets:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertificateItem"
+        configMaps:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertificateItem"
+
+    # New schema for RoleBinding (simplified, based on k8s V1RoleBinding)
+    RoleBinding:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+          example: rbac.authorization.k8s.io/v1
+        kind:
+          type: string
+          example: RoleBinding
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+            # namespace might be omitted or added by backend
+            labels:
+              type: object
+              additionalProperties:
+                type: string
+        subjects:
+          type: array
+          items:
+            type: object # Define subject structure
+            properties:
+              kind:
+                type: string
+                example: User
+              name:
+                type: string
+              apiGroup:
+                type: string
+                example: rbac.authorization.k8s.io
+        roleRef:
+          type: object # Define roleRef structure
+          properties:
+            kind:
+              type: string
+              example: ClusterRole
+            name:
+              type: string
+            apiGroup:
+              type: string
+              example: rbac.authorization.k8s.io
+
+    # New schema for RoleBinding list
+    RoleBindingList:
+      description: List of RoleBinding entities.
+      type: object
+      properties:
+        items:
+          description: Array of `RoleBinding` entities.
+          type: array
+          items:
+            $ref: "#/components/schemas/RoleBinding"
+        # Consider adding pagination fields if needed
+
+    # New schema for Model Registry Settings Payload (POST/PATCH)
+    ModelRegistrySettingsPayload:
+      description: Payload for creating or updating Model Registry settings, potentially including credentials and certificates.
+      type: object
+      required:
+        - modelRegistry # The core ModelRegistryKind is required
+      properties:
+        modelRegistry:
+          $ref: "#/components/schemas/ModelRegistryKind"
+        databasePassword:
+          type: string
+          description: Optional new password for the database connection. If provided, it will update the associated secret.
+          nullable: true # Indicates it's optional
+          example: "new-secure-password"
+        newDatabaseCACertificate:
+          type: string
+          description: Optional new CA certificate content for the database connection (PEM format). If provided, it will update the associated ConfigMap or Secret.
+          nullable: true # Indicates it's optional
+          example: |
+            -----BEGIN CERTIFICATE-----
+            MIID...
+            -----END CERTIFICATE-----
   responses:
     NotFound:
       content:
@@ -1306,6 +1506,12 @@ components:
               data:
                 $ref: "#/components/schemas/Config"
       description: A response containing a list of ModelArtifact entities.
+    ConflictResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Conflict - Role Binding with the same name already exists
     ModelRegistryRespone:
       content:
         application/json:
@@ -1512,6 +1718,48 @@ components:
               data:
                 $ref: "#/components/schemas/ModelRegistryKind"
       description: A response containing a `ModelRegistryKind` entity.
+
+    # New response for Certificate List
+    CertificateListResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                type: object
+                description: Metadata about the response
+              data:
+                $ref: "#/components/schemas/CertificateListData"
+      description: A response containing a list of available certificates (Secrets and ConfigMaps).
+
+    # New response for RoleBinding List
+    RoleBindingListResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                type: object
+                description: Metadata about the response
+              data:
+                $ref: "#/components/schemas/RoleBindingList"
+      description: A response containing a list of `RoleBinding` entities.
+
+    # New response for a single RoleBinding
+    RoleBindingResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                type: object
+                description: Metadata about the response
+              data:
+                $ref: "#/components/schemas/RoleBinding"
+      description: A response containing a single `RoleBinding` entity.
   parameters:
     registeredmodelId:
       name: registeredmodelId
@@ -1520,8 +1768,8 @@ components:
         type: string
       in: path
       required: true
-    modelRegsitryId:
-      name: modelRegsitryId
+    modelRegistryId:
+      name: modelRegistryId
       description: A unique identifier for a `Model Registry`.
       schema:
         type: string
@@ -1530,6 +1778,20 @@ components:
     kubeflowUserId:
       in: header
       name: kubeflow-userid
+      schema:
+        type: string
+      required: true
+    modelArtifactId:
+      name: modelArtifactId
+      in: path
+      description: A unique identifier for a `ModelVersion`.
+      schema:
+        type: string
+      required: true
+    modelversionId:
+      name: modelversionId
+      in: path
+      description: A unique identifier for a `ModelVersion`.
       schema:
         type: string
       required: true
@@ -1618,6 +1880,13 @@ components:
         $ref: "#/components/schemas/SortOrder"
       in: query
       required: false
+    roleBindingName:
+      name: roleBindingName
+      description: The name of the Role Binding resource.
+      schema:
+        type: string
+      in: path
+      required: true
   securitySchemes:
     Bearer:
       scheme: bearer

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -38,16 +38,21 @@ const (
 	SettingsPath                  = ApiPathPrefix + "/settings"
 	ModelRegistrySettingsListPath = SettingsPath + "/model_registry"
 	ModelRegistrySettingsPath     = ModelRegistrySettingsListPath + "/:" + ModelRegistryId
-	RegisteredModelListPath       = ModelRegistryPath + "/registered_models"
-	RegisteredModelPath           = RegisteredModelListPath + "/:" + RegisteredModelId
-	RegisteredModelVersionsPath   = RegisteredModelPath + "/versions"
-	ModelVersionListPath          = ModelRegistryPath + "/model_versions"
-	ModelVersionPath              = ModelVersionListPath + "/:" + ModelVersionId
-	ModelVersionArtifactListPath  = ModelVersionPath + "/artifacts"
-	ModelArtifactListPath         = ModelRegistryPath + "/model_artifacts"
-	ModelArtifactPath             = ModelArtifactListPath + "/:" + ModelArtifactId
-	ArtifactListPath              = ModelRegistryPath + "/artifacts"
-	ArtifactPath                  = ArtifactListPath + "/:" + ArtifactId
+	// Add new constants for certificates and role bindings
+	CertificatesPath    = SettingsPath + "/certificates"
+	RoleBindingListPath = SettingsPath + "/role_bindings"
+	RoleBindingPath     = RoleBindingListPath + "/:" + RoleBindingNameParam // Use the constant defined in the rbac handler
+
+	RegisteredModelListPath      = ModelRegistryPath + "/registered_models"
+	RegisteredModelPath          = RegisteredModelListPath + "/:" + RegisteredModelId
+	RegisteredModelVersionsPath  = RegisteredModelPath + "/versions"
+	ModelVersionListPath         = ModelRegistryPath + "/model_versions"
+	ModelVersionPath             = ModelVersionListPath + "/:" + ModelVersionId
+	ModelVersionArtifactListPath = ModelVersionPath + "/artifacts"
+	ModelArtifactListPath        = ModelRegistryPath + "/model_artifacts"
+	ModelArtifactPath            = ModelArtifactListPath + "/:" + ModelArtifactId
+	ArtifactListPath             = ModelRegistryPath + "/artifacts"
+	ArtifactPath                 = ArtifactListPath + "/:" + ArtifactId
 )
 
 type App struct {
@@ -157,12 +162,20 @@ func (app *App) Routes() http.Handler {
 	// Standalone "only" routes
 	if app.config.StandaloneMode {
 		apiRouter.GET(NamespaceListPath, app.GetNamespacesHandler)
-		//Those endpoints are not implement yet. This is a STUB API to unblock frontend development
+		// Model Registry Settings endpoints
 		apiRouter.GET(ModelRegistrySettingsListPath, app.AttachNamespace(app.GetAllModelRegistriesSettingsHandler))
 		apiRouter.POST(ModelRegistrySettingsListPath, app.AttachNamespace(app.CreateModelRegistrySettingsHandler))
 		apiRouter.GET(ModelRegistrySettingsPath, app.AttachNamespace(app.GetModelRegistrySettingsHandler))
 		apiRouter.PATCH(ModelRegistrySettingsPath, app.AttachNamespace(app.UpdateModelRegistrySettingsHandler))
 		apiRouter.DELETE(ModelRegistrySettingsPath, app.AttachNamespace(app.DeleteModelRegistrySettingsHandler))
+
+		// Certificate endpoints
+		apiRouter.GET(CertificatesPath, app.AttachNamespace(app.GetCertificatesHandler))
+
+		// Role Binding endpoints
+		apiRouter.GET(RoleBindingListPath, app.AttachNamespace(app.GetRoleBindingsHandler))
+		apiRouter.POST(RoleBindingListPath, app.AttachNamespace(app.CreateRoleBindingHandler))
+		apiRouter.DELETE(RoleBindingPath, app.AttachNamespace(app.DeleteRoleBindingHandler))
 	}
 
 	// App Router

--- a/clients/ui/bff/internal/api/model_registry_settings_rbac_handler.go
+++ b/clients/ui/bff/internal/api/model_registry_settings_rbac_handler.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	// Add other necessary imports like context, slog, helpers etc.
+)
+
+type CertificateListEnvelope Envelope[models.CertificateList, None]
+type RoleBindingListEnvelope Envelope[models.RoleBindingList, None]
+type RoleBindingEnvelope Envelope[models.RoleBinding, None]
+
+const (
+	// Define constants for path parameters if not already defined elsewhere
+	RoleBindingNameParam = "roleBindingName"
+)
+
+// GetCertificatesHandler handles GET /api/v1/settings/certificates
+// STUB IMPLEMENTATION
+func (app *App) GetCertificatesHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	// TODO: Implement actual logic: use K8s client to list Secrets and ConfigMaps in relevant namespaces
+	// For now, return dummy data
+	dummyCerts := CertificateListEnvelope{
+		Metadata: nil,
+		Data: models.CertificateList{
+			Secrets: []models.CertificateItem{
+				{Name: "stub-secret-1", Keys: []string{"tls.crt", "tls.key"}},
+				{Name: "stub-secret-2", Keys: []string{"ca.crt"}},
+			},
+			ConfigMaps: []models.CertificateItem{
+				{Name: "stub-cm-1", Keys: []string{"ca-bundle.crt"}},
+			},
+		},
+	}
+
+	err := app.WriteJSON(w, http.StatusOK, dummyCerts, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// GetRoleBindingsHandler handles GET /api/v1/settings/role_bindings
+// STUB IMPLEMENTATION
+func (app *App) GetRoleBindingsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	// TODO: Implement actual logic: use K8s client to list RoleBindings (potentially filtered)
+	// For now, return dummy data
+	dummyBindings := RoleBindingListEnvelope{
+		Metadata: nil,
+		Data: models.RoleBindingList{
+			Items: []models.RoleBinding{
+				{ /* Dummy RoleBinding 1 */ ObjectMeta: metav1.ObjectMeta{Name: "stub-rb-1"}},
+				{ /* Dummy RoleBinding 2 */ ObjectMeta: metav1.ObjectMeta{Name: "stub-rb-2"}},
+			},
+		},
+	}
+
+	err := app.WriteJSON(w, http.StatusOK, dummyBindings, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// CreateRoleBindingHandler handles POST /api/v1/settings/role_bindings
+// STUB IMPLEMENTATION
+func (app *App) CreateRoleBindingHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	// TODO: Implement actual logic: parse payload, use K8s client to create RoleBinding
+	var input models.RoleBinding // Assuming input is the direct RoleBinding structure
+	err := app.ReadJSON(w, r, &input)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	// For now, return the created object representation
+	dummyCreated := RoleBindingEnvelope{
+		Metadata: nil,
+		Data:     input, // Return the input for now
+	}
+
+	err = app.WriteJSON(w, http.StatusCreated, dummyCreated, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// DeleteRoleBindingHandler handles DELETE /api/v1/settings/role_bindings/{roleBindingName}
+// STUB IMPLEMENTATION
+func (app *App) DeleteRoleBindingHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	roleBindingName := ps.ByName(RoleBindingNameParam)
+
+	// TODO: Implement actual logic: use K8s client to delete RoleBinding
+	app.logger.Info("STUB: Deleting Role Binding", "name", roleBindingName)
+
+	w.WriteHeader(http.StatusNoContent) // Standard response for successful DELETE
+}

--- a/clients/ui/bff/internal/models/model_registry_settings_types.go
+++ b/clients/ui/bff/internal/models/model_registry_settings_types.go
@@ -1,0 +1,14 @@
+package models
+
+// ModelRegistrySettingsPayload defines the structure for creating a ModelRegistryKind with optional credentials.
+type ModelRegistrySettingsPayload struct {
+	ModelRegistry            ModelRegistryKind `json:"modelRegistry"`
+	DatabasePassword         *string           `json:"databasePassword,omitempty"`         // Use pointer for optional field
+	NewDatabaseCACertificate *string           `json:"newDatabaseCACertificate,omitempty"` // Use pointer for optional field
+}
+
+// ModelRegistryKindDetail includes ModelRegistryKind and potentially the database password.
+type ModelRegistryKindDetail struct {
+	ModelRegistryKind         // Embed ModelRegistryKind
+	DatabasePassword  *string `json:"databasePassword,omitempty"` // Use pointer for optional field
+}

--- a/clients/ui/bff/internal/models/rbac_types.go
+++ b/clients/ui/bff/internal/models/rbac_types.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// CertificateItem represents a Secret or ConfigMap suitable for certificate usage.
+type CertificateItem struct {
+	Name string   `json:"name"`
+	Keys []string `json:"keys"`
+}
+
+// CertificateList holds lists of Secrets and ConfigMaps.
+type CertificateList struct {
+	Secrets    []CertificateItem `json:"secrets"`
+	ConfigMaps []CertificateItem `json:"configMaps"`
+}
+
+// RoleBinding represents a Kubernetes RoleBinding (simplified for API).
+// Using the actual k8s type for consistency might be better if full fidelity is needed.
+type RoleBinding rbacv1.RoleBinding
+
+// RoleBindingList represents a list of Kubernetes RoleBindings.
+type RoleBindingList struct {
+	Items []RoleBinding `json:"items"`
+	// Add other list metadata if needed (e.g., from metav1.ListMeta)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This pull request includes several changes to the `model-registry/clients/ui` project, focusing on adding new endpoints for model registry settings, certificates, and role bindings, and updating relevant handlers and models. The most important changes include the addition of GitHub Copilot instructions, new constants and endpoints in the Go backend, and updates to the model registry settings handler.

Backend updates:

* [`clients/ui/bff/internal/api/app.go`](diffhunk://#diff-3fabc91970bb3d088ae86035e9998bf9af2c2314adfc72a58e175952328b7888R38-R42): Added new constants for certificates and role bindings paths, and updated the `Routes` function to include new endpoints for certificates and role bindings. [[1]](diffhunk://#diff-3fabc91970bb3d088ae86035e9998bf9af2c2314adfc72a58e175952328b7888R38-R42) [[2]](diffhunk://#diff-3fabc91970bb3d088ae86035e9998bf9af2c2314adfc72a58e175952328b7888L131-R149)
* [`clients/ui/bff/internal/api/model_registry_settings_handler.go`](diffhunk://#diff-ae39d0db19d8855ff9c597b7b699db0dedf9ddd84195a3effb09f65a2593af31L74-R101): Updated the `CreateModelRegistrySettingsHandler` to decode JSON payloads and validate the model registry name.

New handlers:

* [`clients/ui/bff/internal/api/model_registry_settings_rbac_handler.go`](diffhunk://#diff-9cf13ab892f8cfd0e49599c844a230f58724da96c1c3ed6fbebaed0b43ee19efR1-R98): Added stub implementations for handling certificates and role bindings endpoints, including `GetCertificatesHandler`, `GetRoleBindingsHandler`, `CreateRoleBindingHandler`, and `DeleteRoleBindingHandler`.

Model updates:

* [`clients/ui/bff/internal/models/model_registry_settings_types.go`](diffhunk://#diff-997589e44602096a438ecadcc7c259172fae4b2670a65f42a8601c9a6b8e4130R1-R14): Added `ModelRegistrySettingsPayload` and `ModelRegistryKindDetail` types to handle model registry settings with optional credentials.
* [`clients/ui/bff/internal/models/rbac_types.go`](diffhunk://#diff-f5a7616d052cac6e7acf0ce71d8ce714ba4e9f66be65f8503fb6fc32f9b75b38R1-R27): Added types for certificates and role bindings, including `CertificateItem`, `CertificateList`, `RoleBinding`, and `RoleBindingList`.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Set up the bff
2. Test the new endpoints with curl

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
