### PR TITLE
chore(manifests): remove default namespace

### DIFF
--- a/manifests/kustomize/options/istio/kustomization.yaml
+++ b/manifests/kustomize/options/istio/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kubeflow
 
 resources:
 - istio-authorization-policy.yaml

--- a/manifests/kustomize/overlays/db/kustomization.yaml
+++ b/manifests/kustomize/overlays/db/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kubeflow
 
 resources:
 - model-registry-db-pvc.yaml

--- a/manifests/kustomize/overlays/postgres/kustomization.yaml
+++ b/manifests/kustomize/overlays/postgres/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kubeflow
 
 bases:
 - ../../base

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -35,14 +35,14 @@ else
     kubectl create namespace "$MR_NAMESPACE"
 fi
 
-kubectl apply -k manifests/kustomize/overlays/db
+kubectl apply -k manifests/kustomize/overlays/db -n "$MR_NAMESPACE"
 kubectl patch deployment -n "$MR_NAMESPACE" model-registry-deployment \
 --patch '{"spec": {"template": {"spec": {"containers": [{"name": "rest-container", "image": "'$IMG'", "imagePullPolicy": "IfNotPresent"}]}}}}'
 
 if ! kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-db --timeout=5m ; then
     kubectl events -A
-    kubectl describe deployment/model-registry-db -n kubeflow
-    kubectl logs deployment/model-registry-db -n kubeflow
+    kubectl describe deployment/model-registry-db -n "$MR_NAMESPACE"
+    kubectl logs deployment/model-registry-db -n "$MR_NAMESPACE"
     exit 1
 fi
 


### PR DESCRIPTION
## Description

Remove `namespace: kubeflow` from the core model registry manifests.

Fixes #1045

## How Has This Been Tested?

Tested with a local kind cluster.

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
