### PR TITLE
feat(catalog): Implement ListModels endpoint

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -20,13 +20,12 @@ paths:
       parameters:
         - name: source
           description: |-
-            Filter models by source. If not provided, models from all sources
-            are returned. If multiple sources are provided, models from any of
-            the sources are returned.
+            Filter models by source. This parameter is currently required and
+            may only be specified once.
           schema:
             type: string
           in: query
-          required: false
+          required: true
         - name: q
           description: Free-form keyword search used to filter the response.
           schema:

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -20,13 +20,12 @@ paths:
       parameters:
         - name: source
           description: |-
-            Filter models by source. If not provided, models from all sources
-            are returned. If multiple sources are provided, models from any of
-            the sources are returned.
+            Filter models by source. This parameter is currently required and
+            may only be specified once.
           schema:
             type: string
           in: query
-          required: false
+          required: true
         - name: q
           description: Free-form keyword search used to filter the response.
           schema:

--- a/catalog/internal/catalog/catalog.go
+++ b/catalog/internal/catalog/catalog.go
@@ -13,25 +13,10 @@ import (
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 )
 
-type SortDirection int
-
-const (
-	SortDirectionAscending SortDirection = iota
-	SortDirectionDescending
-)
-
-type SortField int
-
-const (
-	SortByUnspecified SortField = iota
-	SortByName
-	SortByPublished
-)
-
 type ListModelsParams struct {
-	Query         string
-	SortBy        SortField
-	SortDirection SortDirection
+	Query     string
+	OrderBy   model.OrderByField
+	SortOrder model.SortOrder
 }
 
 // CatalogSourceProvider is implemented by catalog source types, e.g. YamlCatalog
@@ -40,7 +25,14 @@ type CatalogSourceProvider interface {
 	// nothing is found with the name provided it returns nil, without an
 	// error.
 	GetModel(ctx context.Context, name string) (*model.CatalogModel, error)
+
+	// ListModels returns all models according to the parameters. If
+	// nothing suitable is found, it returns an empty list.
 	ListModels(ctx context.Context, params ListModelsParams) (model.CatalogModelList, error)
+
+	// GetArtifacts returns all artifacts for a particular model. If no
+	// model is found with that name, it returns nil. If the model is
+	// found, but has no artifacts, an empty list is returned.
 	GetArtifacts(ctx context.Context, name string) (*model.CatalogModelArtifactList, error)
 }
 

--- a/catalog/internal/catalog/testdata/empty-catalog.yaml
+++ b/catalog/internal/catalog/testdata/empty-catalog.yaml
@@ -1,0 +1,4 @@
+
+source: empty-catalog
+models: []
+

--- a/catalog/internal/catalog/testdata/test-list-models-catalog.yaml
+++ b/catalog/internal/catalog/testdata/test-list-models-catalog.yaml
@@ -1,0 +1,40 @@
+
+source: test-list-models
+models:
+  - name: model-alpha
+    description: A model for text generation.
+    tasks: ["text-generation", "nlp"]
+    provider: IBM
+    libraryName: transformers
+    createTimeSinceEpoch: "1678886400000" # March 15, 2023 00:00:00 GMT
+  - name: model-beta
+    description: Another model for image recognition.
+    tasks: ["image-recognition"]
+    provider: Google
+    libraryName: tensorflow
+    createTimeSinceEpoch: "1681564800000" # April 15, 2023 00:00:00 GMT
+  - name: model-gamma
+    description: A specialized model for natural language processing.
+    tasks: ["nlp"]
+    provider: IBM
+    libraryName: pytorch
+    createTimeSinceEpoch: "1675209600000" # February 1, 2023 00:00:00 GMT
+  - name: another-model-alpha
+    description: A different model for text summarization.
+    tasks: ["text-summarization", "nlp"]
+    provider: Microsoft
+    libraryName: huggingface
+    createTimeSinceEpoch: "1684243200000" # May 16, 2023 00:00:00 GMT
+  - name: model-with-no-tasks
+    description: This model has no specific tasks.
+    tasks: []
+    provider: None
+    libraryName: custom
+    createTimeSinceEpoch: "1672531200000" # January 1, 2023 00:00:00 GMT
+  - name: Z-model
+    description: The last model in alphabetical order.
+    tasks: ["optimization"]
+    provider: Oracle
+    libraryName: scikit-learn
+    createTimeSinceEpoch: "1690934400000" # August 2, 2023 00:00:00 GMT
+

--- a/catalog/internal/catalog/yaml_catalog_test.go
+++ b/catalog/internal/catalog/yaml_catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,6 +57,120 @@ func TestYAMLCatalogGetArtifacts(t *testing.T) {
 	notFoundArtifacts, err := provider.GetArtifacts(context.Background(), "non-existent-model")
 	assert.NoError(err)
 	assert.Nil(notFoundArtifacts)
+}
+
+func TestYAMLCatalogListModels(t *testing.T) {
+	assert := assert.New(t)
+	provider := testYAMLProvider(t, "testdata/test-list-models-catalog.yaml")
+	ctx := context.Background()
+
+	// Test case 1: List all models, default sort (by name ascending)
+	models, err := provider.ListModels(ctx, ListModelsParams{})
+	if assert.NoError(err) {
+		assert.NotNil(models)
+		assert.Equal(int32(6), models.Size)
+		assert.Equal(int32(6), models.PageSize)
+		assert.Len(models.Items, 6)
+		assert.Equal("Z-model", models.Items[0].Name) // Z-model should be first due to string comparison for alphabetical sort
+		assert.Equal("another-model-alpha", models.Items[1].Name)
+		assert.Equal("model-alpha", models.Items[2].Name)
+		assert.Equal("model-beta", models.Items[3].Name)
+		assert.Equal("model-gamma", models.Items[4].Name)
+		assert.Equal("model-with-no-tasks", models.Items[5].Name)
+	}
+
+	// Test case 2: List all models, sort by name ascending
+	models, err = provider.ListModels(ctx, ListModelsParams{OrderBy: model.ORDERBYFIELD_NAME, SortOrder: model.SORTORDER_ASC})
+	if assert.NoError(err) {
+		assert.Equal(int32(6), models.Size)
+		assert.Equal("Z-model", models.Items[0].Name)
+		assert.Equal("another-model-alpha", models.Items[1].Name)
+	}
+
+	// Test case 3: List all models, sort by name descending
+	models, err = provider.ListModels(ctx, ListModelsParams{OrderBy: model.ORDERBYFIELD_NAME, SortOrder: model.SORTORDER_DESC})
+	if assert.NoError(err) {
+		assert.Equal(int32(6), models.Size)
+		assert.Equal("model-with-no-tasks", models.Items[0].Name)
+		assert.Equal("model-gamma", models.Items[1].Name)
+	}
+
+	// Test case 4: List all models, sort by created (CreateTimeSinceEpoch) ascending
+	models, err = provider.ListModels(ctx, ListModelsParams{OrderBy: model.ORDERBYFIELD_CREATE_TIME, SortOrder: model.SORTORDER_ASC})
+	if assert.NoError(err) {
+		assert.Equal(int32(6), models.Size)
+		assert.Equal("model-with-no-tasks", models.Items[0].Name) // Jan 1, 2023
+		assert.Equal("model-gamma", models.Items[1].Name)         // Feb 1, 2023
+	}
+
+	// Test case 5: List all models, sort by published (CreateTimeSinceEpoch) descending
+	models, err = provider.ListModels(ctx, ListModelsParams{OrderBy: model.ORDERBYFIELD_CREATE_TIME, SortOrder: model.SORTORDER_DESC})
+	if assert.NoError(err) {
+		assert.Equal(int32(6), models.Size)
+		assert.Equal("Z-model", models.Items[0].Name)             // Aug 2, 2023
+		assert.Equal("another-model-alpha", models.Items[1].Name) // May 16, 2023
+	}
+
+	// Test case 6: Filter by query "model" (should match all 6 models)
+	models, err = provider.ListModels(ctx, ListModelsParams{Query: "model"})
+	if assert.NoError(err) {
+		assert.Equal(int32(6), models.Size)
+		assert.Equal("Z-model", models.Items[0].Name)
+		assert.Equal("another-model-alpha", models.Items[1].Name)
+		assert.Equal("model-alpha", models.Items[2].Name)
+		assert.Equal("model-beta", models.Items[3].Name)
+		assert.Equal("model-gamma", models.Items[4].Name)
+		assert.Equal("model-with-no-tasks", models.Items[5].Name)
+	}
+
+	// Test case 7: Filter by query "text" (should match model-alpha, another-model-alpha)
+	models, err = provider.ListModels(ctx, ListModelsParams{Query: "text"})
+	if assert.NoError(err) {
+		assert.Equal(int32(2), models.Size)
+		assert.Equal("another-model-alpha", models.Items[0].Name) // Alphabetical order
+		assert.Equal("model-alpha", models.Items[1].Name)
+	}
+
+	// Test case 8: Filter by query "nlp" (should match model-alpha, model-gamma, another-model-alpha)
+	models, err = provider.ListModels(ctx, ListModelsParams{Query: "nlp"})
+	if assert.NoError(err) {
+		assert.Equal(int32(3), models.Size)
+		assert.Equal("another-model-alpha", models.Items[0].Name)
+		assert.Equal("model-alpha", models.Items[1].Name)
+		assert.Equal("model-gamma", models.Items[2].Name)
+	}
+
+	// Test case 9: Filter by query "IBM" (should match model-alpha, model-gamma)
+	models, err = provider.ListModels(ctx, ListModelsParams{Query: "IBM"})
+	if assert.NoError(err) {
+		assert.Equal(int32(2), models.Size)
+		assert.Equal("model-alpha", models.Items[0].Name)
+		assert.Equal("model-gamma", models.Items[1].Name)
+	}
+
+	// Test case 10: Filter by query "transformers" (should match model-alpha)
+	models, err = provider.ListModels(ctx, ListModelsParams{Query: "transformers"})
+	if assert.NoError(err) {
+		assert.Equal(int32(1), models.Size)
+		assert.Equal("model-alpha", models.Items[0].Name)
+	}
+
+	// Test case 11: Filter by query "nonexistent" (should return empty list)
+	models, err = provider.ListModels(ctx, ListModelsParams{Query: "nonexistent"})
+	assert.NoError(err)
+	assert.NotNil(models)
+	assert.Equal(int32(0), models.Size)
+	assert.Equal(int32(0), models.PageSize)
+	assert.Len(models.Items, 0)
+
+	// Test case 12: Empty catalog
+	emptyProvider := testYAMLProvider(t, "testdata/empty-catalog.yaml") // Assuming an empty-catalog.yaml exists or will be created
+	emptyModels, err := emptyProvider.ListModels(ctx, ListModelsParams{})
+	assert.NoError(err)
+	assert.NotNil(emptyModels)
+	assert.Equal(int32(0), emptyModels.Size)
+	assert.Equal(int32(0), emptyModels.PageSize)
+	assert.Len(emptyModels.Items, 0)
 }
 
 func testYAMLProvider(t *testing.T, path string) CatalogSourceProvider {

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -3,14 +3,314 @@ package openapi
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog"
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// timeToMillisStringPointer converts time.Time to *string representing milliseconds since epoch.
+func timeToMillisStringPointer(t time.Time) *string {
+	s := strconv.FormatInt(t.UnixMilli(), 10)
+	return &s
+}
+
+// pointerOrDefault returns the value pointed to by p, or def if p is nil.
+func pointerOrDefault(p *string, def string) string {
+	if p == nil {
+		return def
+	}
+	return *p
+}
+
+func TestFindModels(t *testing.T) {
+	// Define common models for testing
+	time1 := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	time2 := time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)
+	time3 := time.Date(2023, 1, 3, 0, 0, 0, 0, time.UTC)
+	time4 := time.Date(2023, 1, 4, 0, 0, 0, 0, time.UTC)
+
+	// Updated model definitions to match OpenAPI schema (no direct Id or Published, use Name, CreateTime, LastUpdateTime)
+	modelA := &model.CatalogModel{Name: "Model A", CreateTimeSinceEpoch: timeToMillisStringPointer(time1), LastUpdateTimeSinceEpoch: timeToMillisStringPointer(time4)}
+	modelB := &model.CatalogModel{Name: "Model B", CreateTimeSinceEpoch: timeToMillisStringPointer(time2), LastUpdateTimeSinceEpoch: timeToMillisStringPointer(time3)}
+	modelC := &model.CatalogModel{Name: "Another Model C", CreateTimeSinceEpoch: timeToMillisStringPointer(time3), LastUpdateTimeSinceEpoch: timeToMillisStringPointer(time2)}
+	modelD := &model.CatalogModel{Name: "My Model D", CreateTimeSinceEpoch: timeToMillisStringPointer(time4), LastUpdateTimeSinceEpoch: timeToMillisStringPointer(time1)}
+
+	testCases := []struct {
+		name              string
+		sourceID          string
+		mockModels        map[string]*model.CatalogModel
+		q                 string
+		pageSize          string
+		orderBy           model.OrderByField
+		sortOrder         model.SortOrder
+		nextPageToken     string
+		expectedStatus    int
+		expectedModelList *model.CatalogModelList
+	}{
+		{
+			name:     "Successful query with no filters",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA, "modelB": modelB, "modelC": modelC, "modelD": modelD,
+			},
+			q:              "",
+			pageSize:       "10",
+			orderBy:        model.ORDERBYFIELD_NAME,
+			sortOrder:      model.SORTORDER_ASC,
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{*modelC, *modelA, *modelB, *modelD}, // Sorted by Name ASC: Another Model C, Model A, Model B, My Model D
+				Size:          4,
+				PageSize:      10, // Default page size
+				NextPageToken: "",
+			},
+		},
+		{
+			name:     "Filter by query 'Model'",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA, "modelB": modelB, "modelC": modelC, "modelD": modelD,
+			},
+			q:              "Model",
+			pageSize:       "10",
+			orderBy:        model.ORDERBYFIELD_NAME,
+			sortOrder:      model.SORTORDER_ASC,
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{*modelC, *modelA, *modelB, *modelD}, // Corrected to include modelC and sorted by name ASC
+				Size:          4,                                                        // Corrected from 3 to 4
+				PageSize:      10,
+				NextPageToken: "",
+			},
+		},
+		{
+			name:     "Filter by query 'model' (case insensitive)",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA, "modelB": modelB, "modelC": modelC, "modelD": modelD,
+			},
+			q:              "model",
+			pageSize:       "10",
+			orderBy:        model.ORDERBYFIELD_NAME,
+			sortOrder:      model.SORTORDER_ASC,
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{*modelC, *modelA, *modelB, *modelD}, // Corrected to include modelC and sorted by name ASC
+				Size:          4,                                                        // Corrected from 3 to 4
+				PageSize:      10,
+				NextPageToken: "",
+			},
+		},
+		{
+			name:     "Page size limit",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA, "modelB": modelB, "modelC": modelC, "modelD": modelD,
+			},
+			q:              "",
+			pageSize:       "2",
+			orderBy:        model.ORDERBYFIELD_NAME,
+			sortOrder:      model.SORTORDER_ASC,
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{*modelC, *modelA}, // First 2 after sorting by Name ASC
+				Size:          4,                                      // Total size remains 4
+				PageSize:      2,
+				NextPageToken: (&stringCursor{Value: "Model A", ID: "Model A"}).String(),
+			},
+		},
+		{
+			name:     "Sort by ID Descending (mocked as Name Descending)",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA, "modelB": modelB, "modelC": modelC, "modelD": modelD,
+			},
+			q:              "",
+			pageSize:       "10",
+			orderBy:        model.ORDERBYFIELD_ID,
+			sortOrder:      model.SORTORDER_DESC,
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{*modelD, *modelB, *modelA, *modelC}, // Sorted by Name DESC
+				Size:          4,
+				PageSize:      10,
+				NextPageToken: "",
+			},
+		},
+		{
+			name:     "Sort by CreateTime Ascending",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA, "modelB": modelB, "modelC": modelC, "modelD": modelD,
+			},
+			q:              "",
+			pageSize:       "10",
+			orderBy:        model.ORDERBYFIELD_CREATE_TIME,
+			sortOrder:      model.SORTORDER_ASC,
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{*modelA, *modelB, *modelC, *modelD}, // Sorted by CreateTime ASC
+				Size:          4,
+				PageSize:      10,
+				NextPageToken: "",
+			},
+		},
+		{
+			name:     "Sort by LastUpdateTime Descending",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA, "modelB": modelB, "modelC": modelC, "modelD": modelD,
+			},
+			q:              "",
+			pageSize:       "10",
+			orderBy:        model.ORDERBYFIELD_LAST_UPDATE_TIME,
+			sortOrder:      model.SORTORDER_DESC,
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{*modelA, *modelB, *modelC, *modelD}, // Corrected to be sorted by LastUpdateTime DESC (modelA has latest time4, modelD has earliest time1)
+				Size:          4,
+				PageSize:      10,
+				NextPageToken: "",
+			},
+		},
+		{
+			name:              "Invalid source ID",
+			sourceID:          "unknown-source",
+			mockModels:        map[string]*model.CatalogModel{},
+			q:                 "",
+			pageSize:          "10",
+			orderBy:           model.ORDERBYFIELD_ID,
+			sortOrder:         model.SORTORDER_ASC,
+			expectedStatus:    http.StatusNotFound,
+			expectedModelList: nil,
+		},
+		{
+			name:     "Invalid pageSize string",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA,
+			},
+			q:                 "",
+			pageSize:          "abc",
+			orderBy:           model.ORDERBYFIELD_ID,
+			sortOrder:         model.SORTORDER_ASC,
+			expectedStatus:    http.StatusBadRequest,
+			expectedModelList: nil,
+		},
+		{
+			name:     "Unsupported orderBy field",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA,
+			},
+			q:                 "",
+			pageSize:          "10",
+			orderBy:           "UNSUPPORTED_FIELD",
+			sortOrder:         model.SORTORDER_ASC,
+			expectedStatus:    http.StatusBadRequest,
+			expectedModelList: nil,
+		},
+		{
+			name:     "Unsupported sortOrder field",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelA": modelA,
+			},
+			q:                 "",
+			pageSize:          "10",
+			orderBy:           model.ORDERBYFIELD_ID,
+			sortOrder:         "UNSUPPORTED_ORDER",
+			expectedStatus:    http.StatusBadRequest,
+			expectedModelList: nil,
+		},
+		{
+			name:           "Empty models in source",
+			sourceID:       "source1",
+			mockModels:     map[string]*model.CatalogModel{},
+			q:              "",
+			pageSize:       "10",
+			orderBy:        model.ORDERBYFIELD_ID,
+			sortOrder:      model.SORTORDER_ASC,
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{},
+				Size:          0,
+				PageSize:      10,
+				NextPageToken: "",
+			},
+		},
+		{
+			name:     "Default sort (ID ascending) and default page size",
+			sourceID: "source1",
+			mockModels: map[string]*model.CatalogModel{
+				"modelB": modelB, "modelA": modelA, "modelD": modelD, "modelC": modelC,
+			},
+			q:              "",
+			pageSize:       "", // Default page size
+			orderBy:        "", // Default order by ID
+			sortOrder:      "", // Default sort order ASC
+			expectedStatus: http.StatusOK,
+			expectedModelList: &model.CatalogModelList{
+				Items:         []model.CatalogModel{*modelC, *modelA, *modelB, *modelD}, // Sorted by Name ASC (as ID is mocked to use Name)
+				Size:          4,
+				PageSize:      10, // Default page size
+				NextPageToken: "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock source collection
+			sources := catalog.NewSourceCollection(map[string]catalog.CatalogSource{
+				"source1": {
+					Metadata: model.CatalogSource{Id: "source1", Name: "Test Source 1"},
+					Provider: &mockModelProvider{
+						models: tc.mockModels,
+					},
+				},
+			})
+			service := NewModelCatalogServiceAPIService(sources)
+
+			resp, err := service.FindModels(
+				context.Background(),
+				tc.sourceID,
+				tc.q,
+				tc.pageSize,
+				tc.orderBy,
+				tc.sortOrder,
+				tc.nextPageToken,
+			)
+
+			assert.Equal(t, tc.expectedStatus, resp.Code)
+
+			if tc.expectedStatus != http.StatusOK {
+				assert.NotNil(t, err)
+				return
+			}
+
+			require.NotNil(t, resp.Body)
+			modelList, ok := resp.Body.(model.CatalogModelList)
+			require.True(t, ok, "Response body should be a CatalogModelList")
+
+			assert.Equal(t, tc.expectedModelList.Size, modelList.Size)
+			assert.Equal(t, tc.expectedModelList.PageSize, modelList.PageSize)
+			if !assert.Equal(t, tc.expectedModelList.NextPageToken, modelList.NextPageToken) && tc.expectedModelList.NextPageToken != "" {
+				assert.Equal(t, decodeStringCursor(tc.expectedModelList.NextPageToken), decodeStringCursor(modelList.NextPageToken))
+			}
+
+			// Deep equality check for items
+			assert.Equal(t, tc.expectedModelList.Items, modelList.Items)
+		})
+	}
+}
 
 func TestFindSources(t *testing.T) {
 	// Setup test cases
@@ -407,7 +707,50 @@ func (m *mockModelProvider) GetModel(ctx context.Context, name string) (*model.C
 }
 
 func (m *mockModelProvider) ListModels(ctx context.Context, params catalog.ListModelsParams) (model.CatalogModelList, error) {
-	return model.CatalogModelList{}, nil
+	var filteredModels []*model.CatalogModel
+	for _, mdl := range m.models {
+		if params.Query == "" || strings.Contains(strings.ToLower(mdl.Name), strings.ToLower(params.Query)) {
+			filteredModels = append(filteredModels, mdl)
+		}
+	}
+
+	// Sort the filtered models
+	sort.SliceStable(filteredModels, func(i, j int) bool {
+		cmp := 0
+		switch params.OrderBy {
+		case model.ORDERBYFIELD_CREATE_TIME:
+			// Parse CreateTimeSinceEpoch strings to int64 for comparison
+			t1, _ := strconv.ParseInt(pointerOrDefault(filteredModels[i].CreateTimeSinceEpoch, "0"), 10, 64)
+			t2, _ := strconv.ParseInt(pointerOrDefault(filteredModels[j].CreateTimeSinceEpoch, "0"), 10, 64)
+			cmp = int(t1 - t2)
+		case model.ORDERBYFIELD_LAST_UPDATE_TIME:
+			// Parse LastUpdateTimeSinceEpoch strings to int64 for comparison
+			t1, _ := strconv.ParseInt(pointerOrDefault(filteredModels[i].LastUpdateTimeSinceEpoch, "0"), 10, 64)
+			t2, _ := strconv.ParseInt(pointerOrDefault(filteredModels[j].LastUpdateTimeSinceEpoch, "0"), 10, 64)
+			cmp = int(t1 - t2)
+		case model.ORDERBYFIELD_NAME:
+			fallthrough
+		default:
+			cmp = strings.Compare(filteredModels[i].Name, filteredModels[j].Name)
+		}
+
+		if params.SortOrder == model.SORTORDER_DESC {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+
+	items := make([]model.CatalogModel, len(filteredModels))
+	for i, mdl := range filteredModels {
+		items[i] = *mdl
+	}
+
+	return model.CatalogModelList{
+		Items:         items,
+		Size:          int32(len(items)),
+		PageSize:      int32(len(items)), // Mock returns all filtered items as one "page"
+		NextPageToken: "",
+	}, nil
 }
 
 func (m *mockModelProvider) GetArtifacts(ctx context.Context, name string) (*model.CatalogModelArtifactList, error) {

--- a/catalog/pkg/openapi/api_model_catalog_service.go
+++ b/catalog/pkg/openapi/api_model_catalog_service.go
@@ -33,7 +33,7 @@ type ApiFindModelsRequest struct {
 	nextPageToken *string
 }
 
-// Filter models by source. If not provided, models from all sources are returned. If multiple sources are provided, models from any of the sources are returned.
+// Filter models by source. This parameter is currently required and may only be specified once.
 func (r ApiFindModelsRequest) Source(source string) ApiFindModelsRequest {
 	r.source = &source
 	return r
@@ -107,10 +107,11 @@ func (a *ModelCatalogServiceAPIService) FindModelsExecute(r ApiFindModelsRequest
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-
-	if r.source != nil {
-		parameterAddToHeaderOrQuery(localVarQueryParams, "source", r.source, "")
+	if r.source == nil {
+		return localVarReturnValue, nil, reportError("source is required and must be specified")
 	}
+
+	parameterAddToHeaderOrQuery(localVarQueryParams, "source", r.source, "")
 	if r.q != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "q", r.q, "")
 	}

--- a/catalog/pkg/openapi/sortable.go
+++ b/catalog/pkg/openapi/sortable.go
@@ -1,0 +1,37 @@
+package openapi
+
+type Sortable interface {
+	// SortValue returns the value of a requested field converted to a string.
+	SortValue(field OrderByField) string
+}
+
+func (s CatalogSource) SortValue(field OrderByField) string {
+	switch field {
+	case ORDERBYFIELD_ID:
+		return s.Id
+	case ORDERBYFIELD_NAME:
+		return s.Name
+	}
+	return ""
+}
+
+func (m CatalogModel) SortValue(field OrderByField) string {
+	switch field {
+	case ORDERBYFIELD_ID:
+		return m.Name // Name is ID for models
+	case ORDERBYFIELD_NAME:
+		return m.Name
+	case ORDERBYFIELD_LAST_UPDATE_TIME:
+		return unrefString(m.LastUpdateTimeSinceEpoch)
+	case ORDERBYFIELD_CREATE_TIME:
+		return unrefString(m.CreateTimeSinceEpoch)
+	}
+	return ""
+}
+
+func unrefString(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}


### PR DESCRIPTION
## Description
Implements `/api/model_catalog/v1alpha1/models` for static catalogs.

## How Has This Been Tested?
In a local kind cluster and unit tests.

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
