### PR TITLE
sorted out kustomize warnings in overlays/db and overlays/postgres

### DIFF
--- a/manifests/kustomize/base/model-registry-deployment.yaml
+++ b/manifests/kustomize/base/model-registry-deployment.yaml
@@ -91,7 +91,7 @@ spec:
           args: ["--grpc_port=9090",
                  "--mysql_config_database=$(MYSQL_DATABASE)",
                  "--mysql_config_host=$(MYSQL_HOST)",
-                 "--mysql_config_port=$(MYSQL_PORT)",
+                 "--mysql_config_port=MYSQL_PORT_PLACEHOLDER",
                  "--mysql_config_user=$(DBCONFIG_USER)",
                  "--mysql_config_password=$(DBCONFIG_PASSWORD)",
                  "--enable_database_upgrade=true"

--- a/manifests/kustomize/overlays/db/kustomization.yaml
+++ b/manifests/kustomize/overlays/db/kustomization.yaml
@@ -68,4 +68,3 @@ replacements:
       kind: Deployment
       name: model-registry-deployment
       version: v1
-  

--- a/manifests/kustomize/overlays/db/kustomization.yaml
+++ b/manifests/kustomize/overlays/db/kustomization.yaml
@@ -8,8 +8,6 @@ resources:
 - model-registry-db-service.yaml
 - ../../base
 
-patchesStrategicMerge:
-- patches/model-registry-deployment.yaml
 
 configMapGenerator:
 - envs:
@@ -28,18 +26,46 @@ images:
   newName: mysql
   newTag: 8.0.39
 
-vars:
-- fieldref:
+patches:
+- path: patches/model-registry-deployment.yaml
+replacements:
+- source:
     fieldPath: metadata.name
-  name: MLMD_DB_HOST
-  objref:
-    apiVersion: v1
     kind: Service
     name: model-registry-db
-- name: MYSQL_PORT
-  objref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.1.args.1
+    options:
+      delimiter: "="
+      index: 1
+    select: 
+      group: apps
+      kind: Deployment
+      name: model-registry-deployment
+      version: v1
+- source:
+    fieldPath: data.MYSQL_PORT
     kind: ConfigMap
     name: model-registry-db-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.MYSQL_PORT
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.1.args.3
+    options:
+      delimiter: =
+      index: 1
+    select: 
+      group: apps
+      kind: Deployment
+      name: model-registry-deployment
+      version: v1
+  - fieldPaths:
+    - spec.template.metadata.annotations.[traffic.sidecar.istio.io/excludeOutboundPorts]
+    select:
+      group: apps
+      kind: Deployment
+      name: model-registry-deployment
+      version: v1
+  

--- a/manifests/kustomize/overlays/db/kustomization.yaml
+++ b/manifests/kustomize/overlays/db/kustomization.yaml
@@ -40,7 +40,7 @@ replacements:
     options:
       delimiter: =
       index: 1
-    select: 
+    select:
       group: apps
       kind: Deployment
       name: model-registry-deployment

--- a/manifests/kustomize/overlays/db/kustomization.yaml
+++ b/manifests/kustomize/overlays/db/kustomization.yaml
@@ -56,7 +56,7 @@ replacements:
     options:
       delimiter: =
       index: 1
-    select: 
+    select:
       group: apps
       kind: Deployment
       name: model-registry-deployment

--- a/manifests/kustomize/overlays/db/kustomization.yaml
+++ b/manifests/kustomize/overlays/db/kustomization.yaml
@@ -38,7 +38,7 @@ replacements:
   - fieldPaths:
     - spec.template.spec.containers.1.args.1
     options:
-      delimiter: "="
+      delimiter: =
       index: 1
     select: 
       group: apps

--- a/manifests/kustomize/overlays/db/patches/model-registry-deployment.yaml
+++ b/manifests/kustomize/overlays/db/patches/model-registry-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     metadata:
       annotations:
         # db doesn't use istio
-        traffic.sidecar.istio.io/excludeOutboundPorts: $(MYSQL_PORT)
+        traffic.sidecar.istio.io/excludeOutboundPorts: MYSQL_PORT_PLACEHOLDER
     spec:
       containers:
         - name: rest-container
@@ -35,8 +35,8 @@ spec:
           - configMapRef:
               name: model-registry-configmap
           args: ["--grpc_port=$(MODEL_REGISTRY_GRPC_SERVICE_PORT)",
-                 "--mysql_config_host=$(MLMD_DB_HOST)",
+                 "--mysql_config_host=MLMD_DB_HOST_PLACEHOLDER",
                  "--mysql_config_database=$(MYSQL_DATABASE)",
-                 "--mysql_config_port=$(MYSQL_PORT)",
+                 "--mysql_config_port=MYSQL_PORT_PLACEHOLDER",
                  "--mysql_config_user=$(MYSQL_USER_NAME)",
                  "--mysql_config_password=$(MYSQL_ROOT_PASSWORD)"]

--- a/manifests/kustomize/overlays/postgres/kustomization.yaml
+++ b/manifests/kustomize/overlays/postgres/kustomization.yaml
@@ -2,24 +2,21 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 
-bases:
-- ../../base
 resources:
 - model-registry-db-pvc.yaml
 - model-registry-db-deployment.yaml
 - model-registry-db-service.yaml
+- ../../base
 
-patchesStrategicMerge:
-- patches/model-registry-deployment.yaml
 
 configMapGenerator:
-- name: metadata-registry-db-parameters
-  envs:
+- envs:
   - params.env
+  name: metadata-registry-db-parameters
 secretGenerator:
-- name: metadata-registry-db-secrets
-  envs:
+- envs:
   - secrets.env
+  name: metadata-registry-db-secrets
 generatorOptions:
   disableNameSuffixHash: true
 
@@ -28,18 +25,45 @@ images:
   newName: postgres
   newTag: 14.7-alpine3.17
 
-vars:
-- name: MLMD_DB_HOST
-  objref:
+patches:
+- path: patches/model-registry-deployment.yaml
+replacements:
+- source:
+    fieldPath: metadata.name
     kind: Service
     name: metadata-postgres-db
-    apiVersion: v1
-  fieldref:
-    fieldpath: metadata.name
-- name: POSTGRES_PORT
-  objref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.0.args.2
+    options:
+      delimiter: =
+      index: 1
+    select:
+      group: apps
+      kind: Deployment
+      name: model-registry-deployment
+      version: v1
+- source:
+    fieldPath: data.POSTGRES_PORT
     kind: ConfigMap
     name: metadata-registry-db-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.POSTGRES_PORT
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.metadata.annotations.[traffic.sidecar.istio.io/excludeOutboundPorts]
+    select: 
+      group: apps
+      kind: Deployment
+      name: model-registry-deployment
+      version: v1
+  - fieldPaths:
+    - spec.template.spec.containers.0.args.3
+    options:
+      delimiter: =
+      index: 1
+    select:
+      group: apps
+      kind: Deployment
+      name: model-registry-deployment
+      version: v1

--- a/manifests/kustomize/overlays/postgres/kustomization.yaml
+++ b/manifests/kustomize/overlays/postgres/kustomization.yaml
@@ -52,7 +52,7 @@ replacements:
   targets:
   - fieldPaths:
     - spec.template.metadata.annotations.[traffic.sidecar.istio.io/excludeOutboundPorts]
-    select: 
+    select:
       group: apps
       kind: Deployment
       name: model-registry-deployment

--- a/manifests/kustomize/overlays/postgres/patches/model-registry-deployment.yaml
+++ b/manifests/kustomize/overlays/postgres/patches/model-registry-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     metadata:
       annotations:
         # db doesn't use istio
-        traffic.sidecar.istio.io/excludeOutboundPorts: $(POSTGRES_PORT)
+        traffic.sidecar.istio.io/excludeOutboundPorts: POSTGRES_PORT_PLACEHOLDER
     spec:
       containers:
         - name: grpc-container
@@ -23,8 +23,8 @@ spec:
               name: model-registry-configmap
           args: ["--grpc_port=$(MODEL_REGISTRY_GRPC_SERVICE_PORT)",
                  "--metadata_source_config_type=postgresql",
-                 "--postgres_config_host=$(MLMD_DB_HOST)",
-                 "--postgres_config_port=$(POSTGRES_PORT)",
+                 "--postgres_config_host=MLMD_DB_HOST_PLACEHOLDER",
+                 "--postgres_config_port=POSTGRES_PORT_PLACEHOLDER",
                  "--postgres_config_dbname=$(POSTGRES_DBNAME)",
                  "--postgres_config_user=$(POSTGRES_USER)",
                  "--postgres_config_password=$(POSTGRES_PASSWORD)",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
As part of https://github.com/kubeflow/manifests/issues/2991, we need to fix up kustomize warnings in upstream. This MR does the same.

## How Has This Been Tested?
The rendered yamls after fixing warnings have been compared before and after the change to find out any deviations. Currently there aren't any see snapshot for details
<img width="882" alt="Screenshot 2025-05-14 at 3 15 24 pm" src="https://github.com/user-attachments/assets/59786b92-bb38-48e9-99c3-37f38f5e42d2" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages; the author will squash them after approval or in case of manual merges will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [x] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes
No UI Changes
