### PR TITLE
chore(mr-client): match up the hand-rolled artifact data model to match the api

### DIFF
--- a/clients/python/src/model_registry/types/artifacts.py
+++ b/clients/python/src/model_registry/types/artifacts.py
@@ -47,7 +47,7 @@ class Artifact(BaseResourceModel, ABC):
     """
 
     name: str | None = None
-    uri: str
+    uri: str | None = None
     state: ArtifactState = ArtifactState.UNKNOWN
 
     @classmethod
@@ -105,7 +105,6 @@ class DocArtifact(Artifact):
     @override
     def from_basemodel(cls, source: DocArtifactBaseModel) -> DocArtifact:
         assert source.name
-        assert source.uri
         assert source.state
         return cls(
             id=source.id,
@@ -189,7 +188,6 @@ class ModelArtifact(Artifact):
     def from_basemodel(cls, source: ModelArtifactBaseModel) -> ModelArtifact:
         """Create a new ModelArtifact object from a BaseModel object."""
         assert source.name
-        assert source.uri
         assert source.state
         return cls(
             id=source.id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There are usecases where a ModelArtifact will not have a `uri` associated to it, such as when kicking off an model synchronization job (the uri will be pending as the synchronization happens). The data model for a ModelArtifact does not require the uri to be populated, so having these asserts in the client will cause errors to be thrown even though the returned (or supplied) data is valid.

This PR does present a breakage risk for consumers of the MR Client.

They might have logic which wraps a call to fetch a ModelArtifact with a try/catch block, and handle that case accordingly. With this change, that logic would need to be changed to check for existence (`is None`) instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
