### PR TITLE
Adding Red hat as one of the adopters of Kubeflow Model Registry

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,4 +5,5 @@ Below are the adopters of the Model Registry project. If you are using Model Reg
 | Organization                  | Contact (GitHub User Name)                 | Environment                                | Description of Use                                                    |
 |-------------------------------|--------------------------------------------|--------------------------------------------|-----------------------------------------------------------------------|
 | [Pepsico](https://www.pepsico.com/) | [@milosjava](https://github.com/milosjava) | Experimenting  | Evaluating a transition from Azure Model Registry to Kubeflow Model Registry |
-| <company name here>           | <your github handle here>                  | Production/Testing/Experimenting/etc       | <any notes you'd like to share>                                       |
+| [Red Hat](https://www.redhat.com)          | [@rareddy](https://github.com/rareddy)| Production       |   Kubeflow Model Registry is part of [OpenShift AI](https://www.redhat.com/en/products/ai/openshift-ai) |
+| < company name here>           | < your github handle here >                  | <Production/Testing/Experimenting/etc>       | <any notes you'd like to share>                                       |


### PR DESCRIPTION
## Description
Adding Red Hat as one of the adopters of the Model Registry

## How Has This Been Tested?
not applicable