### PR TITLE
fix: prevent multiple db instances in parallel

### DIFF
--- a/internal/datastore/embedmd/service.go
+++ b/internal/datastore/embedmd/service.go
@@ -7,9 +7,9 @@ import (
 	"github.com/kubeflow/model-registry/internal/core"
 	"github.com/kubeflow/model-registry/internal/db"
 	"github.com/kubeflow/model-registry/internal/db/service"
+	"github.com/kubeflow/model-registry/internal/db/types"
 	"github.com/kubeflow/model-registry/internal/defaults"
 	"github.com/kubeflow/model-registry/internal/tls"
-	"github.com/kubeflow/model-registry/internal/db/types"
 	"github.com/kubeflow/model-registry/pkg/api"
 )
 
@@ -33,9 +33,14 @@ type EmbedMDService struct {
 }
 
 func NewEmbedMDService(cfg *EmbedMDConfig) (*EmbedMDService, error) {
-	dbConnector, err := db.NewConnector(cfg.DatabaseType, cfg.DatabaseDSN, cfg.TLSConfig)
+	err := db.Init(cfg.DatabaseType, cfg.DatabaseDSN, cfg.TLSConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize database connector: %w", err)
+	}
+
+	dbConnector, ok := db.GetConnector()
+	if !ok {
+		return nil, fmt.Errorf("database connector not initialized")
 	}
 
 	return &EmbedMDService{

--- a/internal/db/connector.go
+++ b/internal/db/connector.go
@@ -2,11 +2,12 @@ package db
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/kubeflow/model-registry/internal/datastore/embedmd/mysql"
-	"github.com/kubeflow/model-registry/internal/tls"
 	"github.com/kubeflow/model-registry/internal/datastore/embedmd/postgres"
 	"github.com/kubeflow/model-registry/internal/db/types"
+	"github.com/kubeflow/model-registry/internal/tls"
 	"gorm.io/gorm"
 )
 
@@ -15,20 +16,57 @@ type Connector interface {
 	DB() *gorm.DB
 }
 
-func NewConnector(dbType string, dsn string, tlsConfig *tls.TLSConfig) (Connector, error) {
-	switch dbType {
-	case "mysql":
-		if tlsConfig != nil {
-			return mysql.NewMySQLDBConnector(
-				dsn,
-				tlsConfig,
-			), nil
-		}
+var (
+	_connectorInstance Connector
+	connectorOnce      sync.Once
+	connectorMutex     sync.RWMutex
+)
 
-		return mysql.NewMySQLDBConnector(dsn, &tls.TLSConfig{}), nil
-	case "postgres":
-		return postgres.NewPostgresDBConnector(dsn), nil
+func NewConnector(dbType string, dsn string, tlsConfig *tls.TLSConfig) (Connector, error) {
+	connectorMutex.RLock()
+	if _connectorInstance != nil {
+		connectorMutex.RUnlock()
+		return _connectorInstance, nil
+	}
+	connectorMutex.RUnlock()
+
+	var err error
+	connectorOnce.Do(func() {
+		connectorMutex.Lock()
+		defer connectorMutex.Unlock()
+
+		switch dbType {
+		case "mysql":
+			if tlsConfig != nil {
+				_connectorInstance = mysql.NewMySQLDBConnector(dsn, tlsConfig)
+			} else {
+				_connectorInstance = mysql.NewMySQLDBConnector(dsn, &tls.TLSConfig{})
+			}
+		case "postgres":
+			_connectorInstance = postgres.NewPostgresDBConnector(dsn)
+		default:
+			err = fmt.Errorf("unsupported database type: %s. Supported types: %s, %s", dbType, types.DatabaseTypeMySQL, types.DatabaseTypePostgres)
+		}
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, fmt.Errorf("unsupported database type: %s. Supported types: %s, %s", dbType, types.DatabaseTypeMySQL, types.DatabaseTypePostgres)
+	return _connectorInstance, nil
+}
+
+func GetConnector() (Connector, bool) {
+	connectorMutex.RLock()
+	defer connectorMutex.RUnlock()
+
+	return _connectorInstance, _connectorInstance != nil
+}
+
+func ClearConnector() {
+	connectorMutex.Lock()
+	defer connectorMutex.Unlock()
+
+	_connectorInstance = nil
+	connectorOnce = sync.Once{}
 }

--- a/internal/proxy/readiness.go
+++ b/internal/proxy/readiness.go
@@ -14,7 +14,7 @@ func ReadinessHandler(datastore datastore.Datastore) http.Handler {
 		// skip embedmd check for mlmd datastore
 		if datastore.Type != "embedmd" {
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
+			_, _ = w.Write([]byte("OK"))
 			return
 		}
 

--- a/internal/proxy/readiness.go
+++ b/internal/proxy/readiness.go
@@ -29,9 +29,9 @@ func ReadinessHandler(datastore datastore.Datastore) http.Handler {
 			return
 		}
 
-		dbConnector, err := db.NewConnector(datastore.EmbedMD.DatabaseType, dsn, datastore.EmbedMD.TLSConfig)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("database new connector error: %s", err), http.StatusServiceUnavailable)
+		dbConnector, ok := db.GetConnector()
+		if !ok {
+			http.Error(w, "database connector not initialized", http.StatusServiceUnavailable)
 			return
 		}
 
@@ -58,6 +58,6 @@ func ReadinessHandler(datastore datastore.Datastore) http.Handler {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("OK"))
 	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR fixes a bug where when running the readinessProbe, multiple db connection instances spawned in parallel

```
W0707 06:58:57.665677       1 connect.go:57] Retrying connection to MySQL (attempt 11/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:58:59.642870       1 connect.go:57] Retrying connection to MySQL (attempt 7/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:01.685816       1 connect.go:57] Retrying connection to MySQL (attempt 7/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:06.644301       1 connect.go:57] Retrying connection to MySQL (attempt 8/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:08.667016       1 connect.go:57] Retrying connection to MySQL (attempt 12/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:08.687063       1 connect.go:57] Retrying connection to MySQL (attempt 8/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:14.648296       1 connect.go:57] Retrying connection to MySQL (attempt 9/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:16.688860       1 connect.go:57] Retrying connection to MySQL (attempt 9/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:20.671773       1 connect.go:57] Retrying connection to MySQL (attempt 13/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:23.651887       1 connect.go:57] Retrying connection to MySQL (attempt 10/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:25.690595       1 connect.go:57] Retrying connection to MySQL (attempt 10/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:33.653012       1 connect.go:57] Retrying connection to MySQL (attempt 11/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:33.672847       1 connect.go:57] Retrying connection to MySQL (attempt 14/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:35.692845       1 connect.go:57] Retrying connection to MySQL (attempt 11/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:40.678532       1 connect.go:57] Retrying connection to MySQL (attempt 1/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:41.679521       1 connect.go:57] Retrying connection to MySQL (attempt 2/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:43.680994       1 connect.go:57] Retrying connection to MySQL (attempt 3/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:44.653876       1 connect.go:57] Retrying connection to MySQL (attempt 12/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:46.682445       1 connect.go:57] Retrying connection to MySQL (attempt 4/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:46.694288       1 connect.go:57] Retrying connection to MySQL (attempt 12/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:47.674161       1 connect.go:57] Retrying connection to MySQL (attempt 15/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:50.684887       1 connect.go:57] Retrying connection to MySQL (attempt 5/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:55.687758       1 connect.go:57] Retrying connection to MySQL (attempt 6/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:56.654756       1 connect.go:57] Retrying connection to MySQL (attempt 13/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 06:59:58.695198       1 connect.go:57] Retrying connection to MySQL (attempt 13/25): dial tcp 10.96.30.249:3306: connect: connection refused
W0707 07:00:01.689178       1 connect.go:57] Retrying connection to MySQL (attempt 7/25): dial tcp 10.96.30.249:3306: connect: connection refused
```

now we have a DB connector singleton instance and the Connect function protected by a mutex

```
I0709 10:52:04.147050       1 proxy.go:118] Proxy server started at 0.0.0.0:8080
I0709 10:52:04.147515       1 service.go:48] Connecting to EmbedMD service...
W0709 10:52:04.149084       1 connect.go:84] Retrying connection to MySQL (attempt 1/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:05.150224       1 connect.go:84] Retrying connection to MySQL (attempt 2/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:07.151753       1 connect.go:84] Retrying connection to MySQL (attempt 3/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:10.153234       1 connect.go:84] Retrying connection to MySQL (attempt 4/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:14.156837       1 connect.go:84] Retrying connection to MySQL (attempt 5/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:19.160778       1 connect.go:84] Retrying connection to MySQL (attempt 6/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:25.162922       1 connect.go:84] Retrying connection to MySQL (attempt 7/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:32.164894       1 connect.go:84] Retrying connection to MySQL (attempt 8/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:40.166632       1 connect.go:84] Retrying connection to MySQL (attempt 9/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:49.168351       1 connect.go:84] Retrying connection to MySQL (attempt 10/25): dial tcp 10.96.189.129:3306: connect: connection refused
W0709 10:52:59.168980       1 connect.go:84] Retrying connection to MySQL (attempt 11/25): dial tcp 10.96.189.129:3306: connect: connection refused
I0709 10:53:10.171516       1 connect.go:93] Successfully connected to MySQL database
I0709 10:53:10.171537       1 service.go:55] Connected to EmbedMD service
I0709 10:53:10.176254       1 service.go:62] Running migrations...
I0709 10:53:10.188505       1 service.go:69] Migrations completed
I0709 10:53:10.188535       1 service.go:73] Getting types...
I0709 10:53:10.191754       1 service.go:86] Types retrieved
I0709 10:53:10.191790       1 service.go:109] EmbedMD service connected
2025/07/09 10:53:13 "GET http://localhost:8080/api/model_registry/v1alpha3/registered_models HTTP/1.1" from 127.0.0.1:33772 - 200 54B in 2.466326ms
2025/07/09 10:53:15 "GET http://localhost:8080/api/model_registry/v1alpha3/registered_models HTTP/1.1" from 127.0.0.1:53730 - 200 54B in 549.558µs
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local kind cluster with db replicas set to 0 for 1 minute and then replicas set to 1

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
