### PR TITLE
ci: add test-e2e for the async-upload Job

### DIFF
--- a/.github/workflows/async-upload-test.yml
+++ b/.github/workflows/async-upload-test.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Run tests
         run: |
           make test
+      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
+        run: |
+          set -x
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Run E2E tests
         run: |
           make test-e2e

--- a/.github/workflows/async-upload-test.yml
+++ b/.github/workflows/async-upload-test.yml
@@ -43,3 +43,6 @@ jobs:
       - name: Run tests
         run: |
           make test
+      - name: Run E2E tests
+        run: |
+          make test-e2e

--- a/jobs/async-upload/Makefile
+++ b/jobs/async-upload/Makefile
@@ -1,8 +1,13 @@
 IMG_VERSION ?= latest
+BUILD_IMAGE ?= true
 
 .PHONY: deploy-latest-mr
 deploy-latest-mr:
-	cd ../../ && IMG_VERSION=${IMG_VERSION} make image/build ARGS="--load$(if ${DEV_BUILD}, --target dev-build)"  && LOCAL=1 ./scripts/deploy_on_kind.sh
+	cd ../../ && \
+	$(if $(filter true,$(BUILD_IMAGE)),\
+		IMG_VERSION=${IMG_VERSION} make image/build ARGS="--load$(if ${DEV_BUILD}, --target dev-build)" && \
+	) \
+	LOCAL=1 ./scripts/deploy_on_kind.sh
 	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 & echo $$! >> .port-forwards.pid
 
 
@@ -25,7 +30,7 @@ test-e2e-run:
 	@echo "Ensuring all extras are installed..."
 	poetry install --all-extras
 	@echo "Running tests..."
-	poetry run pytest -m e2e -s -rA
+	poetry run pytest --e2e -s -x -rA
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup:

--- a/jobs/async-upload/tests/conftest.py
+++ b/jobs/async-upload/tests/conftest.py
@@ -5,7 +5,6 @@ logging.basicConfig(level=logging.INFO)
 
 def pytest_collection_modifyitems(config, items):
     for item in items: 
-        print([k for k in item.keywords])
         skip_e2e = pytest.mark.skip(
             reason="this is an end-to-end test, requires explicit opt-in --e2e option to run."
         )
@@ -15,9 +14,7 @@ def pytest_collection_modifyitems(config, items):
         if "e2e" in item.keywords:
             if not config.getoption("--e2e"):
                 item.add_marker(skip_e2e)
-        # here you can continue and elif if you need future options
-
-        if config.getoption("--e2e"):
+        elif config.getoption("--e2e"):
             item.add_marker(skip_not_e2e)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- adds test-e2e wiring to the existing ci/GHA
- bugfix for argparse to the `--e2e` option
- small refactor for performance, since Job doesn't for 99% case need to modify the server for local development switch defaults

## How Has This Been Tested?
locally with `make test`, `make test-e2e`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
