### PR TITLE
Add rolebinding to manage permissions-project tab

### DIFF
--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissions.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissions.tsx
@@ -32,7 +32,6 @@ type RoleBindingPermissionsProps = {
   }[];
   createRoleBinding: (roleBinding: RoleBindingKind) => Promise<RoleBindingKind>;
   deleteRoleBinding: (name: string, namespace: string) => Promise<K8sStatus>;
-
   projectName: string;
   roleRefKind: RoleBindingRoleRef['kind'];
   roleRefName?: RoleBindingRoleRef['name'];

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsNameInput.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsNameInput.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { TextInput } from '@patternfly/react-core';
 import { RoleBindingSubject, TypeaheadSelect } from 'mod-arch-shared';
+import { ProjectKind } from '~/app/shared/components/types';
 import { RoleBindingPermissionsRBType } from './types';
+import { namespaceToProjectDisplayName } from './utils';
 
 type RoleBindingPermissionsNameInputProps = {
   subjectKind: RoleBindingSubject['kind'];
@@ -10,6 +12,7 @@ type RoleBindingPermissionsNameInputProps = {
   onClear: () => void;
   placeholderText: string;
   typeAhead?: string[];
+  isProjectSubject?: boolean;
 };
 
 const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputProps> = ({
@@ -19,8 +22,10 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
   onClear,
   placeholderText,
   typeAhead,
+  isProjectSubject,
 }) => {
-  // TODO: We don't have project context yet and need to add logic to show projects permission tab under manage permissions of MR - might need to move the project-context part to shared library
+  // TODO: We don't have project context yet - might need to move the project-context part to shared library
+  const projects: ProjectKind[] = [];
   if (!typeAhead) {
     return (
       <TextInput
@@ -30,7 +35,11 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
         type="text"
         value={value}
         placeholder={`Type ${
-          subjectKind === RoleBindingPermissionsRBType.GROUP ? 'group name' : 'username'
+          isProjectSubject
+            ? 'project name'
+            : subjectKind === RoleBindingPermissionsRBType.GROUP
+              ? 'group name'
+              : 'username'
         }`}
         onChange={(e, newValue) => onChange(newValue)}
       />
@@ -38,7 +47,7 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
   }
 
   const selectOptions = typeAhead.map((option) => {
-    const displayName = option;
+    const displayName = isProjectSubject ? namespaceToProjectDisplayName(option, projects) : option;
     return { value: displayName, content: displayName };
   });
   // If we've selected an option that doesn't exist via isCreatable, include it in the options so it remains selected

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTable.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTable.tsx
@@ -20,6 +20,7 @@ type RoleBindingPermissionsTableProps = {
   roleRefKind: RoleBindingRoleRef['kind'];
   roleRefName?: RoleBindingRoleRef['name'];
   labels?: { [key: string]: string };
+  isProjectSubject?: boolean;
   defaultRoleBindingName?: string;
   permissions: RoleBindingKind[];
   permissionOptions: {
@@ -46,6 +47,7 @@ const RoleBindingPermissionsTable: React.FC<RoleBindingPermissionsTableProps> = 
   permissions,
   permissionOptions,
   typeAhead,
+  isProjectSubject,
   isAdding,
   createRoleBinding,
   deleteRoleBinding,
@@ -109,6 +111,7 @@ const RoleBindingPermissionsTable: React.FC<RoleBindingPermissionsTableProps> = 
             key="add-permissions-row"
             subjectKind={subjectKind}
             permissionOptions={permissionOptions}
+            isProjectSubject={isProjectSubject}
             typeAhead={typeAhead}
             isEditing={false}
             isAdding
@@ -130,12 +133,15 @@ const RoleBindingPermissionsTable: React.FC<RoleBindingPermissionsTableProps> = 
       }
       rowRenderer={(rb) => (
         <RoleBindingPermissionsTableRow
+          isProjectSubject={isProjectSubject}
           defaultRoleBindingName={defaultRoleBindingName}
           key={rb.metadata.name || ''}
           permissionOptions={permissionOptions}
           roleBindingObject={rb}
           subjectKind={subjectKind}
-          isEditing={firstSubject(rb) === '' || editCell.includes(rb.metadata.name)}
+          isEditing={
+            firstSubject(rb, isProjectSubject) === '' || editCell.includes(rb.metadata.name)
+          }
           isAdding={false}
           typeAhead={typeAhead}
           onChange={(subjectName, rbRoleRefName) => {

--- a/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTableSection.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/roleBinding/RoleBindingPermissionsTableSection.tsx
@@ -40,6 +40,7 @@ export type RoleBindingPermissionsTableSectionAltProps = {
   typeModifier: string;
   defaultRoleBindingName?: string;
   labels?: { [key: string]: string };
+  isProjectSubject?: boolean;
 };
 
 const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSectionAltProps> = ({
@@ -57,6 +58,7 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
   typeModifier,
   defaultRoleBindingName,
   labels,
+  isProjectSubject,
 }) => {
   const [addField, setAddField] = React.useState(false);
   const [error, setError] = React.useState<React.ReactNode>();
@@ -72,14 +74,20 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
         >
           <HeaderIcon
             type={
-              subjectKind === RoleBindingPermissionsRBType.USER
-                ? ProjectObjectType.user
-                : ProjectObjectType.group
+              isProjectSubject
+                ? ProjectObjectType.project
+                : subjectKind === RoleBindingPermissionsRBType.USER
+                  ? ProjectObjectType.user
+                  : ProjectObjectType.group
             }
           />
           <FlexItem>
             <Title id={`user-permission-${typeModifier}`} headingLevel="h2" size="xl">
-              {subjectKind === RoleBindingPermissionsRBType.USER ? 'Users' : 'Groups'}
+              {isProjectSubject
+                ? 'Projects'
+                : subjectKind === RoleBindingPermissionsRBType.USER
+                  ? 'Users'
+                  : 'Groups'}
             </Title>
           </FlexItem>
         </Flex>
@@ -93,6 +101,7 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
           namespace={projectName}
           roleRefKind={roleRefKind}
           roleRefName={roleRefName}
+          isProjectSubject={isProjectSubject}
           labels={labels}
           subjectKind={subjectKind}
           typeAhead={typeAhead}
@@ -133,7 +142,11 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
           onClick={() => setAddField(true)}
           style={{ paddingLeft: 'var(--pf-t--global--spacer--lg)' }}
         >
-          {subjectKind === RoleBindingPermissionsRBType.USER ? 'Add user' : 'Add group'}
+          {isProjectSubject
+            ? 'Add project'
+            : subjectKind === RoleBindingPermissionsRBType.USER
+              ? 'Add user'
+              : 'Add group'}
         </Button>
       </StackItem>
     </Stack>

--- a/clients/ui/frontend/src/app/shared/components/types.ts
+++ b/clients/ui/frontend/src/app/shared/components/types.ts
@@ -34,3 +34,17 @@ export type K8sDSGResource = K8sResourceCommon & {
     name: string;
   };
 };
+
+export type ProjectKind = K8sResourceCommon & {
+  metadata: {
+    annotations?: DisplayNameAnnotations &
+      Partial<{
+        'openshift.io/requester': string; // the username of the user that requested this project
+      }>;
+    labels?: Record<string, string>;
+    name: string;
+  };
+  status?: {
+    phase: 'Active' | 'Terminating';
+  };
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a followup PR to https://github.com/kubeflow/model-registry/pull/1183 - based on this comment [here](https://github.com/kubeflow/model-registry/pull/1210#discussion_r2158839033)

## How Has This Been Tested?
This PR adds missing logic related to project permissions tab.
Once we have the Project context upstream -  Project permissions tab should work as expected

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
