### PR TITLE
feat: Add SSL/TLS Support for EmbedMD

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -140,6 +140,12 @@ func init() {
 
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.DatabaseType, "embedmd-database-type", "mysql", "EmbedMD database type")
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.DatabaseDSN, "embedmd-database-dsn", "", "EmbedMD database DSN")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLCert, "embedmd-database-ssl-cert", "", "EmbedMD SSL cert path")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLKey, "embedmd-database-ssl-key", "", "EmbedMD SSL key path")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLRootCert, "embedmd-database-ssl-root-cert", "", "EmbedMD SSL root cert path")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLCA, "embedmd-database-ssl-ca", "", "EmbedMD SSL CA path")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLCipher, "embedmd-database-ssl-cipher", "", "EmbedMD SSL cipher")
+	proxyCmd.Flags().BoolVar(&proxyCfg.Datastore.EmbedMD.SSLVerifyServerCert, "embedmd-database-ssl-verify-server-cert", false, "EmbedMD SSL verify server cert")
 
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.Type, "datastore-type", proxyCfg.Datastore.Type, "Datastore type")
 }

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/kubeflow/model-registry/internal/datastore"
+	"github.com/kubeflow/model-registry/internal/datastore/embedmd"
 	"github.com/kubeflow/model-registry/internal/proxy"
 	"github.com/kubeflow/model-registry/internal/server/openapi"
+	"github.com/kubeflow/model-registry/internal/tls"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +28,9 @@ var (
 	proxyCfg = ProxyConfig{
 		Datastore: datastore.Datastore{
 			Type: "embedmd",
+			EmbedMD: embedmd.EmbedMDConfig{
+				TLSConfig: &tls.TLSConfig{},
+			},
 		},
 	}
 
@@ -140,12 +145,12 @@ func init() {
 
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.DatabaseType, "embedmd-database-type", "mysql", "EmbedMD database type")
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.DatabaseDSN, "embedmd-database-dsn", "", "EmbedMD database DSN")
-	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLCert, "embedmd-database-ssl-cert", "", "EmbedMD SSL cert path")
-	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLKey, "embedmd-database-ssl-key", "", "EmbedMD SSL key path")
-	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLRootCert, "embedmd-database-ssl-root-cert", "", "EmbedMD SSL root cert path")
-	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLCA, "embedmd-database-ssl-ca", "", "EmbedMD SSL CA path")
-	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.SSLCipher, "embedmd-database-ssl-cipher", "", "EmbedMD SSL cipher")
-	proxyCmd.Flags().BoolVar(&proxyCfg.Datastore.EmbedMD.SSLVerifyServerCert, "embedmd-database-ssl-verify-server-cert", false, "EmbedMD SSL verify server cert")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.CertPath, "embedmd-database-ssl-cert", "", "EmbedMD SSL cert path")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.KeyPath, "embedmd-database-ssl-key", "", "EmbedMD SSL key path")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.RootCertPath, "embedmd-database-ssl-root-cert", "", "EmbedMD SSL root cert path")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.CAPath, "embedmd-database-ssl-ca", "", "EmbedMD SSL CA path")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.Cipher, "embedmd-database-ssl-cipher", "", "EmbedMD SSL cipher")
+	proxyCmd.Flags().BoolVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.VerifyServerCert, "embedmd-database-ssl-verify-server-cert", false, "EmbedMD SSL verify server cert")
 
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.Type, "datastore-type", proxyCfg.Datastore.Type, "Datastore type")
 }

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -149,7 +149,7 @@ func init() {
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.KeyPath, "embedmd-database-ssl-key", "", "EmbedMD SSL key path")
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.RootCertPath, "embedmd-database-ssl-root-cert", "", "EmbedMD SSL root cert path")
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.CAPath, "embedmd-database-ssl-ca", "", "EmbedMD SSL CA path")
-	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.Cipher, "embedmd-database-ssl-cipher", "", "EmbedMD SSL cipher")
+	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.Cipher, "embedmd-database-ssl-cipher", "", "Colon-separated list of allowed TLS ciphers for the EmbedMD database connection. Values are from the list at https://pkg.go.dev/crypto/tls#pkg-constants e.g. 'TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256'")
 	proxyCmd.Flags().BoolVar(&proxyCfg.Datastore.EmbedMD.TLSConfig.VerifyServerCert, "embedmd-database-ssl-verify-server-cert", false, "EmbedMD SSL verify server cert")
 
 	proxyCmd.Flags().StringVar(&proxyCfg.Datastore.Type, "datastore-type", proxyCfg.Datastore.Type, "Datastore type")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/cors v1.2.1
 	github.com/go-logr/logr v1.4.2
+	github.com/go-sql-driver/mysql v1.8.1
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/golang/glog v1.2.5
 	github.com/kserve/kserve v0.15.0
@@ -68,7 +69,6 @@ require (
 	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/internal/core/test_utils.go
+++ b/internal/core/test_utils.go
@@ -29,7 +29,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	)
 	require.NoError(t, err)
 
-	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx))
+	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), "", "", "", "", "", false)
 	require.NoError(t, err)
 
 	db, err := dbConnector.Connect()

--- a/internal/core/test_utils.go
+++ b/internal/core/test_utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeflow/model-registry/internal/db/schema"
 	"github.com/kubeflow/model-registry/internal/db/service"
 	"github.com/kubeflow/model-registry/internal/defaults"
+	"github.com/kubeflow/model-registry/internal/tls"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	cont_mysql "github.com/testcontainers/testcontainers-go/modules/mysql"
@@ -29,7 +30,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	)
 	require.NoError(t, err)
 
-	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), "", "", "", "", "", false)
+	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), &tls.TLSConfig{})
 	require.NoError(t, err)
 
 	db, err := dbConnector.Connect()

--- a/internal/datastore/embedmd/mysql/connect.go
+++ b/internal/datastore/embedmd/mysql/connect.go
@@ -1,13 +1,27 @@
 package mysql
 
 import (
-	"gorm.io/driver/mysql"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	gorm_mysql "gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 type MySQLDBConnector struct {
-	DSN string
-	db  *gorm.DB
+	DSN                 string
+	SSLCertPath         string
+	SSLKeyPath          string
+	SSLRootCertPath     string
+	SSLCAPath           string
+	SSLCipher           string
+	SSLVerifyServerCert bool
+	db                  *gorm.DB
 }
 
 func NewMySQLDBConnector(dsn string) *MySQLDBConnector {
@@ -17,7 +31,13 @@ func NewMySQLDBConnector(dsn string) *MySQLDBConnector {
 }
 
 func (c *MySQLDBConnector) Connect() (*gorm.DB, error) {
-	db, err := gorm.Open(mysql.Open(c.DSN), &gorm.Config{})
+	if err := c.registerTLSConfig(); err != nil {
+		return nil, err
+	}
+
+	db, err := gorm.Open(gorm_mysql.Open(c.DSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Info),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -29,4 +49,119 @@ func (c *MySQLDBConnector) Connect() (*gorm.DB, error) {
 
 func (c *MySQLDBConnector) DB() *gorm.DB {
 	return c.db
+}
+
+func (c *MySQLDBConnector) registerTLSConfig() error {
+	var rootCAs *x509.CertPool
+	var err error
+
+	// Skip TLS registration only if no SSL configuration is provided at all
+	// If SSLVerifyServerCert is false or SSLCipher is set, we should register a custom TLS config
+	if c.SSLCertPath == "" && c.SSLKeyPath == "" && c.SSLRootCertPath == "" && c.SSLCAPath == "" && c.SSLCipher == "" && c.SSLVerifyServerCert {
+		return nil
+	}
+
+	if c.SSLRootCertPath != "" || c.SSLCAPath != "" {
+		rootCAs = x509.NewCertPool()
+
+		if c.SSLRootCertPath != "" {
+			rootCert, err := os.ReadFile(c.SSLRootCertPath)
+			if err != nil {
+				return fmt.Errorf("failed to read SSL root certificate from %s: %w", c.SSLRootCertPath, err)
+			}
+			if !rootCAs.AppendCertsFromPEM(rootCert) {
+				return fmt.Errorf("failed to parse SSL root certificate from %s", c.SSLRootCertPath)
+			}
+		}
+
+		if c.SSLCAPath != "" && c.SSLCAPath != c.SSLRootCertPath {
+			caCert, err := os.ReadFile(c.SSLCAPath)
+			if err != nil {
+				return fmt.Errorf("failed to read SSL CA certificate from %s: %w", c.SSLCAPath, err)
+			}
+			if !rootCAs.AppendCertsFromPEM(caCert) {
+				return fmt.Errorf("failed to parse SSL CA certificate from %s", c.SSLCAPath)
+			}
+		}
+	} else if c.SSLVerifyServerCert {
+		rootCAs, err = x509.SystemCertPool()
+		if err != nil {
+			return fmt.Errorf("failed to get system cert pool: %w", err)
+		}
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs:            rootCAs,
+		InsecureSkipVerify: !c.SSLVerifyServerCert,
+	}
+
+	if c.SSLCertPath != "" && c.SSLKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(c.SSLCertPath, c.SSLKeyPath)
+		if err != nil {
+			return fmt.Errorf("failed to load SSL certificate pair (cert: %s, key: %s): %w",
+				c.SSLCertPath, c.SSLKeyPath, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	if c.SSLCipher != "" {
+		cipherSuites := parseCipherSuites(c.SSLCipher)
+		if len(cipherSuites) > 0 {
+			tlsConfig.CipherSuites = cipherSuites
+		}
+	}
+
+	if err := mysql.RegisterTLSConfig("custom", tlsConfig); err != nil {
+		return fmt.Errorf("failed to register TLS config: %w", err)
+	}
+
+	return nil
+}
+
+// parseCipherSuites parses a comma-separated list of cipher suite names
+// and returns the corresponding cipher suite IDs
+func parseCipherSuites(cipherStr string) []uint16 {
+	if cipherStr == "" {
+		return nil
+	}
+
+	cipherMap := map[string]uint16{
+		"TLS_RSA_WITH_RC4_128_SHA":                      tls.TLS_RSA_WITH_RC4_128_SHA,
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA":                  tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_RSA_WITH_AES_256_CBC_SHA":                  tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA256":               tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_RSA_WITH_AES_128_GCM_SHA256":               tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_RSA_WITH_AES_256_GCM_SHA384":               tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":              tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_RC4_128_SHA":                tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		"TLS_AES_128_GCM_SHA256":                        tls.TLS_AES_128_GCM_SHA256,
+		"TLS_AES_256_GCM_SHA384":                        tls.TLS_AES_256_GCM_SHA384,
+		"TLS_CHACHA20_POLY1305_SHA256":                  tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+
+	var cipherSuites []uint16
+	ciphers := strings.Split(strings.TrimSpace(cipherStr), ",")
+
+	for _, cipher := range ciphers {
+		cipher = strings.TrimSpace(cipher)
+		if cipherID, exists := cipherMap[cipher]; exists {
+			cipherSuites = append(cipherSuites, cipherID)
+		}
+	}
+
+	return cipherSuites
 }

--- a/internal/datastore/embedmd/mysql/connect.go
+++ b/internal/datastore/embedmd/mysql/connect.go
@@ -52,7 +52,7 @@ func (c *MySQLDBConnector) DB() *gorm.DB {
 }
 
 func (c *MySQLDBConnector) needsTLSConfig() bool {
-	return c.TLSConfig.CertPath != "" || c.TLSConfig.KeyPath != "" || c.TLSConfig.RootCertPath != "" || c.TLSConfig.CAPath != "" || c.TLSConfig.Cipher != "" || c.TLSConfig.VerifyServerCert
+	return c.TLSConfig != nil && (c.TLSConfig.CertPath != "" || c.TLSConfig.KeyPath != "" || c.TLSConfig.RootCertPath != "" || c.TLSConfig.CAPath != "" || c.TLSConfig.Cipher != "" || c.TLSConfig.VerifyServerCert)
 }
 
 func (c *MySQLDBConnector) registerTLSConfig() error {

--- a/internal/datastore/embedmd/mysql/connect.go
+++ b/internal/datastore/embedmd/mysql/connect.go
@@ -1,56 +1,42 @@
 package mysql
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/go-sql-driver/mysql"
+	_tls "github.com/kubeflow/model-registry/internal/tls"
 	gorm_mysql "gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
 type MySQLDBConnector struct {
-	DSN                 string
-	SSLCertPath         string
-	SSLKeyPath          string
-	SSLRootCertPath     string
-	SSLCAPath           string
-	SSLCipher           string
-	SSLVerifyServerCert bool
-	db                  *gorm.DB
+	DSN       string
+	TLSConfig *_tls.TLSConfig
+	db        *gorm.DB
 }
 
 func NewMySQLDBConnector(
-	dsn,
-	sslCertPath,
-	sslKeyPath,
-	sslRootCertPath,
-	sslCAPath,
-	sslCipher string,
-	sslVerifyServerCert bool,
+	dsn string,
+	tlsConfig *_tls.TLSConfig,
 ) *MySQLDBConnector {
 	return &MySQLDBConnector{
-		DSN:                 dsn,
-		SSLCertPath:         sslCertPath,
-		SSLKeyPath:          sslKeyPath,
-		SSLRootCertPath:     sslRootCertPath,
-		SSLCAPath:           sslCAPath,
-		SSLCipher:           sslCipher,
-		SSLVerifyServerCert: sslVerifyServerCert,
+		DSN:       dsn,
+		TLSConfig: tlsConfig,
 	}
 }
 
 func (c *MySQLDBConnector) Connect() (*gorm.DB, error) {
-	if err := c.registerTLSConfig(); err != nil {
-		return nil, err
+	if c.needsTLSConfig() {
+		if err := c.registerTLSConfig(); err != nil {
+			return nil, err
+		}
+
+		c.DSN += "&tls=custom"
 	}
 
 	db, err := gorm.Open(gorm_mysql.Open(c.DSN), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Info),
+		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	if err != nil {
 		return nil, err
@@ -65,64 +51,14 @@ func (c *MySQLDBConnector) DB() *gorm.DB {
 	return c.db
 }
 
+func (c *MySQLDBConnector) needsTLSConfig() bool {
+	return c.TLSConfig.CertPath != "" || c.TLSConfig.KeyPath != "" || c.TLSConfig.RootCertPath != "" || c.TLSConfig.CAPath != "" || c.TLSConfig.Cipher != "" || c.TLSConfig.VerifyServerCert
+}
+
 func (c *MySQLDBConnector) registerTLSConfig() error {
-	var rootCAs *x509.CertPool
-	var err error
-
-	// Skip TLS registration only if no SSL configuration is provided at all
-	// If SSLVerifyServerCert is false or SSLCipher is set, we should register a custom TLS config
-	if c.SSLCertPath == "" && c.SSLKeyPath == "" && c.SSLRootCertPath == "" && c.SSLCAPath == "" && c.SSLCipher == "" && c.SSLVerifyServerCert {
-		return nil
-	}
-
-	if c.SSLRootCertPath != "" || c.SSLCAPath != "" {
-		rootCAs = x509.NewCertPool()
-
-		if c.SSLRootCertPath != "" {
-			rootCert, err := os.ReadFile(c.SSLRootCertPath)
-			if err != nil {
-				return fmt.Errorf("failed to read SSL root certificate from %s: %w", c.SSLRootCertPath, err)
-			}
-			if !rootCAs.AppendCertsFromPEM(rootCert) {
-				return fmt.Errorf("failed to parse SSL root certificate from %s", c.SSLRootCertPath)
-			}
-		}
-
-		if c.SSLCAPath != "" && c.SSLCAPath != c.SSLRootCertPath {
-			caCert, err := os.ReadFile(c.SSLCAPath)
-			if err != nil {
-				return fmt.Errorf("failed to read SSL CA certificate from %s: %w", c.SSLCAPath, err)
-			}
-			if !rootCAs.AppendCertsFromPEM(caCert) {
-				return fmt.Errorf("failed to parse SSL CA certificate from %s", c.SSLCAPath)
-			}
-		}
-	} else if c.SSLVerifyServerCert {
-		rootCAs, err = x509.SystemCertPool()
-		if err != nil {
-			return fmt.Errorf("failed to get system cert pool: %w", err)
-		}
-	}
-
-	tlsConfig := &tls.Config{
-		RootCAs:            rootCAs,
-		InsecureSkipVerify: !c.SSLVerifyServerCert,
-	}
-
-	if c.SSLCertPath != "" && c.SSLKeyPath != "" {
-		cert, err := tls.LoadX509KeyPair(c.SSLCertPath, c.SSLKeyPath)
-		if err != nil {
-			return fmt.Errorf("failed to load SSL certificate pair (cert: %s, key: %s): %w",
-				c.SSLCertPath, c.SSLKeyPath, err)
-		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
-	}
-
-	if c.SSLCipher != "" {
-		cipherSuites := parseCipherSuites(c.SSLCipher)
-		if len(cipherSuites) > 0 {
-			tlsConfig.CipherSuites = cipherSuites
-		}
+	tlsConfig, err := c.TLSConfig.BuildTLSConfig()
+	if err != nil {
+		return err
 	}
 
 	if err := mysql.RegisterTLSConfig("custom", tlsConfig); err != nil {
@@ -130,52 +66,4 @@ func (c *MySQLDBConnector) registerTLSConfig() error {
 	}
 
 	return nil
-}
-
-// parseCipherSuites parses a comma-separated list of cipher suite names
-// and returns the corresponding cipher suite IDs
-func parseCipherSuites(cipherStr string) []uint16 {
-	if cipherStr == "" {
-		return nil
-	}
-
-	cipherMap := map[string]uint16{
-		"TLS_RSA_WITH_RC4_128_SHA":                      tls.TLS_RSA_WITH_RC4_128_SHA,
-		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-		"TLS_RSA_WITH_AES_128_CBC_SHA":                  tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-		"TLS_RSA_WITH_AES_256_CBC_SHA":                  tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		"TLS_RSA_WITH_AES_128_CBC_SHA256":               tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
-		"TLS_RSA_WITH_AES_128_GCM_SHA256":               tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		"TLS_RSA_WITH_AES_256_GCM_SHA384":               tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":              tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
-		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		"TLS_ECDHE_RSA_WITH_RC4_128_SHA":                tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
-		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-		"TLS_AES_128_GCM_SHA256":                        tls.TLS_AES_128_GCM_SHA256,
-		"TLS_AES_256_GCM_SHA384":                        tls.TLS_AES_256_GCM_SHA384,
-		"TLS_CHACHA20_POLY1305_SHA256":                  tls.TLS_CHACHA20_POLY1305_SHA256,
-	}
-
-	var cipherSuites []uint16
-	ciphers := strings.Split(strings.TrimSpace(cipherStr), ",")
-
-	for _, cipher := range ciphers {
-		cipher = strings.TrimSpace(cipher)
-		if cipherID, exists := cipherMap[cipher]; exists {
-			cipherSuites = append(cipherSuites, cipherID)
-		}
-	}
-
-	return cipherSuites
 }

--- a/internal/datastore/embedmd/mysql/connect.go
+++ b/internal/datastore/embedmd/mysql/connect.go
@@ -24,9 +24,23 @@ type MySQLDBConnector struct {
 	db                  *gorm.DB
 }
 
-func NewMySQLDBConnector(dsn string) *MySQLDBConnector {
+func NewMySQLDBConnector(
+	dsn,
+	sslCertPath,
+	sslKeyPath,
+	sslRootCertPath,
+	sslCAPath,
+	sslCipher string,
+	sslVerifyServerCert bool,
+) *MySQLDBConnector {
 	return &MySQLDBConnector{
-		DSN: dsn,
+		DSN:                 dsn,
+		SSLCertPath:         sslCertPath,
+		SSLKeyPath:          sslKeyPath,
+		SSLRootCertPath:     sslRootCertPath,
+		SSLCAPath:           sslCAPath,
+		SSLCipher:           sslCipher,
+		SSLVerifyServerCert: sslVerifyServerCert,
 	}
 }
 

--- a/internal/datastore/embedmd/mysql/connect_test.go
+++ b/internal/datastore/embedmd/mysql/connect_test.go
@@ -1,0 +1,502 @@
+package mysql_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubeflow/model-registry/internal/datastore/embedmd/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	cont_mysql "github.com/testcontainers/testcontainers-go/modules/mysql"
+)
+
+func TestMySQLDBConnector_Connect_Insecure(t *testing.T) {
+	ctx := context.Background()
+
+	// Start MySQL container without SSL
+	mysqlContainer, err := cont_mysql.Run(
+		ctx,
+		"mysql:8.0",
+		cont_mysql.WithUsername("root"),
+		cont_mysql.WithPassword("testpass"),
+		cont_mysql.WithDatabase("testdb"),
+	)
+	require.NoError(t, err)
+	defer func() {
+		err := testcontainers.TerminateContainer(mysqlContainer)
+		require.NoError(t, err)
+	}()
+
+	// Test basic connection without SSL
+	t.Run("BasicConnection", func(t *testing.T) {
+		dsn := mysqlContainer.MustConnectionString(ctx)
+		connector := mysql.NewMySQLDBConnector(dsn)
+
+		db, err := connector.Connect()
+		require.NoError(t, err)
+		assert.NotNil(t, db)
+
+		// Test that we can perform a simple query
+		var result int
+		err = db.Raw("SELECT 1").Scan(&result).Error
+		require.NoError(t, err)
+		assert.Equal(t, 1, result)
+
+		// Clean up
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.Close()
+	})
+
+	t.Run("EmptySSLConfig", func(t *testing.T) {
+		dsn := mysqlContainer.MustConnectionString(ctx)
+		connector := &mysql.MySQLDBConnector{
+			DSN:                 dsn,
+			SSLCertPath:         "",
+			SSLKeyPath:          "",
+			SSLRootCertPath:     "",
+			SSLCAPath:           "",
+			SSLCipher:           "",
+			SSLVerifyServerCert: false,
+		}
+
+		db, err := connector.Connect()
+		require.NoError(t, err)
+		assert.NotNil(t, db)
+
+		// Clean up
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.Close()
+	})
+}
+
+func TestMySQLDBConnector_Connect_SSL(t *testing.T) {
+	// Create temporary directory for certificates
+	tempDir, err := os.MkdirTemp("", "mysql_ssl_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Generate test certificates
+	caCertPath, _, _, _, clientCertPath, clientKeyPath := generateTestCertificates(t, tempDir)
+
+	t.Run("SSLConfigurationValidation", func(t *testing.T) {
+		// Test that SSL configuration is properly validated without actual connection
+		connector := &mysql.MySQLDBConnector{
+			DSN:                 "root:pass@tcp(localhost:3306)/test?tls=custom",
+			SSLRootCertPath:     caCertPath,
+			SSLVerifyServerCert: true,
+		}
+
+		// This will fail to connect but should validate SSL config first
+		_, err := connector.Connect()
+		// We expect a connection error, not an SSL config error
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "failed to read SSL")
+		assert.NotContains(t, err.Error(), "failed to parse SSL")
+	})
+
+	t.Run("SSLWithClientCertValidation", func(t *testing.T) {
+		connector := &mysql.MySQLDBConnector{
+			DSN:                 "root:pass@tcp(localhost:3306)/test?tls=custom",
+			SSLCertPath:         clientCertPath,
+			SSLKeyPath:          clientKeyPath,
+			SSLRootCertPath:     caCertPath,
+			SSLVerifyServerCert: true,
+		}
+
+		// This will fail to connect but should validate SSL config first
+		_, err := connector.Connect()
+		// We expect a connection error, not an SSL config error
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "failed to load SSL certificate pair")
+	})
+
+	t.Run("SSLWithCipherSuitesValidation", func(t *testing.T) {
+		connector := &mysql.MySQLDBConnector{
+			DSN:                 "root:pass@tcp(localhost:3306)/test?tls=custom",
+			SSLRootCertPath:     caCertPath,
+			SSLCipher:           "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			SSLVerifyServerCert: true,
+		}
+
+		// This will fail to connect but should validate SSL config first
+		_, err := connector.Connect()
+		// We expect a connection error, not an SSL config error
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "failed to register TLS config")
+	})
+}
+
+func TestMySQLDBConnector_Connect_Secure(t *testing.T) {
+	ctx := context.Background()
+
+	// Start MySQL container with SSL enabled using built-in SSL support
+	mysqlContainer, err := cont_mysql.Run(
+		ctx,
+		"mysql:8.0",
+		cont_mysql.WithUsername("root"),
+		cont_mysql.WithPassword("testpass"),
+		cont_mysql.WithDatabase("testdb"),
+		// Enable SSL with default certificates
+		testcontainers.WithEnv(map[string]string{
+			"MYSQL_ROOT_HOST": "%",
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		err := testcontainers.TerminateContainer(mysqlContainer)
+		require.NoError(t, err)
+	}()
+
+	baseDSN := mysqlContainer.MustConnectionString(ctx)
+
+	t.Run("SSLConnectionWithSkipVerify", func(t *testing.T) {
+		// Test SSL connection with skip verify (most practical test)
+		// Parse the DSN and add TLS parameter properly
+		dsn := baseDSN
+		if strings.Contains(dsn, "?") {
+			dsn += "&tls=skip-verify"
+		} else {
+			dsn += "?tls=skip-verify"
+		}
+		connector := mysql.NewMySQLDBConnector(dsn)
+
+		db, err := connector.Connect()
+		require.NoError(t, err)
+		assert.NotNil(t, db)
+
+		// Test that we can perform a simple query over SSL
+		var result int
+		err = db.Raw("SELECT 1").Scan(&result).Error
+		require.NoError(t, err)
+		assert.Equal(t, 1, result)
+
+		// Verify SSL is actually being used by checking the connection
+		var sslCipher string
+		err = db.Raw("SHOW STATUS LIKE 'Ssl_cipher'").Row().Scan(&sslCipher, &sslCipher)
+		if err == nil && sslCipher != "" {
+			t.Logf("SSL cipher in use: %s", sslCipher)
+		}
+
+		// Clean up
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.Close()
+	})
+
+	t.Run("SSLConnectionWithPreferredMode", func(t *testing.T) {
+		// Test SSL connection with preferred mode
+		dsn := baseDSN
+		if strings.Contains(dsn, "?") {
+			dsn += "&tls=preferred"
+		} else {
+			dsn += "?tls=preferred"
+		}
+		connector := mysql.NewMySQLDBConnector(dsn)
+
+		db, err := connector.Connect()
+		require.NoError(t, err)
+		assert.NotNil(t, db)
+
+		// Test that we can perform operations
+		var result int
+		err = db.Raw("SELECT 1").Scan(&result).Error
+		require.NoError(t, err)
+		assert.Equal(t, 1, result)
+
+		// Clean up
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.Close()
+	})
+
+	t.Run("CustomSSLConfigWithInsecureSkipVerify", func(t *testing.T) {
+		// Test our custom SSL configuration with skip verify
+		dsn := baseDSN
+		if strings.Contains(dsn, "?") {
+			dsn += "&tls=custom"
+		} else {
+			dsn += "?tls=custom"
+		}
+		connector := &mysql.MySQLDBConnector{
+			DSN:                 dsn,
+			SSLVerifyServerCert: false, // Skip verification for testing
+		}
+
+		db, err := connector.Connect()
+		require.NoError(t, err)
+		assert.NotNil(t, db)
+
+		// Test database operations
+		var result int
+		err = db.Raw("SELECT 1").Scan(&result).Error
+		require.NoError(t, err)
+		assert.Equal(t, 1, result)
+
+		// Test that we can create and query a table
+		err = db.Exec("CREATE TEMPORARY TABLE test_ssl (id INT, name VARCHAR(50))").Error
+		require.NoError(t, err)
+
+		err = db.Exec("INSERT INTO test_ssl (id, name) VALUES (1, 'ssl_test')").Error
+		require.NoError(t, err)
+
+		var name string
+		err = db.Raw("SELECT name FROM test_ssl WHERE id = 1").Scan(&name).Error
+		require.NoError(t, err)
+		assert.Equal(t, "ssl_test", name)
+
+		// Clean up
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.Close()
+	})
+
+	t.Run("CustomSSLConfigWithCipherSuites", func(t *testing.T) {
+		// Test custom cipher suites
+		dsn := baseDSN
+		if strings.Contains(dsn, "?") {
+			dsn += "&tls=custom"
+		} else {
+			dsn += "?tls=custom"
+		}
+		connector := &mysql.MySQLDBConnector{
+			DSN:                 dsn,
+			SSLCipher:           "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			SSLVerifyServerCert: false,
+		}
+
+		db, err := connector.Connect()
+		require.NoError(t, err)
+		assert.NotNil(t, db)
+
+		// Test basic operation
+		var result int
+		err = db.Raw("SELECT 1").Scan(&result).Error
+		require.NoError(t, err)
+		assert.Equal(t, 1, result)
+
+		// Clean up
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.Close()
+	})
+}
+
+func TestMySQLDBConnector_Connect_ErrorCases(t *testing.T) {
+	t.Run("InvalidDSN", func(t *testing.T) {
+		connector := mysql.NewMySQLDBConnector("invalid-dsn")
+
+		db, err := connector.Connect()
+		assert.Error(t, err)
+		assert.Nil(t, db)
+	})
+
+	t.Run("NonExistentCertFile", func(t *testing.T) {
+		connector := &mysql.MySQLDBConnector{
+			DSN:             "root:pass@tcp(localhost:3306)/test",
+			SSLRootCertPath: "/nonexistent/cert.pem",
+		}
+
+		db, err := connector.Connect()
+		assert.Error(t, err)
+		assert.Nil(t, db)
+		assert.Contains(t, err.Error(), "failed to read SSL root certificate")
+	})
+
+	t.Run("InvalidCertPair", func(t *testing.T) {
+		// Create temporary files with invalid content
+		tempDir, err := os.MkdirTemp("", "invalid_cert_test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		invalidCertPath := filepath.Join(tempDir, "invalid.crt")
+		invalidKeyPath := filepath.Join(tempDir, "invalid.key")
+
+		err = os.WriteFile(invalidCertPath, []byte("invalid cert"), 0600)
+		require.NoError(t, err)
+		err = os.WriteFile(invalidKeyPath, []byte("invalid key"), 0600)
+		require.NoError(t, err)
+
+		connector := &mysql.MySQLDBConnector{
+			DSN:         "root:pass@tcp(localhost:3306)/test",
+			SSLCertPath: invalidCertPath,
+			SSLKeyPath:  invalidKeyPath,
+		}
+
+		db, err := connector.Connect()
+		assert.Error(t, err)
+		assert.Nil(t, db)
+		assert.Contains(t, err.Error(), "failed to load SSL certificate pair")
+	})
+
+	t.Run("InvalidRootCert", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "invalid_root_cert_test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		invalidRootCertPath := filepath.Join(tempDir, "invalid_root.crt")
+		err = os.WriteFile(invalidRootCertPath, []byte("invalid root cert"), 0600)
+		require.NoError(t, err)
+
+		connector := &mysql.MySQLDBConnector{
+			DSN:             "root:pass@tcp(localhost:3306)/test",
+			SSLRootCertPath: invalidRootCertPath,
+		}
+
+		db, err := connector.Connect()
+		assert.Error(t, err)
+		assert.Nil(t, db)
+		assert.Contains(t, err.Error(), "failed to parse SSL root certificate")
+	})
+}
+
+// generateTestCertificates creates a set of test certificates for SSL testing
+func generateTestCertificates(t *testing.T, tempDir string) (caCertPath, caKeyPath, serverCertPath, serverKeyPath, clientCertPath, clientKeyPath string) {
+	// Generate CA private key
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// Create CA certificate template
+	caTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{"Test CA"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Test"},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// Create CA certificate
+	caCertDER, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	// Save CA certificate
+	caCertPath = filepath.Join(tempDir, "ca-cert.pem")
+	caCertFile, err := os.Create(caCertPath)
+	require.NoError(t, err)
+	defer caCertFile.Close()
+	err = pem.Encode(caCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+	require.NoError(t, err)
+
+	// Save CA private key
+	caKeyPath = filepath.Join(tempDir, "ca-key.pem")
+	caKeyFile, err := os.Create(caKeyPath)
+	require.NoError(t, err)
+	defer caKeyFile.Close()
+	caKeyDER, err := x509.MarshalPKCS8PrivateKey(caKey)
+	require.NoError(t, err)
+	err = pem.Encode(caKeyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: caKeyDER})
+	require.NoError(t, err)
+
+	// Parse CA certificate for signing
+	caCert, err := x509.ParseCertificate(caCertDER)
+	require.NoError(t, err)
+
+	// Generate server certificate
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	serverTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization:  []string{"Test Server"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Test"},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		DNSNames:     []string{"localhost"},
+	}
+
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, &serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	// Save server certificate
+	serverCertPath = filepath.Join(tempDir, "server-cert.pem")
+	serverCertFile, err := os.Create(serverCertPath)
+	require.NoError(t, err)
+	defer serverCertFile.Close()
+	err = pem.Encode(serverCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
+	require.NoError(t, err)
+
+	// Save server private key
+	serverKeyPath = filepath.Join(tempDir, "server-key.pem")
+	serverKeyFile, err := os.Create(serverKeyPath)
+	require.NoError(t, err)
+	defer serverKeyFile.Close()
+	serverKeyDER, err := x509.MarshalPKCS8PrivateKey(serverKey)
+	require.NoError(t, err)
+	err = pem.Encode(serverKeyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: serverKeyDER})
+	require.NoError(t, err)
+
+	// Generate client certificate
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	clientTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject: pkix.Name{
+			Organization:  []string{"Test Client"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Test"},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		SubjectKeyId: []byte{1, 2, 3, 4, 5},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, &clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	// Save client certificate
+	clientCertPath = filepath.Join(tempDir, "client-cert.pem")
+	clientCertFile, err := os.Create(clientCertPath)
+	require.NoError(t, err)
+	defer clientCertFile.Close()
+	err = pem.Encode(clientCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
+	require.NoError(t, err)
+
+	// Save client private key
+	clientKeyPath = filepath.Join(tempDir, "client-key.pem")
+	clientKeyFile, err := os.Create(clientKeyPath)
+	require.NoError(t, err)
+	defer clientKeyFile.Close()
+	clientKeyDER, err := x509.MarshalPKCS8PrivateKey(clientKey)
+	require.NoError(t, err)
+	err = pem.Encode(clientKeyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: clientKeyDER})
+	require.NoError(t, err)
+
+	return caCertPath, caKeyPath, serverCertPath, serverKeyPath, clientCertPath, clientKeyPath
+}

--- a/internal/datastore/embedmd/mysql/connect_test.go
+++ b/internal/datastore/embedmd/mysql/connect_test.go
@@ -41,7 +41,7 @@ func TestMySQLDBConnector_Connect_Insecure(t *testing.T) {
 	// Test basic connection without SSL
 	t.Run("BasicConnection", func(t *testing.T) {
 		dsn := mysqlContainer.MustConnectionString(ctx)
-		connector := mysql.NewMySQLDBConnector(dsn)
+		connector := mysql.NewMySQLDBConnector(dsn, "", "", "", "", "", false)
 
 		db, err := connector.Connect()
 		require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestMySQLDBConnector_Connect_Insecure(t *testing.T) {
 		// Clean up
 		sqlDB, err := db.DB()
 		require.NoError(t, err)
-		sqlDB.Close()
+		sqlDB.Close() //nolint:errcheck
 	})
 
 	t.Run("EmptySSLConfig", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestMySQLDBConnector_Connect_Insecure(t *testing.T) {
 		// Clean up
 		sqlDB, err := db.DB()
 		require.NoError(t, err)
-		sqlDB.Close()
+		sqlDB.Close() //nolint:errcheck
 	})
 }
 
@@ -86,7 +86,7 @@ func TestMySQLDBConnector_Connect_SSL(t *testing.T) {
 	// Create temporary directory for certificates
 	tempDir, err := os.MkdirTemp("", "mysql_ssl_test")
 	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	defer os.RemoveAll(tempDir) //nolint:errcheck
 
 	// Generate test certificates
 	caCertPath, _, _, _, clientCertPath, clientKeyPath := generateTestCertificates(t, tempDir)
@@ -171,7 +171,7 @@ func TestMySQLDBConnector_Connect_Secure(t *testing.T) {
 		} else {
 			dsn += "?tls=skip-verify"
 		}
-		connector := mysql.NewMySQLDBConnector(dsn)
+		connector := mysql.NewMySQLDBConnector(dsn, "", "", "", "", "", false)
 
 		db, err := connector.Connect()
 		require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestMySQLDBConnector_Connect_Secure(t *testing.T) {
 		// Clean up
 		sqlDB, err := db.DB()
 		require.NoError(t, err)
-		sqlDB.Close()
+		sqlDB.Close() //nolint:errcheck
 	})
 
 	t.Run("SSLConnectionWithPreferredMode", func(t *testing.T) {
@@ -204,7 +204,7 @@ func TestMySQLDBConnector_Connect_Secure(t *testing.T) {
 		} else {
 			dsn += "?tls=preferred"
 		}
-		connector := mysql.NewMySQLDBConnector(dsn)
+		connector := mysql.NewMySQLDBConnector(dsn, "", "", "", "", "", false)
 
 		db, err := connector.Connect()
 		require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestMySQLDBConnector_Connect_Secure(t *testing.T) {
 		// Clean up
 		sqlDB, err := db.DB()
 		require.NoError(t, err)
-		sqlDB.Close()
+		sqlDB.Close() //nolint:errcheck
 	})
 
 	t.Run("CustomSSLConfigWithInsecureSkipVerify", func(t *testing.T) {
@@ -260,7 +260,7 @@ func TestMySQLDBConnector_Connect_Secure(t *testing.T) {
 		// Clean up
 		sqlDB, err := db.DB()
 		require.NoError(t, err)
-		sqlDB.Close()
+		sqlDB.Close() //nolint:errcheck
 	})
 
 	t.Run("CustomSSLConfigWithCipherSuites", func(t *testing.T) {
@@ -290,13 +290,13 @@ func TestMySQLDBConnector_Connect_Secure(t *testing.T) {
 		// Clean up
 		sqlDB, err := db.DB()
 		require.NoError(t, err)
-		sqlDB.Close()
+		sqlDB.Close() //nolint:errcheck
 	})
 }
 
 func TestMySQLDBConnector_Connect_ErrorCases(t *testing.T) {
 	t.Run("InvalidDSN", func(t *testing.T) {
-		connector := mysql.NewMySQLDBConnector("invalid-dsn")
+		connector := mysql.NewMySQLDBConnector("invalid-dsn", "", "", "", "", "", false)
 
 		db, err := connector.Connect()
 		assert.Error(t, err)
@@ -319,7 +319,7 @@ func TestMySQLDBConnector_Connect_ErrorCases(t *testing.T) {
 		// Create temporary files with invalid content
 		tempDir, err := os.MkdirTemp("", "invalid_cert_test")
 		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+		defer os.RemoveAll(tempDir) //nolint:errcheck
 
 		invalidCertPath := filepath.Join(tempDir, "invalid.crt")
 		invalidKeyPath := filepath.Join(tempDir, "invalid.key")
@@ -344,7 +344,7 @@ func TestMySQLDBConnector_Connect_ErrorCases(t *testing.T) {
 	t.Run("InvalidRootCert", func(t *testing.T) {
 		tempDir, err := os.MkdirTemp("", "invalid_root_cert_test")
 		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+		defer os.RemoveAll(tempDir) //nolint:errcheck
 
 		invalidRootCertPath := filepath.Join(tempDir, "invalid_root.crt")
 		err = os.WriteFile(invalidRootCertPath, []byte("invalid root cert"), 0600)
@@ -395,7 +395,7 @@ func generateTestCertificates(t *testing.T, tempDir string) (caCertPath, caKeyPa
 	caCertPath = filepath.Join(tempDir, "ca-cert.pem")
 	caCertFile, err := os.Create(caCertPath)
 	require.NoError(t, err)
-	defer caCertFile.Close()
+	defer caCertFile.Close() //nolint:errcheck
 	err = pem.Encode(caCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
 	require.NoError(t, err)
 
@@ -403,7 +403,7 @@ func generateTestCertificates(t *testing.T, tempDir string) (caCertPath, caKeyPa
 	caKeyPath = filepath.Join(tempDir, "ca-key.pem")
 	caKeyFile, err := os.Create(caKeyPath)
 	require.NoError(t, err)
-	defer caKeyFile.Close()
+	defer caKeyFile.Close() //nolint:errcheck
 	caKeyDER, err := x509.MarshalPKCS8PrivateKey(caKey)
 	require.NoError(t, err)
 	err = pem.Encode(caKeyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: caKeyDER})
@@ -442,7 +442,7 @@ func generateTestCertificates(t *testing.T, tempDir string) (caCertPath, caKeyPa
 	serverCertPath = filepath.Join(tempDir, "server-cert.pem")
 	serverCertFile, err := os.Create(serverCertPath)
 	require.NoError(t, err)
-	defer serverCertFile.Close()
+	defer serverCertFile.Close() //nolint:errcheck
 	err = pem.Encode(serverCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
 	require.NoError(t, err)
 
@@ -450,7 +450,7 @@ func generateTestCertificates(t *testing.T, tempDir string) (caCertPath, caKeyPa
 	serverKeyPath = filepath.Join(tempDir, "server-key.pem")
 	serverKeyFile, err := os.Create(serverKeyPath)
 	require.NoError(t, err)
-	defer serverKeyFile.Close()
+	defer serverKeyFile.Close() //nolint:errcheck
 	serverKeyDER, err := x509.MarshalPKCS8PrivateKey(serverKey)
 	require.NoError(t, err)
 	err = pem.Encode(serverKeyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: serverKeyDER})
@@ -484,7 +484,7 @@ func generateTestCertificates(t *testing.T, tempDir string) (caCertPath, caKeyPa
 	clientCertPath = filepath.Join(tempDir, "client-cert.pem")
 	clientCertFile, err := os.Create(clientCertPath)
 	require.NoError(t, err)
-	defer clientCertFile.Close()
+	defer clientCertFile.Close() //nolint:errcheck
 	err = pem.Encode(clientCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
 	require.NoError(t, err)
 
@@ -492,7 +492,7 @@ func generateTestCertificates(t *testing.T, tempDir string) (caCertPath, caKeyPa
 	clientKeyPath = filepath.Join(tempDir, "client-key.pem")
 	clientKeyFile, err := os.Create(clientKeyPath)
 	require.NoError(t, err)
-	defer clientKeyFile.Close()
+	defer clientKeyFile.Close() //nolint:errcheck
 	clientKeyDER, err := x509.MarshalPKCS8PrivateKey(clientKey)
 	require.NoError(t, err)
 	err = pem.Encode(clientKeyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: clientKeyDER})

--- a/internal/datastore/embedmd/mysql/migrate_test.go
+++ b/internal/datastore/embedmd/mysql/migrate_test.go
@@ -52,7 +52,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	)
 	require.NoError(t, err)
 
-	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx))
+	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), "", "", "", "", "", false)
 	require.NoError(t, err)
 
 	db, err := dbConnector.Connect()

--- a/internal/datastore/embedmd/mysql/migrate_test.go
+++ b/internal/datastore/embedmd/mysql/migrate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kubeflow/model-registry/internal/datastore/embedmd/mysql"
+	_tls "github.com/kubeflow/model-registry/internal/tls"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -52,7 +53,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	)
 	require.NoError(t, err)
 
-	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), "", "", "", "", "", false)
+	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), &_tls.TLSConfig{})
 	require.NoError(t, err)
 
 	db, err := dbConnector.Connect()

--- a/internal/datastore/embedmd/service.go
+++ b/internal/datastore/embedmd/service.go
@@ -18,6 +18,7 @@ const (
 type EmbedMDConfig struct {
 	DatabaseType string
 	DatabaseDSN  string
+	db.SSLConfig
 }
 
 func (c *EmbedMDConfig) Validate() error {
@@ -34,7 +35,16 @@ type EmbedMDService struct {
 }
 
 func NewEmbedMDService(cfg *EmbedMDConfig) (*EmbedMDService, error) {
-	dbConnector, err := db.NewConnector(cfg.DatabaseType, cfg.DatabaseDSN)
+	sslConfig := &db.SSLConfig{
+		SSLCert:             cfg.SSLCert,
+		SSLKey:              cfg.SSLKey,
+		SSLRootCert:         cfg.SSLRootCert,
+		SSLCA:               cfg.SSLCA,
+		SSLCipher:           cfg.SSLCipher,
+		SSLVerifyServerCert: cfg.SSLVerifyServerCert,
+	}
+
+	dbConnector, err := db.NewConnector(cfg.DatabaseType, cfg.DatabaseDSN, sslConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datastore/embedmd/service.go
+++ b/internal/datastore/embedmd/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubeflow/model-registry/internal/db"
 	"github.com/kubeflow/model-registry/internal/db/service"
 	"github.com/kubeflow/model-registry/internal/defaults"
+	"github.com/kubeflow/model-registry/internal/tls"
 	"github.com/kubeflow/model-registry/pkg/api"
 )
 
@@ -18,7 +19,7 @@ const (
 type EmbedMDConfig struct {
 	DatabaseType string
 	DatabaseDSN  string
-	db.SSLConfig
+	TLSConfig    *tls.TLSConfig
 }
 
 func (c *EmbedMDConfig) Validate() error {
@@ -35,16 +36,7 @@ type EmbedMDService struct {
 }
 
 func NewEmbedMDService(cfg *EmbedMDConfig) (*EmbedMDService, error) {
-	sslConfig := &db.SSLConfig{
-		SSLCert:             cfg.SSLCert,
-		SSLKey:              cfg.SSLKey,
-		SSLRootCert:         cfg.SSLRootCert,
-		SSLCA:               cfg.SSLCA,
-		SSLCipher:           cfg.SSLCipher,
-		SSLVerifyServerCert: cfg.SSLVerifyServerCert,
-	}
-
-	dbConnector, err := db.NewConnector(cfg.DatabaseType, cfg.DatabaseDSN, sslConfig)
+	dbConnector, err := db.NewConnector(cfg.DatabaseType, cfg.DatabaseDSN, cfg.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/connector.go
+++ b/internal/db/connector.go
@@ -12,10 +12,31 @@ type Connector interface {
 	DB() *gorm.DB
 }
 
-func NewConnector(dbType string, dsn string) (Connector, error) {
+type SSLConfig struct {
+	SSLCert             string
+	SSLKey              string
+	SSLRootCert         string
+	SSLCA               string
+	SSLCipher           string
+	SSLVerifyServerCert bool
+}
+
+func NewConnector(dbType string, dsn string, sslConfig *SSLConfig) (Connector, error) {
 	switch dbType {
 	case "mysql":
-		return mysql.NewMySQLDBConnector(dsn), nil
+		if sslConfig != nil {
+			return mysql.NewMySQLDBConnector(
+				dsn,
+				sslConfig.SSLCert,
+				sslConfig.SSLKey,
+				sslConfig.SSLRootCert,
+				sslConfig.SSLCA,
+				sslConfig.SSLCipher,
+				sslConfig.SSLVerifyServerCert,
+			), nil
+		}
+
+		return mysql.NewMySQLDBConnector(dsn, "", "", "", "", "", false), nil
 	}
 
 	return nil, fmt.Errorf("unsupported database type: %s", dbType)

--- a/internal/db/connector.go
+++ b/internal/db/connector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kubeflow/model-registry/internal/datastore/embedmd/mysql"
+	"github.com/kubeflow/model-registry/internal/tls"
 	"gorm.io/gorm"
 )
 
@@ -12,31 +13,17 @@ type Connector interface {
 	DB() *gorm.DB
 }
 
-type SSLConfig struct {
-	SSLCert             string
-	SSLKey              string
-	SSLRootCert         string
-	SSLCA               string
-	SSLCipher           string
-	SSLVerifyServerCert bool
-}
-
-func NewConnector(dbType string, dsn string, sslConfig *SSLConfig) (Connector, error) {
+func NewConnector(dbType string, dsn string, tlsConfig *tls.TLSConfig) (Connector, error) {
 	switch dbType {
 	case "mysql":
-		if sslConfig != nil {
+		if tlsConfig != nil {
 			return mysql.NewMySQLDBConnector(
 				dsn,
-				sslConfig.SSLCert,
-				sslConfig.SSLKey,
-				sslConfig.SSLRootCert,
-				sslConfig.SSLCA,
-				sslConfig.SSLCipher,
-				sslConfig.SSLVerifyServerCert,
+				tlsConfig,
 			), nil
 		}
 
-		return mysql.NewMySQLDBConnector(dsn, "", "", "", "", "", false), nil
+		return mysql.NewMySQLDBConnector(dsn, &tls.TLSConfig{}), nil
 	}
 
 	return nil, fmt.Errorf("unsupported database type: %s", dbType)

--- a/internal/db/service/registered_model_test.go
+++ b/internal/db/service/registered_model_test.go
@@ -32,7 +32,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	)
 	require.NoError(t, err)
 
-	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx))
+	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), "", "", "", "", "", false)
 	require.NoError(t, err)
 
 	db, err := dbConnector.Connect()

--- a/internal/db/service/registered_model_test.go
+++ b/internal/db/service/registered_model_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubeflow/model-registry/internal/db/schema"
 	"github.com/kubeflow/model-registry/internal/db/service"
 	"github.com/kubeflow/model-registry/internal/defaults"
+	"github.com/kubeflow/model-registry/internal/tls"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -32,7 +33,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	)
 	require.NoError(t, err)
 
-	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), "", "", "", "", "", false)
+	dbConnector := mysql.NewMySQLDBConnector(mysqlContainer.MustConnectionString(ctx), &tls.TLSConfig{})
 	require.NoError(t, err)
 
 	db, err := dbConnector.Connect()

--- a/internal/proxy/readiness.go
+++ b/internal/proxy/readiness.go
@@ -30,7 +30,7 @@ func ReadinessHandler(datastore datastore.Datastore) http.Handler {
 			return
 		}
 
-		dbConnector, err := db.NewConnector(datastore.EmbedMD.DatabaseType, dsn)
+		dbConnector, err := db.NewConnector(datastore.EmbedMD.DatabaseType, dsn, nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("database new connector error: %s", err), http.StatusServiceUnavailable)
 			return

--- a/internal/proxy/readiness_test.go
+++ b/internal/proxy/readiness_test.go
@@ -31,7 +31,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, string, func()) {
 	require.NoError(t, err)
 
 	dsn := mysqlContainer.MustConnectionString(ctx)
-	dbConnector := mysql.NewMySQLDBConnector(dsn)
+	dbConnector := mysql.NewMySQLDBConnector(dsn, nil)
 
 	db, err := dbConnector.Connect()
 	require.NoError(t, err)

--- a/internal/tls/config.go
+++ b/internal/tls/config.go
@@ -1,0 +1,134 @@
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type TLSConfig struct {
+	CertPath         string
+	KeyPath          string
+	RootCertPath     string
+	CAPath           string
+	Cipher           string
+	VerifyServerCert bool
+}
+
+func NewTLSConfig(certPath, keyPath, rootCertPath, caPath, cipher string, verifyServerCert bool) *TLSConfig {
+	return &TLSConfig{
+		CertPath:         certPath,
+		KeyPath:          keyPath,
+		RootCertPath:     rootCertPath,
+		CAPath:           caPath,
+		Cipher:           cipher,
+		VerifyServerCert: verifyServerCert,
+	}
+}
+
+func (c *TLSConfig) BuildTLSConfig() (*tls.Config, error) {
+	var rootCAs *x509.CertPool
+	var err error
+
+	if c.RootCertPath != "" || c.CAPath != "" {
+		rootCAs = x509.NewCertPool()
+
+		if c.RootCertPath != "" {
+			rootCert, err := os.ReadFile(c.RootCertPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read SSL root certificate from %s: %w", c.RootCertPath, err)
+			}
+			if !rootCAs.AppendCertsFromPEM(rootCert) {
+				return nil, fmt.Errorf("failed to parse SSL root certificate from %s", c.RootCertPath)
+			}
+		}
+
+		if c.CAPath != "" && c.CAPath != c.RootCertPath {
+			caCert, err := os.ReadFile(c.CAPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read SSL CA certificate from %s: %w", c.CAPath, err)
+			}
+			if !rootCAs.AppendCertsFromPEM(caCert) {
+				return nil, fmt.Errorf("failed to parse SSL CA certificate from %s", c.CAPath)
+			}
+		}
+	} else if c.VerifyServerCert {
+		rootCAs, err = x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get system cert pool: %w", err)
+		}
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs:            rootCAs,
+		InsecureSkipVerify: !c.VerifyServerCert,
+	}
+
+	if c.CertPath != "" && c.KeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(c.CertPath, c.KeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load SSL certificate pair (cert: %s, key: %s): %w",
+				c.CertPath, c.KeyPath, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	if c.Cipher != "" {
+		cipherSuites := parseCipherSuites(c.Cipher)
+		if len(cipherSuites) > 0 {
+			tlsConfig.CipherSuites = cipherSuites
+		}
+	}
+
+	return tlsConfig, nil
+}
+
+// parseCipherSuites parses a colon-separated list of cipher suite names
+// and returns the corresponding cipher suite IDs
+func parseCipherSuites(cipherStr string) []uint16 {
+	if cipherStr == "" {
+		return nil
+	}
+
+	cipherMap := map[string]uint16{
+		"TLS_RSA_WITH_RC4_128_SHA":                      tls.TLS_RSA_WITH_RC4_128_SHA,
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA":                  tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_RSA_WITH_AES_256_CBC_SHA":                  tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA256":               tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_RSA_WITH_AES_128_GCM_SHA256":               tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_RSA_WITH_AES_256_GCM_SHA384":               tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":              tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_RC4_128_SHA":                tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		"TLS_AES_128_GCM_SHA256":                        tls.TLS_AES_128_GCM_SHA256,
+		"TLS_AES_256_GCM_SHA384":                        tls.TLS_AES_256_GCM_SHA384,
+		"TLS_CHACHA20_POLY1305_SHA256":                  tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+
+	var cipherSuites []uint16
+	ciphers := strings.Split(strings.TrimSpace(cipherStr), ":")
+
+	for _, cipher := range ciphers {
+		cipher = strings.TrimSpace(cipher)
+		if cipherID, exists := cipherMap[cipher]; exists {
+			cipherSuites = append(cipherSuites, cipherID)
+		}
+	}
+
+	return cipherSuites
+}

--- a/internal/tls/config.go
+++ b/internal/tls/config.go
@@ -76,7 +76,11 @@ func (c *TLSConfig) BuildTLSConfig() (*tls.Config, error) {
 	}
 
 	if c.Cipher != "" {
-		cipherSuites := parseCipherSuites(c.Cipher)
+		cipherSuites, err := parseCipherSuites(c.Cipher)
+		if err != nil {
+			return nil, err
+		}
+
 		if len(cipherSuites) > 0 {
 			tlsConfig.CipherSuites = cipherSuites
 		}
@@ -87,9 +91,9 @@ func (c *TLSConfig) BuildTLSConfig() (*tls.Config, error) {
 
 // parseCipherSuites parses a colon-separated list of cipher suite names
 // and returns the corresponding cipher suite IDs
-func parseCipherSuites(cipherStr string) []uint16 {
+func parseCipherSuites(cipherStr string) ([]uint16, error) {
 	if cipherStr == "" {
-		return nil
+		return nil, nil
 	}
 
 	cipherMap := map[string]uint16{
@@ -127,8 +131,10 @@ func parseCipherSuites(cipherStr string) []uint16 {
 		cipher = strings.TrimSpace(cipher)
 		if cipherID, exists := cipherMap[cipher]; exists {
 			cipherSuites = append(cipherSuites, cipherID)
+		} else {
+			return nil, fmt.Errorf("invalid cipher suite: %s", cipher)
 		}
 	}
 
-	return cipherSuites
+	return cipherSuites, nil
 }

--- a/internal/tls/config_test.go
+++ b/internal/tls/config_test.go
@@ -1,0 +1,436 @@
+package tls_test
+
+import (
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tlsconfig "github.com/kubeflow/model-registry/internal/tls"
+)
+
+const (
+	// Test certificate and key (self-signed, for testing only)
+	testCert = `-----BEGIN CERTIFICATE-----
+MIIDczCCAlugAwIBAgIUMF77xY8/4njgitPJbFfCpfdDYvYwDQYJKoZIhvcNAQEL
+BQAwSTELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx
+DTALBgNVBAoMBFRlc3QxDTALBgNVBAMMBHRlc3QwHhcNMjUwNjIwMTA1MTU0WhcN
+MjYwNjIwMTA1MTU0WjBJMQswCQYDVQQGEwJVUzENMAsGA1UECAwEVGVzdDENMAsG
+A1UEBwwEVGVzdDENMAsGA1UECgwEVGVzdDENMAsGA1UEAwwEdGVzdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBALNB2t9FATuWauWWZIpoHCC9fIfX/DxT
+hxHpDA72dsJlP8aScOPzSDBlmZf6cWBEpZsaYRKdkCT3eqANhXg+ciid6nh3ZPqm
+BJQx3AqY2YtfMQFjBljp/Glwyc21vgoP7v4Gk1ZUojhFwBfZJWWlW0mdzJshpYTB
+quBYPqrD+5q23PVFgZqQSOGSUpiAERg93wTy7VeRxiws4FoKgxUCdbLJPw9KTDf4
+PhQ+dnaWBYfWlBQxgEuB38vhMAn7RAinNxjoQDxfPethiBQU06xMqay0QNVueiAG
+iR7e+QeQugIRj7yELpSgAGHxIibrcs6TPNGcI58+gAP/NfkI4hi272kCAwEAAaNT
+MFEwHQYDVR0OBBYEFJ0eGqMERBgaN8GeggJj2yM+MnfyMB8GA1UdIwQYMBaAFJ0e
+GqMERBgaN8GeggJj2yM+MnfyMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
+BQADggEBAGfcNw+HjYu/I6MhOgk1jgWov2yTXE2kjq097irdrHmlZcPXGWaMl+lw
+rN4/hdFf0vhjSVWKjCjMP0dBAPCyht8xUg0/rsxYEa9UszFqYhtTT/k8HNyEXtSH
+f2c5eSbc8n/IGvbiHPGmq/iHtZyDSKw83GQyRxSsXdgM7ru7N0YcP7qAkA6aqjYq
+3/LbAvJOrPUMYlbpG7/+ZKareiMDy/1z8bWVFd3LiT12RhSJuqsCwMa3KePNAjaq
+QTYxfer470vq8Y9cBwlMid0+RNGOcuQxbr20QeexEpGN8wHyxC4sO5ByBbpnPUsN
+lcYEIoSHV3P8mTOqEVmCzBnDerbQfis=
+-----END CERTIFICATE-----`
+
+	testKey = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCzQdrfRQE7lmrl
+lmSKaBwgvXyH1/w8U4cR6QwO9nbCZT/GknDj80gwZZmX+nFgRKWbGmESnZAk93qg
+DYV4PnIonep4d2T6pgSUMdwKmNmLXzEBYwZY6fxpcMnNtb4KD+7+BpNWVKI4RcAX
+2SVlpVtJncybIaWEwargWD6qw/uattz1RYGakEjhklKYgBEYPd8E8u1XkcYsLOBa
+CoMVAnWyyT8PSkw3+D4UPnZ2lgWH1pQUMYBLgd/L4TAJ+0QIpzcY6EA8Xz3rYYgU
+FNOsTKmstEDVbnogBoke3vkHkLoCEY+8hC6UoABh8SIm63LOkzzRnCOfPoAD/zX5
+COIYtu9pAgMBAAECggEAGuP36LLiELWLkyXYrr+X6pxqTDmNE+Km2ju2zJ7R6W8F
+Xm005Kkn7OSs4hTWga3Clw4hvkhnKXh7i3uDyGo7t1abKBenDQevG6kQHIHZ7pOo
+1w+rEdcF/65FA6guGjXSMQa8/wAitqTWAG3Zc5JW66fxm9r0CMKBtvZd7kGIoqhn
+1b3CZUQyzgOqqB8jkyTYzhGxqqL/83L43O8dPtF3mRl3xHBDRMwuJtwaeik9ENJ5
+mAZhWHiihE4icPXh7okrOKRhf4+2PtGVJVEcsCOoWn+u8Lrknr0pnWRw/RoX6qOB
+NBcQKIhidl9XjbxLHGSZDGiKI8UuLqjLKfy+L5JARQKBgQDrb23cnmUSNFn28uDn
+pEq9+Qpmyo0XZJsikcUmGodq/qIClDghNzeBfh1mO5vdgVd6yVkXprFIA6HeIvQs
+10m2Y4ryKncrw5fIm3FsN66yjZPQBRq7Booh+h7JT10yYGO/Ew4Ec9q883PiNmjx
+6JBjzKPSkd9W5fonXJFpThUBRQKBgQDC6jp14rTRKAx/JOoKJxcE7Rc28j3/7R0W
+80GQMyFe6dhGcyQkjn5Fun45QU4+puycGEizWtFcgvWC5KSmwbtNlcGoPvZWy2Xw
+lY4Lj/m4ziFSMz+q4GMdra1ymBlcFm3BdyqAJY+JpzihnioDNuJVIS5wM0iFRLcH
+LsIv+9Dt1QKBgB43N9dXsMsMUvuBomG4USteefpFRqRY8hwWr0G7p+OQeIRyN13z
+8zi4UdecEN31yp9klf2WFCyU4sJapBHZM4mn7t4zmwXP3XwOjxj/cHlT+EN7VDnq
+lfHUYv0dJW3gtwx/yo3BvLIBYL8IkqFxYo6cZe4RcKN7coZ4t+TW85UtAoGAZoAG
+fjfaHqOQ7svax7wGvvBvZNW/BPcMdSU3NT2uLtuKgIHMX+0POlv4ROOy4f+mLfAX
+SzpXHu8/bLYQYCFA/mviizeRE9OiqAH90NbF3AmKPE/3C0U02kabD8gsjeC9lx+z
+mfAmq5zkixlBvq7+FwZ8BUTyviKEnaJZPCKQnIECgYEAt26lsdwbUtistx9isZ8/
+/NB4rd/GPQnBCyiQZy2mftYROuEonOHZq0XmuGhoU/Vvv0/9149eDCOED0BllBRy
+qaXDpxpd8DoJVEvJDXAQVPu9WqcrYieJDc9a40tBMaf3YvcaCuHPj6LywzXlH45f
+COUgUAV+r5AGr5R23tHluuQ=
+-----END PRIVATE KEY-----`
+
+	testRootCA = `-----BEGIN CERTIFICATE-----
+MIIDczCCAlugAwIBAgIUMF77xY8/4njgitPJbFfCpfdDYvYwDQYJKoZIhvcNAQEL
+BQAwSTELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx
+DTALBgNVBAoMBFRlc3QxDTALBgNVBAMMBHRlc3QwHhcNMjUwNjIwMTA1MTU0WhcN
+MjYwNjIwMTA1MTU0WjBJMQswCQYDVQQGEwJVUzENMAsGA1UECAwEVGVzdDENMAsG
+A1UEBwwEVGVzdDENMAsGA1UECgwEVGVzdDENMAsGA1UEAwwEdGVzdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBALNB2t9FATuWauWWZIpoHCC9fIfX/DxT
+hxHpDA72dsJlP8aScOPzSDBlmZf6cWBEpZsaYRKdkCT3eqANhXg+ciid6nh3ZPqm
+BJQx3AqY2YtfMQFjBljp/Glwyc21vgoP7v4Gk1ZUojhFwBfZJWWlW0mdzJshpYTB
+quBYPqrD+5q23PVFgZqQSOGSUpiAERg93wTy7VeRxiws4FoKgxUCdbLJPw9KTDf4
+PhQ+dnaWBYfWlBQxgEuB38vhMAn7RAinNxjoQDxfPethiBQU06xMqay0QNVueiAG
+iR7e+QeQugIRj7yELpSgAGHxIibrcs6TPNGcI58+gAP/NfkI4hi272kCAwEAAaNT
+MFEwHQYDVR0OBBYEFJ0eGqMERBgaN8GeggJj2yM+MnfyMB8GA1UdIwQYMBaAFJ0e
+GqMERBgaN8GeggJj2yM+MnfyMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
+BQADggEBAGfcNw+HjYu/I6MhOgk1jgWov2yTXE2kjq097irdrHmlZcPXGWaMl+lw
+rN4/hdFf0vhjSVWKjCjMP0dBAPCyht8xUg0/rsxYEa9UszFqYhtTT/k8HNyEXtSH
+f2c5eSbc8n/IGvbiHPGmq/iHtZyDSKw83GQyRxSsXdgM7ru7N0YcP7qAkA6aqjYq
+3/LbAvJOrPUMYlbpG7/+ZKareiMDy/1z8bWVFd3LiT12RhSJuqsCwMa3KePNAjaq
+QTYxfer470vq8Y9cBwlMid0+RNGOcuQxbr20QeexEpGN8wHyxC4sO5ByBbpnPUsN
+lcYEIoSHV3P8mTOqEVmCzBnDerbQfis=
+-----END CERTIFICATE-----`
+)
+
+func TestNewTLSConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		certPath         string
+		keyPath          string
+		rootCertPath     string
+		caPath           string
+		cipher           string
+		verifyServerCert bool
+	}{
+		{
+			name:             "all parameters",
+			certPath:         "/path/to/cert.pem",
+			keyPath:          "/path/to/key.pem",
+			rootCertPath:     "/path/to/root.pem",
+			caPath:           "/path/to/ca.pem",
+			cipher:           "TLS_AES_256_GCM_SHA384",
+			verifyServerCert: true,
+		},
+		{
+			name:             "minimal parameters",
+			certPath:         "",
+			keyPath:          "",
+			rootCertPath:     "",
+			caPath:           "",
+			cipher:           "",
+			verifyServerCert: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tlsconfig.NewTLSConfig(tt.certPath, tt.keyPath, tt.rootCertPath, tt.caPath, tt.cipher, tt.verifyServerCert)
+
+			if config.CertPath != tt.certPath {
+				t.Errorf("CertPath = %v, want %v", config.CertPath, tt.certPath)
+			}
+			if config.KeyPath != tt.keyPath {
+				t.Errorf("KeyPath = %v, want %v", config.KeyPath, tt.keyPath)
+			}
+			if config.RootCertPath != tt.rootCertPath {
+				t.Errorf("RootCertPath = %v, want %v", config.RootCertPath, tt.rootCertPath)
+			}
+			if config.CAPath != tt.caPath {
+				t.Errorf("CAPath = %v, want %v", config.CAPath, tt.caPath)
+			}
+			if config.Cipher != tt.cipher {
+				t.Errorf("Cipher = %v, want %v", config.Cipher, tt.cipher)
+			}
+			if config.VerifyServerCert != tt.verifyServerCert {
+				t.Errorf("VerifyServerCert = %v, want %v", config.VerifyServerCert, tt.verifyServerCert)
+			}
+		})
+	}
+}
+
+func TestBuildTLSConfig_Basic(t *testing.T) {
+	// Test basic configuration without certificates
+	config := tlsconfig.NewTLSConfig("", "", "", "", "", false)
+	tlsConf, err := config.BuildTLSConfig()
+
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v", err)
+	}
+
+	if tlsConf == nil {
+		t.Fatal("BuildTLSConfig() returned nil config")
+	}
+
+	if !tlsConf.InsecureSkipVerify {
+		t.Error("Expected InsecureSkipVerify to be true when VerifyServerCert is false")
+	}
+
+	if tlsConf.RootCAs != nil {
+		t.Error("Expected RootCAs to be nil when no cert paths provided and VerifyServerCert is false")
+	}
+}
+
+func TestBuildTLSConfig_VerifyServerCert(t *testing.T) {
+	// Test with server cert verification enabled
+	config := tlsconfig.NewTLSConfig("", "", "", "", "", true)
+	tlsConf, err := config.BuildTLSConfig()
+
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v", err)
+	}
+
+	if tlsConf.InsecureSkipVerify {
+		t.Error("Expected InsecureSkipVerify to be false when VerifyServerCert is true")
+	}
+
+	// Should use system cert pool when VerifyServerCert is true but no custom certs provided
+	if tlsConf.RootCAs == nil {
+		t.Error("Expected RootCAs to be set when VerifyServerCert is true")
+	}
+}
+
+func TestBuildTLSConfig_WithCertificates(t *testing.T) {
+	// Create temporary files for testing
+	tempDir := t.TempDir()
+
+	certFile := filepath.Join(tempDir, "cert.pem")
+	keyFile := filepath.Join(tempDir, "key.pem")
+	rootCAFile := filepath.Join(tempDir, "rootca.pem")
+
+	// Write test certificates
+	if err := os.WriteFile(certFile, []byte(testCert), 0644); err != nil {
+		t.Fatalf("Failed to write cert file: %v", err)
+	}
+	if err := os.WriteFile(keyFile, []byte(testKey), 0644); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+	if err := os.WriteFile(rootCAFile, []byte(testRootCA), 0644); err != nil {
+		t.Fatalf("Failed to write root CA file: %v", err)
+	}
+
+	config := tlsconfig.NewTLSConfig(certFile, keyFile, rootCAFile, "", "", true)
+	tlsConf, err := config.BuildTLSConfig()
+
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v", err)
+	}
+
+	if len(tlsConf.Certificates) != 1 {
+		t.Errorf("Expected 1 certificate, got %d", len(tlsConf.Certificates))
+	}
+
+	if tlsConf.RootCAs == nil {
+		t.Error("Expected RootCAs to be set")
+	}
+
+	if tlsConf.InsecureSkipVerify {
+		t.Error("Expected InsecureSkipVerify to be false when VerifyServerCert is true")
+	}
+}
+
+func TestBuildTLSConfig_WithCiphers(t *testing.T) {
+	config := tlsconfig.NewTLSConfig("", "", "", "", "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256", false)
+	tlsConf, err := config.BuildTLSConfig()
+
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v", err)
+	}
+
+	expectedCiphers := []uint16{tls.TLS_AES_256_GCM_SHA384, tls.TLS_AES_128_GCM_SHA256}
+	if len(tlsConf.CipherSuites) != len(expectedCiphers) {
+		t.Errorf("Expected %d cipher suites, got %d", len(expectedCiphers), len(tlsConf.CipherSuites))
+	}
+
+	for i, expected := range expectedCiphers {
+		if i >= len(tlsConf.CipherSuites) || tlsConf.CipherSuites[i] != expected {
+			t.Errorf("Expected cipher suite %x at index %d, got %x", expected, i, tlsConf.CipherSuites[i])
+		}
+	}
+}
+
+func TestBuildTLSConfig_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupConfig  func(t *testing.T) *tlsconfig.TLSConfig
+		wantErrorMsg string
+	}{
+		{
+			name: "invalid cert file",
+			setupConfig: func(t *testing.T) *tlsconfig.TLSConfig {
+				return tlsconfig.NewTLSConfig("/nonexistent/cert.pem", "/nonexistent/key.pem", "", "", "", false)
+			},
+			wantErrorMsg: "failed to load SSL certificate pair",
+		},
+		{
+			name: "invalid root cert file",
+			setupConfig: func(t *testing.T) *tlsconfig.TLSConfig {
+				return tlsconfig.NewTLSConfig("", "", "/nonexistent/root.pem", "", "", false)
+			},
+			wantErrorMsg: "failed to read SSL root certificate",
+		},
+		{
+			name: "invalid CA cert file",
+			setupConfig: func(t *testing.T) *tlsconfig.TLSConfig {
+				return tlsconfig.NewTLSConfig("", "", "", "/nonexistent/ca.pem", "", false)
+			},
+			wantErrorMsg: "failed to read SSL CA certificate",
+		},
+		{
+			name: "invalid cert content",
+			setupConfig: func(t *testing.T) *tlsconfig.TLSConfig {
+				tempDir := t.TempDir()
+				invalidCertFile := filepath.Join(tempDir, "invalid.pem")
+				if err := os.WriteFile(invalidCertFile, []byte("invalid certificate content"), 0644); err != nil {
+					t.Fatalf("Failed to write invalid cert file: %v", err)
+				}
+				return tlsconfig.NewTLSConfig("", "", invalidCertFile, "", "", false)
+			},
+			wantErrorMsg: "failed to parse SSL root certificate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.setupConfig(t)
+			_, err := config.BuildTLSConfig()
+
+			if err == nil {
+				t.Error("Expected error, got nil")
+				return
+			}
+
+			if !strings.Contains(err.Error(), tt.wantErrorMsg) {
+				t.Errorf("Expected error containing %q, got %q", tt.wantErrorMsg, err.Error())
+			}
+		})
+	}
+}
+
+func TestParseCipherSuites(t *testing.T) {
+	tests := []struct {
+		name        string
+		cipherStr   string
+		expectedLen int
+		expected    []uint16
+	}{
+		{
+			name:        "empty string",
+			cipherStr:   "",
+			expectedLen: 0,
+			expected:    nil,
+		},
+		{
+			name:        "single cipher",
+			cipherStr:   "TLS_AES_256_GCM_SHA384",
+			expectedLen: 1,
+			expected:    []uint16{tls.TLS_AES_256_GCM_SHA384},
+		},
+		{
+			name:        "multiple ciphers",
+			cipherStr:   "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256",
+			expectedLen: 2,
+			expected:    []uint16{tls.TLS_AES_256_GCM_SHA384, tls.TLS_AES_128_GCM_SHA256},
+		},
+		{
+			name:        "cipher with spaces",
+			cipherStr:   " TLS_AES_256_GCM_SHA384 : TLS_AES_128_GCM_SHA256 ",
+			expectedLen: 2,
+			expected:    []uint16{tls.TLS_AES_256_GCM_SHA384, tls.TLS_AES_128_GCM_SHA256},
+		},
+		{
+			name:        "unknown cipher ignored",
+			cipherStr:   "TLS_AES_256_GCM_SHA384:UNKNOWN_CIPHER:TLS_AES_128_GCM_SHA256",
+			expectedLen: 2,
+			expected:    []uint16{tls.TLS_AES_256_GCM_SHA384, tls.TLS_AES_128_GCM_SHA256},
+		},
+		{
+			name:        "all unknown ciphers",
+			cipherStr:   "UNKNOWN_CIPHER1:UNKNOWN_CIPHER2",
+			expectedLen: 0,
+			expected:    nil,
+		},
+		{
+			name:        "comprehensive cipher list",
+			cipherStr:   "TLS_RSA_WITH_AES_128_CBC_SHA:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256",
+			expectedLen: 3,
+			expected: []uint16{
+				tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_CHACHA20_POLY1305_SHA256,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use reflection to access the unexported function
+			// Since we can't access unexported functions directly, we'll test through BuildTLSConfig
+			config := tlsconfig.NewTLSConfig("", "", "", "", tt.cipherStr, false)
+			tlsConf, err := config.BuildTLSConfig()
+
+			if err != nil {
+				t.Fatalf("BuildTLSConfig() error = %v", err)
+			}
+
+			if len(tlsConf.CipherSuites) != tt.expectedLen {
+				t.Errorf("Expected %d cipher suites, got %d", tt.expectedLen, len(tlsConf.CipherSuites))
+			}
+
+			if tt.expected != nil {
+				for i, expected := range tt.expected {
+					if i >= len(tlsConf.CipherSuites) || tlsConf.CipherSuites[i] != expected {
+						t.Errorf("Expected cipher suite %x at index %d, got %x", expected, i, tlsConf.CipherSuites[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTLSConfig_SeparateCAAndRootCert(t *testing.T) {
+	tempDir := t.TempDir()
+
+	rootCAFile := filepath.Join(tempDir, "rootca.pem")
+	caFile := filepath.Join(tempDir, "ca.pem")
+
+	// Write different certificates to test both are loaded
+	if err := os.WriteFile(rootCAFile, []byte(testRootCA), 0644); err != nil {
+		t.Fatalf("Failed to write root CA file: %v", err)
+	}
+	if err := os.WriteFile(caFile, []byte(testCert), 0644); err != nil {
+		t.Fatalf("Failed to write CA file: %v", err)
+	}
+
+	config := tlsconfig.NewTLSConfig("", "", rootCAFile, caFile, "", true)
+	tlsConf, err := config.BuildTLSConfig()
+
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v", err)
+	}
+
+	if tlsConf.RootCAs == nil {
+		t.Error("Expected RootCAs to be set")
+	}
+
+	// Verify both certificates were added to the pool
+	// We can't directly inspect the cert pool contents, but we can verify it was created
+	if tlsConf.RootCAs == nil {
+		t.Error("Expected certificate pool to contain both root CA and CA certificates")
+	}
+}
+
+func TestBuildTLSConfig_SameCAAndRootCert(t *testing.T) {
+	tempDir := t.TempDir()
+
+	rootCAFile := filepath.Join(tempDir, "rootca.pem")
+
+	if err := os.WriteFile(rootCAFile, []byte(testRootCA), 0644); err != nil {
+		t.Fatalf("Failed to write root CA file: %v", err)
+	}
+
+	// Use same file for both root cert and CA path
+	config := tlsconfig.NewTLSConfig("", "", rootCAFile, rootCAFile, "", true)
+	tlsConf, err := config.BuildTLSConfig()
+
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v", err)
+	}
+
+	if tlsConf.RootCAs == nil {
+		t.Error("Expected RootCAs to be set")
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

closes #1019 

This PR adds comprehensive SSL/TLS support for connecting to secured MySQL databases in the embedded metadata store. The implementation includes new command-line flags, a dedicated TLS configuration package, and extensive testing.

**Changes Made**

_New Command-Line Flags_

Added the following flags to support SSL/TLS database connections:

- --embedmd-database-ssl-cert - Path to client SSL certificate file
- --embedmd-database-ssl-key - Path to client SSL private key file
- --embedmd-database-ssl-root-cert - Path to SSL root certificate file
- --embedmd-database-ssl-ca - Path to SSL CA certificate file
- --embedmd-database-ssl-cipher - Colon-separated list of SSL cipher suites
- --embedmd-database-ssl-verify-server-cert - Enable SSL server certificate verification

_New TLS Configuration Package_

- Created internal/tls/config.go with a reusable TLSConfig struct
- Supports client certificates, root CA certificates, custom cipher suites
- Handles both server certificate verification and skip-verify modes
- Comprehensive error handling for certificate loading and parsing

_MySQL SSL Integration_

- Enhanced MySQLDBConnector to accept and use TLS configuration
- Proper SSL/TLS config registration with the MySQL driver
- Support for custom SSL configurations via tls=custom parameter

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `make test`

- tested locally with custom made secure-db manifests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
