### PR TITLE
fix: allow omitted fields in MLMD types

### DIFF
--- a/internal/mlmdtypes/mlmdtypes.go
+++ b/internal/mlmdtypes/mlmdtypes.go
@@ -18,6 +18,7 @@ type MLMDTypeNamesConfig struct {
 	InferenceServiceTypeName   string
 	ServeModelTypeName         string
 	CanAddFields               bool
+	CanOmitFields              bool
 }
 
 func NewMLMDTypeNamesConfigFromDefaults() MLMDTypeNamesConfig {
@@ -30,6 +31,7 @@ func NewMLMDTypeNamesConfigFromDefaults() MLMDTypeNamesConfig {
 		InferenceServiceTypeName:   defaults.InferenceServiceTypeName,
 		ServeModelTypeName:         defaults.ServeModelTypeName,
 		CanAddFields:               true,
+		CanOmitFields:              true,
 	}
 }
 
@@ -39,7 +41,8 @@ func CreateMLMDTypes(cc grpc.ClientConnInterface, nameConfig MLMDTypeNamesConfig
 	client := proto.NewMetadataStoreServiceClient(cc)
 
 	registeredModelReq := proto.PutContextTypeRequest{
-		CanAddFields: &nameConfig.CanAddFields,
+		CanAddFields:  &nameConfig.CanAddFields,
+		CanOmitFields: &nameConfig.CanOmitFields,
 		ContextType: &proto.ContextType{
 			Name: &nameConfig.RegisteredModelTypeName,
 			Properties: map[string]proto.PropertyType{
@@ -60,7 +63,8 @@ func CreateMLMDTypes(cc grpc.ClientConnInterface, nameConfig MLMDTypeNamesConfig
 	}
 
 	modelVersionReq := proto.PutContextTypeRequest{
-		CanAddFields: &nameConfig.CanAddFields,
+		CanAddFields:  &nameConfig.CanAddFields,
+		CanOmitFields: &nameConfig.CanOmitFields,
 		ContextType: &proto.ContextType{
 			Name: &nameConfig.ModelVersionTypeName,
 			Properties: map[string]proto.PropertyType{
@@ -104,7 +108,8 @@ func CreateMLMDTypes(cc grpc.ClientConnInterface, nameConfig MLMDTypeNamesConfig
 	}
 
 	servingEnvironmentReq := proto.PutContextTypeRequest{
-		CanAddFields: &nameConfig.CanAddFields,
+		CanAddFields:  &nameConfig.CanAddFields,
+		CanOmitFields: &nameConfig.CanOmitFields,
 		ContextType: &proto.ContextType{
 			Name: &nameConfig.ServingEnvironmentTypeName,
 			Properties: map[string]proto.PropertyType{
@@ -114,7 +119,8 @@ func CreateMLMDTypes(cc grpc.ClientConnInterface, nameConfig MLMDTypeNamesConfig
 	}
 
 	inferenceServiceReq := proto.PutContextTypeRequest{
-		CanAddFields: &nameConfig.CanAddFields,
+		CanAddFields:  &nameConfig.CanAddFields,
+		CanOmitFields: &nameConfig.CanOmitFields,
 		ContextType: &proto.ContextType{
 			Name: &nameConfig.InferenceServiceTypeName,
 			Properties: map[string]proto.PropertyType{


### PR DESCRIPTION
## Description

The recently added fields to RegisteredModel cause the pod to crash in clusters created without those fields. Allowing omitted fields in MLMD avoids the problem.

The error was:

```
F0609 15:10:31.711149       1 root.go:45] error: error connecting to datastore: error creating MLMD types: error setting up context type kf.RegisteredModel: rpc error: code = AlreadyExists desc = Type already exists with different properties: can_omit_fields is false while stored type has more properties: stored type:
 id: 10
name: "kf.RegisteredModel"
...
```

## How Has This Been Tested?
I upgraded an old cluster with the new code and witnessed the problem. Then I replaced the image after this update and verified that the pod started and model-registry was functional.

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
