### PR TITLE
fix(client): Prevent model overwrite on duplicate registration

### DIFF
--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -234,7 +234,13 @@ class ModelRegistry:
             Registered model. See: :meth:`~ModelRegistry.register_model`
         """
         # Check if model does not already exist in Registry
-        if self.get_model_version(name=name, version=version):
+        ver = None
+        try:
+            ver = self.get_model_version(name=name, version=version)
+        except StoreError:
+            pass
+
+        if ver:
             raise StoreError(f"Model `{name}:{version}` already exists in Model Registry.")
 
         if isinstance(upload_params, S3Params):

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -28,6 +28,7 @@ from .utils import (
     s3_uri_from,
     save_to_oci_registry,
 )
+import contextlib
 
 ModelTypes = Union[RegisteredModel, ModelVersion, ModelArtifact]
 TModel = TypeVar("TModel", bound=ModelTypes)
@@ -235,15 +236,12 @@ class ModelRegistry:
         """
         # Check if model does not already exist in Registry
         ver = None
-        try:
+        with contextlib.suppress(StoreError):
             ver = self.get_model_version(name=name, version=version)
-        except StoreError:
-            pass
 
         if ver:
-            raise StoreError(
-                f"Model `{name}:{version}` already exists in Model Registry."
-            )
+            msg = f"Model `{name}:{version}` already exists in Model Registry."
+            raise StoreError(msg)
 
         if isinstance(upload_params, S3Params):
             destination_uri = self.save_to_s3(

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -241,7 +241,9 @@ class ModelRegistry:
             pass
 
         if ver:
-            raise StoreError(f"Model `{name}:{version}` already exists in Model Registry.")
+            raise StoreError(
+                f"Model `{name}:{version}` already exists in Model Registry."
+            )
 
         if isinstance(upload_params, S3Params):
             destination_uri = self.save_to_s3(

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -233,6 +233,10 @@ class ModelRegistry:
         Returns:
             Registered model. See: :meth:`~ModelRegistry.register_model`
         """
+        # Check if model does not already exist in Registry
+        if self.get_model_version(name=name, version=version):
+            raise StoreError(f"Model `{name}:{version}` already exists in Model Registry.")
+
         if isinstance(upload_params, S3Params):
             destination_uri = self.save_to_s3(
                 **asdict(upload_params), path=model_files_path

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import inspect
 import logging
 import os
@@ -28,7 +29,6 @@ from .utils import (
     s3_uri_from,
     save_to_oci_registry,
 )
-import contextlib
 
 ModelTypes = Union[RegisteredModel, ModelVersion, ModelArtifact]
 TModel = TypeVar("TModel", bound=ModelTypes)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -893,7 +893,7 @@ def test_upload_artifact_and_register_model_with_default_oci(
     upload_params = utils.OCIParams(
         "quay.io/mmortari/hello-world-wait:latest",
         oci_ref,
-        custom_oci_backend=get_skopeo_backend_for_local_e2e_testing()
+        custom_oci_backend=get_skopeo_backend_for_local_e2e_testing(),
     )
 
     assert client.upload_artifact_and_register_model(
@@ -910,18 +910,15 @@ def test_upload_artifact_and_register_model_with_default_oci(
     assert ma.uri == f"oci://{oci_ref}"
 
     # Assert fail on duplicate
-    with pytest.raises(
-        StoreError, match="already exists"
-):
+    with pytest.raises(StoreError, match="already exists"):
         client.upload_artifact_and_register_model(
             name,
             model_files_path=model_dir,
             version=version,
             model_format_name="test format",
             model_format_version="test version",
-            upload_params=upload_params
+            upload_params=upload_params,
         )
-        
 
 
 @pytest.mark.e2e

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -909,6 +909,20 @@ def test_upload_artifact_and_register_model_with_default_oci(
     assert (ma := client.get_model_artifact(name, version))
     assert ma.uri == f"oci://{oci_ref}"
 
+    # Assert fail on duplicate
+    with pytest.raises(
+        StoreError, match="already exists"
+):
+        client.upload_artifact_and_register_model(
+            name,
+            model_files_path=model_dir,
+            version=version,
+            model_format_name="test format",
+            model_format_version="test version",
+            upload_params=upload_params
+        )
+        
+
 
 @pytest.mark.e2e
 def test_upload_artifact_and_register_model_with_default_s3(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
closes https://github.com/kubeflow/model-registry/issues/935
## Description
<!--- Describe your changes in detail -->
Check if model + version exists before storing (overriding) existing models in place, throw an error that model is already registered without having a drift case when the new model is stored but the model + version artifact already exists. 

**-> From the issue**
**To Reproduce**
Steps to reproduce the behavior:
```
s3 = S3Params(bucket_name="models", s3_prefix="my_models/")
# run once
registry.upload_artifact_and_register_model(name="mnist", model_files_path="models/", version="v3", upload_params=s3, model_format_version="v1", model_format_name="onnx", storage_path="test")
# run again
registry.upload_artifact_and_register_model(name="mnist", model_files_path="models/", version="v3", upload_params=s3, model_format_version="v1", model_format_name="onnx", storage_path="test")
```


<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Tests added to `tests/client_client.py`
<!--- Include details of your testing environment, and the tests you ran to -->
![image](https://github.com/user-attachments/assets/3f5abc67-6ead-4eb1-9cad-1a9509559b0c)

<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [x] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
