### PR TITLE
feat(catalog): reload sources and static catalogs

### DIFF
--- a/catalog/internal/catalog/catalog_test.go
+++ b/catalog/internal/catalog/catalog_test.go
@@ -30,8 +30,8 @@ func TestLoadCatalogSources(t *testing.T) {
 				t.Errorf("LoadCatalogSources() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			gotKeys := make([]string, 0, len(got))
-			for k := range got {
+			gotKeys := make([]string, 0, len(got.All()))
+			for k := range got.All() {
 				gotKeys = append(gotKeys, k)
 			}
 			sort.Strings(gotKeys)

--- a/catalog/internal/catalog/monitor.go
+++ b/catalog/internal/catalog/monitor.go
@@ -1,0 +1,238 @@
+package catalog
+
+import (
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/golang/glog"
+)
+
+// monitor sends events when the contents of a file have changed.
+//
+// Unfortunately, simply watching the file misses events for our primary case
+// of k8s mounted configmaps because the files we're watching are actually
+// symlinks which aren't modified:
+//
+//	drwxrwxrwx    1 root     root           138 Jul  2 15:45 .
+//	drwxr-xr-x    1 root     root           116 Jul  2 15:52 ..
+//	drwxr-xr-x    1 root     root            62 Jul  2 15:45 ..2025_07_02_15_45_09.2837733502
+//	lrwxrwxrwx    1 root     root            32 Jul  2 15:45 ..data -> ..2025_07_02_15_45_09.2837733502
+//	lrwxrwxrwx    1 root     root            26 Jul  2 13:18 sample-catalog.yaml -> ..data/sample-catalog.yaml
+//	lrwxrwxrwx    1 root     root            19 Jul  2 13:18 sources.yaml -> ..data/sources.yaml
+//
+// Updates are written to a new directory and the ..data symlink is updated. No
+// fsnotify events will ever be triggered for the YAML files.
+//
+// The approach taken here is to watch the directory containing the file for
+// any change and then hash the contents of the file to avoid false-positives.
+type monitor struct {
+	watcher *fsnotify.Watcher
+	closed  <-chan struct{}
+
+	recordsMu sync.RWMutex
+	records   map[string]map[string]*monitorRecord
+}
+
+var _monitor *monitor
+var initMonitor sync.Once
+
+// getMonitor returns a singleton monitor instance. Panics on failure.
+func getMonitor() *monitor {
+	initMonitor.Do(func() {
+		var err error
+		_monitor, err = newMonitor()
+		if err != nil {
+			panic(fmt.Sprintf("Unable to create file monitor: %v", err))
+		}
+	})
+	if _monitor == nil {
+		// Panic in case someone traps the panic that occurred during
+		// initialization and tries to call this again.
+		panic("Unable to get file monitor")
+	}
+
+	return _monitor
+}
+
+func newMonitor() (*monitor, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	m := &monitor{
+		watcher: watcher,
+		records: map[string]map[string]*monitorRecord{},
+	}
+
+	go m.monitor()
+	return m, nil
+}
+
+// Close stops the monitor and waits for the background goroutine to exit.
+//
+// All channels returned by Path() will be closed.
+func (m *monitor) Close() {
+	select {
+	case <-m.closed:
+		// Already closed, nothing to do.
+		return
+	default:
+		// Fallthrough
+	}
+
+	m.watcher.Close()
+	<-m.closed
+
+	m.recordsMu.Lock()
+	defer m.recordsMu.Unlock()
+
+	uniqCh := make(map[chan<- struct{}]struct{})
+	for dir := range m.records {
+		for file := range m.records[dir] {
+			record, ok := m.records[dir][file]
+			if !ok {
+				continue
+			}
+			for _, ch := range record.channels {
+				uniqCh[ch] = struct{}{}
+			}
+		}
+	}
+	for ch := range uniqCh {
+		close(ch)
+	}
+	m.records = nil
+}
+
+// Path returns a channel that receives an event when the contents of a file
+// change. The file does not need to exist before calling this method, however
+// the provided path should only be a file or a symlink (not a directory,
+// device, etc.). The returned channel will be closed when the monitor is
+// closed.
+func (m *monitor) Path(p string) (<-chan struct{}, error) {
+	absPath, err := filepath.Abs(p)
+	if err != nil {
+		return nil, fmt.Errorf("abs: %w", err)
+	}
+
+	m.recordsMu.Lock()
+	defer m.recordsMu.Unlock()
+
+	dir, base := filepath.Split(absPath)
+	dir = filepath.Clean(dir)
+
+	err = m.watcher.Add(dir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to watch directory %q: %w", dir, err)
+	}
+
+	if _, exists := m.records[dir]; !exists {
+		m.records[dir] = make(map[string]*monitorRecord, 1)
+	}
+
+	ch := make(chan struct{}, 1)
+
+	if _, exists := m.records[dir][base]; !exists {
+		m.records[dir][base] = &monitorRecord{
+			channels: []chan<- struct{}{ch},
+		}
+	} else {
+		r := m.records[dir][base]
+		r.channels = append(r.channels, ch)
+	}
+	m.records[dir][base].updateHash(filepath.Join(dir, base))
+
+	return ch, nil
+}
+
+func (m *monitor) monitor() {
+	closed := make(chan struct{})
+	m.closed = closed
+	defer close(closed)
+
+	for {
+		select {
+		case err, ok := <-m.watcher.Errors:
+			if !ok {
+				return
+			}
+
+			glog.Errorf("fsnotify error: %v", err)
+		case e, ok := <-m.watcher.Events:
+			if !ok {
+				return
+			}
+
+			glog.V(2).Infof("fsnotify.Event: %v", e)
+
+			switch e.Op {
+			case fsnotify.Create, fsnotify.Write:
+				// Fallthrough
+			default:
+				// Ignore fsnotify.Remove, fsnotify.Rename and fsnotify.Chmod
+				continue
+			}
+
+			func() {
+				m.recordsMu.RLock()
+				defer m.recordsMu.RUnlock()
+
+				dir := filepath.Dir(e.Name)
+
+				dc := m.records[dir]
+				if dc == nil {
+					return
+				}
+
+				for base, record := range dc {
+					path := filepath.Join(dir, base)
+					if !record.updateHash(path) {
+						continue
+					}
+					for _, ch := range record.channels {
+						// Send the event, ignore any that would block.
+						select {
+						case ch <- struct{}{}:
+						default:
+							glog.Errorf("monitor: missed event for path %s", path)
+						}
+					}
+				}
+			}()
+		}
+	}
+}
+
+type monitorRecord struct {
+	channels []chan<- struct{}
+	hash     uint32
+}
+
+// updateHash recalculates the hash and returns true if it has changed.
+func (mr *monitorRecord) updateHash(path string) bool {
+	newHash := mr.calculateHash(path)
+	oldHash := atomic.SwapUint32(&mr.hash, newHash)
+	return oldHash != newHash
+}
+
+func (monitorRecord) calculateHash(path string) uint32 {
+	fh, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer fh.Close()
+
+	h := crc32.NewIEEE()
+	_, err = io.Copy(h, fh)
+	if err != nil {
+		return 0
+	}
+	return h.Sum32()
+}

--- a/catalog/internal/catalog/monitor_test.go
+++ b/catalog/internal/catalog/monitor_test.go
@@ -1,0 +1,175 @@
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonitor(t *testing.T) {
+	assert := assert.New(t)
+
+	mon, err := newMonitor()
+	if !assert.NoError(err) {
+		return
+	}
+
+	tmpDir := t.TempDir()
+	fileA := filepath.Join(tmpDir, "a")
+	fileB := filepath.Join(tmpDir, "b")
+	fileC := filepath.Join(tmpDir, "c")
+
+	_watchMonitor := func(ch <-chan struct{}, err error) *monitorWatcher {
+		if err != nil {
+			t.Fatalf("watchMonitor passed error %v", err)
+		}
+		return watchMonitor(ch)
+	}
+
+	a := _watchMonitor(mon.Path(fileA))
+	b := _watchMonitor(mon.Path(fileB))
+
+	updateFile(t, fileA)
+	a.AssertCount(t, 1)
+	b.AssertCount(t, 0, "unchanged file should not have any events")
+
+	a.Reset()
+	updateFile(t, fileB)
+	b.AssertCount(t, 1)
+	updateFile(t, fileB)
+	b.AssertCount(t, 2)
+	a.AssertCount(t, 0, "unchanged file should not have any events")
+
+	b.Reset()
+	updateFile(t, fileC)
+	a.AssertCount(t, 0, "unchanged file should not have an event")
+	b.AssertCount(t, 0, "unchanged file should not have an event")
+
+	// Ensure that Close doesn't hang.
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		mon.Close()
+	}()
+	assert.Eventually(func() bool {
+		select {
+		case <-finished:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 50*time.Millisecond)
+
+	// Verify that the monitor channels closed.
+	assert.True(a.Done())
+	assert.True(b.Done())
+}
+
+func TestMonitorSymlinks(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpDir := t.TempDir()
+	mon, err := newMonitor()
+	if !assert.NoError(err) {
+		return
+	}
+	defer mon.Close()
+
+	// Watch the files on the published path.
+	_watchMonitor := func(ch <-chan struct{}, err error) *monitorWatcher {
+		if err != nil {
+			t.Fatalf("watchMonitor passed error %v", err)
+		}
+		return watchMonitor(ch)
+	}
+
+	a := _watchMonitor(mon.Path(filepath.Join(tmpDir, "a")))
+	b := _watchMonitor(mon.Path(filepath.Join(tmpDir, "b")))
+
+	// Set up a directory structure with symlinks like k8s does for mounted
+	// configmaps.
+	// a -> latest/a, b -> latest/b, latest -> v1
+	assert.NoError(os.Mkdir(filepath.Join(tmpDir, "v1"), 0777))
+	updateFile(t, filepath.Join(tmpDir, "v1", "a"), "foo")
+	updateFile(t, filepath.Join(tmpDir, "v1", "b"), "bar")
+	assert.NoError(os.Symlink("v1", filepath.Join(tmpDir, "latest")))
+	assert.NoError(os.Symlink(filepath.Join("latest", "a"), filepath.Join(tmpDir, "a")))
+	assert.NoError(os.Symlink(filepath.Join("latest", "b"), filepath.Join(tmpDir, "b")))
+
+	a.AssertCount(t, 1)
+	b.AssertCount(t, 1)
+
+	// Make a new version directory
+	os.Mkdir(filepath.Join(tmpDir, "v2"), 0777)
+	updateFile(t, filepath.Join(tmpDir, "v2", "a"), "UPDATED")
+	updateFile(t, filepath.Join(tmpDir, "v2", "b"), "bar")
+
+	a.Reset()
+	b.Reset()
+
+	// Update the symlink to point to the new version:
+	assert.NoError(os.Rename(filepath.Join(tmpDir, "latest"), filepath.Join(tmpDir, "latest_tmp")))
+	assert.NoError(os.Symlink(filepath.Join("v2"), filepath.Join(tmpDir, "latest")))
+	assert.NoError(os.Remove(filepath.Join(tmpDir, "latest_tmp")))
+	assert.NoError(os.RemoveAll(filepath.Join(tmpDir, "v1")))
+
+	a.AssertCount(t, 1)
+	b.AssertCount(t, 0)
+}
+
+type monitorWatcher struct {
+	count int32
+	done  int32
+}
+
+func (mw *monitorWatcher) Reset() {
+	atomic.StoreInt32(&mw.count, 0)
+}
+
+func (mw *monitorWatcher) AssertCount(t *testing.T, expected int, args ...any) bool {
+	t.Helper()
+	return assert.Eventually(t, func() bool {
+		return int(atomic.LoadInt32(&mw.count)) == expected
+	}, time.Second, 10*time.Millisecond, args...)
+}
+
+func (mw *monitorWatcher) Count() int {
+	return int(atomic.LoadInt32(&mw.count))
+}
+
+func (mw *monitorWatcher) Done() bool {
+	return atomic.LoadInt32(&mw.done) != 0
+}
+
+func watchMonitor(ch <-chan struct{}) *monitorWatcher {
+	mw := &monitorWatcher{}
+
+	go func() {
+		defer atomic.StoreInt32(&mw.done, 1)
+		for range ch {
+			atomic.AddInt32(&mw.count, 1)
+		}
+	}()
+
+	return mw
+}
+
+func updateFile(t *testing.T, path string, contents ...string) {
+	fh, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("unable to open %q: %v", path, err)
+	}
+	if len(contents) == 0 {
+		fmt.Fprintf(fh, "%s\n", time.Now())
+	} else {
+		for _, line := range contents {
+			fmt.Fprintf(fh, "%s\n", line)
+		}
+	}
+	fh.Close()
+}

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -310,7 +310,7 @@ func TestFindSources(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create service with test catalogs
-			service := NewModelCatalogServiceAPIService(tc.catalogs)
+			service := NewModelCatalogServiceAPIService(catalog.NewSourceCollection(tc.catalogs))
 
 			// Call FindSources
 			resp, err := service.FindSources(
@@ -472,7 +472,7 @@ func TestGetModel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create service with test sources
-			service := NewModelCatalogServiceAPIService(tc.sources)
+			service := NewModelCatalogServiceAPIService(catalog.NewSourceCollection(tc.sources))
 
 			// Call GetModel
 			resp, _ := service.GetModel(

--- a/go.mod
+++ b/go.mod
@@ -173,7 +173,7 @@ require (
 	github.com/docker/docker v28.0.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Description

Reload sources and static catalogs after changes are made to the files they were loaded from.

## How Has This Been Tested?
Local kind cluster and unit tests.

## Merge criteria:
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
