### PR TITLE
chore(bff): cleanup as a fup to #918

### DIFF
--- a/clients/ui/bff/internal/api/errors.go
+++ b/clients/ui/bff/internal/api/errors.go
@@ -3,9 +3,10 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/mrserver"
 	"net/http"
 	"strconv"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/mrserver"
 )
 
 type HTTPError struct {
@@ -43,11 +44,14 @@ func (app *App) badRequestResponse(w http.ResponseWriter, r *http.Request, err e
 }
 
 func (app *App) forbiddenResponse(w http.ResponseWriter, r *http.Request, message string) {
+	// Log the detailed error message as a warning
+	app.logger.Warn("Access forbidden", "message", message, "method", r.Method, "uri", r.URL.RequestURI())
+
 	httpError := &mrserver.HTTPError{
 		StatusCode: http.StatusForbidden,
 		ErrorResponse: mrserver.ErrorResponse{
 			Code:    strconv.Itoa(http.StatusForbidden),
-			Message: message,
+			Message: "Access forbidden",
 		},
 	}
 	app.errorResponse(w, r, httpError)

--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -3,12 +3,13 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
-	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/mrserver"
 	"log/slog"
 	"net/http"
 	"runtime/debug"
 	"strings"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/mrserver"
 
 	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
@@ -180,11 +181,11 @@ func (app *App) RequireListServiceAccessInNamespace(next func(http.ResponseWrite
 
 		allowed, err := client.CanListServicesInNamespace(ctx, identity, namespace)
 		if err != nil {
-			app.forbiddenResponse(w, r, fmt.Sprintf("failed to perform SAR: %v", err))
+			app.forbiddenResponse(w, r, fmt.Sprintf("SAR or SelfSAR failed for namespace %s: %v", namespace, err))
 			return
 		}
 		if !allowed {
-			app.forbiddenResponse(w, r, "access denied")
+			app.forbiddenResponse(w, r, fmt.Sprintf("SAR or SelfSAR denied access to namespace %s", namespace))
 			return
 		}
 
@@ -228,11 +229,11 @@ func (app *App) RequireAccessToService(next func(http.ResponseWriter, *http.Requ
 		allowed, err := client.CanAccessServiceInNamespace(r.Context(), identity, namespace, serviceName)
 
 		if err != nil {
-			app.forbiddenResponse(w, r, "failed to perform SAR: %v")
+			app.forbiddenResponse(w, r, fmt.Sprintf("SAR or SelfSAR AccessReview failed for service %s in namespace %s: %v", serviceName, namespace, err))
 			return
 		}
 		if !allowed {
-			app.forbiddenResponse(w, r, "access denied")
+			app.forbiddenResponse(w, r, fmt.Sprintf("SAR or SelfSAR AccessReview denied access to service %s in namespace %s", serviceName, namespace))
 			return
 		}
 


### PR DESCRIPTION
## Description

This PR is a fup for #918. It prevents information disclosure about internal security mechanisms

- Modified the `forbiddenResponse` function to return a generic error message instead of specific access control details
- Changed the default forbiddenResponse to Access forbidden" 


## How Has This Been Tested?
 ```
curl -i -H "kubeflow-userid: usfsdfdser@example.com" "localhost:4000/api/v1/model_registry?namespace=kubeflow"                           (kind-kubeflow/default)
\HTTP/1.1 403 Forbidden
Content-Type: application/json
Date: Wed, 07 May 2025 14:39:22 GMT
Content-Length: 68

{
	"error": {
		"code": "403",
		"message": "Access forbidden"
	}
}

```

On server log:

```
time=2025-05-07T10:52:00.981-04:00 level=WARN msg="access denied" user=usfsdfdser@example.com verb=get resource=services namespace=kubeflow
time=2025-05-07T10:52:00.981-04:00 level=WARN msg="Access forbidden" message="SAR or SelfSAR denied access to namespace kubeflow" method=GET uri="/api/v1/model_registry?namespace=kubeflow"
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
