### PR TITLE
feat(bff): Add namespace listing for settings

### DIFF
--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -39,11 +39,11 @@ const (
 	SettingsPath                  = ApiPathPrefix + "/settings"
 	ModelRegistrySettingsListPath = SettingsPath + "/model_registry"
 	ModelRegistrySettingsPath     = ModelRegistrySettingsListPath + "/:" + ModelRegistryId
-	// Add new constants for certificates and role bindings
-	CertificatesPath    = SettingsPath + "/certificates"
-	RoleBindingListPath = SettingsPath + "/role_bindings"
-	GroupsPath          = SettingsPath + "/groups"
-	RoleBindingPath     = RoleBindingListPath + "/:" + RoleBindingNameParam // Use the constant defined in the rbac handler
+	CertificatesPath              = SettingsPath + "/certificates"
+	RoleBindingListPath           = SettingsPath + "/role_bindings"
+	GroupsPath                    = SettingsPath + "/groups"
+	SettingsNamespacePath         = SettingsPath + "/namespaces"
+	RoleBindingPath               = RoleBindingListPath + "/:" + RoleBindingNameParam
 
 	RegisteredModelListPath      = ModelRegistryPath + "/registered_models"
 	RegisteredModelPath          = RegisteredModelListPath + "/:" + RegisteredModelId
@@ -163,24 +163,33 @@ func (app *App) Routes() http.Handler {
 
 	// Standalone "only" routes
 	if app.config.StandaloneMode {
+		// This namespace endpoint is used on standalone mode to simulate
+		// Kubeflow Central Dashboard namespace selector dropdown on our standalone web app
 		apiRouter.GET(NamespaceListPath, app.GetNamespacesHandler)
-		// Model Registry Settings endpoints
+
+		// SettingsPath endpoints are used to manage the model registry settings and create new model registries
+		// We are still discussing the best way to create model registries in the community
+		// But in the meantime, those endpoints are STUBs endpoints used to unblock the frontend development
 		apiRouter.GET(ModelRegistrySettingsListPath, app.AttachNamespace(app.GetAllModelRegistriesSettingsHandler))
 		apiRouter.POST(ModelRegistrySettingsListPath, app.AttachNamespace(app.CreateModelRegistrySettingsHandler))
 		apiRouter.GET(ModelRegistrySettingsPath, app.AttachNamespace(app.GetModelRegistrySettingsHandler))
 		apiRouter.PATCH(ModelRegistrySettingsPath, app.AttachNamespace(app.UpdateModelRegistrySettingsHandler))
 		apiRouter.DELETE(ModelRegistrySettingsPath, app.AttachNamespace(app.DeleteModelRegistrySettingsHandler))
 
-		// Certificate endpoints
+		//SettingsPath: Certificate endpoints
 		apiRouter.GET(CertificatesPath, app.AttachNamespace(app.GetCertificatesHandler))
 
-		// Role Binding endpoints
+		//SettingsPath: Role Binding endpoints
 		apiRouter.GET(RoleBindingListPath, app.AttachNamespace(app.GetRoleBindingsHandler))
 		apiRouter.POST(RoleBindingListPath, app.AttachNamespace(app.CreateRoleBindingHandler))
 		apiRouter.DELETE(RoleBindingPath, app.AttachNamespace(app.DeleteRoleBindingHandler))
 
-		// Groups endpoints
+		//SettingsPath Groups endpoints
 		apiRouter.GET(GroupsPath, app.GetGroupsHandler)
+
+		//SettingsPath Namespace endpoints
+		//This namespace endpoint is used to get the namespaces for the current user inside the model registry settings
+		apiRouter.GET(SettingsNamespacePath, app.GetNamespacesHandler)
 
 	}
 

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -3,12 +3,13 @@ package api
 import (
 	"context"
 	"fmt"
-	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
-	k8mocks "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes/k8mocks"
-	"k8s.io/client-go/kubernetes"
 	"log/slog"
 	"net/http"
 	"path"
+
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+	k8mocks "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes/k8mocks"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	helper "github.com/kubeflow/model-registry/ui/bff/internal/helpers"
@@ -41,6 +42,7 @@ const (
 	// Add new constants for certificates and role bindings
 	CertificatesPath    = SettingsPath + "/certificates"
 	RoleBindingListPath = SettingsPath + "/role_bindings"
+	GroupsPath          = SettingsPath + "/groups"
 	RoleBindingPath     = RoleBindingListPath + "/:" + RoleBindingNameParam // Use the constant defined in the rbac handler
 
 	RegisteredModelListPath      = ModelRegistryPath + "/registered_models"
@@ -176,6 +178,10 @@ func (app *App) Routes() http.Handler {
 		apiRouter.GET(RoleBindingListPath, app.AttachNamespace(app.GetRoleBindingsHandler))
 		apiRouter.POST(RoleBindingListPath, app.AttachNamespace(app.CreateRoleBindingHandler))
 		apiRouter.DELETE(RoleBindingPath, app.AttachNamespace(app.DeleteRoleBindingHandler))
+
+		// Groups endpoints
+		apiRouter.GET(GroupsPath, app.GetGroupsHandler)
+
 	}
 
 	// App Router

--- a/clients/ui/bff/internal/api/model_registry_settings_groups_handler.go
+++ b/clients/ui/bff/internal/api/model_registry_settings_groups_handler.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+)
+
+type GroupsEnvelope Envelope[[]models.GroupModel, None]
+
+// STUB IMPLEMENTATION (see kubernetes clients for more details)
+func (app *App) GetGroupsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+
+	ctx := r.Context()
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*kubernetes.RequestIdentity)
+	if !ok || identity == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing RequestIdentity in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to get Kubernetes client: %w", err))
+		return
+	}
+
+	groups, err := app.repositories.ModelRegistrySettings.GetGroups(r.Context(), client)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to get groups: %w", err))
+		return
+	}
+
+	resp := GroupsEnvelope{Data: groups}
+
+	err = app.WriteJSON(w, http.StatusOK, resp, nil)
+
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/clients/ui/bff/internal/api/model_registry_settings_groups_handler_test.go
+++ b/clients/ui/bff/internal/api/model_registry_settings_groups_handler_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/config"
+	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestGroupsHandler", func() {
+	Context("when fetching group list in standalone mode", Ordered, func() {
+		var testApp App
+
+		BeforeAll(func() {
+			testApp = App{
+				config:                  config.EnvConfig{StandaloneMode: true},
+				kubernetesClientFactory: kubernetesMockedStaticClientFactory,
+				repositories:            repositories.NewRepositories(mockMRClient),
+				logger:                  logger,
+			}
+		})
+
+		It("should return the group names for user@example.com", func() {
+			req, err := http.NewRequest(http.MethodGet, GroupsPath+"?namespace=kubeflow", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			})
+			ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "kubeflow")
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			testApp.GetGroupsHandler(rr, req, nil)
+
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			var actual GroupsEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+
+			expected := []models.GroupModel{
+				{Name: "dora-group-mock"},
+				{Name: "bella-group-mock"},
+			}
+
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			Expect(actual.Data).To(ConsistOf(expected))
+		})
+	})
+})

--- a/clients/ui/bff/internal/integrations/kubernetes/client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/client.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -24,4 +25,7 @@ type KubernetesClientInterface interface {
 	IsClusterAdmin(identity *RequestIdentity) (bool, error)
 	BearerToken() (string, error)
 	GetUser(identity *RequestIdentity) (string, error)
+
+	// Model Registry Settings
+	GetGroups(ctx context.Context) ([]string, error)
 }

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/internal_k8s_client_mock.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/internal_k8s_client_mock.go
@@ -3,9 +3,10 @@ package k8mocks
 import (
 	"context"
 	"fmt"
+	"log/slog"
+
 	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
 	"k8s.io/client-go/kubernetes"
-	"log/slog"
 )
 
 type InternalKubernetesClientMock struct {
@@ -53,4 +54,8 @@ func (m *InternalKubernetesClientMock) GetServiceDetailsByName(sessionCtx contex
 // BearerToken always returns a fake token for tests
 func (m *InternalKubernetesClientMock) BearerToken() (string, error) {
 	return "FAKE-BEARER-TOKEN", nil
+}
+
+func (kc *InternalKubernetesClientMock) GetGroups(ctx context.Context) ([]string, error) {
+	return []string{"dora-group-mock", "bella-group-mock"}, nil
 }

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/token_k8s_client_mock.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/token_k8s_client_mock.go
@@ -3,9 +3,10 @@ package k8mocks
 import (
 	"context"
 	"fmt"
+	"log/slog"
+
 	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
 	"k8s.io/client-go/kubernetes"
-	"log/slog"
 )
 
 // ⚠️ WHY THIS FILE EXISTS:
@@ -58,4 +59,8 @@ func (m *TokenKubernetesClientMock) GetServiceDetailsByName(sessionCtx context.C
 // BearerToken always returns a fake token for tests
 func (m *TokenKubernetesClientMock) BearerToken() (string, error) {
 	return "FAKE-BEARER-TOKEN", nil
+}
+
+func (kc *TokenKubernetesClientMock) GetGroups(ctx context.Context) ([]string, error) {
+	return []string{"dora-group-mock", "bella-group-mock"}, nil
 }

--- a/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
@@ -3,12 +3,13 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"time"
+
 	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"log/slog"
-	"time"
 )
 
 type SharedClientLogic struct {
@@ -138,4 +139,9 @@ func (kc *SharedClientLogic) GetServiceDetailsByName(sessionCtx context.Context,
 func (kc *SharedClientLogic) BearerToken() (string, error) {
 	// Token is retained for follow-up calls; do not log it.
 	return kc.Token.Raw(), nil
+}
+
+func (kc *SharedClientLogic) GetGroups(ctx context.Context) ([]string, error) {
+	kc.Logger.Info("This functionality is not implement yet. This is a STUB API to unblock frontend development until we have a definition on how to create model registries")
+	return []string{}, nil
 }

--- a/clients/ui/bff/internal/models/groups.go
+++ b/clients/ui/bff/internal/models/groups.go
@@ -1,0 +1,11 @@
+package models
+
+type GroupModel struct {
+	Name string `json:"name"`
+}
+
+func NewGroupModel(name string) GroupModel {
+	return GroupModel{
+		Name: name,
+	}
+}

--- a/clients/ui/bff/internal/repositories/model_registry_settings.go
+++ b/clients/ui/bff/internal/repositories/model_registry_settings.go
@@ -1,0 +1,30 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+)
+
+type ModelRegistrySettingsRepository struct {
+}
+
+func NewModelRegistrySettingsRepository() *ModelRegistrySettingsRepository {
+	return &ModelRegistrySettingsRepository{}
+}
+
+func (r *ModelRegistrySettingsRepository) GetGroups(ctx context.Context, client k8s.KubernetesClientInterface) ([]models.GroupModel, error) {
+	groupNames, err := client.GetGroups(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching groups: %w", err)
+	}
+
+	var groups []models.GroupModel
+	for _, name := range groupNames {
+		groups = append(groups, models.NewGroupModel(name))
+	}
+
+	return groups, nil
+}

--- a/clients/ui/bff/internal/repositories/model_registry_settings_test.go
+++ b/clients/ui/bff/internal/repositories/model_registry_settings_test.go
@@ -1,0 +1,33 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/mocks"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestModelRegistrySettingsRepository", func() {
+	Context("fetching groups from the stub", Ordered, func() {
+
+		It("should return the mocked group list", func() {
+			By("initializing the repository and client")
+			repo := NewModelRegistrySettingsRepository()
+			k8sClient, err := kubernetesMockedStaticClientFactory.GetClient(mocks.NewMockSessionContextNoParent())
+			Expect(err).NotTo(HaveOccurred())
+
+			By("fetching groups")
+			groups, err := repo.GetGroups(context.Background(), k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the returned group models")
+			expected := []models.GroupModel{
+				{Name: "dora-group-mock"},
+				{Name: "bella-group-mock"},
+			}
+			Expect(groups).To(ConsistOf(expected))
+		})
+	})
+})

--- a/clients/ui/bff/internal/repositories/repositories.go
+++ b/clients/ui/bff/internal/repositories/repositories.go
@@ -2,19 +2,21 @@ package repositories
 
 // Repositories struct is a single convenient container to hold and represent all our repositories.
 type Repositories struct {
-	HealthCheck         *HealthCheckRepository
-	ModelRegistry       *ModelRegistryRepository
-	ModelRegistryClient ModelRegistryClientInterface
-	User                *UserRepository
-	Namespace           *NamespaceRepository
+	HealthCheck           *HealthCheckRepository
+	ModelRegistry         *ModelRegistryRepository
+	ModelRegistrySettings *ModelRegistrySettingsRepository
+	ModelRegistryClient   ModelRegistryClientInterface
+	User                  *UserRepository
+	Namespace             *NamespaceRepository
 }
 
 func NewRepositories(modelRegistryClient ModelRegistryClientInterface) *Repositories {
 	return &Repositories{
-		HealthCheck:         NewHealthCheckRepository(),
-		ModelRegistry:       NewModelRegistryRepository(),
-		ModelRegistryClient: modelRegistryClient,
-		User:                NewUserRepository(),
-		Namespace:           NewNamespaceRepository(),
+		HealthCheck:           NewHealthCheckRepository(),
+		ModelRegistry:         NewModelRegistryRepository(),
+		ModelRegistrySettings: NewModelRegistrySettingsRepository(),
+		ModelRegistryClient:   modelRegistryClient,
+		User:                  NewUserRepository(),
+		Namespace:             NewNamespaceRepository(),
 	}
 }


### PR DESCRIPTION
## Description
This PR builds upon https://github.com/kubeflow/model-registry/pull/1151 and introduces an endpoint to list namespaces in settings. The purpose of this PR is to unblock frontend development for the namespace listing on the model registry settings screens until we, as a community, decide how we are going to automate the creation of model registries.

## How Has This Been Tested?
```code
 curl -i -H "kubeflow-userid: user@example.com" "localhost:4000/api/v1/settings/namespaces"
HTTP/1.1 200 OK
Content-Type: application/json
Date: Fri, 23 May 2025 16:09:48 GMT
Content-Length: 297

{
	"data": [
		{
			"name": "bella-namespace"
		},
		{
			"name": "bento-namespace"
		},
		{
			"name": "default"
		},
		{
			"name": "dora-namespace"
		},
		{
			"name": "kube-node-lease"
		},
		{
			"name": "kube-public"
		},
		{
			"name": "kube-system"
		},
		{
			"name": "kubeflow"
		}
	]
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [X] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [X] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
 .
