### PR TITLE
chore(bff): adding vscode/cursor debug capabilities on bff

### DIFF
--- a/clients/ui/bff/.gitignore
+++ b/clients/ui/bff/.gitignore
@@ -1,2 +1,6 @@
 /bin
 /static-local-run
+# Ignore personal vscode settings but keep launch/tasks
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json

--- a/clients/ui/bff/.vscode/launch.json
+++ b/clients/ui/bff/.vscode/launch.json
@@ -1,0 +1,68 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug BFF (default mocks enabled)",
+      "type": "go",
+      "request": "launch",
+      "mode": "exec",
+      "program": "${workspaceFolder}/bin/bff",
+      "args": [
+        "--port=4000",
+        "--auth-method=internal",
+        "--auth-token-header=Authorization",
+        "--auth-token-prefix=Bearer",
+        "--static-assets-dir=./static",
+        "--mock-k8s-client=true",
+        "--mock-mr-client=true",
+        "--dev-mode=false",
+        "--dev-mode-port=8080",
+        "--standalone-mode=true",
+        "--log-level=info"
+      ],
+      "preLaunchTask": "make build debug"
+    },
+    {
+      "name": "Debug BFF (MOCK_K8S_CLIENT=false, MOCK_MR_CLIENT=true)",
+      "type": "go",
+      "request": "launch",
+      "mode": "exec",
+      "program": "${workspaceFolder}/bin/bff",
+      "args": [
+        "--port=4000",
+        "--auth-method=internal",
+        "--auth-token-header=Authorization",
+        "--auth-token-prefix=Bearer",
+        "--static-assets-dir=./static",
+        "--mock-k8s-client=false",
+        "--mock-mr-client=true",
+        "--dev-mode=false",
+        "--dev-mode-port=8080",
+        "--standalone-mode=true",
+        "--log-level=info" 
+      ],
+      "preLaunchTask": "make build debug"
+    },
+    {
+      "name": "Debug BFF (MOCK_K8S_CLIENT=false, MOCK_MR_CLIENT=false)",
+      "type": "go",
+      "request": "launch",
+      "mode": "exec",
+      "program": "${workspaceFolder}/bin/bff",
+      "args": [
+        "--port=4000",
+        "--auth-method=internal",
+        "--auth-token-header=Authorization",
+        "--auth-token-prefix=Bearer",
+        "--static-assets-dir=./static",
+        "--mock-k8s-client=false",
+        "--mock-mr-client=false",
+        "--dev-mode=false",
+        "--dev-mode-port=8080",
+        "--standalone-mode=true",
+        "--log-level=info" 
+      ],
+      "preLaunchTask": "make build debug"
+    }
+  ]
+}

--- a/clients/ui/bff/.vscode/tasks.json
+++ b/clients/ui/bff/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "make build debug",
+        "type": "shell",
+        "command": "make build DEBUG=true",
+        "group": "build",
+        "problemMatcher": []
+      }
+    ]
+  }
+  

--- a/clients/ui/bff/Makefile
+++ b/clients/ui/bff/Makefile
@@ -13,6 +13,8 @@ STATIC_ASSETS_DIR ?= ./static
 ENVTEST_K8S_VERSION = 1.29.0
 LOG_LEVEL ?= info
 ALLOWED_ORIGINS ?= ""
+DEBUG ?= false
+GCFLAGS_DEBUG := -gcflags="all=-N -l"
 
 .PHONY: all
 all: build
@@ -48,7 +50,11 @@ test: fmt vet envtest ## Runs the full test suite.
 
 .PHONY: build
 build: fmt vet test ## Builds the project to produce a binary executable.
+ifeq ($(DEBUG), true) ## If DEBUG is true, build with debugging symbols
+	go build $(GCFLAGS_DEBUG) -o bin/bff ./cmd
+else
 	go build -o bin/bff ./cmd
+endif
 
 .PHONY: run
 run: fmt vet envtest ## Runs the project.


### PR DESCRIPTION
## Description
As more people move to VS Code and Cursor, this PR introduces debug support on BFF.

## How Has This Been Tested?
 

## Merge criteria:
<img width="2551" alt="Screenshot 2025-05-07 at 9 02 48 AM" src="https://github.com/user-attachments/assets/f40f3958-f353-4200-9c48-3d35db2db3f4" />
<img width="2557" alt="Screenshot 2025-05-07 at 9 02 00 AM" src="https://github.com/user-attachments/assets/3f5af559-9bd7-499e-a521-908993262b3a" />

<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/). 
 