### PR TITLE
ci: fix root Make image/push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BUILD_PATH ?= .
 ifdef IMG
 	IMG := ${IMG}
 else ifdef IMG_REGISTRY
-    IMG := ${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}:${IMG_VERSION}
+    IMG := ${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}
 else
     IMG := ${IMG_ORG}/${IMG_REPO}
 endif

--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ endif
 # build docker image
 .PHONY: image/build
 image/build:
-	${DOCKER} build ${BUILD_PATH} -f ${DOCKERFILE} -t ${IMG} $(ARGS)
+	${DOCKER} build ${BUILD_PATH} -f ${DOCKERFILE} -t ${IMG}:$(IMG_VERSION) $(ARGS)
 
 # build docker image using buildx
 # PLATFORMS defines the target platforms for the model registry image be built to provide support to multiple

--- a/jobs/async-upload/Makefile
+++ b/jobs/async-upload/Makefile
@@ -6,9 +6,9 @@ JOB_IMG ?= $(JOB_IMG_REGISTRY)/$(JOB_IMG_ORG)/$(JOB_IMG_NAME):$(JOB_IMG_VERSION)
 BUILD_IMAGE ?= true # whether to build the MR server image
 CLUSTER_NAME ?= mr-e2e
 
-# MR Server Params 
+# MR Server Params
 IMG_VERSION ?= latest
-IMG ?= ghcr.io/kubeflow/model-registry/server:$(IMG_VERSION)
+IMG ?= ghcr.io/kubeflow/model-registry/server # keep consistent with root Makefile and ci/GHA
 
 .PHONY: deploy-latest-mr
 deploy-latest-mr:

--- a/jobs/async-upload/Makefile
+++ b/jobs/async-upload/Makefile
@@ -6,7 +6,7 @@ JOB_IMG ?= $(JOB_IMG_REGISTRY)/$(JOB_IMG_ORG)/$(JOB_IMG_NAME):$(JOB_IMG_VERSION)
 BUILD_IMAGE ?= true # whether to build the MR server image
 CLUSTER_NAME ?= mr-e2e
 
-# MR Server Params
+# MR Server Params 
 IMG_VERSION ?= latest
 IMG ?= ghcr.io/kubeflow/model-registry/server:$(IMG_VERSION)
 

--- a/jobs/async-upload/Makefile
+++ b/jobs/async-upload/Makefile
@@ -8,7 +8,8 @@ CLUSTER_NAME ?= mr-e2e
 
 # MR Server Params
 IMG_VERSION ?= latest
-IMG ?= ghcr.io/kubeflow/model-registry/server # keep consistent with root Makefile and ci/GHA
+# keep IMG consistent with root Makefile and ci/GHA:
+IMG ?= ghcr.io/kubeflow/model-registry/server
 
 .PHONY: deploy-latest-mr
 deploy-latest-mr:
@@ -16,7 +17,8 @@ deploy-latest-mr:
 	$(if $(filter true,$(BUILD_IMAGE)),\
 		IMG_VERSION=${IMG_VERSION} IMG=${IMG} make image/build ARGS="--load$(if ${DEV_BUILD}, --target dev-build)" && \
 	) \
-	LOCAL=1 IMG=${IMG} ./scripts/deploy_on_kind.sh
+	LOCAL=1 IMG=$(IMG):$(IMG_VERSION) ./scripts/deploy_on_kind.sh
+# TODO RHOAIENG-30453 align consistency ./scripts/deploy_on_kind.sh uses IMG with :tag, Vs, Makefile(s) and ci/GHA we use IMG without trailing :tag
 	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 & echo $$! >> .port-forwards.pid
 
 .PHONY: deploy-test-minio


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
merging #1326 the 
https://github.com/kubeflow/model-registry/pull/1326/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52
root Makefile changes I didn't catch during review it inadvertently included inconsistency since:
- in root Makefile and in ci/GHA, we use `IMG` without trailing `:tag`
- the ./scripts/deploy_on_kind.sh uses IMG with `:tag`

this [reverts](https://github.com/tarilabs/model-registry/commit/8356c82a6bdeeca62ba42b8e34e918733e9f4489) the changes in root Makefile and make the whole if/elseif consistent without the trailing tag:

before (currently on main):
https://github.com/kubeflow/model-registry/blob/8356c82a6bdeeca62ba42b8e34e918733e9f4489/Makefile#L34-L40

after (this PR):
```sh
ifdef IMG
	IMG := ${IMG}
else ifdef IMG_REGISTRY
    IMG := ${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}
else
    IMG := ${IMG_ORG}/${IMG_REPO}
endif
```
 
it is to be noted inconsistency between IMG variable semantic in ./scripts/deploy_on_kind.sh vs Makefile existed prior #1326 

This PR just keep re-aligns root Makefile and ci/GHA, dealing with ./scripts/deploy_on_kind.sh can be done as a followup PR.

## How Has This Been Tested?
this is purely ci/GHA

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
