### PR TITLE
feat: improve dev QoL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the model-registry binary
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.23 AS common
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -10,20 +10,8 @@ COPY ["go.mod", "go.sum", "./"]
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-USER root
-# default NodeJS 14 is not enough for openapi-generator-cli, switch to Node JS currently supported
-RUN yum remove -y nodejs npm
-RUN yum module -y reset nodejs
-RUN yum module -y enable nodejs:18
-# install npm and java for openapi-generator-cli
-RUN yum install -y nodejs npm java-11 python3
-
 # Download tools
 COPY Makefile .
-COPY scripts/install_protoc.sh scripts/
-RUN make deps
-
-# Copy rest of the source
 COPY ["main.go", ".openapi-generator-ignore", "openapitools.json", "./"]
 COPY cmd/ cmd/
 COPY api/ api/
@@ -33,8 +21,35 @@ COPY pkg/ pkg/
 COPY patches/ patches/
 COPY templates/ templates/
 
-# Build
+###### Dev stage - start ######
+
+FROM common AS dev
+
 USER root
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o model-registry
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as dev-build
+
+WORKDIR /
+COPY --from=dev /workspace/model-registry .
+USER 65532:65532
+
+ENTRYPOINT ["/model-registry"]
+
+###### Dev stage - end ######
+
+FROM common as builder
+
+USER root
+# default NodeJS 14 is not enough for openapi-generator-cli, switch to Node JS currently supported
+RUN yum remove -y nodejs npm
+RUN yum module -y reset nodejs
+RUN yum module -y enable nodejs:18
+# install npm and java for openapi-generator-cli
+RUN yum install -y nodejs npm java-11 python3
+
+RUN make deps
 
 # NOTE: The two instructions below are effectively equivalent to 'make clean build'
 # DO NOT REMOVE THE 'build/prepare' TARGET!!!

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -1,6 +1,6 @@
 all: install tidy
 
-IMG_VERSION ?= latest 
+IMG_VERSION ?= latest
 
 .PHONY: install
 install:
@@ -15,7 +15,7 @@ clean:
 
 .PHONY: deploy-latest-mr
 deploy-latest-mr:
-	cd ../../ && IMG_VERSION=${IMG_VERSION} make image/build ARGS=--load && LOCAL=1 ./scripts/deploy_on_kind.sh
+	cd ../../ && IMG_VERSION=${IMG_VERSION} make image/build ARGS="--load$(if ${DEV_BUILD}, --target dev-build)"  && LOCAL=1 ./scripts/deploy_on_kind.sh
 	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 &
 
 .PHONY: deploy-test-minio

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -49,6 +49,6 @@ fi
 kubectl delete pod -n "$MR_NAMESPACE" --selector='component=model-registry-server'
 
 repeat_cmd_until "kubectl get pod -n "$MR_NAMESPACE" --selector='component=model-registry-server' \
--o jsonpath=\"{.items[*].spec.containers[?(@.name=='rest-container')].image}\"" "= $IMG" 300 "kubectl describe pod -n $MR_NAMESPACE --selector='component=model-registry-server'"
+-o jsonpath=\"{.items[*].spec.containers[?(@.name=='rest-container')].image}\"" "= $IMG" 500 "kubectl describe pod -n $MR_NAMESPACE --selector='component=model-registry-server'"
 
 kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-deployment --timeout=5m


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Refactor of the mr Dockerfile, now there's a common stage that prepares the data, a dev-build stage that skips all the autogen/lint/vet and just builds the binary, and the normal stage that is built by default if no `--target` is specified, this greatly improves the build times when testing locally.

To take advantage of this new feature, you can use the `ARGS="--target dev-build"` when running the make image/build target, or use the `DEV_BUILD=true` when running the make test-e2e target in the clients/python folder.

I also increased the timeout when waiting for the mr deployment in the deploy_on_kind.sh script, as it occasionally failed and gave false negatives.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
time make image/build .

...

real    2m41.152s
user    9m18.038s
sys     2m10.551s
```
vs

```shell
time ARGS="--target dev-build" make image/build .

...

real    0m14.952s
user    0m39.747s
sys     0m11.835s
```
-----------------------------------
```shell
time make test-e2e

...

real    5m49.049s
user    9m41.787s
sys     2m18.887s
```
vs

```shell
time DEV_BUILD=true make test-e2

...

real    3m17.977s
user    1m3.871s
sys     0m19.981s
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

