### PR TITLE
Add rolebinding PATCH for bff

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -279,7 +279,34 @@ paths:
   /api/v1/settings/role_bindings/{roleBindingName}:
     summary: Path used to manage a single Role Binding for Model Registries.
     description: >-
-      The REST endpoint/path used to delete a specific Role Binding associated with Model Registries.
+      The REST endpoint/path used to update or delete a specific Role Binding associated with Model Registries.
+    patch:
+      requestBody:
+        description: Updated Role Binding data.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleBinding"
+        required: true
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: '#/components/parameters/roleBindingName'
+      responses:
+        "200":
+          $ref: "#/components/responses/RoleBindingResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: patchRoleBinding
+      summary: Update Model Registry Role Binding
+      description: Updates an existing Role Binding associated with Model Registries.
     delete:
       tags:
         - K8SOperation

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -182,6 +182,7 @@ func (app *App) Routes() http.Handler {
 		//SettingsPath: Role Binding endpoints
 		apiRouter.GET(RoleBindingListPath, app.AttachNamespace(app.GetRoleBindingsHandler))
 		apiRouter.POST(RoleBindingListPath, app.AttachNamespace(app.CreateRoleBindingHandler))
+		apiRouter.PATCH(RoleBindingPath, app.AttachNamespace(app.PatchRoleBindingHandler))
 		apiRouter.DELETE(RoleBindingPath, app.AttachNamespace(app.DeleteRoleBindingHandler))
 
 		//SettingsPath Groups endpoints

--- a/clients/ui/bff/internal/api/model_registry_settings_rbac_handler.go
+++ b/clients/ui/bff/internal/api/model_registry_settings_rbac_handler.go
@@ -67,7 +67,7 @@ func (app *App) GetRoleBindingsHandler(w http.ResponseWriter, r *http.Request, p
 // STUB IMPLEMENTATION
 func (app *App) CreateRoleBindingHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	// TODO: Implement actual logic: parse payload, use K8s client to create RoleBinding
-	var input models.RoleBinding // Assuming input is the direct RoleBinding structure
+	var input RoleBindingEnvelope
 	err := app.ReadJSON(w, r, &input)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
@@ -77,7 +77,7 @@ func (app *App) CreateRoleBindingHandler(w http.ResponseWriter, r *http.Request,
 	// For now, return the created object representation
 	dummyCreated := RoleBindingEnvelope{
 		Metadata: nil,
-		Data:     input, // Return the input for now
+		Data:     input.Data, // Return the input data for now
 	}
 
 	err = app.WriteJSON(w, http.StatusCreated, dummyCreated, nil)
@@ -95,4 +95,36 @@ func (app *App) DeleteRoleBindingHandler(w http.ResponseWriter, r *http.Request,
 	app.logger.Info("STUB: Deleting Role Binding", "name", roleBindingName)
 
 	w.WriteHeader(http.StatusNoContent) // Standard response for successful DELETE
+}
+
+// PatchRoleBindingHandler handles PATCH /api/v1/settings/role_bindings/{roleBindingName}
+// STUB IMPLEMENTATION
+func (app *App) PatchRoleBindingHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	roleBindingName := ps.ByName(RoleBindingNameParam)
+
+	// TODO: Implement actual logic: parse payload, use K8s client to update RoleBinding
+	var input RoleBindingEnvelope
+	err := app.ReadJSON(w, r, &input)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	// For stub implementation, set the name from the path parameter
+	if input.Data.Name == "" {
+		input.Data.Name = roleBindingName
+	}
+
+	app.logger.Info("STUB: Patching Role Binding", "name", roleBindingName)
+
+	// For now, return the patched object representation
+	patchedResponse := RoleBindingEnvelope{
+		Metadata: nil,
+		Data:     input.Data, // Return the input data for now
+	}
+
+	err = app.WriteJSON(w, http.StatusOK, patchedResponse, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
 }

--- a/clients/ui/bff/internal/api/model_registry_settings_rbac_handler_test.go
+++ b/clients/ui/bff/internal/api/model_registry_settings_rbac_handler_test.go
@@ -1,0 +1,188 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/model-registry/ui/bff/internal/config"
+	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/model-registry/ui/bff/internal/models"
+	"github.com/kubeflow/model-registry/ui/bff/internal/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("TestRoleBindingHandlers", func() {
+	Context("Role Binding operations in standalone mode", Ordered, func() {
+		var testApp App
+
+		BeforeAll(func() {
+			testApp = App{
+				config:                  config.EnvConfig{StandaloneMode: true},
+				kubernetesClientFactory: kubernetesMockedStaticClientFactory,
+				repositories:            repositories.NewRepositories(mockMRClient),
+				logger:                  logger,
+			}
+		})
+
+		It("should retrieve all role bindings", func() {
+			req, err := http.NewRequest(http.MethodGet, RoleBindingListPath+"?namespace=kubeflow", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			})
+			ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "kubeflow")
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			testApp.GetRoleBindingsHandler(rr, req, nil)
+
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			var actual RoleBindingListEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			Expect(actual.Data.Items).To(HaveLen(2))
+			Expect(actual.Data.Items[0].Name).To(Equal("stub-rb-1"))
+			Expect(actual.Data.Items[1].Name).To(Equal("stub-rb-2"))
+		})
+
+		It("should create a role binding", func() {
+			newRoleBinding := models.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-role-binding",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind: "User",
+						Name: "test-user@example.com",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind:     "ClusterRole",
+					Name:     "view",
+					APIGroup: "rbac.authorization.k8s.io",
+				},
+			}
+
+			reqBody, err := json.Marshal(RoleBindingEnvelope{Data: newRoleBinding})
+			Expect(err).NotTo(HaveOccurred())
+
+			req, err := http.NewRequest(http.MethodPost, RoleBindingListPath+"?namespace=kubeflow", bytes.NewReader(reqBody))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+
+			ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			})
+			ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "kubeflow")
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			testApp.CreateRoleBindingHandler(rr, req, nil)
+
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			var actual RoleBindingEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rr.Code).To(Equal(http.StatusCreated))
+			Expect(actual.Data.Name).To(Equal("test-role-binding"))
+			Expect(actual.Data.Subjects[0].Name).To(Equal("test-user@example.com"))
+		})
+
+		It("should patch a role binding", func() {
+			updatedRoleBinding := models.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-role-binding",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind: "User",
+						Name: "updated-user@example.com",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind:     "ClusterRole",
+					Name:     "edit",
+					APIGroup: "rbac.authorization.k8s.io",
+				},
+			}
+
+			reqBody, err := json.Marshal(RoleBindingEnvelope{Data: updatedRoleBinding})
+			Expect(err).NotTo(HaveOccurred())
+
+			req, err := http.NewRequest(http.MethodPatch, RoleBindingListPath+"/test-role-binding?namespace=kubeflow", bytes.NewReader(reqBody))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+
+			ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			})
+			ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "kubeflow")
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			// We need to simulate the router params since we're calling the handler directly
+			ps := httprouter.Params{
+				{Key: RoleBindingNameParam, Value: "test-role-binding"},
+			}
+			testApp.PatchRoleBindingHandler(rr, req, ps)
+
+			rs := rr.Result()
+			defer rs.Body.Close()
+			body, err := io.ReadAll(rs.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			var actual RoleBindingEnvelope
+			err = json.Unmarshal(body, &actual)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			Expect(actual.Data.Name).To(Equal("test-role-binding"))
+			Expect(actual.Data.Subjects[0].Name).To(Equal("updated-user@example.com"))
+			Expect(actual.Data.RoleRef.Name).To(Equal("edit"))
+		})
+
+		It("should delete a role binding", func() {
+			req, err := http.NewRequest(http.MethodDelete, RoleBindingListPath+"/test-role-binding?namespace=kubeflow", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			})
+			ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "kubeflow")
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			// We need to simulate the router params since we're calling the handler directly
+			ps := httprouter.Params{
+				{Key: RoleBindingNameParam, Value: "test-role-binding"},
+			}
+			testApp.DeleteRoleBindingHandler(rr, req, ps)
+
+			rs := rr.Result()
+			defer rs.Body.Close()
+
+			Expect(rr.Code).To(Equal(http.StatusNoContent))
+		})
+	})
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This pull request introduces a new PATCH endpoint for updating Role Bindings in the Model Registry settings, along with its handler implementation and corresponding tests. Additionally, it refactors the existing Role Binding creation logic to improve data handling.

### API Enhancements:
* Added a PATCH endpoint (`PATCH /api/v1/settings/role_bindings/{roleBindingName}`) to update Role Bindings in the OpenAPI specification. The endpoint includes request body validation, response definitions, and operation metadata.
* Updated the router in `app.go` to register the new PATCH endpoint and link it to the `PatchRoleBindingHandler`.

### Handler Implementations:
* Implemented the `PatchRoleBindingHandler` in `model_registry_settings_rbac_handler.go` as a stub, handling input validation, name assignment, and returning a patched response.

### Refactoring:
* Modified the `CreateRoleBindingHandler` to use `RoleBindingEnvelope` for input validation and to return the `Data` field instead of the entire input object. [[1]](diffhunk://#diff-9cf13ab892f8cfd0e49599c844a230f58724da96c1c3ed6fbebaed0b43ee19efL70-R70) [[2]](diffhunk://#diff-9cf13ab892f8cfd0e49599c844a230f58724da96c1c3ed6fbebaed0b43ee19efL80-R80)

### Testing:
* Added comprehensive tests for Role Binding operations, including GET, POST, PATCH, and DELETE, in `model_registry_settings_rbac_handler_test.go`. The tests validate behavior in standalone mode and ensure proper request handling and response generation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fist start bff

```
cd clients/ui
make dev-bff
```

And then execute

```
curl  -X PATCH \
  'http://localhost:4000/api/v1/settings/role_bindings/stub-rb-1?namespace=kubeflow' \
  --header 'Accept: */*' \
  --header 'User-Agent: Thunder Client (https://www.thunderclient.com)' \
  --header 'kubeflow-userid: user@example.com' \
  --header 'Content-Type: application/json' \
  --data-raw '{
  "data": {
      "metadata": {
        "name": "stub-rb-1",
        "creationTimestamp": null
      },
      "roleRef": {
        "apiGroup": "",
        "kind": "",
        "name": ""
      }
  }
}'
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [X] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
