### PR TITLE
Move robot TC to pytest

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -362,6 +362,35 @@ Check out our [recommendations on setting up your docker engine](https://github.
 
 ### Troubleshooting
 
-- On running `make test test-e2e` if you see a similar problem `unknown flag: --load`, install [buildx](https://formulae.brew.sh/formula/docker-buildx)
+- On running `make test test-e2e` if you see a similar problem `unknown flag: --load`, install [buildx](https://formulae.brew.sh/formula/docker-buildx). You will then need to add `cliPluginsExtraDirs` to ~/.docker/config.json, like so:
+```
+"cliPluginsExtraDirs": [
+      "/opt/homebrew/lib/docker/cli-plugins"  # depending on your system config, brew should give you the proper one
+  ]
+```
+Before running make, ensure docker is running (`docker ps -a`). If it's not, assuming you're using `colima` on macos, run
+`colima start`.
+
+- On running `make test-e2e` you might see an error similar to
+```
+102.7 /workspace/bin/golangci-lint run cmd/... internal/... ./pkg/...  --timeout 3m
+124.6 make: *** [Makefile:243: lint] Killed
+------
+Dockerfile:60
+--------------------
+  58 |     
+  59 |     # prepare the build in a separate layer
+  60 | >>> RUN make clean build/prepare
+  61 |     # compile separately to optimize multi-platform builds
+  62 |     RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build/compile
+--------------------
+ERROR: failed to solve: process "/bin/sh -c make clean build/prepare" did not complete successfully: exit code: 2
+make[1]: *** [image/build] Error 1
+make: *** [deploy-latest-mr] Error 2
+```
+To solve it, you can try launching `colima` with these settings:
+```
+colima start --cpu 6 --memory 16 --profile docker --arch aarch64 --vm-type=vz --vz-rosetta
+```
 
 <!-- github-only -->

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1031,32 +1031,19 @@ async def test_register_model_with_s3_data_connection(client: ModelRegistry):
     rm = client.register_model(**model_params)
     assert rm.id
 
-    # Get model version ID by name and parent model ID
-    mv = await client._api.get_model_version_by_params(rm.id, model_params["version"])
-    assert mv
-    assert mv.id
+    # Get and verify the registered model
+    rm_by_name = client.get_registered_model(model_params["name"])
+    assert rm_by_name.id == rm.id
 
-    # Get model artifact ID by name and parent version ID
-    ma = await client._api.get_model_artifact_by_params(model_params["name"], mv.id)
-    assert ma
-    assert ma.id
+    # Get and verify the model version
+    mv = client.get_model_version(model_params["name"], model_params["version"])
+    assert mv.description == "The Model"
+    assert mv.name == "v1.0"
 
-    # Now fetch each resource by their ID
-    rm_by_id = await client._api.get_registered_model_by_id(rm.id)
-    assert rm_by_id
-    assert rm_by_id.id == rm.id
-
-    mv_by_id = await client._api.get_model_version_by_id(mv.id)
-    assert mv_by_id
-    assert mv_by_id.id == mv.id
-    assert mv_by_id.description == "The Model"  # This is set during registration
-    assert mv_by_id.name == "v1.0"
-
-    ma_by_id = await client._api.get_model_artifact_by_id(ma.id)
-    assert ma_by_id
-    assert ma_by_id.id == ma.id
-    assert ma_by_id.uri == uri
-    assert ma_by_id.model_format_name == "onnx"
-    assert ma_by_id.model_format_version == "1"
-    assert ma_by_id.storage_key == data_connection_name
-    assert ma_by_id.storage_path == s3_path
+    # Get and verify the model artifact
+    ma = client.get_model_artifact(model_params["name"], model_params["version"])
+    assert ma.uri == uri
+    assert ma.model_format_name == "onnx"
+    assert ma.model_format_version == "1"
+    assert ma.storage_key == data_connection_name
+    assert ma.storage_path == s3_path

--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -100,6 +100,7 @@ As a MLOps engineer I would like to store an owner for the RegisteredModel
           And Should be equal    ${r["owner"]}    My owner
 
 As a MLOps engineer I want to track a Model from an S3 bucket Data Connection
+    # MIGRATED TO test_register_model_with_s3_data_connection in pytest
     ${data_connection_name}  Set Variable   aws-connection-my-data-connection
     ${s3_bucket}  Set Variable  my-bucket
     ${s3_path}  Set Variable  my-path


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Moving `As a MLOps engineer I want to track a Model from an S3 bucket Data Connection` robot TC to pytest.
Updated the troubleshooting section of the README to include a couple issues I encountered on MacOS with running `make test-e2e`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `make test-e2e`, all tests pass when running from my IDE (VSC)
Somehow, when running the same command from my terminal, I get a single failure on test `test_create_tagged_version`
```
ValueError: Newline or carriage return detected in headers. Potential header injection attack.
```
Unsure how it will behave here in CI, but it's a test that hasn't been touched in a long time.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
