### PR TITLE
Clean up port forwards after tests run

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -119,7 +119,8 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12"] # see below for versions 3.9-3.11
-        kubernetes-version: ["v1.27.11", "v1.28.7", "v1.29.2", "v1.30.6", "v1.31.0"]
+        kubernetes-version:
+          ["v1.27.11", "v1.28.7", "v1.29.2", "v1.30.6", "v1.31.0"]
         exclude: # on main merges (not PRs), use also different K8s versions for E2E testing
           - kubernetes-version: ${{ github.event_name != 'push' && 'v1.28.7' }}
           - kubernetes-version: ${{ github.event_name != 'push' && 'v1.29.2' }}
@@ -218,6 +219,7 @@ jobs:
         run: |
           kubectl port-forward -n kubeflow service/model-registry-service 8080:8080 &
           kubectl port-forward -n minio svc/minio 9000:9000 &
+          kubectl port-forward service/distribution-registry-test-service 5001:5001 &
           sleep 2
           nox --python=${{ matrix.python }} --session=e2e -- --cov-report=xml
 

--- a/clients/python/.gitignore
+++ b/clients/python/.gitignore
@@ -6,3 +6,4 @@
 /.python-version
 __pycache__/
 venv/
+.port-forwards.pid

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -16,22 +16,39 @@ clean:
 .PHONY: deploy-latest-mr
 deploy-latest-mr:
 	cd ../../ && IMG_VERSION=${IMG_VERSION} make image/build ARGS="--load$(if ${DEV_BUILD}, --target dev-build)"  && LOCAL=1 ./scripts/deploy_on_kind.sh
-	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 &
+	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 & echo $$! >> .port-forwards.pid
 
 .PHONY: deploy-test-minio
 deploy-test-minio:
 	cd ../../ && ./scripts/deploy_minio_on_kind.sh
-	kubectl port-forward -n minio svc/minio 9000:9000 &
+	kubectl port-forward -n minio svc/minio 9000:9000 & echo $$! >> .port-forwards.pid
 
 .PHONY: deploy-local-registry
 deploy-local-registry:
 	cd ../../ && ./scripts/deploy_local_kind_registry.sh
+	kubectl port-forward service/distribution-registry-test-service 5001:5001 & echo $$! >> .port-forwards.pid
 
 .PHONY: test-e2e
 test-e2e: deploy-latest-mr deploy-local-registry deploy-test-minio
+	@echo "Starting test-e2e"
+	-$(MAKE) test-e2e-run; STATUS=$$?
+	$(MAKE) test-e2e-cleanup
+	@exit $$STATUS
+
+.PHONY: test-e2e-run
+test-e2e-run:
+	@echo "Running tests..."
 	@set -a; . ../../scripts/manifests/minio/.env; set +a; \
 	poetry run pytest --e2e -s -rA
-	rm -fr ../../scripts/manifests/minio/.env
+	@rm -f ../../scripts/manifests/minio/.env
+
+.PHONY: test-e2e-cleanup
+test-e2e-cleanup:
+	@echo "Cleaning up port-forward processes..."
+	@if [ -f .port-forwards.pid ]; then \
+		kill $$(cat .port-forwards.pid) || true; \
+		rm -f .port-forwards.pid; \
+	fi
 
 .PHONY: test
 test:

--- a/scripts/deploy_local_kind_registry.sh
+++ b/scripts/deploy_local_kind_registry.sh
@@ -10,8 +10,3 @@ kubectl wait --for=condition=available deployment/distribution-registry-test-dep
 kubectl logs deployment/distribution-registry-test-deployment
 echo "Deployment looks ready."
 
-echo "Starting port-forward..."
-kubectl port-forward service/distribution-registry-test-service 5001:5001 &
-PID=$!
-sleep 2
-echo "I have launched port-forward in background with: $PID."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the current setup with e2e tests, if you run the test suite twice in a row, you may get an unexpected failure due to port-forwards still persisting between test runs. This reduces iteration speed significantly as you will have to run the test suite for a 3rd time for everything to work again.

The solution I chose was to store the PIDs of the port-forward processes in a file, and after the test suite finishes executing to `kill` those PIDs.

Here is an example of the file produced (`.port-forwards.pid`)

```
46026
46036
46057
```

These pids are for portforward processes for the MR itself, Minio, and the in-Kind Docker Registry.

A key requirement is that even if the test suite fails, the PIDs are still cleaned up.

To facilitate this, I spilt the `test-e2e` target into two, a "run" and a "cleanup" step and ran the "run" target capturing the exit code and re-throwing it after the "cleanup" step finishes.

When executing the test-suite with a failure the output looks like this:

```
....
FAILED tests/test_utils.py::test_save_to_oci_registry_with_custom_backend - model_registry.exceptions.StoreError: Package `olot` is not installed.
FAILED tests/test_utils.py::test_save_to_oci_registry_backend_not_found - model_registry.exceptions.StoreError: Package `olot` is not installed.
================================= 5 failed, 57 passed, 6 skipped, 1 xfailed, 29 warnings in 23.36s ==================================
make[1]: *** [test-e2e-run] Error 1
/Library/Developer/CommandLineTools/usr/bin/make test-e2e-cleanup
Cleaning up port-forward processes..
```

And checking the running PIDs, none of the PIDs are still executing. In addition, running the test suite again actually works and doesn't fail due to the "port in use" error.

```
$ ps aux | grep kubectl

edobrove         46818   0.0  0.0 410724304   1376 s020  R+   10:03AM   0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox --exclude-dir=.venv --exclude-dir=venv kubectl
```

WITHOUT these changes, the same command will show the kubectl port forwards still persisting

```
$ ps aux | grep kubectl

edobrove         44930   0.0  0.0 410724304   1392 s020  S+   10:01AM   0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox --exclude-dir=.venv --exclude-dir=venv kubectl
edobrove         43937   0.0  0.1 411894640  32432 s010  S    10:00AM   0:00.05 kubectl port-forward service/distribution-registry-test-service 5001:5001
edobrove         43927   0.0  0.1 411896528  46896 s010  S    10:00AM   0:00.57 kubectl port-forward -n kubeflow services/model-registry-service 8080:8080
```

## How Has This Been Tested?

On my local laptop (MacOS M3) with a test suite that both succeeded and fails.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
