### PR TITLE
Update mock version function to filter versions based on rmID

### DIFF
--- a/clients/ui/bff/internal/api/registered_models_handler_test.go
+++ b/clients/ui/bff/internal/api/registered_models_handler_test.go
@@ -85,7 +85,19 @@ var _ = Describe("TestGetRegisteredModelHandler", func() {
 		It("get all model versions for registered model", func() {
 			By("get to registered models versions")
 			data := mocks.GetModelVersionListMock()
-			expected := ModelVersionListEnvelope{Data: &data}
+			filtered := openapi.ModelVersionList{
+				Items:         []openapi.ModelVersion{},
+				NextPageToken: data.NextPageToken,
+				PageSize:      data.PageSize,
+				Size:          0,
+			}
+			for _, mv := range data.Items {
+				if mv.RegisteredModelId == "1" {
+					filtered.Items = append(filtered.Items, mv)
+				}
+			}
+			filtered.Size = int32(len(filtered.Items))
+			expected := ModelVersionListEnvelope{Data: &filtered}
 
 			requestIdentity := kubernetes.RequestIdentity{
 				UserID: "user@example.com",

--- a/clients/ui/bff/internal/mocks/model_registry_client_mock.go
+++ b/clients/ui/bff/internal/mocks/model_registry_client_mock.go
@@ -71,8 +71,21 @@ func (m *ModelRegistryClientMock) UpdateModelVersion(_ mrserver.HTTPClientInterf
 	return &mockData, nil
 }
 
-func (m *ModelRegistryClientMock) GetAllModelVersionsForRegisteredModel(_ mrserver.HTTPClientInterface, _ string, _ url.Values) (*openapi.ModelVersionList, error) {
-	mockData := GetModelVersionListMock()
+func (m *ModelRegistryClientMock) GetAllModelVersionsForRegisteredModel(_ mrserver.HTTPClientInterface, id string, _ url.Values) (*openapi.ModelVersionList, error) {
+	mockList := GetModelVersionListMock()
+	mockData := openapi.ModelVersionList{
+		Items:         []openapi.ModelVersion{},
+		NextPageToken: mockList.NextPageToken,
+		PageSize:      mockList.PageSize,
+		Size:          0,
+	}
+
+	for _, mv := range mockList.Items {
+		if mv.RegisteredModelId == id {
+			mockData.Items = append(mockData.Items, mv)
+		}
+	}
+	mockData.Size = int32(len(mockData.Items))
 	return &mockData, nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to update `GetAllModelVersionsForRegisteredModelHandler` function to send model versions based on registered model id. 
As we are getting all the versions, we are having routing issue on the frontend
1. the versions of archived models are leading the active version details page - as they were having the active registered model id
2. the few archived versions of the active models are leading to the archived version details page of the archived model.
sending the model versions based on their registered ID will solve this issue - but we might need to add few versions in mocks to see other cases(ex - archived versions for active model - currently we don't have any archived versions mock under active model)

## How Has This Been Tested?
1. Go to a version inside archived models - the version details page should be read only and route, breadcrumb should work as expected.
Route should be - `/registeredModels/archive/:registeredModelId/versions/:versionId/details`

<img width="1270" height="247" alt="Screenshot 2025-07-16 at 5 09 14 PM" src="https://github.com/user-attachments/assets/f19f768f-0681-4fc4-b20d-0fd35417543e" />

2. Go to archived versions inside active models - the archive page should be read only. the breadcrumb and routing should work.
route -` registeredModels/:registeredModelId/versions/archive/:versionId/details`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
