### PR TITLE
Fix artifacts fetched twice on model version details page

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionArchive.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionArchive.cy.ts
@@ -16,6 +16,7 @@ import {
 } from '~/__tests__/cypress/cypress/pages/modelRegistryView/modelVersionArchive';
 import { MODEL_REGISTRY_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { ToastNotification } from '~/__tests__/cypress/cypress/pages/components/Notification';
+import { mockModelArtifactList } from '~/__mocks__/mockModelArtifactList';
 
 type HandlersProps = {
   registeredModelsSize?: number;
@@ -146,6 +147,18 @@ const initIntercepts = ({
       },
     },
     mockModelVersion({ id: '3', name: 'model version 3', state: ModelState.LIVE }),
+  );
+
+  cy.interceptApi(
+    `GET /api/:apiVersion/model_registry/:modelRegistryName/model_versions/:modelVersionId/artifacts`,
+    {
+      path: {
+        modelRegistryName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 3,
+      },
+    },
+    mockModelArtifactList({}),
   );
 };
 

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -10,7 +10,7 @@ import {
   ActionListItem,
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router';
-import { ModelState, ModelVersion } from '~/app/types';
+import { ModelState, ModelVersion, ModelArtifactList } from '~/app/types';
 import { ModelRegistryContext } from '~/app/context/ModelRegistryContext';
 import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import { ArchiveModelVersionModal } from '~/app/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
@@ -19,12 +19,15 @@ import { modelVersionListUrl } from '~/app/pages/modelRegistry/screens/routeUtil
 interface ModelVersionsDetailsHeaderActionsProps {
   mv: ModelVersion;
   refresh: () => void;
+  modelArtifacts: ModelArtifactList;
 }
 
 const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActionsProps> = ({
   mv,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   refresh,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  modelArtifacts,
 }) => {
   const { apiState } = React.useContext(ModelRegistryContext);
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
-import { ModelVersion } from '~/app/types';
+import { ModelVersion, ModelArtifactList } from '~/app/types';
 import { ModelVersionDetailsTabTitle, ModelVersionDetailsTab } from './const';
 import ModelVersionDetailsView from './ModelVersionDetailsView';
 
@@ -10,6 +10,7 @@ type ModelVersionDetailTabsProps = {
   modelVersion: ModelVersion;
   isArchiveVersion?: boolean;
   refresh: () => void;
+  modelArtifacts: ModelArtifactList;
 };
 
 const ModelVersionDetailsTabs: React.FC<ModelVersionDetailTabsProps> = ({
@@ -17,6 +18,7 @@ const ModelVersionDetailsTabs: React.FC<ModelVersionDetailTabsProps> = ({
   modelVersion: mv,
   isArchiveVersion,
   refresh,
+  modelArtifacts,
 }) => {
   const navigate = useNavigate();
   return (
@@ -42,6 +44,7 @@ const ModelVersionDetailsTabs: React.FC<ModelVersionDetailTabsProps> = ({
             modelVersion={mv}
             refresh={refresh}
             isArchiveVersion={isArchiveVersion}
+            modelArtifacts={modelArtifacts}
           />
         </PageSection>
       </Tab>

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -34,6 +34,10 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
   const { apiState } = React.useContext(ModelRegistryContext);
 
+  // TODO: Fetch model artifacts for when deploy functionality is enabled
+  // const [modelArtifacts, modelArtifactsLoaded, modelArtifactsLoadError] =
+  //   useModelArtifactsByVersionId(mv.id);
+
   const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
 
@@ -119,6 +123,23 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
               modelVersionName={mv.name}
             />
           ) : null}
+          {/* TODO: [Model Serving] Uncomment when model serving is available */}
+          {/* NOTE: When uncommenting, pass modelArtifacts prop to avoid duplicate fetching */}
+          {/* {isDeployModalOpen ? (
+            <DeployRegisteredModelModal
+              onSubmit={() => {
+                navigate(
+                  modelVersionDeploymentsUrl(
+                    mv.id,
+                    mv.registeredModelId,
+                    preferredModelRegistry.metadata.name,
+                  ),
+                );
+              }}
+              onCancel={() => setIsDeployModalOpen(false)}
+              modelVersion={mv}
+            />
+          ) : null} */}
           {isRestoreModalOpen ? (
             <RestoreModelVersionModal
               onCancel={() => setIsRestoreModalOpen(false)}

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionsArchive/ArchiveModelVersionDetails.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionsArchive/ArchiveModelVersionDetails.tsx
@@ -5,6 +5,7 @@ import { ApplicationsPage } from 'mod-arch-shared';
 import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import useRegisteredModelById from '~/app/hooks/useRegisteredModelById';
 import useModelVersionById from '~/app/hooks/useModelVersionById';
+import useModelArtifactsByVersionId from '~/app/hooks/useModelArtifactsByVersionId';
 import { ModelState } from '~/app/types';
 import { modelVersionUrl } from '~/app/pages/modelRegistry/screens/routeUtils';
 import ModelVersionDetailsTabs from '~/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs';
@@ -26,7 +27,17 @@ const ArchiveModelVersionDetails: React.FC<ArchiveModelVersionDetailsProps> = ({
   const { modelVersionId: mvId, registeredModelId: rmId } = useParams();
   const [rm] = useRegisteredModelById(rmId);
   const [mv, mvLoaded, mvLoadError, refreshModelVersion] = useModelVersionById(mvId);
+  const [modelArtifacts, modelArtifactsLoaded, modelArtifactsLoadError, refreshModelArtifacts] =
+    useModelArtifactsByVersionId(mvId);
   const navigate = useNavigate();
+
+  const refresh = React.useCallback(() => {
+    refreshModelVersion();
+    refreshModelArtifacts();
+  }, [refreshModelVersion, refreshModelArtifacts]);
+
+  const loaded = mvLoaded && modelArtifactsLoaded;
+  const loadError = mvLoadError || modelArtifactsLoadError;
 
   useEffect(() => {
     if (rm?.state === ModelState.LIVE && mv?.id) {
@@ -64,8 +75,8 @@ const ArchiveModelVersionDetails: React.FC<ArchiveModelVersionDetailsProps> = ({
         </Tooltip>
       }
       description={<Truncate content={mv?.description || ''} />}
-      loadError={mvLoadError}
-      loaded={mvLoaded}
+      loadError={loadError}
+      loaded={loaded}
       provideChildrenPadding
     >
       {mv !== null && (
@@ -73,7 +84,8 @@ const ArchiveModelVersionDetails: React.FC<ArchiveModelVersionDetailsProps> = ({
           isArchiveVersion
           tab={tab}
           modelVersion={mv}
-          refresh={refreshModelVersion}
+          refresh={refresh}
+          modelArtifacts={modelArtifacts}
         />
       )}
     </ApplicationsPage>

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetails.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetails.tsx
@@ -6,6 +6,7 @@ import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelecto
 import { ModelRegistryContext } from '~/app/context/ModelRegistryContext';
 import useRegisteredModelById from '~/app/hooks/useRegisteredModelById';
 import useModelVersionById from '~/app/hooks/useModelVersionById';
+import useModelArtifactsByVersionId from '~/app/hooks/useModelArtifactsByVersionId';
 import { ModelState } from '~/app/types';
 import {
   archiveModelVersionDetailsUrl,
@@ -35,7 +36,17 @@ const ModelVersionsArchiveDetails: React.FC<ModelVersionsArchiveDetailsProps> = 
   const { modelVersionId: mvId, registeredModelId: rmId } = useParams();
   const [rm] = useRegisteredModelById(rmId);
   const [mv, mvLoaded, mvLoadError, refreshModelVersion] = useModelVersionById(mvId);
+  const [modelArtifacts, modelArtifactsLoaded, modelArtifactsLoadError, refreshModelArtifacts] =
+    useModelArtifactsByVersionId(mvId);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
+
+  const refresh = React.useCallback(() => {
+    refreshModelVersion();
+    refreshModelArtifacts();
+  }, [refreshModelVersion, refreshModelArtifacts]);
+
+  const loaded = mvLoaded && modelArtifactsLoaded;
+  const loadError = mvLoadError || modelArtifactsLoadError;
 
   useEffect(() => {
     if (rm?.state === ModelState.ARCHIVED && mv?.id) {
@@ -72,8 +83,8 @@ const ModelVersionsArchiveDetails: React.FC<ModelVersionsArchiveDetailsProps> = 
           </Button>
         }
         description={<Truncate content={mv?.description || ''} />}
-        loadError={mvLoadError}
-        loaded={mvLoaded}
+        loadError={loadError}
+        loaded={loaded}
         provideChildrenPadding
       >
         {mv !== null && (
@@ -81,7 +92,8 @@ const ModelVersionsArchiveDetails: React.FC<ModelVersionsArchiveDetailsProps> = 
             isArchiveVersion
             tab={tab}
             modelVersion={mv}
-            refresh={refreshModelVersion}
+            refresh={refresh}
+            modelArtifacts={modelArtifacts}
           />
         )}
       </ApplicationsPage>

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/getModelVersionTuningData.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/getModelVersionTuningData.ts
@@ -1,13 +1,14 @@
-import { useContext } from 'react';
-import type { ModelVersion, RegisteredModel } from '~/app/types';
-import useModelArtifactsByVersionId from '~/app/hooks/useModelArtifactsByVersionId';
+import type { ModelVersion, RegisteredModel, ModelArtifactList, ModelRegistry } from '~/app/types';
 import { getServerAddress } from '~/app/pages/modelRegistry/screens/utils';
-import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 
-export const useModelVersionTuningData = (
+// Utility function to get model version tuning data without hook dependencies
+export const getModelVersionTuningData = (
   modelVersionId: string | null,
   modelVersion: ModelVersion | null,
   registeredModel: RegisteredModel | null,
+  artifacts: ModelArtifactList,
+  preferredModelRegistry: ModelRegistry | undefined,
+  modelRegistries: ModelRegistry[],
 ): {
   tuningData: {
     modelRegistryName: string;
@@ -19,14 +20,8 @@ export const useModelVersionTuningData = (
     inputModelLocationUri: string;
     outputModelRegistryApiUrl: string;
   } | null;
-  loaded: boolean;
-  loadError: Error | null;
 } => {
-  const { preferredModelRegistry, modelRegistries } = useContext(ModelRegistrySelectorContext);
   const registryService = modelRegistries.find((s) => s.name === preferredModelRegistry?.name);
-
-  const [artifacts, loaded, loadError] = useModelArtifactsByVersionId(modelVersionId || undefined);
-
   const inputModelLocationUri = artifacts.items[0]?.uri;
   const modelRegistryDisplayName = registryService ? registryService.displayName : '';
   const outputModelRegistryApiUrl = registryService ? getServerAddress(registryService) : '';
@@ -45,7 +40,5 @@ export const useModelVersionTuningData = (
             outputModelRegistryApiUrl,
           }
         : null,
-    loaded,
-    loadError: loadError || null,
   };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Upstream port of https://github.com/opendatahub-io/odh-dashboard/pull/4206

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
