### PR TITLE
py: add options to cleanup local registry and minio set up for e2e tests

### DIFF
--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -52,6 +52,16 @@ test-e2e-cleanup:
 		rm -f .port-forwards.pid; \
 	fi
 
+.PHONY: undeploy-minio
+undeploy-minio:
+	@echo "Undeploy Minio..."
+	cd ../../ && ./scripts/undeploy_minio.sh
+
+.PHONY: undeploy-local-kind-registry
+undeploy-local-kind-registry:
+	@echo "Undeploy Local Kind Registry..."
+	cd ../../ && ./scripts/undeploy_local_registry.sh
+
 .PHONY: test
 test:
 	poetry run pytest -s -rA

--- a/scripts/undeploy_local_registry.sh
+++ b/scripts/undeploy_local_registry.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+echo "Undeploy local registry:"
+echo "Delete Deployment"
+kubectl delete deployment -l app=distribution-registry-test
+echo "Delete Service"
+kubectl delete Service -l app=distribution-registry-test
+echo "Delete PersistentVolumeClaim"
+kubectl delete persistentvolumeclaim distribution-registry-pvc
+
+echo "Local registry clean up completed"

--- a/scripts/undeploy_minio.sh
+++ b/scripts/undeploy_minio.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+MINIO_NAMESPACE="minio"
+unset KF_MR_TEST_ACCESS_KEY_ID KF_MR_TEST_SECRET_ACCESS_KEY KF_MR_TEST_S3_ENDPOINT KF_MR_TEST_BUCKET_NAME
+
+echo 'Delete Minio namespace if exists'
+kubectl delete namespace $MINIO_NAMESPACE --wait=False
+
+echo "Waiting for namespace $NAMESPACE_TO_DELETE to be deleted..."
+
+kubectl wait --for=delete namespace/"$MINIO_NAMESPACE" --timeout=300s


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
