### PR TITLE
fix: add backoff also to postgresql

### DIFF
--- a/internal/datastore/embedmd/postgres/connect.go
+++ b/internal/datastore/embedmd/postgres/connect.go
@@ -1,9 +1,18 @@
 package postgres
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/golang/glog"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+const (
+	// postgresMaxRetries is the maximum number of attempts to retry PostgreSQL connection.
+	postgresMaxRetries = 25 // 25 attempts with incremental backoff (1s, 2s, 3s, ..., 25s) it's ~5 minutes
 )
 
 type PostgresDBConnector struct {
@@ -18,16 +27,33 @@ func NewPostgresDBConnector(dsn string) *PostgresDBConnector {
 }
 
 func (c *PostgresDBConnector) Connect() (*gorm.DB, error) {
+	var db *gorm.DB
+	var err error
+
 	glog.V(2).Infof("Attempting to connect with DSN: %q", c.DSN)
-	db, err := gorm.Open(postgres.Open(c.DSN), &gorm.Config{})
+
+	for i := range postgresMaxRetries {
+		db, err = gorm.Open(postgres.Open(c.DSN), &gorm.Config{
+			Logger:         logger.Default.LogMode(logger.Silent),
+			TranslateError: true,
+		})
+		if err == nil {
+			break
+		}
+
+		glog.Warningf("Retrying connection to PostgreSQL (attempt %d/%d): %v", i+1, postgresMaxRetries, err)
+
+		time.Sleep(time.Duration(i+1) * time.Second)
+	}
+
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to PostgreSQL: %w", err)
 	}
 
 	c.db = db
 	glog.Info("Successfully connected to PostgreSQL database")
 	return db, nil
-} 
+}
 
 func (c *PostgresDBConnector) DB() *gorm.DB {
 	return c.db


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
