### PR TITLE
fix(manifests): add fsGroup to database deployments

### DIFF
--- a/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsNonRoot: true
+        fsGroup: 999
       containers:
       - name: db-container
         image: mysql:8.3

--- a/manifests/kustomize/overlays/postgres/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/postgres/model-registry-db-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsNonRoot: true
+        fsGroup: 70
       containers:
       - name: db-container
         image: postgres


### PR DESCRIPTION
## Description

Fixes #1251

## How Has This Been Tested?
The issue came up when using Longhorn and I was able to reproduce it using k3s with Longhorn (it's likely that other provisioners have this problem too). Verified that the problem does not exist after this change, and that our normal Kind test environments still work.

## Merge criteria:
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
