### PR TITLE
Update ModelPropertiesDescriptionListGroup component filtering logic

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
@@ -5,14 +5,9 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { DashboardDescriptionListGroup } from 'mod-arch-shared';
-import {
-  filterCustomProperties,
-  getProperties,
-  mergeUpdatedProperty,
-} from '~/app/pages/modelRegistry/screens/utils';
+import { getProperties, mergeUpdatedProperty } from '~/app/pages/modelRegistry/screens/utils';
 import { ModelRegistryCustomProperties } from '~/app/types';
 import ModelPropertiesTableRow from '~/app/pages/modelRegistry/screens/ModelPropertiesTableRow';
-import { pipelineRunSpecificKeys } from './ModelVersionDetails/const';
 
 type ModelPropertiesDescriptionListGroupProps = {
   customProperties: ModelRegistryCustomProperties;
@@ -35,13 +30,9 @@ const ModelPropertiesDescriptionListGroup: React.FC<ModelPropertiesDescriptionLi
   const isEditingSomeRow = isAdding || editingPropertyKeys.length > 0;
 
   const [isSavingEdits, setIsSavingEdits] = React.useState(false);
-  const filteredCustomProperties = filterCustomProperties(
-    customProperties,
-    pipelineRunSpecificKeys,
-  );
 
   // We only show string properties with a defined value (no labels or other property types)
-  const filteredProperties = getProperties(filteredCustomProperties);
+  const filteredProperties = getProperties(customProperties);
 
   const [isShowingMoreProperties, setIsShowingMoreProperties] = React.useState(false);
   const keys = Object.keys(filteredProperties);

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/const.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/const.ts
@@ -7,8 +7,3 @@ export enum ModelVersionDetailsTabTitle {
   DETAILS = 'Details',
   DEPLOYMENTS = 'Deployments',
 }
-export const pipelineRunSpecificKeys: string[] = [
-  '_registeredFromPipelineProject',
-  '_registeredFromPipelineRunId',
-  '_registeredFromPipelineRunName',
-];

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -1,0 +1,63 @@
+/* eslint-disable camelcase */
+import {
+  ModelRegistryCustomProperties,
+  ModelRegistryMetadataType,
+  ModelRegistryStringCustomProperties,
+} from '~/app/types';
+import { getProperties } from '~/app/pages/modelRegistry/screens/utils';
+
+describe('getProperties', () => {
+  it('should return an empty object when customProperties is empty', () => {
+    const customProperties: ModelRegistryCustomProperties = {};
+    const result = getProperties(customProperties);
+    expect(result).toEqual({});
+  });
+
+  it('should return a filtered object including only string properties with a non-empty value', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      property2: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'another-non-empty',
+      },
+      label1: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      label2: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      int1: { metadataType: ModelRegistryMetadataType.INT, int_value: '1' },
+      int2: { metadataType: ModelRegistryMetadataType.INT, int_value: '2' },
+    };
+    const result = getProperties(customProperties);
+    expect(result).toEqual({
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      property2: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'another-non-empty',
+      },
+    } satisfies ModelRegistryStringCustomProperties);
+  });
+
+  it('should return an empty object when all values in customProperties are empty strings or non-string values', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      label2: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      int1: { metadataType: ModelRegistryMetadataType.INT, int_value: '1' },
+      int2: { metadataType: ModelRegistryMetadataType.INT, int_value: '2' },
+    };
+    const result = getProperties(customProperties);
+    expect(result).toEqual({});
+  });
+
+  it('should return with _lastModified and _registeredFrom props filtered out', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      _lastModified: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      _registeredFromSomething: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'non-empty',
+      },
+    };
+    const result = getProperties(customProperties);
+    expect(result).toEqual({
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+    });
+  });
+});

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -45,7 +45,7 @@ export const mergeUpdatedLabels = (
   return customPropertiesCopy;
 };
 
-// Retrives the customProperties that are not labels (they have a defined string_value).
+// Retrieves the customProperties that are not special (_RegisteredFrom) or labels (they have a defined string_value).
 export const getProperties = <T extends ModelRegistryCustomProperties>(
   customProperties: T,
 ): ModelRegistryStringCustomProperties => {
@@ -53,7 +53,7 @@ export const getProperties = <T extends ModelRegistryCustomProperties>(
   return Object.keys(customProperties).reduce((acc, key) => {
     // _lastModified is a property that is required to update the timestamp on the backend and we have a workaround for it. It should be resolved by
     // backend team
-    if (key === '_lastModified') {
+    if (key === '_lastModified' || /^_registeredFrom/.test(key)) {
       return acc;
     }
 
@@ -183,21 +183,4 @@ export const isValidHttpUrl = (value: string): boolean => {
   }
 };
 
-export const filterCustomProperties = (
-  customProperties: ModelRegistryCustomProperties,
-  keys: string[],
-): ModelRegistryCustomProperties => {
-  const filteredCustomProperties: ModelRegistryCustomProperties = {};
-  Object.keys(customProperties).forEach((key) => {
-    if (!keys.includes(key)) {
-      filteredCustomProperties[key] = customProperties[key];
-    }
-  });
-  return filteredCustomProperties;
-};
-
-export const isPipelineRunExist = (
-  customProperties: ModelRegistryCustomProperties,
-  keys: string[],
-): boolean => keys.every((key) => key in customProperties);
 export const isRedHatRegistryUri = (uri: string): boolean => uri.startsWith('oci://example.io/'); // TODO: Change this to a proper check


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-29300

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Update the logic in `ModelPropertiesDescriptionListGroup` component, remove `filterCustomProperties` function and update the logic in `getProperties` function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Don't have the real data now. But it should be able to filter out all the properties that the key starts with `_registeredFrom`. Also add some unit tests to make sure it can filter correctly.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
