### PR TITLE
chore(manifests): remove CPU limits

### DIFF
--- a/cmd/csi/GET_STARTED.md
+++ b/cmd/csi/GET_STARTED.md
@@ -176,7 +176,6 @@ spec:
         cpu: 100m
       limits:
         memory: 1Gi
-        cpu: "1"
   supportedUriFormats:
     - prefix: model-registry://
 

--- a/cmd/csi/samples/modelregistry.clusterstoragecontainer.yaml
+++ b/cmd/csi/samples/modelregistry.clusterstoragecontainer.yaml
@@ -15,6 +15,5 @@ spec:
         cpu: 100m
       limits:
         memory: 1Gi
-        cpu: "1"
   supportedUriFormats:
     - prefix: model-registry://

--- a/manifests/kustomize/options/controller/manager/manager.yaml
+++ b/manifests/kustomize/options/controller/manager/manager.yaml
@@ -95,7 +95,6 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 500m
             memory: 128Mi
           requests:
             cpu: 10m

--- a/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
+++ b/manifests/kustomize/options/csi/clusterstoragecontainer.yaml
@@ -15,6 +15,5 @@ spec:
         cpu: 100m
       limits:
         memory: 1Gi
-        cpu: "1"
   supportedUriFormats:
     - prefix: model-registry://

--- a/manifests/kustomize/options/ui/base/model-registry-ui-deployment.yaml
+++ b/manifests/kustomize/options/ui/base/model-registry-ui-deployment.yaml
@@ -45,7 +45,6 @@ spec:
           failureThreshold: 3
         resources:
           limits:
-            cpu: 500m
             memory: 2Gi
           requests:
             cpu: 500m

--- a/test/csi/e2e_test.sh
+++ b/test/csi/e2e_test.sh
@@ -75,7 +75,6 @@ spec:
         cpu: 100m
       limits:
         memory: 1Gi
-        cpu: "1"
   supportedUriFormats:
     - prefix: model-registry://
 EOF


### PR DESCRIPTION
## Description

CPU limits are largely unnecessary because pods are guaranteed their CPU request, and unused CPU time on the node might as well go to bursting pods.

## How Has This Been Tested?

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
