### PR TITLE
chore(python-client): ensure extras install when running e2e tests

### DIFF
--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -37,6 +37,8 @@ test-e2e: deploy-latest-mr deploy-local-registry deploy-test-minio
 
 .PHONY: test-e2e-run
 test-e2e-run:
+	@echo "Ensuring extras are installed..."
+	poetry install --all-extras
 	@echo "Running tests..."
 	@set -a; . ../../scripts/manifests/minio/.env; set +a; \
 	poetry run pytest --e2e -s -rA

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -37,7 +37,7 @@ test-e2e: deploy-latest-mr deploy-local-registry deploy-test-minio
 
 .PHONY: test-e2e-run
 test-e2e-run:
-	@echo "Ensuring extras are installed..."
+	@echo "Ensuring all extras are installed..."
 	poetry install --all-extras
 	@echo "Running tests..."
 	@set -a; . ../../scripts/manifests/minio/.env; set +a; \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sometimes if you are on a fresh env or decide not to use the `devenv` you might not have the extras installed for the python-client when executing the E2E tests.

This PR just adds a quick line to ensure all the extras are installed when running the E2E tests. Impact on runtime is quite minimal.

## How Has This Been Tested?
Locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
