### PR TITLE
Federated mr implementation

### DIFF
--- a/clients/ui/Makefile
+++ b/clients/ui/Makefile
@@ -32,11 +32,11 @@ dev-install-dependencies:
 
 .PHONY: dev-bff
 dev-bff:
-	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true DEV_MODE=true STANDALONE_MODE=true FEDERATED_PLATFORM=false
+	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true DEV_MODE=true DEPLOYMENT_MODE=standalone
 
 .PHONY: dev-frontend
 dev-frontend:
-	DEPLOYMENT_MODE=standalone && STYLE_THEME=mui-theme cd frontend && npm run start:dev
+	cd frontend && DEPLOYMENT_MODE=standalone STYLE_THEME=mui-theme npm run start:dev
 
 .PHONY: dev-start
 dev-start: 
@@ -49,24 +49,24 @@ dev-start-kubeflow:
 
 .PHONY: dev-frontend-kubeflow
 dev-frontend-kubeflow:
-	DEPLOYMENT_MODE=kubeflow && STYLE_THEME=mui-theme && cd frontend && npm run start:dev
+	cd frontend && DEPLOYMENT_MODE=kubeflow STYLE_THEME=mui-theme npm run start:dev
 
 .PHONY: dev-bff-kubeflow
 dev-bff-kubeflow:
-	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false DEV_MODE=true STANDALONE_MODE=false FEDERATED_PLATFORM=false DEV_MODE_PORT=8085
+	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=kubeflow DEV_MODE_PORT=8085
 
-########### Dev Federated ############
+########### Dev Federated ###########
 .PHONY: dev-start-federated
 dev-start-federated: 
 	make -j 2 dev-bff-federated dev-frontend-federated
 
 .PHONY: dev-frontend-federated
 dev-frontend-federated:
-	DEPLOYMENT_MODE=federated && STYLE_THEME=patternfly && cd frontend && npm run start:dev
+	cd frontend && AUTH_METHOD=user_token DEPLOYMENT_MODE=federated STYLE_THEME=patternfly npm run start:dev
 
 .PHONY: dev-bff-federated
 dev-bff-federated:
-	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false DEV_MODE=true STANDALONE_MODE=false FEDERATED_PLATFORM=true DEV_MODE_PORT=8085
+	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=federated DEV_MODE_PORT=8085 AUTH_METHOD=user_token AUTH_TOKEN_HEADER=x-forwarded-access-token AUTH_TOKEN_PREFIX=""
 
 ############ Build ############
 
@@ -121,7 +121,7 @@ kubeflow-deployment:
 ############ Build ############	
 .PHONY: frontend-build
 frontend-build:
-	cd frontend && DEPLOYMENT_MODE=kubeflow && npm run build:prod
+	cd frontend && DEPLOYMENT_MODE=kubeflow npm run build:prod
 
 .PHONY: frontend-build-standalone
 frontend-build-standalone:

--- a/clients/ui/bff/internal/api/model_registry_handler.go
+++ b/clients/ui/bff/internal/api/model_registry_handler.go
@@ -25,7 +25,7 @@ func (app *App) GetAllModelRegistriesHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	registries, err := app.repositories.ModelRegistry.GetAllModelRegistries(r.Context(), client, namespace)
+	registries, err := app.repositories.ModelRegistry.GetAllModelRegistriesWithMode(r.Context(), client, namespace, app.config.DeploymentMode.IsFederatedMode())
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/kubeflow/model-registry/ui/bff/internal/constants"
@@ -96,25 +97,30 @@ func buildServiceDetails(service *corev1.Service, logger *slog.Logger) (*Service
 
 	displayName := ""
 	description := ""
+	externalAddressRest := ""
+
+	// Check for annotations including external-address-rest
 	if service.Annotations != nil {
 		displayName = service.Annotations["displayName"]
 		description = service.Annotations["description"]
-	}
 
-	if displayName == "" {
-		logger.Warn("service missing displayName annotation", "serviceName", service.Name)
-	}
-	if description == "" {
-		logger.Warn("service missing description annotation", "serviceName", service.Name)
+		// Look for external-address-rest annotation with any prefix
+		for key, value := range service.Annotations {
+			if strings.HasSuffix(key, "/external-address-rest") {
+				externalAddressRest = value
+				break
+			}
+		}
 	}
 
 	return &ServiceDetails{
-		Name:        service.Name,
-		DisplayName: displayName,
-		Description: description,
-		ClusterIP:   service.Spec.ClusterIP,
-		HTTPPort:    httpPort,
-		IsHTTPS:     isHTTPS,
+		Name:                service.Name,
+		DisplayName:         displayName,
+		Description:         description,
+		ClusterIP:           service.Spec.ClusterIP,
+		HTTPPort:            httpPort,
+		IsHTTPS:             isHTTPS,
+		ExternalAddressRest: externalAddressRest,
 	}, nil
 }
 

--- a/clients/ui/bff/internal/integrations/kubernetes/types.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/types.go
@@ -1,12 +1,13 @@
 package kubernetes
 
 type ServiceDetails struct {
-	Name        string
-	DisplayName string
-	Description string
-	ClusterIP   string
-	HTTPPort    int32
-	IsHTTPS     bool
+	Name                string
+	DisplayName         string
+	Description         string
+	ClusterIP           string
+	HTTPPort            int32
+	IsHTTPS             bool
+	ExternalAddressRest string
 }
 
 type RequestIdentity struct {

--- a/clients/ui/bff/internal/integrations/mrserver/http_test.go
+++ b/clients/ui/bff/internal/integrations/mrserver/http_test.go
@@ -37,7 +37,7 @@ func TestHTTPClient_GET_Success(t *testing.T) {
 
 	// Create http client pointing to test server
 	logger := setupTestLogger()
-	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	client, err := NewHTTPClient(logger, "test-registry", server.URL, nil)
 	require.NoError(t, err)
 
 	// Make the request
@@ -73,7 +73,7 @@ func TestHTTPClient_GET_Error(t *testing.T) {
 
 	// Create http client pointing to test server
 	logger := setupTestLogger()
-	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	client, err := NewHTTPClient(logger, "test-registry", server.URL, nil)
 	require.NoError(t, err)
 
 	// Make the request
@@ -123,7 +123,7 @@ func TestHTTPClient_POST_Success(t *testing.T) {
 
 	// Create http client pointing to test server
 	logger := setupTestLogger()
-	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	client, err := NewHTTPClient(logger, "test-registry", server.URL, nil)
 	require.NoError(t, err)
 
 	// Prepare request body
@@ -164,7 +164,7 @@ func TestHTTPClient_POST_Error(t *testing.T) {
 
 	// Create http client pointing to test server
 	logger := setupTestLogger()
-	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	client, err := NewHTTPClient(logger, "test-registry", server.URL, nil)
 	require.NoError(t, err)
 
 	// Prepare request body
@@ -218,7 +218,7 @@ func TestHTTPClient_PATCH_Success(t *testing.T) {
 
 	// Create http client pointing to test server
 	logger := setupTestLogger()
-	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	client, err := NewHTTPClient(logger, "test-registry", server.URL, nil)
 	require.NoError(t, err)
 
 	// Prepare request body
@@ -259,7 +259,7 @@ func TestHTTPClient_PATCH_Error(t *testing.T) {
 
 	// Create client pointing to test server
 	logger := setupTestLogger()
-	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	client, err := NewHTTPClient(logger, "test-registry", server.URL, nil)
 	require.NoError(t, err)
 
 	// Prepare request body
@@ -300,7 +300,7 @@ func TestHTTPClient_GET_NonJSONError(t *testing.T) {
 
 	// Create http client pointing to test server
 	logger := setupTestLogger()
-	client, err := NewHTTPClient(logger, "test-registry", server.URL)
+	client, err := NewHTTPClient(logger, "test-registry", server.URL, nil)
 	require.NoError(t, err)
 
 	// Make the request

--- a/clients/ui/bff/internal/repositories/model_registry.go
+++ b/clients/ui/bff/internal/repositories/model_registry.go
@@ -17,6 +17,12 @@ func NewModelRegistryRepository() *ModelRegistryRepository {
 }
 
 func (m *ModelRegistryRepository) GetAllModelRegistries(sessionCtx context.Context, client k8s.KubernetesClientInterface, namespace string) ([]models.ModelRegistryModel, error) {
+	// Default to non-federated mode for backward compatibility
+	return m.GetAllModelRegistriesWithMode(sessionCtx, client, namespace, false)
+}
+
+// GetAllModelRegistriesWithMode fetches all model registries with support for federated mode
+func (m *ModelRegistryRepository) GetAllModelRegistriesWithMode(sessionCtx context.Context, client k8s.KubernetesClientInterface, namespace string, isFederatedMode bool) ([]models.ModelRegistryModel, error) {
 
 	// TODO: In default mode fetch Routes for external access.
 	resources, err := client.GetServiceDetails(sessionCtx, namespace)
@@ -27,7 +33,7 @@ func (m *ModelRegistryRepository) GetAllModelRegistries(sessionCtx context.Conte
 
 	var registries = []models.ModelRegistryModel{}
 	for _, s := range resources {
-		serverAddress := m.ResolveServerAddress(s.ClusterIP, s.HTTPPort, s.IsHTTPS)
+		serverAddress := m.ResolveServerAddress(s.ClusterIP, s.HTTPPort, s.IsHTTPS, s.ExternalAddressRest, isFederatedMode)
 		registry := models.ModelRegistryModel{
 			Name:          s.Name,
 			Description:   s.Description,
@@ -42,6 +48,12 @@ func (m *ModelRegistryRepository) GetAllModelRegistries(sessionCtx context.Conte
 }
 
 func (m *ModelRegistryRepository) GetModelRegistry(sessionCtx context.Context, client k8s.KubernetesClientInterface, namespace string, modelRegistryID string) (models.ModelRegistryModel, error) {
+	// Default to non-federated mode for backward compatibility
+	return m.GetModelRegistryWithMode(sessionCtx, client, namespace, modelRegistryID, false)
+}
+
+// GetModelRegistryWithMode fetches a specific model registry with support for federated mode
+func (m *ModelRegistryRepository) GetModelRegistryWithMode(sessionCtx context.Context, client k8s.KubernetesClientInterface, namespace string, modelRegistryID string, isFederatedMode bool) (models.ModelRegistryModel, error) {
 
 	s, err := client.GetServiceDetailsByName(sessionCtx, namespace, modelRegistryID)
 	if err != nil {
@@ -52,18 +64,26 @@ func (m *ModelRegistryRepository) GetModelRegistry(sessionCtx context.Context, c
 		Name:          s.Name,
 		Description:   s.Description,
 		DisplayName:   s.DisplayName,
-		ServerAddress: m.ResolveServerAddress(s.ClusterIP, s.HTTPPort, s.IsHTTPS),
+		ServerAddress: m.ResolveServerAddress(s.ClusterIP, s.HTTPPort, s.IsHTTPS, s.ExternalAddressRest, isFederatedMode),
 		IsHTTPS:       s.IsHTTPS,
 	}
 
 	return modelRegistry, nil
 }
 
-func (m *ModelRegistryRepository) ResolveServerAddress(clusterIP string, httpPort int32, isHTTPS bool) string {
+func (m *ModelRegistryRepository) ResolveServerAddress(clusterIP string, httpPort int32, isHTTPS bool, externalAddressRest string, isFederatedMode bool) string {
+	// Default behavior - use cluster IP and port
 	protocol := "http"
 	if isHTTPS {
 		protocol = "https"
 	}
+	// In federated mode, if external address is available, use it
+	if isFederatedMode && externalAddressRest != "" {
+		// External address is assumed to be HTTPS
+		url := fmt.Sprintf("%s://%s/api/model_registry/v1alpha3", protocol, externalAddressRest)
+		return url
+	}
+
 	url := fmt.Sprintf("%s://%s:%d/api/model_registry/v1alpha3", protocol, clusterIP, httpPort)
 	return url
 }

--- a/clients/ui/frontend/config/dotenv.js
+++ b/clients/ui/frontend/config/dotenv.js
@@ -146,6 +146,7 @@ const setupDotenvFilesForEnv = ({ env }) => {
   setupDotenvFile(path.resolve(RELATIVE_DIRNAME, '.env'));
 
   const DEPLOYMENT_MODE = process.env.DEPLOYMENT_MODE || 'kubeflow';
+  const AUTH_METHOD = process.env.AUTH_METHOD || 'internal';
   const IMAGES_DIRNAME = process.env.IMAGES_DIRNAME || 'images';
   const PUBLIC_PATH = process.env.PUBLIC_PATH || '/';
   const SRC_DIR = path.resolve(RELATIVE_DIRNAME, process.env.SRC_DIR || TS_BASE_URL || 'src');
@@ -174,6 +175,7 @@ const setupDotenvFilesForEnv = ({ env }) => {
   process.env._OUTPUT_ONLY = OUTPUT_ONLY;
   process.env._DEV_MODE = DEV_MODE;
   process.env._DEPLOYMENT_MODE = DEPLOYMENT_MODE;
+  process.env._AUTH_METHOD = AUTH_METHOD;
 };
 
 module.exports = { setupWebpackDotenvFilesForEnv, setupDotenvFilesForEnv };

--- a/clients/ui/frontend/src/app/utilities/const.ts
+++ b/clients/ui/frontend/src/app/utilities/const.ts
@@ -8,6 +8,7 @@ const POLL_INTERVAL = process.env.POLL_INTERVAL ? parseInt(process.env.POLL_INTE
 const KUBEFLOW_USERNAME = process.env.KUBEFLOW_USERNAME || 'user@example.com';
 const IMAGE_DIR = process.env.IMAGE_DIR || 'images';
 const LOGO_LIGHT = process.env.LOGO || 'logo-light-theme.svg';
+const MANDATORY_NAMESPACE = process.env.MANDATORY_NAMESPACE || undefined;
 const URL_PREFIX = '/model-registry';
 const BFF_API_VERSION = 'v1';
 
@@ -21,6 +22,7 @@ export {
   URL_PREFIX,
   DEPLOYMENT_MODE,
   BFF_API_VERSION,
+  MANDATORY_NAMESPACE,
 };
 
 export const FindAdministratorOptions = [

--- a/clients/ui/frontend/src/bootstrap.tsx
+++ b/clients/ui/frontend/src/bootstrap.tsx
@@ -9,7 +9,13 @@ import {
   ModularArchConfig,
 } from 'mod-arch-shared';
 import App from './app/App';
-import { BFF_API_VERSION, DEPLOYMENT_MODE, STYLE_THEME, URL_PREFIX } from './app/utilities/const';
+import {
+  BFF_API_VERSION,
+  DEPLOYMENT_MODE,
+  MANDATORY_NAMESPACE,
+  STYLE_THEME,
+  URL_PREFIX,
+} from './app/utilities/const';
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 
@@ -17,6 +23,7 @@ const modularArchConfig: ModularArchConfig = {
   deploymentMode: DEPLOYMENT_MODE,
   URL_PREFIX,
   BFF_API_VERSION,
+  mandatoryNamespace: MANDATORY_NAMESPACE,
 };
 
 root.render(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Enable MR access in federated mode.

This pull request introduces significant updates to support multiple deployment modes (standalone, federated, and Kubeflow) and enhance the handling of external addresses and authentication in the backend-for-frontend (BFF) service. Key changes include replacing legacy deployment mode flags with a unified `DEPLOYMENT_MODE` variable, adding support for federated mode-specific configurations, and improving the HTTP client to handle custom headers for authentication.

### Deployment Mode Enhancements:
* Updated `Makefile` in `clients/ui` to replace legacy flags (`STANDALONE_MODE`, `FEDERATED_PLATFORM`) with `DEPLOYMENT_MODE` for better clarity and extensibility across deployment modes. [[1]](diffhunk://#diff-3c870f30eb606b04f3864f6e5fe5a2002c1eb5f0b278181ebe5a4f4aa67e3fe2L35-R35) [[2]](diffhunk://#diff-3c870f30eb606b04f3864f6e5fe5a2002c1eb5f0b278181ebe5a4f4aa67e3fe2L56-R56) [[3]](diffhunk://#diff-3c870f30eb606b04f3864f6e5fe5a2002c1eb5f0b278181ebe5a4f4aa67e3fe2L69-R69)

### Federated Mode Support:
* Enhanced `AttachRESTClient` in `middleware.go` to respect federated mode by avoiding server address overrides and forwarding user token authentication headers. [[1]](diffhunk://#diff-2d4a078e3bd8797ad21822e86be3543f905966e1de2f62593af0d446297a18bcL105-R106) [[2]](diffhunk://#diff-2d4a078e3bd8797ad21822e86be3543f905966e1de2f62593af0d446297a18bcL114-R117) [[3]](diffhunk://#diff-2d4a078e3bd8797ad21822e86be3543f905966e1de2f62593af0d446297a18bcL130-R146)
* Added logic to handle federated mode in `GetAllModelRegistries` and `GetModelRegistry` methods, including resolving external addresses when available. [[1]](diffhunk://#diff-d7c55dc236374954b43e3377c4e6cd4699734cef58996bd8db4b0c3e0527bbbeR20-R25) [[2]](diffhunk://#diff-d7c55dc236374954b43e3377c4e6cd4699734cef58996bd8db4b0c3e0527bbbeR51-R56) [[3]](diffhunk://#diff-d7c55dc236374954b43e3377c4e6cd4699734cef58996bd8db4b0c3e0527bbbeL55-R86)

### HTTP Client Improvements:
* Modified `HTTPClient` in `mrserver/http.go` to accept custom headers and apply them to all HTTP requests, enabling user token authentication in federated mode. [[1]](diffhunk://#diff-1b7ae6770d366675333980f3650441f8b005b908581c6f87a194faeaaf27ec30R27) [[2]](diffhunk://#diff-1b7ae6770d366675333980f3650441f8b005b908581c6f87a194faeaaf27ec30L43-R44) [[3]](diffhunk://#diff-1b7ae6770d366675333980f3650441f8b005b908581c6f87a194faeaaf27ec30R229-R238)
* Updated HTTP client tests to reflect the new `headers` parameter in `NewHTTPClient`. [[1]](diffhunk://#diff-1fee42f1a63bdee8be356a66822e9fb56fe8d6c3e0684487a820e0e940a4eaeeL40-R40) [[2]](diffhunk://#diff-1fee42f1a63bdee8be356a66822e9fb56fe8d6c3e0684487a820e0e940a4eaeeL76-R76) [[3]](diffhunk://#diff-1fee42f1a63bdee8be356a66822e9fb56fe8d6c3e0684487a820e0e940a4eaeeL126-R126) [[4]](diffhunk://#diff-1fee42f1a63bdee8be356a66822e9fb56fe8d6c3e0684487a820e0e940a4eaeeL167-R167) [[5]](diffhunk://#diff-1fee42f1a63bdee8be356a66822e9fb56fe8d6c3e0684487a820e0e940a4eaeeL221-R221) [[6]](diffhunk://#diff-1fee42f1a63bdee8be356a66822e9fb56fe8d6c3e0684487a820e0e940a4eaeeL262-R262) [[7]](diffhunk://#diff-1fee42f1a63bdee8be356a66822e9fb56fe8d6c3e0684487a820e0e940a4eaeeL303-R303)

### Kubernetes Integration Enhancements:
* Added support for reading `external-address-rest` annotations in Kubernetes services and included this field in `ServiceDetails`. [[1]](diffhunk://#diff-6bf977037f5f90268ce12254d59147f64dd11645a40262a3d3b7449055fc32f9R100-L108) [[2]](diffhunk://#diff-6bf977037f5f90268ce12254d59147f64dd11645a40262a3d3b7449055fc32f9R123) [[3]](diffhunk://#diff-a2c2f4da5791de54f5d9fc6cbd7adfc460f5a7d65bf899d196b81e87acf0c0a1R10)
* Updated `ResolveServerAddress` to prioritize external addresses in federated mode. [[1]](diffhunk://#diff-d7c55dc236374954b43e3377c4e6cd4699734cef58996bd8db4b0c3e0527bbbeL30-R36) [[2]](diffhunk://#diff-d7c55dc236374954b43e3377c4e6cd4699734cef58996bd8db4b0c3e0527bbbeL55-R86)

### Miscellaneous Improvements:
* Imported the `config` package in `middleware.go` for deployment mode and authentication configuration.
* Added string utility imports in `shared_k8s_client.go` to support annotation parsing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
