### PR TITLE
fix: prevent dsn format bugs when adding tls mode in mysql

### DIFF
--- a/internal/datastore/embedmd/mysql/connect.go
+++ b/internal/datastore/embedmd/mysql/connect.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
-	_tls "github.com/kubeflow/model-registry/internal/tls"
 	"github.com/golang/glog"
+	_tls "github.com/kubeflow/model-registry/internal/tls"
 	gorm_mysql "gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -42,7 +42,14 @@ func (c *MySQLDBConnector) Connect() (*gorm.DB, error) {
 			return nil, err
 		}
 
-		c.DSN += "&tls=custom"
+		cfg, err := mysql.ParseDSN(c.DSN)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse DSN: %w", err)
+		}
+
+		cfg.TLSConfig = "custom"
+
+		c.DSN = cfg.FormatDSN()
 	}
 
 	for i := range mysqlMaxRetries {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR addresses a bug where if the mysql DNS doesn't have a query param character `?`, it incorrectly appends `&tls=custom` which makes the DNS string invalid as it should be `?tls=custom`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tested locally with both 

`- --embedmd-database-dsn=$(MYSQL_USER_NAME):$(MYSQL_ROOT_PASSWORD)@tcp(model-registry-db:$(MYSQL_PORT))/$(MYSQL_DATABASE)?charset=utf8mb4&parseTime=True&loc=Local&tls=custom`

and

`- --embedmd-database-dsn=$(MYSQL_USER_NAME):$(MYSQL_ROOT_PASSWORD)@tcp(model-registry-db:$(MYSQL_PORT))/$(MYSQL_DATABASE)`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
