### PR TITLE
gha: when 'on.pull_request.path' include workflows

### DIFF
--- a/.github/workflows/build-image-ui-pr.yml
+++ b/.github/workflows/build-image-ui-pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "clients/ui/**"
+      - ".github/workflows/**"
       - "!LICENSE*"
       - "!DOCKERFILE*"
       - "!**.gitignore"

--- a/.github/workflows/check-openapi-spec-pr.yaml
+++ b/.github/workflows/check-openapi-spec-pr.yaml
@@ -2,6 +2,7 @@ name: Validate OpenAPI spec
 on:
   pull_request:
     paths:
+      - ".github/workflows/**"
       - "api/openapi/model-registry.yaml"
 jobs:
   validate:

--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     paths:
       - "cmd/controller/**"
+      - ".github/workflows/**"
       - "internal/controller/**"
       - "internal/server/openapi/api_model_registry_service*"
       - "pkg/openapi/**"

--- a/.github/workflows/csi-test.yml
+++ b/.github/workflows/csi-test.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     paths:
       - "cmd/csi/**"
+      - ".github/workflows/**"
       - "internal/csi/**"
       - "internal/server/openapi/api_model_registry_service*"
       - "pkg/openapi/**"

--- a/.github/workflows/ui-bff-build.yml
+++ b/.github/workflows/ui-bff-build.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     paths:
       - "clients/ui/**"
+      - ".github/workflows/**"
       - "!LICENSE*"
       - "!DOCKERFILE*"
       - "!**.gitignore"

--- a/.github/workflows/ui-frontend-build.yml
+++ b/.github/workflows/ui-frontend-build.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     paths:
       - "clients/ui/**"
+      - ".github/workflows/**"
       - "!LICENSE*"
       - "!DOCKERFILE*"
       - "!**.gitignore"


### PR DESCRIPTION
to test the Dependabot/Renovate changes to GHA
are fully tested, we must ensure the path is explicitly included for 'on.pull_request.path' does include
in scope also the GHAs themselves.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Resolves #949

## How Has This Been Tested?
can't be tested locally being GHA-oriented trigger, so using this PR for testing

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
