### PR TITLE
Add rolebinding to manage permissions

### DIFF
--- a/clients/ui/frontend/src/__mocks__/mockRoleBindingK8sResource.ts
+++ b/clients/ui/frontend/src/__mocks__/mockRoleBindingK8sResource.ts
@@ -1,0 +1,48 @@
+import { RoleBindingKind, RoleBindingSubject } from 'mod-arch-shared';
+import { genUID } from './mockUtils';
+
+type MockResourceConfigType = {
+  name?: string;
+  namespace?: string;
+  subjects?: RoleBindingSubject[];
+  roleRefName?: string;
+  uid?: string;
+  modelRegistryName?: string;
+};
+
+export const mockRoleBindingK8sResource = ({
+  name = 'test-name-view',
+  namespace = 'test-project',
+  subjects = [
+    {
+      kind: 'ServiceAccount',
+      apiGroup: 'rbac.authorization.k8s.io',
+      name: 'test-name-sa',
+    },
+  ],
+  roleRefName = 'view',
+  uid = genUID('rolebinding'),
+  modelRegistryName = '',
+}: MockResourceConfigType): RoleBindingKind => ({
+  kind: 'RoleBinding',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  metadata: {
+    name,
+    namespace,
+    uid,
+    creationTimestamp: '2023-02-14T21:43:59Z',
+    labels: {
+      'app.kubernetes.io/name': modelRegistryName,
+      app: modelRegistryName,
+      'app.kubernetes.io/component': 'model-registry',
+      'app.kubernetes.io/part-of': 'model-registry',
+      component: 'model-registry',
+    },
+  },
+  subjects,
+  roleRef: {
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: modelRegistryName ? 'Role' : 'ClusterRole',
+    name: roleRefName,
+  },
+});

--- a/clients/ui/frontend/src/__mocks__/mockUtils.ts
+++ b/clients/ui/frontend/src/__mocks__/mockUtils.ts
@@ -1,0 +1,4 @@
+// TODO: Move this code to shared library once the migration completes.
+import { genRandomChars } from 'mod-arch-shared';
+
+export const genUID = (name: string): string => `test-uid_${name}_${genRandomChars()}`;

--- a/clients/ui/frontend/src/app/api/k8s.ts
+++ b/clients/ui/frontend/src/app/api/k8s.ts
@@ -12,9 +12,14 @@ import {
   restPATCH,
   GroupKind,
   RoleBindingKind,
+  K8sResourceCommon,
+  RoleBindingSubject,
+  RoleBindingRoleRef,
+  genRandomChars,
 } from 'mod-arch-shared';
 import { ModelRegistry } from '~/app/types';
 import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
+import { RoleBindingPermissionsRoleType } from '~/app/pages/settings/roleBinding/types';
 
 export const getListModelRegistries =
   (hostPath: string, queryParams: Record<string, unknown> = {}) =>
@@ -242,3 +247,67 @@ export const deleteRoleBinding =
       }
       throw new Error('Invalid response format');
     });
+
+export const addOwnerReference = <R extends K8sResourceCommon>(
+  resource: R,
+  owner?: K8sResourceCommon,
+  blockOwnerDeletion = false,
+): R => {
+  if (!owner) {
+    return resource;
+  }
+  const ownerReferences = resource.metadata?.ownerReferences || [];
+  if (
+    owner.metadata?.uid &&
+    owner.metadata.name &&
+    !ownerReferences.find((r) => r.uid === owner.metadata?.uid)
+  ) {
+    ownerReferences.push({
+      uid: owner.metadata.uid,
+      name: owner.metadata.name,
+      apiVersion: owner.apiVersion,
+      kind: owner.kind,
+      blockOwnerDeletion,
+    });
+  }
+  return {
+    ...resource,
+    metadata: {
+      ...resource.metadata,
+      ownerReferences,
+    },
+  };
+};
+
+export const generateRoleBindingPermissions = (
+  namespace: string,
+  rbSubjectKind: RoleBindingSubject['kind'],
+  rbSubjectName: RoleBindingSubject['name'],
+  rbRoleRefName: RoleBindingPermissionsRoleType | string, //string because with MR this can include MR name
+  rbRoleRefKind: RoleBindingRoleRef['kind'],
+  rbLabels?: { [key: string]: string },
+  ownerReference?: K8sResourceCommon,
+): RoleBindingKind => {
+  const roleBindingObject: RoleBindingKind = {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'RoleBinding',
+    metadata: {
+      name: `dashboard-permissions-${genRandomChars()}`,
+      namespace,
+      labels: rbLabels,
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: rbRoleRefKind,
+      name: rbRoleRefName,
+    },
+    subjects: [
+      {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: rbSubjectKind,
+        name: rbSubjectName,
+      },
+    ],
+  };
+  return addOwnerReference(roleBindingObject, ownerReference);
+};

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissions.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissions.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react';
+import {
+  Alert,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  PageSection,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import {
+  FetchStateObject,
+  GroupKind,
+  K8sResourceCommon,
+  K8sStatus,
+  RoleBindingKind,
+  RoleBindingRoleRef,
+} from 'mod-arch-shared';
+import RoleBindingPermissionsTableSection from './RoleBindingPermissionsTableSection';
+import { RoleBindingPermissionsRBType, RoleBindingPermissionsRoleType } from './types';
+import { filterRoleBindingSubjects } from './utils';
+
+type RoleBindingPermissionsProps = {
+  ownerReference?: K8sResourceCommon;
+  roleBindingPermissionsRB: FetchStateObject<RoleBindingKind[]>;
+  defaultRoleBindingName?: string;
+  permissionOptions: {
+    type: RoleBindingPermissionsRoleType;
+    description: string;
+  }[];
+  createRoleBinding: (roleBinding: RoleBindingKind) => Promise<RoleBindingKind>;
+  deleteRoleBinding: (name: string, namespace: string) => Promise<K8sStatus>;
+
+  projectName: string;
+  roleRefKind: RoleBindingRoleRef['kind'];
+  roleRefName?: RoleBindingRoleRef['name'];
+  labels?: { [key: string]: string };
+  description: React.ReactElement | string;
+  groups: GroupKind[];
+  isGroupFirst?: boolean;
+};
+
+const RoleBindingPermissions: React.FC<RoleBindingPermissionsProps> = ({
+  ownerReference,
+  roleBindingPermissionsRB,
+  defaultRoleBindingName,
+  permissionOptions,
+  projectName,
+  createRoleBinding,
+  deleteRoleBinding,
+  roleRefKind,
+  roleRefName,
+  labels,
+  description,
+  groups,
+  isGroupFirst = false,
+}) => {
+  const {
+    data: roleBindings,
+    loaded,
+    error: loadError,
+    refresh: refreshRB,
+  } = roleBindingPermissionsRB;
+  if (loadError) {
+    return (
+      <EmptyState
+        headingLevel="h2"
+        icon={ExclamationCircleIcon}
+        titleText="There was an issue loading permissions."
+        variant={EmptyStateVariant.lg}
+        data-id="error-empty-state"
+        id="permissions"
+      >
+        <EmptyStateBody>{loadError.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  if (!loaded) {
+    return (
+      <EmptyState
+        headingLevel="h2"
+        titleText="Loading"
+        variant={EmptyStateVariant.lg}
+        data-id="loading-empty-state"
+        id="permissions"
+      >
+        <Spinner size="xl" />
+      </EmptyState>
+    );
+  }
+
+  const userTable = (
+    <RoleBindingPermissionsTableSection
+      ownerReference={ownerReference}
+      defaultRoleBindingName={defaultRoleBindingName}
+      projectName={projectName}
+      roleRefKind={roleRefKind}
+      roleRefName={roleRefName}
+      labels={labels}
+      permissionOptions={permissionOptions}
+      roleBindings={filterRoleBindingSubjects(roleBindings, RoleBindingPermissionsRBType.USER)}
+      subjectKind={RoleBindingPermissionsRBType.USER}
+      refresh={refreshRB}
+      typeModifier="user"
+      createRoleBinding={createRoleBinding}
+      deleteRoleBinding={deleteRoleBinding}
+    />
+  );
+
+  const groupTable = (
+    <RoleBindingPermissionsTableSection
+      ownerReference={ownerReference}
+      defaultRoleBindingName={defaultRoleBindingName}
+      projectName={projectName}
+      roleRefKind={roleRefKind}
+      roleRefName={roleRefName}
+      permissionOptions={permissionOptions}
+      labels={labels}
+      roleBindings={filterRoleBindingSubjects(roleBindings, RoleBindingPermissionsRBType.GROUP)}
+      subjectKind={RoleBindingPermissionsRBType.GROUP}
+      refresh={refreshRB}
+      typeAhead={
+        groups.length > 0 ? groups.map((group: GroupKind) => group.metadata.name) : undefined
+      }
+      typeModifier="group"
+      createRoleBinding={createRoleBinding}
+      deleteRoleBinding={deleteRoleBinding}
+    />
+  );
+
+  return (
+    <PageSection
+      hasBodyWrapper={false}
+      isFilled
+      aria-label="project-sharing-page-section"
+      id="permissions"
+    >
+      <Stack hasGutter>
+        <Alert variant="warning" title="Warning" isInline>
+          Changing user or group permissions may remove their access to this resource.
+        </Alert>
+        <StackItem>{description}</StackItem>
+        <StackItem>{isGroupFirst ? groupTable : userTable}</StackItem>
+        <StackItem>{isGroupFirst ? userTable : groupTable}</StackItem>
+      </Stack>
+    </PageSection>
+  );
+};
+
+export default RoleBindingPermissions;

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsChangeModal.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsChangeModal.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import DeleteModal from '~/app/shared/components/DeleteModal';
+
+type RoleBindingPermissionsChangeModalProps = {
+  onClose: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  isDeleting: boolean;
+  roleName?: string;
+};
+
+const RoleBindingPermissionsChangeModal: React.FC<RoleBindingPermissionsChangeModalProps> = ({
+  onClose,
+  onEdit,
+  onDelete,
+  isDeleting,
+  roleName,
+}) => {
+  const textToShow = isDeleting ? 'Delete' : 'Edit';
+  const [submitted, setSubmitted] = React.useState(false);
+  return (
+    <DeleteModal
+      title={`Confirm ${textToShow.toLowerCase()}`}
+      onClose={onClose}
+      deleting={submitted}
+      onDelete={() => {
+        setSubmitted(true);
+        if (isDeleting) {
+          onDelete();
+        } else {
+          onEdit();
+        }
+      }}
+      deleteName={roleName || 'delete'}
+      submitButtonLabel={isDeleting ? 'Delete' : 'Save'}
+      genericLabel
+    >
+      Are you sure you want to {isDeleting ? 'delete' : 'edit'} permissions for{' '}
+      <strong>{roleName || 'this role binding'}</strong>? {isDeleting ? 'Deleting' : 'Editing'}{' '}
+      these permissions may result in loss of access to this resource.
+    </DeleteModal>
+  );
+};
+
+export default RoleBindingPermissionsChangeModal;

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsNameInput.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsNameInput.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { TextInput } from '@patternfly/react-core';
+import { RoleBindingSubject, TypeaheadSelect } from 'mod-arch-shared';
+import { RoleBindingPermissionsRBType } from './types';
+
+type RoleBindingPermissionsNameInputProps = {
+  subjectKind: RoleBindingSubject['kind'];
+  value: string;
+  onChange: (selection: string) => void;
+  onClear: () => void;
+  placeholderText: string;
+  typeAhead?: string[];
+};
+
+const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputProps> = ({
+  subjectKind,
+  value,
+  onChange,
+  onClear,
+  placeholderText,
+  typeAhead,
+}) => {
+  // TODO: We don't have project context yet and need to add logic to show projects permission tab under manage permissions of MR - might need to move the project-context part to shared library
+  if (!typeAhead) {
+    return (
+      <TextInput
+        data-testid={`role-binding-name-input ${value}`}
+        isRequired
+        aria-label="role-binding-name-input"
+        type="text"
+        value={value}
+        placeholder={`Type ${
+          subjectKind === RoleBindingPermissionsRBType.GROUP ? 'group name' : 'username'
+        }`}
+        onChange={(e, newValue) => onChange(newValue)}
+      />
+    );
+  }
+
+  const selectOptions = typeAhead.map((option) => {
+    const displayName = option;
+    return { value: displayName, content: displayName };
+  });
+  // If we've selected an option that doesn't exist via isCreatable, include it in the options so it remains selected
+  if (value && !selectOptions.some((option) => option.value === value)) {
+    selectOptions.push({ value, content: value });
+  }
+  return (
+    <TypeaheadSelect
+      dataTestId={`role-binding-name-select ${value}`}
+      isScrollable
+      selectOptions={selectOptions}
+      selected={value}
+      isCreatable
+      onClearSelection={onClear}
+      onSelect={(_ev, selectedValue) => {
+        if (typeof selectedValue === 'string') {
+          onChange(selectedValue);
+        }
+      }}
+      placeholder={placeholderText}
+      createOptionMessage={(newValue) => `Select "${newValue}"`}
+    />
+  );
+};
+
+export default RoleBindingPermissionsNameInput;

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsPermissionSelection.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsPermissionSelection.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { SimpleSelect } from 'mod-arch-shared';
+import { SimpleSelectOption } from 'mod-arch-shared/dist/components/SimpleSelect';
+import { RoleBindingPermissionsRoleType } from './types';
+import { castRoleBindingPermissionsRoleType, roleLabel } from './utils';
+
+type RoleBindingPermissionsPermissionSelectionProps = {
+  selection: RoleBindingPermissionsRoleType;
+  permissionOptions: {
+    type: RoleBindingPermissionsRoleType;
+    description: string;
+  }[];
+  onSelect: (roleType: RoleBindingPermissionsRoleType) => void;
+};
+
+const RoleBindingPermissionsPermissionSelection: React.FC<
+  RoleBindingPermissionsPermissionSelectionProps
+> = ({ selection, onSelect, permissionOptions }) => (
+  <SimpleSelect
+    isFullWidth
+    options={permissionOptions.map(
+      (option): SimpleSelectOption => ({
+        ...option,
+        label: roleLabel(option.type),
+        key: option.type,
+      }),
+    )}
+    value={selection}
+    toggleLabel={roleLabel(selection)}
+    onChange={(newSelection) => {
+      onSelect(castRoleBindingPermissionsRoleType(newSelection));
+    }}
+    popperProps={{ direction: 'down' }}
+    previewDescription={false}
+  />
+);
+
+export default RoleBindingPermissionsPermissionSelection;

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTable.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTable.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+import {
+  K8sResourceCommon,
+  K8sStatus,
+  RoleBindingKind,
+  RoleBindingRoleRef,
+  RoleBindingSubject,
+  Table,
+} from 'mod-arch-shared';
+import { generateRoleBindingPermissions } from '~/app/api/k8s';
+import RoleBindingPermissionsTableRow from './RoleBindingPermissionsTableRow';
+import { columnsRoleBindingPermissions } from './data';
+import { RoleBindingPermissionsRoleType } from './types';
+import { firstSubject, tryPatchRoleBinding } from './utils';
+
+type RoleBindingPermissionsTableProps = {
+  ownerReference?: K8sResourceCommon;
+  subjectKind: RoleBindingSubject['kind'];
+  namespace: string;
+  roleRefKind: RoleBindingRoleRef['kind'];
+  roleRefName?: RoleBindingRoleRef['name'];
+  labels?: { [key: string]: string };
+  defaultRoleBindingName?: string;
+  permissions: RoleBindingKind[];
+  permissionOptions: {
+    type: RoleBindingPermissionsRoleType;
+    description: string;
+  }[];
+  isAdding: boolean;
+  typeAhead?: string[];
+  createRoleBinding: (roleBinding: RoleBindingKind) => Promise<RoleBindingKind>;
+  deleteRoleBinding: (name: string, namespace: string) => Promise<K8sStatus>;
+  onDismissNewRow: () => void;
+  onError: (error: React.ReactNode) => void;
+  refresh: () => void;
+};
+
+const RoleBindingPermissionsTable: React.FC<RoleBindingPermissionsTableProps> = ({
+  ownerReference,
+  subjectKind,
+  namespace,
+  roleRefKind,
+  roleRefName,
+  labels,
+  defaultRoleBindingName,
+  permissions,
+  permissionOptions,
+  typeAhead,
+  isAdding,
+  createRoleBinding,
+  deleteRoleBinding,
+  onDismissNewRow,
+  onError,
+  refresh,
+}) => {
+  const [editCell, setEditCell] = React.useState<string[]>([]);
+
+  const createProjectRoleBinding = async (
+    newRBObject: RoleBindingKind,
+    oldRBObject?: RoleBindingKind,
+  ) => {
+    if (isAdding) {
+      // Add new role binding
+      createRoleBinding(newRBObject)
+        .then(() => {
+          onDismissNewRow();
+          refresh();
+        })
+        .catch((e) => {
+          onError(<>{e}</>);
+        });
+    } else if (oldRBObject) {
+      const patchSucceeded = await tryPatchRoleBinding(oldRBObject, newRBObject);
+      if (patchSucceeded) {
+        setEditCell((prev) => prev.filter((cell) => cell !== oldRBObject.metadata.name));
+        onDismissNewRow();
+        refresh();
+      } else {
+        createRoleBinding(newRBObject)
+          .then(() => {
+            deleteRoleBinding(oldRBObject.metadata.name, oldRBObject.metadata.namespace)
+              .then(() => refresh())
+              .catch((e) => {
+                onError(<>{e}</>);
+                setEditCell((prev) => prev.filter((cell) => cell !== oldRBObject.metadata.name));
+              });
+          })
+          .then(() => {
+            onDismissNewRow();
+            refresh();
+          })
+          .catch((e) => {
+            onError(<>{e}</>);
+            setEditCell((prev) => prev.filter((cell) => cell !== oldRBObject.metadata.name));
+          });
+      }
+    }
+  };
+  return (
+    <Table
+      variant="compact"
+      data={permissions}
+      data-testid={`role-binding-table ${subjectKind}`}
+      columns={columnsRoleBindingPermissions}
+      disableRowRenderSupport
+      footerRow={() =>
+        isAdding ? (
+          <RoleBindingPermissionsTableRow
+            key="add-permissions-row"
+            subjectKind={subjectKind}
+            permissionOptions={permissionOptions}
+            typeAhead={typeAhead}
+            isEditing={false}
+            isAdding
+            onChange={(subjectName, rbRoleRefName) => {
+              const newRBObject = generateRoleBindingPermissions(
+                namespace,
+                subjectKind,
+                subjectName,
+                roleRefName || rbRoleRefName,
+                roleRefKind,
+                labels,
+                ownerReference,
+              );
+              createProjectRoleBinding(newRBObject);
+            }}
+            onCancel={onDismissNewRow}
+          />
+        ) : null
+      }
+      rowRenderer={(rb) => (
+        <RoleBindingPermissionsTableRow
+          defaultRoleBindingName={defaultRoleBindingName}
+          key={rb.metadata.name || ''}
+          permissionOptions={permissionOptions}
+          roleBindingObject={rb}
+          subjectKind={subjectKind}
+          isEditing={firstSubject(rb) === '' || editCell.includes(rb.metadata.name)}
+          isAdding={false}
+          typeAhead={typeAhead}
+          onChange={(subjectName, rbRoleRefName) => {
+            const newRBObject = generateRoleBindingPermissions(
+              namespace,
+              subjectKind,
+              subjectName,
+              roleRefName || rbRoleRefName,
+              roleRefKind,
+              labels,
+              ownerReference,
+            );
+            createProjectRoleBinding(newRBObject, rb);
+            refresh();
+          }}
+          onDelete={() => {
+            deleteRoleBinding(rb.metadata.name, rb.metadata.namespace).then(() => refresh());
+          }}
+          onEdit={() => {
+            setEditCell((prev) => [...prev, rb.metadata.name]);
+          }}
+          onCancel={() => {
+            setEditCell((prev) => prev.filter((cell) => cell !== rb.metadata.name));
+            onDismissNewRow();
+          }}
+        />
+      )}
+    />
+  );
+};
+export default RoleBindingPermissionsTable;

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTableRow.tsx
@@ -1,0 +1,260 @@
+import * as React from 'react';
+import { ActionsColumn, Tbody, Td, Tr } from '@patternfly/react-table';
+import {
+  Button,
+  Popover,
+  Split,
+  SplitItem,
+  Content,
+  Timestamp,
+  TimestampTooltipVariant,
+  Tooltip,
+  Truncate,
+} from '@patternfly/react-core';
+import {
+  CheckIcon,
+  OutlinedQuestionCircleIcon,
+  TimesIcon,
+  EllipsisVIcon,
+} from '@patternfly/react-icons';
+import {
+  DashboardPopupIconButton,
+  relativeTime,
+  RoleBindingKind,
+  RoleBindingSubject,
+} from 'mod-arch-shared';
+import useUser from '~/app/hooks/useUser';
+import {
+  castRoleBindingPermissionsRoleType,
+  firstSubject,
+  roleLabel,
+  isCurrentUserChanging,
+} from './utils';
+import { RoleBindingPermissionsRoleType } from './types';
+import RoleBindingPermissionsNameInput from './RoleBindingPermissionsNameInput';
+import RoleBindingPermissionsPermissionSelection from './RoleBindingPermissionsPermissionSelection';
+import RoleBindingPermissionsChangeModal from './RoleBindingPermissionsChangeModal';
+
+type RoleBindingPermissionsTableRowProps = {
+  roleBindingObject?: RoleBindingKind;
+  subjectKind: RoleBindingSubject['kind'];
+  isEditing: boolean;
+  isAdding: boolean;
+  defaultRoleBindingName?: string;
+  permissionOptions: {
+    type: RoleBindingPermissionsRoleType;
+    description: string;
+  }[];
+  typeAhead?: string[];
+  onChange: (name: string, roleType: RoleBindingPermissionsRoleType) => void;
+  onCancel: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+};
+
+const defaultValueName = (obj: RoleBindingKind) => firstSubject(obj);
+const defaultValueRole = (obj: RoleBindingKind) =>
+  castRoleBindingPermissionsRoleType(obj.roleRef.name);
+
+const RoleBindingPermissionsTableRow: React.FC<RoleBindingPermissionsTableRowProps> = ({
+  roleBindingObject: obj,
+  subjectKind,
+  isEditing,
+  isAdding,
+  defaultRoleBindingName,
+  permissionOptions,
+  typeAhead,
+  onChange,
+  onCancel,
+  onEdit,
+  onDelete,
+}) => {
+  // TODO: We don't have project context yet and need to add logic to show projects permission tab under manage permissions of MR - might need to move the project-context part to shared library
+  const currentUser = useUser();
+  const isCurrentUserBeingChanged = isCurrentUserChanging(obj, currentUser.userId);
+  const [roleBindingName, setRoleBindingName] = React.useState(() => {
+    if (isAdding || !obj) {
+      return '';
+    }
+    return defaultValueName(obj);
+  });
+  const [roleBindingRoleRef, setRoleBindingRoleRef] =
+    React.useState<RoleBindingPermissionsRoleType>(() => {
+      if (isAdding || !obj) {
+        return permissionOptions[0]?.type;
+      }
+      return defaultValueRole(obj);
+    });
+  const [isLoading, setIsLoading] = React.useState(false);
+  const createdDate = new Date(obj?.metadata.creationTimestamp ?? '');
+  const isDefaultGroup = obj?.metadata.name === defaultRoleBindingName;
+  const [showModal, setShowModal] = React.useState(false);
+  const [isDeleting, setIsDeleting] = React.useState(false);
+
+  //Sync local state with props if exiting edit mode
+  React.useEffect(() => {
+    if (!isEditing && obj) {
+      setRoleBindingName(defaultValueName(obj));
+      setRoleBindingRoleRef(defaultValueRole(obj));
+    }
+  }, [obj, isEditing]);
+
+  return (
+    <>
+      <Tbody>
+        <Tr>
+          <Td dataLabel="Username">
+            {isEditing || isAdding ? (
+              <RoleBindingPermissionsNameInput
+                subjectKind={subjectKind}
+                value={roleBindingName}
+                onChange={(selection: React.SetStateAction<string>) => {
+                  setRoleBindingName(selection);
+                }}
+                onClear={() => setRoleBindingName('')}
+                placeholderText="Select a group"
+                typeAhead={typeAhead}
+              />
+            ) : (
+              <Content component="p">
+                <Truncate content={roleBindingName} />
+                {` `}
+                {isDefaultGroup && (
+                  <Popover
+                    bodyContent={
+                      <div>
+                        This group is created by default. You can add users to this group in
+                        OpenShift user management, or ask the cluster admin to do so.
+                      </div>
+                    }
+                  >
+                    <DashboardPopupIconButton
+                      icon={<OutlinedQuestionCircleIcon />}
+                      aria-label="More info"
+                    />
+                  </Popover>
+                )}
+              </Content>
+            )}
+          </Td>
+          <Td dataLabel="Permission">
+            {(isEditing || isAdding) && permissionOptions.length > 1 ? (
+              <RoleBindingPermissionsPermissionSelection
+                permissionOptions={permissionOptions}
+                selection={roleBindingRoleRef}
+                onSelect={(selection) => {
+                  setRoleBindingRoleRef(selection);
+                }}
+              />
+            ) : (
+              <Content component="p">{roleLabel(roleBindingRoleRef)}</Content>
+            )}
+          </Td>
+          <Td dataLabel="Date added">
+            {!isEditing && !isAdding && (
+              <Content component="p">
+                <Timestamp
+                  date={createdDate}
+                  tooltip={{ variant: TimestampTooltipVariant.default }}
+                >
+                  {relativeTime(Date.now(), createdDate.getTime())}
+                </Timestamp>
+              </Content>
+            )}
+          </Td>
+          <Td isActionCell modifier="nowrap" style={{ textAlign: 'right' }}>
+            {isEditing || isAdding ? (
+              <Split>
+                <SplitItem>
+                  <Button
+                    data-testid={isAdding ? `save-new-button` : `save-button ${roleBindingName}`}
+                    data-id="save-rolebinding-button"
+                    aria-label="Save role binding"
+                    variant="link"
+                    icon={<CheckIcon />}
+                    isDisabled={isLoading || !roleBindingName || !roleBindingRoleRef}
+                    onClick={() => {
+                      if (isCurrentUserBeingChanged) {
+                        setIsDeleting(false);
+                        setShowModal(true);
+                      } else {
+                        setIsLoading(true);
+                        onChange(roleBindingName, roleBindingRoleRef);
+                        setIsLoading(false);
+                      }
+                    }}
+                  />
+                </SplitItem>
+                <SplitItem>
+                  <Button
+                    data-id="cancel-rolebinding-button"
+                    aria-label="Cancel role binding"
+                    variant="plain"
+                    isDisabled={isLoading}
+                    icon={<TimesIcon />}
+                    onClick={() => {
+                      onCancel();
+                    }}
+                  />
+                </SplitItem>
+              </Split>
+            ) : isDefaultGroup ? (
+              <Tooltip content="The default group cannot be edited or deleted. The group's members can be managed via the API.">
+                <Button
+                  icon={<EllipsisVIcon />}
+                  variant="plain"
+                  isAriaDisabled
+                  aria-label="The default group always has access to model registry."
+                />
+              </Tooltip>
+            ) : (
+              <ActionsColumn
+                items={[
+                  {
+                    title: 'Edit',
+                    onClick: () => {
+                      onEdit?.();
+                    },
+                  },
+                  { isSeparator: true },
+                  {
+                    title: 'Delete',
+                    onClick: () => {
+                      if (isCurrentUserBeingChanged) {
+                        setIsDeleting(true);
+                        setShowModal(true);
+                      } else {
+                        onDelete?.();
+                      }
+                    },
+                  },
+                ]}
+              />
+            )}
+          </Td>
+        </Tr>
+      </Tbody>
+      {showModal && (
+        <RoleBindingPermissionsChangeModal
+          roleName={currentUser.userId}
+          onClose={() => {
+            setShowModal(false);
+            if (isEditing) {
+              onCancel();
+            }
+          }}
+          onEdit={() => {
+            setIsLoading(true);
+            onChange(roleBindingName, roleBindingRoleRef);
+            setIsLoading(false);
+            setShowModal(false);
+          }}
+          onDelete={() => onDelete?.()}
+          isDeleting={isDeleting}
+        />
+      )}
+    </>
+  );
+};
+
+export default RoleBindingPermissionsTableRow;

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTableSection.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTableSection.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import {
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+import {
+  HeaderIcon,
+  K8sResourceCommon,
+  K8sStatus,
+  ProjectObjectType,
+  RoleBindingKind,
+  RoleBindingRoleRef,
+  RoleBindingSubject,
+} from 'mod-arch-shared';
+import { RoleBindingPermissionsRBType, RoleBindingPermissionsRoleType } from './types';
+import RoleBindingPermissionsTable from './RoleBindingPermissionsTable';
+
+export type RoleBindingPermissionsTableSectionAltProps = {
+  ownerReference?: K8sResourceCommon;
+  roleBindings: RoleBindingKind[];
+  projectName: string;
+  roleRefKind: RoleBindingRoleRef['kind'];
+  roleRefName?: RoleBindingRoleRef['name'];
+  subjectKind: RoleBindingSubject['kind'];
+  permissionOptions: {
+    type: RoleBindingPermissionsRoleType;
+    description: string;
+  }[];
+  typeAhead?: string[];
+  createRoleBinding: (roleBinding: RoleBindingKind) => Promise<RoleBindingKind>;
+  deleteRoleBinding: (name: string, namespace: string) => Promise<K8sStatus>;
+  refresh: () => void;
+  typeModifier: string;
+  defaultRoleBindingName?: string;
+  labels?: { [key: string]: string };
+};
+
+const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSectionAltProps> = ({
+  ownerReference,
+  roleBindings,
+  projectName,
+  roleRefKind,
+  roleRefName,
+  subjectKind,
+  permissionOptions,
+  typeAhead,
+  createRoleBinding,
+  deleteRoleBinding,
+  refresh,
+  typeModifier,
+  defaultRoleBindingName,
+  labels,
+}) => {
+  const [addField, setAddField] = React.useState(false);
+  const [error, setError] = React.useState<React.ReactNode>();
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Flex
+          direction={{ default: 'row' }}
+          gap={{ default: 'gapSm' }}
+          alignItems={{ default: 'alignItemsCenter' }}
+          className={typeModifier}
+        >
+          <HeaderIcon
+            type={
+              subjectKind === RoleBindingPermissionsRBType.USER
+                ? ProjectObjectType.user
+                : ProjectObjectType.group
+            }
+          />
+          <FlexItem>
+            <Title id={`user-permission-${typeModifier}`} headingLevel="h2" size="xl">
+              {subjectKind === RoleBindingPermissionsRBType.USER ? 'Users' : 'Groups'}
+            </Title>
+          </FlexItem>
+        </Flex>
+      </StackItem>
+      <StackItem>
+        <RoleBindingPermissionsTable
+          ownerReference={ownerReference}
+          defaultRoleBindingName={defaultRoleBindingName}
+          permissions={roleBindings}
+          permissionOptions={permissionOptions}
+          namespace={projectName}
+          roleRefKind={roleRefKind}
+          roleRefName={roleRefName}
+          labels={labels}
+          subjectKind={subjectKind}
+          typeAhead={typeAhead}
+          isAdding={addField}
+          onDismissNewRow={() => {
+            setAddField(false);
+            setError(undefined);
+          }}
+          onError={(e) => {
+            setError(e);
+          }}
+          refresh={() => {
+            refresh();
+          }}
+          createRoleBinding={createRoleBinding}
+          deleteRoleBinding={deleteRoleBinding}
+        />
+      </StackItem>
+      {error && (
+        <StackItem>
+          <Alert
+            isInline
+            variant="danger"
+            title="Error"
+            actionClose={<AlertActionCloseButton onClose={() => setError(undefined)} />}
+          >
+            <p>{error}</p>
+          </Alert>
+        </StackItem>
+      )}
+      <StackItem>
+        <Button
+          data-testid={`add-button ${typeModifier}`}
+          variant="link"
+          isInline
+          icon={<PlusCircleIcon />}
+          iconPosition="left"
+          onClick={() => setAddField(true)}
+          style={{ paddingLeft: 'var(--pf-t--global--spacer--lg)' }}
+        >
+          {subjectKind === RoleBindingPermissionsRBType.USER ? 'Add user' : 'Add group'}
+        </Button>
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default RoleBindingPermissionsTableSection;

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/__tests__/utils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/__tests__/utils.spec.ts
@@ -1,0 +1,84 @@
+import { mockRoleBindingK8sResource } from '~/__mocks__/mockRoleBindingK8sResource';
+import { RoleBindingPermissionsRoleType } from '~/app/pages/settings/roleBinding/types';
+import {
+  castRoleBindingPermissionsRoleType,
+  firstSubject,
+  isCurrentUserChanging,
+  roleLabel,
+} from '~/app/pages/settings/roleBinding/utils';
+
+describe('firstSubject', () => {
+  it('should return name', () => {
+    const roleBinding = mockRoleBindingK8sResource({
+      name: 'test-user',
+      subjects: [{ kind: 'User', apiGroup: 'rbac.authorization.k8s.io', name: 'test-user' }],
+    });
+    const result = firstSubject(roleBinding);
+    expect(result).toBe('test-user');
+  });
+});
+describe('isCurrentUserChanging', () => {
+  it('should return true when role binding subject matches current username', () => {
+    const roleBinding = mockRoleBindingK8sResource({
+      name: 'test-user',
+      subjects: [{ kind: 'User', apiGroup: 'rbac.authorization.k8s.io', name: 'test-user' }],
+    });
+    expect(isCurrentUserChanging(roleBinding, 'test-user')).toBe(true);
+  });
+
+  it('should return false when role binding subject does not match current username', () => {
+    const roleBinding = mockRoleBindingK8sResource({
+      name: 'other-user',
+      subjects: [{ kind: 'User', apiGroup: 'rbac.authorization.k8s.io', name: 'other-user' }],
+    });
+    expect(isCurrentUserChanging(roleBinding, 'test-user')).toBe(false);
+  });
+
+  it('should return false when role binding is undefined', () => {
+    expect(isCurrentUserChanging(undefined, 'test-user')).toBe(false);
+  });
+});
+
+describe('castRoleBindingPermissionsRoleType', () => {
+  it('should return default when role includes registry-user', () => {
+    expect(castRoleBindingPermissionsRoleType('registry-user')).toBe(
+      RoleBindingPermissionsRoleType.DEFAULT,
+    );
+  });
+
+  it('should return admin when role is admin', () => {
+    expect(castRoleBindingPermissionsRoleType('admin')).toBe(RoleBindingPermissionsRoleType.ADMIN);
+  });
+
+  it('should return edit when role is edit', () => {
+    expect(castRoleBindingPermissionsRoleType('edit')).toBe(RoleBindingPermissionsRoleType.EDIT);
+  });
+
+  it('should return custom when role is not admin, edit, or registry-user', () => {
+    expect(castRoleBindingPermissionsRoleType('custom')).toBe(
+      RoleBindingPermissionsRoleType.CUSTOM,
+    );
+  });
+});
+
+describe('roleLabel', () => {
+  it('should return contributor, when the RoleBindingPermissionsRoleType is Edit', () => {
+    const result = roleLabel(RoleBindingPermissionsRoleType.EDIT);
+    expect(result).toBe('Contributor');
+  });
+
+  it('should return Default, when the RoleBindingPermissionsRoleType is other than default', () => {
+    const result = roleLabel(RoleBindingPermissionsRoleType.DEFAULT);
+    expect(result).toBe('Default');
+  });
+
+  it('should return Custom, when the RoleBindingPermissionsRoleType is other than custom', () => {
+    const result = roleLabel(RoleBindingPermissionsRoleType.CUSTOM);
+    expect(result).toBe('Custom');
+  });
+
+  it('should return Admin, when the RoleBindingPermissionsRoleType is Admin', () => {
+    const result = roleLabel(RoleBindingPermissionsRoleType.ADMIN);
+    expect(result).toBe('Admin');
+  });
+});

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/data.ts
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/data.ts
@@ -1,0 +1,25 @@
+import { RoleBindingKind, SortableData } from 'mod-arch-shared';
+import { firstSubject } from './utils';
+
+export const columnsRoleBindingPermissions: SortableData<RoleBindingKind>[] = [
+  {
+    field: 'username',
+    label: 'Name',
+    width: 30,
+    sortable: (a, b) => firstSubject(a).localeCompare(firstSubject(b)),
+  },
+  {
+    field: 'permission',
+    label: 'Permission',
+    width: 20,
+    sortable: (a, b) => a.roleRef.name.localeCompare(b.roleRef.name),
+  },
+  {
+    field: 'date',
+    label: 'Date added',
+    width: 25,
+    sortable: (a, b) =>
+      new Date(b.metadata.creationTimestamp || 0).getTime() -
+      new Date(a.metadata.creationTimestamp || 0).getTime(),
+  },
+];

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/types.ts
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/types.ts
@@ -1,0 +1,11 @@
+export enum RoleBindingPermissionsRBType {
+  USER = 'User',
+  GROUP = 'Group',
+}
+
+export enum RoleBindingPermissionsRoleType {
+  EDIT = 'edit',
+  ADMIN = 'admin',
+  DEFAULT = 'default',
+  CUSTOM = 'custom',
+}

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/utils.ts
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/utils.ts
@@ -1,0 +1,79 @@
+import { capitalize } from '@patternfly/react-core';
+import { RoleBindingKind } from 'mod-arch-shared';
+import { patchRoleBinding } from '~/app/api/k8s';
+import { RoleBindingPermissionsRBType, RoleBindingPermissionsRoleType } from './types';
+
+export const filterRoleBindingSubjects = (
+  roleBindings: RoleBindingKind[],
+  type: RoleBindingPermissionsRBType,
+): RoleBindingKind[] =>
+  roleBindings.filter(
+    (roles) =>
+      roles.subjects[0]?.kind === type &&
+      !(roles.metadata.labels?.['opendatahub.io/rb-project-subject'] === 'true'),
+  );
+
+export const castRoleBindingPermissionsRoleType = (
+  role: string,
+): RoleBindingPermissionsRoleType => {
+  if (role === RoleBindingPermissionsRoleType.ADMIN) {
+    return RoleBindingPermissionsRoleType.ADMIN;
+  }
+  if (role === RoleBindingPermissionsRoleType.EDIT) {
+    return RoleBindingPermissionsRoleType.EDIT;
+  }
+  if (role.includes('registry-user')) {
+    return RoleBindingPermissionsRoleType.DEFAULT;
+  }
+  return RoleBindingPermissionsRoleType.CUSTOM;
+};
+
+export const firstSubject = (roleBinding: RoleBindingKind): string =>
+  roleBinding.subjects[0]?.name || '';
+
+export const roleLabel = (value: RoleBindingPermissionsRoleType): string => {
+  if (value === RoleBindingPermissionsRoleType.EDIT) {
+    return 'Contributor';
+  }
+  return capitalize(value);
+};
+
+export const isCurrentUserChanging = (
+  roleBinding: RoleBindingKind | undefined,
+  currentUsername: string,
+): boolean => {
+  if (!roleBinding) {
+    return false;
+  }
+  return currentUsername === roleBinding.subjects[0].name;
+};
+
+export const tryPatchRoleBinding = async (
+  oldRBObject: RoleBindingKind,
+  newRBObject: RoleBindingKind,
+): Promise<boolean> => {
+  // Trying to patch roleRef will always fail
+  if (oldRBObject.roleRef.name !== newRBObject.roleRef.name) {
+    return false;
+  }
+  try {
+    await patchRoleBinding('', { namespace: oldRBObject.metadata.namespace, dryRun: true })(
+      {},
+      newRBObject,
+      oldRBObject.metadata.name,
+    );
+  } catch {
+    return false;
+  }
+  try {
+    // Actual patch
+    await patchRoleBinding('', { namespace: oldRBObject.metadata.namespace, dryRun: false })(
+      {},
+      newRBObject,
+      oldRBObject.metadata.name,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/clients/ui/frontend/src/app/shared/components/DeleteModal.tsx
+++ b/clients/ui/frontend/src/app/shared/components/DeleteModal.tsx
@@ -1,0 +1,123 @@
+// // TODO: Move this code to shared library once the migration completes.
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
+
+type DeleteModalProps = {
+  title: string;
+  onClose: () => void;
+  deleting: boolean;
+  onDelete: () => void;
+  deleteName: string;
+  submitButtonLabel?: string;
+  error?: Error;
+  children: React.ReactNode;
+  testId?: string;
+  genericLabel?: boolean;
+};
+
+const DeleteModal: React.FC<DeleteModalProps> = ({
+  children,
+  title,
+  onClose,
+  deleting,
+  onDelete,
+  deleteName,
+  error,
+  submitButtonLabel = 'Delete',
+  testId,
+  genericLabel,
+}) => {
+  const [value, setValue] = React.useState('');
+
+  const deleteNameSanitized = React.useMemo(
+    () => deleteName.trim().replace(/\s+/g, ' '),
+    [deleteName],
+  );
+
+  const onBeforeClose = (deleted: boolean) => {
+    if (deleted) {
+      onDelete();
+    } else {
+      onClose();
+    }
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={() => onBeforeClose(false)}
+      variant="small"
+      data-testid={testId || 'delete-modal'}
+    >
+      <ModalHeader title={title} titleIconVariant="warning" />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>{children}</StackItem>
+
+          <StackItem>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                Type <strong>{deleteNameSanitized}</strong> to confirm
+                {genericLabel ? '' : ' deletion'}:
+              </FlexItem>
+
+              <TextInput
+                id="delete-modal-input"
+                data-testid="delete-modal-input"
+                aria-label="Delete modal input"
+                value={value}
+                onChange={(_e, newValue) => setValue(newValue)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && value.trim() === deleteNameSanitized && !deleting) {
+                    onDelete();
+                  }
+                }}
+              />
+            </Flex>
+          </StackItem>
+
+          {error && (
+            <StackItem>
+              <Alert
+                data-testid="delete-model-error-message-alert"
+                title={`Error deleting ${deleteNameSanitized}`}
+                isInline
+                variant="danger"
+              >
+                {error.message}
+              </Alert>
+            </StackItem>
+          )}
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          key="delete-button"
+          variant="danger"
+          isLoading={deleting}
+          isDisabled={deleting || value.trim() !== deleteNameSanitized}
+          onClick={() => onBeforeClose(true)}
+        >
+          {submitButtonLabel}
+        </Button>
+        <Button key="cancel-button" variant="link" onClick={() => onBeforeClose(false)}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default DeleteModal;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to migrate all RBAC related code from the Model Registry (midstream)

## How Has This Been Tested?
Currently there are no route available(will be implemented in another issue) to see the changes. I have plugged RoleBindingPermissions component locally in the codebase to check the UI.

<img width="1263" alt="Screenshot 2025-06-05 at 7 28 35 PM" src="https://github.com/user-attachments/assets/85b7e1ec-2164-44f6-9bce-f151e5c61d84" />

<img width="577" alt="Screenshot 2025-06-06 at 4 45 31 PM" src="https://github.com/user-attachments/assets/10e42ad0-83b7-45c2-9038-4239b8938552" />

<img width="610" alt="Screenshot 2025-06-06 at 4 45 20 PM" src="https://github.com/user-attachments/assets/82880df0-ff6f-4102-a619-024a0bb9cca7" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
