### PR TITLE
Migrate robot test validating ability to store owner, to pytest

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -995,5 +995,6 @@ async  def test_register_model_with_owner(client):
        **model_params,
     )
     assert rm.id
+    assert rm.owner == model_params["owner"]
     assert (_get_rm := client.get_registered_model(name=model_params["name"]))
     assert _get_rm.owner == model_params["owner"]

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -979,3 +979,21 @@ def test_upload_artifact_and_register_model_missing_upload_params(client):
         'Param "upload_params" is required to perform an upload. Please ensure the value provided is valid'
         in str(e.value)
     )
+
+
+@pytest.mark.e2e
+async  def test_register_model_with_owner(client):
+    model_params = {
+        "name": "test_model",
+        "uri": "s3",
+        "model_format_name": "test_format",
+        "model_format_version": "test_version",
+        "version": "1.0.0",
+        "owner": "test owner",
+    }
+    rm = client.register_model(
+       **model_params,
+    )
+    assert rm.id
+    assert (_get_rm := client.get_registered_model(name=model_params["name"]))
+    assert _get_rm.owner == model_params["owner"]

--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -92,6 +92,7 @@ As a MLOps engineer I would like to store some labels
           And Dictionaries Should Be Equal   ${r["customProperties"]}  ${cp3}
 
 As a MLOps engineer I would like to store an owner for the RegisteredModel
+    # MIGRATED TO test_register_model_with_owner in pytest
     Set To Dictionary    ${registered_model}    description=Lorem ipsum dolor sit amet  name=${name}  owner=My owner
     ${rId}  Given I create a RegisteredModel    payload=${registered_model}
     ${r}  Then I get RegisteredModelByID    id=${rId}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
tested locally using `make test-e2e-run`
```
PASSED tests/test_client.py::test_register_model_with_owner
...
69 passed, 1 xfailed, 45 warnings in 34.32s
```
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
