### PR TITLE
Add support for description field for ModelVersion and ModelArtifact in python client

### DIFF
--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -290,6 +290,8 @@ class ModelRegistry:
         owner: str | None = None,
         description: str | None = None,
         metadata: Mapping[str, SupportedTypes] | None = None,
+        model_version_description: str | None = None,
+        model_source_description: str | None = None,
     ) -> RegisteredModel:
         """Register a model.
 
@@ -321,17 +323,19 @@ class ModelRegistry:
             model_source_id: A unique identifier for a source model within kind, class, and group.
             model_source_name: A human-readable name for the source model.
             metadata: Additional version metadata. Defaults to values returned by `default_metadata()`.
+            model_version_description: Model version description
+            model_source_description: Model artifact description
 
         Returns:
             Registered model.
         """
-        rm = self.async_runner(self._register_model(name, owner=owner or self._author))
+        rm = self.async_runner(self._register_model(name, owner=owner or self._author, description=description))
         mv = self.async_runner(
             self._register_new_version(
                 rm,
                 version,
                 author or self._author,
-                description=description,
+                description=model_version_description,
                 custom_properties=metadata or {},
             )
         )
@@ -350,6 +354,7 @@ class ModelRegistry:
                 model_source_group=model_source_group,
                 model_source_id=model_source_id,
                 model_source_name=model_source_name,
+                description=model_source_description
             )
         )
 

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -96,6 +96,7 @@ class RegisteredModel(BaseResourceModel):
     name: str
     owner: str | None = None
     state: RegisteredModelState = RegisteredModelState.LIVE
+    description: str | None = None
 
     @override
     def create(self, **kwargs) -> RegisteredModelCreate:

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -33,6 +33,22 @@ def pytest_collection_modifyitems(config, items):
             continue
 
 
+def pytest_report_teststatus(report, config):
+    test_name = report.head_line
+    if report.passed:
+        if report.when == "call":
+            print(f"\nTEST: {test_name} STATUS: \033[0;32mPASSED\033[0m")
+
+    elif report.skipped:
+       print(f"\nTEST: {test_name} STATUS: \033[1;33mSKIPPED\033[0m")
+
+    elif report.failed:
+        if report.when != "call":
+            print(f"\nTEST: {test_name} [{report.when}] STATUS: \033[0;31mERROR\033[0m")
+        else:
+            print(f"\nTEST: {test_name} STATUS: \033[0;31mFAILED\033[0m")
+
+
 REGISTRY_URL = os.environ.get("MR_URL", "http://localhost:8080")
 parsed = urlparse(REGISTRY_URL)
 host, port = parsed.netloc.split(":")

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -979,3 +979,35 @@ def test_upload_artifact_and_register_model_missing_upload_params(client):
         'Param "upload_params" is required to perform an upload. Please ensure the value provided is valid'
         in str(e.value)
     )
+
+
+@pytest.mark.e2e
+async  def test_register_model_with_description(client):
+    model_params = {
+        "name": "test_model",
+        "uri": "s3",
+        "model_format_name": "test_format",
+        "model_format_version": "test_version",
+        "version": "1.0.0",
+        "description": "test description",
+        "model_version_description": "test model version description",
+        "model_source_description": "test artifact description"
+    }
+    rm = client.register_model(
+       **model_params,
+    )
+    assert rm.id
+    assert rm.description
+    assert (_get_rm := client.get_registered_model(name=model_params["name"]))
+    assert _get_rm.description == model_params["description"]
+    print(f"_get_rm {_get_rm.__dict__}")
+
+    assert (_get_mv := client.get_model_version(name=model_params["name"], version=model_params["version"]))
+    assert _get_mv.id
+    assert _get_mv.description == model_params["model_version_description"]
+    print(f"_get_mv {_get_mv.__dict__}")
+    assert (_get_ma := client.get_model_artifact(name=model_params["name"], version=model_params["version"]))
+    print(f"_get_ma {_get_ma.__dict__}")
+
+    assert _get_ma.id
+    assert _get_ma.description == model_params["model_source_description"]

--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -22,6 +22,7 @@ As a MLOps engineer I would like to store Model name
           And Should be equal    ${r["uri"]}    s3://12345
 
 As a MLOps engineer I would like to store a description of the model
+    # MIGRATED TO test_register_model_with_description in pytest
     Set To Dictionary    ${registered_model}    description=Lorem ipsum dolor sit amet  name=${name}
     Set To Dictionary    ${model_version}    description=consectetur adipiscing elit
     Set To Dictionary    ${model_artifact}    description=sed do eiusmod tempor incididunt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://github.com/kubeflow/model-registry/issues/1027

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
