### PR TITLE
"make build" did not work on macOS due to unavailability of "realpath"

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+realpath_fallback() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$@"
+  elif command -v grealpath >/dev/null 2>&1; then
+    grealpath "$@"
+  else
+    python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+  fi
+} 

--- a/scripts/deploy_local_kind_registry.sh
+++ b/scripts/deploy_local_kind_registry.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(dirname "$(realpath "$BASH_SOURCE")")"
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+SCRIPT_DIR="$(dirname "$(realpath_fallback "$BASH_SOURCE")")"
 set -e
 
 kubectl apply -f "${SCRIPT_DIR}/services/container_registry.yaml"

--- a/scripts/gen_openapi_server.sh
+++ b/scripts/gen_openapi_server.sh
@@ -4,7 +4,9 @@ set -e
 
 echo "Generating the OpenAPI server"
 
-PROJECT_ROOT=$(realpath "$(dirname "$0")"/..)
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+PROJECT_ROOT=$(realpath_fallback "$(dirname "$0")"/..)
 OPENAPI_GENERATOR=${OPENAPI_GENERATOR:-"$PROJECT_ROOT"/bin/openapi-generator-cli}
 
 $OPENAPI_GENERATOR generate \

--- a/scripts/gen_type_asserts.sh
+++ b/scripts/gen_type_asserts.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-PROJECT_ROOT=$(realpath "$(dirname "$0")"/..)
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+PROJECT_ROOT=$(realpath_fallback "$(dirname "$0")"/..)
 
 ASSERT_FILE_PATH="${PROJECT_ROOT}/internal/server/openapi/type_asserts.go"
 PATCH="${PROJECT_ROOT}/patches/type_asserts.patch"

--- a/scripts/install_protoc.sh
+++ b/scripts/install_protoc.sh
@@ -16,7 +16,9 @@ elif [[ "$ARCH" == "ppc64le" ]] ; then
   ARCH="ppcle_64"
 fi
 
-PROJECT_ROOT=$(realpath "$(dirname "$0")"/..)
+source "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+PROJECT_ROOT=$(realpath_fallback "$(dirname "$0")"/..)
 
 VERSION="24.3"
 URL=https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-${OS}-${ARCH}.zip


### PR DESCRIPTION
"make build" did not work on macOS due to the unavailability of `realpath` executable for some of the scripts

## Description
This change provides a fix for macOS users to use `grealpath` instead of `realpath` 

## How Has This Been Tested?
Executed on macOS to make sure the build works

- [ x] The commits have meaningful messages
- [ x] The developer has manually tested the changes and verified that the changes work.
- [x ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).


