### PR TITLE
py: change str repr to mitigate confusion

### DIFF
--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -81,6 +81,18 @@ class ModelVersion(BaseResourceModel):
             if source.custom_properties
             else None,
         )
+    
+    def __repr_str__(self, join_str: str) -> str:
+        """overrides pydantic Representation.__repr_str__ to bring name to the front"""
+        result = []
+        for a, v in self.__repr_args__():
+            if a is None:
+                result.append(repr(v))
+            elif a == "name":
+                result.insert(0, f'{a}={v!r}')
+            else:
+                result.append(f'{a}={v!r}')
+        return join_str.join(result)
 
 
 class RegisteredModel(BaseResourceModel):
@@ -131,3 +143,15 @@ class RegisteredModel(BaseResourceModel):
             if source.custom_properties
             else None,
         )
+    
+    def __repr_str__(self, join_str: str) -> str:
+        """overrides pydantic Representation.__repr_str__ to bring name to the front"""
+        result = []
+        for a, v in self.__repr_args__():
+            if a is None:
+                result.append(repr(v))
+            elif a == "name":
+                result.insert(0, f'{a}={v!r}')
+            else:
+                result.append(f'{a}={v!r}')
+        return join_str.join(result)

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -81,17 +81,17 @@ class ModelVersion(BaseResourceModel):
             if source.custom_properties
             else None,
         )
-    
+
     def __repr_str__(self, join_str: str) -> str:
-        """overrides pydantic Representation.__repr_str__ to bring name to the front"""
+        """Overrides pydantic Representation.__repr_str__ to bring name to the front."""
         result = []
         for a, v in self.__repr_args__():
             if a is None:
                 result.append(repr(v))
             elif a == "name":
-                result.insert(0, f'{a}={v!r}')
+                result.insert(0, f"{a}={v!r}")
             else:
-                result.append(f'{a}={v!r}')
+                result.append(f"{a}={v!r}")
         return join_str.join(result)
 
 
@@ -143,15 +143,15 @@ class RegisteredModel(BaseResourceModel):
             if source.custom_properties
             else None,
         )
-    
+
     def __repr_str__(self, join_str: str) -> str:
-        """overrides pydantic Representation.__repr_str__ to bring name to the front"""
+        """Overrides pydantic Representation.__repr_str__ to bring name to the front."""
         result = []
         for a, v in self.__repr_args__():
             if a is None:
                 result.append(repr(v))
             elif a == "name":
-                result.insert(0, f'{a}={v!r}')
+                result.insert(0, f"{a}={v!r}")
             else:
-                result.append(f'{a}={v!r}')
+                result.append(f"{a}={v!r}")
         return join_str.join(result)

--- a/clients/python/tests/types/test_context.py
+++ b/clients/python/tests/types/test_context.py
@@ -1,0 +1,57 @@
+from model_registry.types.contexts import ModelVersion, RegisteredModel
+
+
+def test_model_version_repr():
+    """Test the repr of a ModelVersion, with name to the front, ensuring other fields are also present"""
+    mv = ModelVersion(name="Version 1", id="123", author="test_author", description="test_description")
+    print(mv)
+    assert str(mv).startswith("name='Version 1'")
+    assert "id='123'" in str(mv)
+    assert "author='test_author'" in str(mv)
+    assert "description='test_description'" in str(mv)
+    print(repr(mv))
+    assert repr(mv).startswith("ModelVersion(name='Version 1'")
+    assert "id='123'" in str(mv)
+    assert "author='test_author'" in str(mv)
+    assert "description='test_description'" in str(mv)
+
+    # Test with empty name, not really used in practice but to increase coverage
+    mv = ModelVersion(name="", id="123", author="test_author", description="test_description")
+    print(mv)
+    assert str(mv).startswith("name=''")
+    assert "id='123'" in str(mv)
+    assert "author='test_author'" in str(mv)
+    assert "description='test_description'" in str(mv)
+    print(repr(mv))
+    assert repr(mv).startswith("ModelVersion(name=''")
+    assert "id='123'" in str(mv)
+    assert "author='test_author'" in str(mv)
+    assert "description='test_description'" in str(mv)
+
+
+def test_registered_model_repr():
+    """Test the repr of a RegisteredModel, with name to the front, ensuring other fields are also present"""
+    rm = RegisteredModel(name="Model 1", id="123", owner="test_owner", description="test_description")
+    print(rm)
+    assert str(rm).startswith("name='Model 1'")
+    assert "id='123'" in str(rm)
+    assert "owner='test_owner'" in str(rm)
+    assert "description='test_description'" in str(rm)
+    print(repr(rm))
+    assert repr(rm).startswith("RegisteredModel(name='Model 1'")
+    assert "id='123'" in str(rm)
+    assert "owner='test_owner'" in str(rm)
+    assert "description='test_description'" in str(rm)
+
+    # Test with empty name, not really used in practice but to increase coverage
+    rm = RegisteredModel(name="", id="123", owner="test_owner", description="test_description")
+    print(rm)
+    assert str(rm).startswith("name=''")
+    assert "id='123'" in str(rm)
+    assert "owner='test_owner'" in str(rm)
+    assert "description='test_description'" in str(rm)
+    print(repr(rm))
+    assert repr(rm).startswith("RegisteredModel(name=''")
+    assert "id='123'" in str(rm)
+    assert "owner='test_owner'" in str(rm)
+    assert "description='test_description'" in str(rm)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the MR py client is used to return information after registering a model (RegisteredModel) or ModelVersion, for example following [the tutorial](https://model-registry.readthedocs.io/en/latest/#basic-usage), we experienced that some users get confused by the "ID" which is internal to the backend (DB) for the actual name of the version.

To mitigate this confusion, it is proposed to change the str representation and bring "name" to the front, so to make it easier to recognize. This also avoids any d/s to consume this str representation in any specific order, which is not part of the contract.

Acceptance Criteria

Given I have a RegisteredModel or ModelVersion instance, When I print it out to be logged, Then the "name" attribute is presented first.

## How Has This Been Tested?
unit tests have been provided as part of this PR

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
