### PR TITLE
feat: reintroduce retries when connecting to the db

### DIFF
--- a/internal/datastore/embedmd/mysql/connect.go
+++ b/internal/datastore/embedmd/mysql/connect.go
@@ -2,12 +2,19 @@ package mysql
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/golang/glog"
 	_tls "github.com/kubeflow/model-registry/internal/tls"
 	gorm_mysql "gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+)
+
+const (
+	// mysqlMaxRetries is the maximum number of attempts to retry MySQL connection.
+	mysqlMaxRetries = 25 // 25 attempts with incremental backoff (1s, 2s, 3s, ..., 25s) it's ~5 minutes
 )
 
 type MySQLDBConnector struct {
@@ -27,6 +34,9 @@ func NewMySQLDBConnector(
 }
 
 func (c *MySQLDBConnector) Connect() (*gorm.DB, error) {
+	var db *gorm.DB
+	var err error
+
 	if c.needsTLSConfig() {
 		if err := c.registerTLSConfig(); err != nil {
 			return nil, err
@@ -35,11 +45,21 @@ func (c *MySQLDBConnector) Connect() (*gorm.DB, error) {
 		c.DSN += "&tls=custom"
 	}
 
-	db, err := gorm.Open(gorm_mysql.Open(c.DSN), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
+	for i := range mysqlMaxRetries {
+		db, err = gorm.Open(gorm_mysql.Open(c.DSN), &gorm.Config{
+			Logger: logger.Default.LogMode(logger.Silent),
+		})
+		if err == nil {
+			break
+		}
+
+		glog.Warningf("Retrying connection to MySQL (attempt %d/%d): %v", i+1, mysqlMaxRetries, err)
+
+		time.Sleep(time.Duration(i+1) * time.Second)
+	}
+
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to MySQL: %w", err)
 	}
 
 	c.db = db


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR reintroduces backoff retries when connecting to the DB as model registry did when trying to connect to MLMD before in #700 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tested on a local cluster with db replicas = 0 and with db in dirty state

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

