### PR TITLE
chore(openapi): flatten base types

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -1209,52 +1209,150 @@ components:
             state:
               $ref: "#/components/schemas/ArtifactState"
     BaseExecution:
-      allOf:
-        - $ref: "#/components/schemas/BaseExecutionCreate"
-        - $ref: "#/components/schemas/BaseResource"
+      properties:
+        lastKnownState:
+          $ref: "#/components/schemas/ExecutionState"
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
+        name:
+          description: |-
+            The client provided name of the artifact. This field is optional. If set,
+            it must be unique among all the artifacts of the same artifact type within
+            a database instance and cannot be changed once set.
+          type: string
+        id:
+          format: int64
+          description: The unique server generated id of the resource.
+          type: string
+        createTimeSinceEpoch:
+          format: int64
+          description: Output only. Create time of the resource in millisecond since epoch.
+          type: string
+          readOnly: true
+        lastUpdateTimeSinceEpoch:
+          format: int64
+          description: |-
+            Output only. Last update time of the resource since epoch in millisecond
+            since epoch.
+          type: string
+          readOnly: true
     BaseExecutionCreate:
-      allOf:
-        - $ref: "#/components/schemas/BaseExecutionUpdate"
-        - $ref: "#/components/schemas/BaseResourceCreate"
+      properties:
+        lastKnownState:
+          $ref: "#/components/schemas/ExecutionState"
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
+        name:
+          description: |-
+            The client provided name of the artifact. This field is optional. If set,
+            it must be unique among all the artifacts of the same artifact type within
+            a database instance and cannot be changed once set.
+          type: string
     BaseExecutionUpdate:
-      allOf:
-        - type: object
-          properties:
-            lastKnownState:
-              $ref: "#/components/schemas/ExecutionState"
-        - $ref: "#/components/schemas/BaseResourceUpdate"
+      type: object
+      properties:
+        lastKnownState:
+          $ref: "#/components/schemas/ExecutionState"
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
     BaseResource:
-      allOf:
-        - $ref: "#/components/schemas/BaseResourceCreate"
-        - type: object
-          properties:
-            id:
-              format: int64
-              description: The unique server generated id of the resource.
-              type: string
-            createTimeSinceEpoch:
-              format: int64
-              description: Output only. Create time of the resource in millisecond since epoch.
-              type: string
-              readOnly: true
-            lastUpdateTimeSinceEpoch:
-              format: int64
-              description: |-
-                Output only. Last update time of the resource since epoch in millisecond
-                since epoch.
-              type: string
-              readOnly: true
+      type: object
+      properties:
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
+        name:
+          description: |-
+            The client provided name of the artifact. This field is optional. If set,
+            it must be unique among all the artifacts of the same artifact type within
+            a database instance and cannot be changed once set.
+          type: string
+        id:
+          format: int64
+          description: The unique server generated id of the resource.
+          type: string
+        createTimeSinceEpoch:
+          format: int64
+          description: Output only. Create time of the resource in millisecond since epoch.
+          type: string
+          readOnly: true
+        lastUpdateTimeSinceEpoch:
+          format: int64
+          description: |-
+            Output only. Last update time of the resource since epoch in millisecond
+            since epoch.
+          type: string
+          readOnly: true
     BaseResourceCreate:
-      allOf:
-        - $ref: "#/components/schemas/BaseResourceUpdate"
-        - type: object
-          properties:
-            name:
-              description: |-
-                The client provided name of the artifact. This field is optional. If set,
-                it must be unique among all the artifacts of the same artifact type within
-                a database instance and cannot be changed once set.
-              type: string
+      type: object
+      properties:
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
+        name:
+          description: |-
+            The client provided name of the artifact. This field is optional. If set,
+            it must be unique among all the artifacts of the same artifact type within
+            a database instance and cannot be changed once set.
+          type: string
     BaseResourceList:
       required:
         - nextPageToken

--- a/clients/python/src/mr_openapi/models/base_execution_update.py
+++ b/clients/python/src/mr_openapi/models/base_execution_update.py
@@ -25,6 +25,7 @@ from mr_openapi.models.metadata_value import MetadataValue
 class BaseExecutionUpdate(BaseModel):
     """BaseExecutionUpdate."""  # noqa: E501
 
+    last_known_state: ExecutionState | None = Field(default=None, alias="lastKnownState")
     custom_properties: dict[str, MetadataValue] | None = Field(
         default=None,
         description="User provided custom properties which are not defined by its type.",
@@ -36,8 +37,7 @@ class BaseExecutionUpdate(BaseModel):
         description="The external id that come from the clients’ system. This field is optional. If set, it must be unique among all resources within a database instance.",
         alias="externalId",
     )
-    last_known_state: ExecutionState | None = Field(default=None, alias="lastKnownState")
-    __properties: ClassVar[list[str]] = ["customProperties", "description", "externalId", "lastKnownState"]
+    __properties: ClassVar[list[str]] = ["lastKnownState", "customProperties", "description", "externalId"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -96,6 +96,7 @@ class BaseExecutionUpdate(BaseModel):
 
         return cls.model_validate(
             {
+                "lastKnownState": obj.get("lastKnownState"),
                 "customProperties": (
                     {_k: MetadataValue.from_dict(_v) for _k, _v in obj["customProperties"].items()}
                     if obj.get("customProperties") is not None
@@ -103,6 +104,5 @@ class BaseExecutionUpdate(BaseModel):
                 ),
                 "description": obj.get("description"),
                 "externalId": obj.get("externalId"),
-                "lastKnownState": obj.get("lastKnownState"),
             }
         )

--- a/pkg/openapi/model_base_execution_update.go
+++ b/pkg/openapi/model_base_execution_update.go
@@ -19,13 +19,13 @@ var _ MappedNullable = &BaseExecutionUpdate{}
 
 // BaseExecutionUpdate struct for BaseExecutionUpdate
 type BaseExecutionUpdate struct {
+	LastKnownState *ExecutionState `json:"lastKnownState,omitempty"`
 	// User provided custom properties which are not defined by its type.
 	CustomProperties *map[string]MetadataValue `json:"customProperties,omitempty"`
 	// An optional description about the resource.
 	Description *string `json:"description,omitempty"`
 	// The external id that come from the clients’ system. This field is optional. If set, it must be unique among all resources within a database instance.
-	ExternalId     *string         `json:"externalId,omitempty"`
-	LastKnownState *ExecutionState `json:"lastKnownState,omitempty"`
+	ExternalId *string `json:"externalId,omitempty"`
 }
 
 // NewBaseExecutionUpdate instantiates a new BaseExecutionUpdate object
@@ -47,6 +47,38 @@ func NewBaseExecutionUpdateWithDefaults() *BaseExecutionUpdate {
 	var lastKnownState ExecutionState = EXECUTIONSTATE_UNKNOWN
 	this.LastKnownState = &lastKnownState
 	return &this
+}
+
+// GetLastKnownState returns the LastKnownState field value if set, zero value otherwise.
+func (o *BaseExecutionUpdate) GetLastKnownState() ExecutionState {
+	if o == nil || IsNil(o.LastKnownState) {
+		var ret ExecutionState
+		return ret
+	}
+	return *o.LastKnownState
+}
+
+// GetLastKnownStateOk returns a tuple with the LastKnownState field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *BaseExecutionUpdate) GetLastKnownStateOk() (*ExecutionState, bool) {
+	if o == nil || IsNil(o.LastKnownState) {
+		return nil, false
+	}
+	return o.LastKnownState, true
+}
+
+// HasLastKnownState returns a boolean if a field has been set.
+func (o *BaseExecutionUpdate) HasLastKnownState() bool {
+	if o != nil && !IsNil(o.LastKnownState) {
+		return true
+	}
+
+	return false
+}
+
+// SetLastKnownState gets a reference to the given ExecutionState and assigns it to the LastKnownState field.
+func (o *BaseExecutionUpdate) SetLastKnownState(v ExecutionState) {
+	o.LastKnownState = &v
 }
 
 // GetCustomProperties returns the CustomProperties field value if set, zero value otherwise.
@@ -145,38 +177,6 @@ func (o *BaseExecutionUpdate) SetExternalId(v string) {
 	o.ExternalId = &v
 }
 
-// GetLastKnownState returns the LastKnownState field value if set, zero value otherwise.
-func (o *BaseExecutionUpdate) GetLastKnownState() ExecutionState {
-	if o == nil || IsNil(o.LastKnownState) {
-		var ret ExecutionState
-		return ret
-	}
-	return *o.LastKnownState
-}
-
-// GetLastKnownStateOk returns a tuple with the LastKnownState field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *BaseExecutionUpdate) GetLastKnownStateOk() (*ExecutionState, bool) {
-	if o == nil || IsNil(o.LastKnownState) {
-		return nil, false
-	}
-	return o.LastKnownState, true
-}
-
-// HasLastKnownState returns a boolean if a field has been set.
-func (o *BaseExecutionUpdate) HasLastKnownState() bool {
-	if o != nil && !IsNil(o.LastKnownState) {
-		return true
-	}
-
-	return false
-}
-
-// SetLastKnownState gets a reference to the given ExecutionState and assigns it to the LastKnownState field.
-func (o *BaseExecutionUpdate) SetLastKnownState(v ExecutionState) {
-	o.LastKnownState = &v
-}
-
 func (o BaseExecutionUpdate) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -187,6 +187,9 @@ func (o BaseExecutionUpdate) MarshalJSON() ([]byte, error) {
 
 func (o BaseExecutionUpdate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.LastKnownState) {
+		toSerialize["lastKnownState"] = o.LastKnownState
+	}
 	if !IsNil(o.CustomProperties) {
 		toSerialize["customProperties"] = o.CustomProperties
 	}
@@ -195,9 +198,6 @@ func (o BaseExecutionUpdate) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.ExternalId) {
 		toSerialize["externalId"] = o.ExternalId
-	}
-	if !IsNil(o.LastKnownState) {
-		toSerialize["lastKnownState"] = o.LastKnownState
 	}
 	return toSerialize, nil
 }


### PR DESCRIPTION
## Description
Duplicate the fields in the Base* types in the OpenAPI spec to make it easier to understand.

## How Has This Been Tested?
Re-generated the code and checked the differences.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
