### PR TITLE
add pytest_report_teststatus to print results

### DIFF
--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -24,13 +24,29 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(config, items):
     for item in items:
-        skip_e2e = pytest.mark.skip(
-            reason="this is an end-to-end test, requires explicit opt-in --e2e option to run."
-        )
         if "e2e" in item.keywords:
+            skip_e2e = pytest.mark.skip(
+                reason="this is an end-to-end test, requires explicit opt-in --e2e option to run."
+            )
             if not config.getoption("--e2e"):
                 item.add_marker(skip_e2e)
             continue
+
+
+def pytest_report_teststatus(report, config):
+    test_name = report.head_line
+    if report.passed:
+        if report.when == "call":
+            print(f"\nTEST: {test_name} STATUS: \033[0;32mPASSED\033[0m")
+
+    elif report.skipped:
+       print(f"\nTEST: {test_name} STATUS: \033[1;33mSKIPPED\033[0m")
+
+    elif report.failed:
+        if report.when != "call":
+            print(f"\nTEST: {test_name} [{report.when}] STATUS: \033[0;31mERROR\033[0m")
+        else:
+            print(f"\nTEST: {test_name} STATUS: \033[0;31mFAILED\033[0m")
 
 
 REGISTRY_URL = os.environ.get("MR_URL", "http://localhost:8080")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add pytest_report_teststatus, for clear information about test results in console.
## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
