### PR TITLE
Enhance groups endpoint

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -300,6 +300,35 @@ paths:
       description: Deletes an existing Role Binding associated with Model Registries.
     parameters: # Add parameters at the path level
       - $ref: '#/components/parameters/roleBindingName' # Ensure this path parameter is defined
+  /api/v1/settings/groups:
+    summary: Path used to get available groups.
+    description: >-
+      The REST endpoint/path used to get a list of all available OpenShift/Kubernetes groups in the cluster.
+    get:
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: "#/components/parameters/namespace"
+      responses:
+        "200":
+          description: 'Ok'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Group"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getGroups
+      summary: Get Available Groups
+      description: Returns available OpenShift/Kubernetes groups in the cluster.
   /api/v1/model_registry/{modelRegistryName}/model_versions/{modelversionId}:
     summary: Path used to manage a single ModelVersion.
     description: >-
@@ -1469,6 +1498,56 @@ components:
             -----BEGIN CERTIFICATE-----
             MIID...
             -----END CERTIFICATE-----
+    Group:
+      description: OpenShift/Kubernetes Group object
+      type: object
+      required:
+        - metadata
+        - users
+      properties:
+        apiVersion:
+          type: string
+          example: "user.openshift.io/v1"
+        kind:
+          type: string
+          example: "Group"
+        metadata:
+          type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              example: "dora-group"
+            namespace:
+              type: string
+              nullable: true
+            annotations:
+              type: object
+              additionalProperties:
+                type: string
+              nullable: true
+            labels:
+              type: object
+              additionalProperties:
+                type: string
+              nullable: true
+            creationTimestamp:
+              type: string
+              format: date-time
+              nullable: true
+              example: "2023-01-15T10:30:00Z"
+            resourceVersion:
+              type: string
+              nullable: true
+            uid:
+              type: string
+              nullable: true
+        users:
+          type: array
+          items:
+            type: string
+          example: ["dora-user@example.com", "dora-admin@example.com"]
   responses:
     NotFound:
       content:
@@ -1887,6 +1966,13 @@ components:
         type: string
       in: path
       required: true
+    namespace:
+      name: namespace
+      description: The namespace to filter resources by.
+      schema:
+        type: string
+      in: query
+      required: false
   securitySchemes:
     Bearer:
       scheme: bearer

--- a/clients/ui/bff/internal/api/model_registry_settings_groups_handler.go
+++ b/clients/ui/bff/internal/api/model_registry_settings_groups_handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kubeflow/model-registry/ui/bff/internal/models"
 )
 
-type GroupsEnvelope Envelope[[]models.GroupModel, None]
+type GroupsEnvelope Envelope[[]models.Group, None]
 
 // STUB IMPLEMENTATION (see kubernetes clients for more details)
 func (app *App) GetGroupsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/clients/ui/bff/internal/api/model_registry_settings_groups_handler_test.go
+++ b/clients/ui/bff/internal/api/model_registry_settings_groups_handler_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kubeflow/model-registry/ui/bff/internal/config"
 	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
 	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
-	"github.com/kubeflow/model-registry/ui/bff/internal/models"
 	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -51,13 +50,18 @@ var _ = Describe("TestGroupsHandler", func() {
 			err = json.Unmarshal(body, &actual)
 			Expect(err).NotTo(HaveOccurred())
 
-			expected := []models.GroupModel{
-				{Name: "dora-group-mock"},
-				{Name: "bella-group-mock"},
-			}
-
 			Expect(rr.Code).To(Equal(http.StatusOK))
-			Expect(actual.Data).To(ConsistOf(expected))
+			Expect(actual.Data).To(HaveLen(2))
+
+			// Verify first group
+			firstGroup := actual.Data[0]
+			Expect(firstGroup.Metadata.Name).To(Equal("dora-group-mock"))
+			Expect(firstGroup.Users).To(ConsistOf("dora-user@example.com", "dora-admin@example.com"))
+
+			// Verify second group
+			secondGroup := actual.Data[1]
+			Expect(secondGroup.Metadata.Name).To(Equal("bella-group-mock"))
+			Expect(secondGroup.Users).To(ConsistOf("bella-user@example.com", "bella-maintainer@example.com"))
 		})
 	})
 })

--- a/clients/ui/bff/internal/models/groups.go
+++ b/clients/ui/bff/internal/models/groups.go
@@ -1,7 +1,46 @@
 package models
 
+import "time"
+
+// K8sObjectMeta represents the metadata of a Kubernetes object
+type K8sObjectMeta struct {
+	Name              string            `json:"name"`
+	Namespace         *string           `json:"namespace,omitempty"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	CreationTimestamp *time.Time        `json:"creationTimestamp,omitempty"`
+	ResourceVersion   *string           `json:"resourceVersion,omitempty"`
+	UID               *string           `json:"uid,omitempty"`
+}
+
+// Group represents an OpenShift/Kubernetes Group object
+type Group struct {
+	APIVersion *string       `json:"apiVersion,omitempty"`
+	Kind       *string       `json:"kind,omitempty"`
+	Metadata   K8sObjectMeta `json:"metadata"`
+	Users      []string      `json:"users"`
+}
+
+// Legacy GroupModel for backward compatibility (if needed)
 type GroupModel struct {
 	Name string `json:"name"`
+}
+
+// NewGroup creates a new Group with the specified name and users
+func NewGroup(name string, users []string) Group {
+	apiVersion := "user.openshift.io/v1"
+	kind := "Group"
+	now := time.Now()
+
+	return Group{
+		APIVersion: &apiVersion,
+		Kind:       &kind,
+		Metadata: K8sObjectMeta{
+			Name:              name,
+			CreationTimestamp: &now,
+		},
+		Users: users,
+	}
 }
 
 func NewGroupModel(name string) GroupModel {

--- a/clients/ui/bff/internal/repositories/model_registry_settings.go
+++ b/clients/ui/bff/internal/repositories/model_registry_settings.go
@@ -15,15 +15,26 @@ func NewModelRegistrySettingsRepository() *ModelRegistrySettingsRepository {
 	return &ModelRegistrySettingsRepository{}
 }
 
-func (r *ModelRegistrySettingsRepository) GetGroups(ctx context.Context, client k8s.KubernetesClientInterface) ([]models.GroupModel, error) {
+func (r *ModelRegistrySettingsRepository) GetGroups(ctx context.Context, client k8s.KubernetesClientInterface) ([]models.Group, error) {
 	groupNames, err := client.GetGroups(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching groups: %w", err)
 	}
 
-	var groups []models.GroupModel
+	var groups []models.Group
 	for _, name := range groupNames {
-		groups = append(groups, models.NewGroupModel(name))
+		// Create mock users for each group to make the data more realistic
+		var users []string
+		switch name {
+		case "dora-group-mock":
+			users = []string{"dora-user@example.com", "dora-admin@example.com"}
+		case "bella-group-mock":
+			users = []string{"bella-user@example.com", "bella-maintainer@example.com"}
+		default:
+			users = []string{fmt.Sprintf("%s-user@example.com", name)}
+		}
+
+		groups = append(groups, models.NewGroup(name, users))
 	}
 
 	return groups, nil

--- a/clients/ui/bff/internal/repositories/model_registry_settings_test.go
+++ b/clients/ui/bff/internal/repositories/model_registry_settings_test.go
@@ -23,11 +23,22 @@ var _ = Describe("TestModelRegistrySettingsRepository", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the returned group models")
-			expected := []models.GroupModel{
-				{Name: "dora-group-mock"},
-				{Name: "bella-group-mock"},
-			}
-			Expect(groups).To(ConsistOf(expected))
+			Expect(groups).To(HaveLen(2))
+
+			// Verify first group
+			firstGroup := groups[0]
+			Expect(firstGroup.Metadata.Name).To(Equal("dora-group-mock"))
+			Expect(firstGroup.Users).To(ConsistOf("dora-user@example.com", "dora-admin@example.com"))
+			Expect(*firstGroup.APIVersion).To(Equal("user.openshift.io/v1"))
+			Expect(*firstGroup.Kind).To(Equal("Group"))
+			Expect(firstGroup).To(BeAssignableToTypeOf(models.Group{}))
+
+			// Verify second group
+			secondGroup := groups[1]
+			Expect(secondGroup.Metadata.Name).To(Equal("bella-group-mock"))
+			Expect(secondGroup.Users).To(ConsistOf("bella-user@example.com", "bella-maintainer@example.com"))
+			Expect(*secondGroup.APIVersion).To(Equal("user.openshift.io/v1"))
+			Expect(*secondGroup.Kind).To(Equal("Group"))
 		})
 	})
 })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Follow up of https://github.com/kubeflow/model-registry/pull/1201
feat(api): add endpoint to retrieve available OpenShift/Kubernetes groups and update models

This pull request introduces several enhancements to the handling of OpenShift/Kubernetes groups in the `clients/ui` module. The changes include the addition of a new OpenAPI endpoint for fetching group data, the introduction of a new `Group` model, updates to the repository and handler logic to use the new model, and corresponding test updates. These changes improve the functionality and structure of the codebase, making it more robust and aligned with Kubernetes standards.

### OpenAPI Specification Updates:
* Added a new endpoint `/api/v1/settings/groups` to fetch available OpenShift/Kubernetes groups, including parameters for filtering by namespace and user ID. The endpoint returns a list of groups with metadata and users. (`clients/ui/api/openapi/mod-arch.yaml`, [clients/ui/api/openapi/mod-arch.yamlR303-R331](diffhunk://#diff-b1725ef347a070092ea049df7472b7bec2e2760ee00284c1dcece83447c8fd87R303-R331))
* Defined a new `Group` schema in the OpenAPI specification to represent Kubernetes group objects, including metadata and user information. (`clients/ui/api/openapi/mod-arch.yaml`, [clients/ui/api/openapi/mod-arch.yamlR1501-R1550](diffhunk://#diff-b1725ef347a070092ea049df7472b7bec2e2760ee00284c1dcece83447c8fd87R1501-R1550))
* Added a `namespace` query parameter to filter resources by namespace. (`clients/ui/api/openapi/mod-arch.yaml`, [clients/ui/api/openapi/mod-arch.yamlR1969-R1975](diffhunk://#diff-b1725ef347a070092ea049df7472b7bec2e2760ee00284c1dcece83447c8fd87R1969-R1975))

### Model and Repository Enhancements:
* Introduced a new `Group` model with detailed metadata and user information, replacing the legacy `GroupModel` where applicable. Added a helper function `NewGroup` to create instances of the new model. (`clients/ui/bff/internal/models/groups.go`, [clients/ui/bff/internal/models/groups.goR3-R45](diffhunk://#diff-63040ccba5299fd671e94890e24300c3d67df0c3b6508d5417d27965d1a8742cR3-R45))
* Updated the `ModelRegistrySettingsRepository` to use the new `Group` model. Added mock user data for groups to simulate realistic data. (`clients/ui/bff/internal/repositories/model_registry_settings.go`, [clients/ui/bff/internal/repositories/model_registry_settings.goL18-R37](diffhunk://#diff-3e3c0d6e915f3ddaf5bdc502d17bbf6ad210fad5d2a090107b4a401d083aa8a6L18-R37))

### Handler and Test Updates:
* Updated the `GetGroupsHandler` and its associated envelope to use the new `Group` model. (`clients/ui/bff/internal/api/model_registry_settings_groups_handler.go`, [clients/ui/bff/internal/api/model_registry_settings_groups_handler.goL13-R13](diffhunk://#diff-0ca3042ec158df900954695ce0155e46ea6289c5b38d9bf7882584201fe84ab2L13-R13))
* Refactored tests for the handler and repository to validate the new `Group` model, including checks for metadata, user lists, and type compatibility. (`clients/ui/bff/internal/api/model_registry_settings_groups_handler_test.go`, [[1]](diffhunk://#diff-460c1a5425609c45a4c193f75d4e772ef5a2c7da16a75571df3150437cd5d88bL54-R64); `clients/ui/bff/internal/repositories/model_registry_settings_test.go`, [[2]](diffhunk://#diff-d94c48e022929039515295272bd11946284369d15d324145449fe2d6e6c69536L26-R41)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [X] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
