### PR TITLE
Add HuggingFace model-catalog source minimal skeleton

### DIFF
--- a/catalog/internal/catalog/hf_catalog.go
+++ b/catalog/internal/catalog/hf_catalog.go
@@ -1,0 +1,125 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/kubeflow/model-registry/catalog/pkg/openapi"
+	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
+)
+
+type hfCatalogImpl struct {
+	client  *http.Client
+	apiKey  string
+	baseURL string
+}
+
+var _ CatalogSourceProvider = &hfCatalogImpl{}
+
+const (
+	defaultHuggingFaceURL = "https://huggingface.co"
+)
+
+func (h *hfCatalogImpl) GetModel(ctx context.Context, name string) (*openapi.CatalogModel, error) {
+	// TODO: Implement HuggingFace model retrieval
+	return nil, fmt.Errorf("HuggingFace model retrieval not yet implemented")
+}
+
+func (h *hfCatalogImpl) ListModels(ctx context.Context, params ListModelsParams) (model.CatalogModelList, error) {
+	// TODO: Implement HuggingFace model listing
+	// For now, return empty list to satisfy interface
+	return model.CatalogModelList{
+		Items:    []model.CatalogModel{},
+		PageSize: 0,
+		Size:     0,
+	}, nil
+}
+
+func (h *hfCatalogImpl) GetArtifacts(ctx context.Context, name string) (*openapi.CatalogModelArtifactList, error) {
+	// TODO: Implement HuggingFace model artifacts retrieval
+	// For now, return empty list to satisfy interface
+	return &openapi.CatalogModelArtifactList{
+		Items:    []openapi.CatalogModelArtifact{},
+		PageSize: 0,
+		Size:     0,
+	}, nil
+}
+
+// validateCredentials checks if the HuggingFace API credentials are valid
+func (h *hfCatalogImpl) validateCredentials(ctx context.Context) error {
+	glog.Infof("Validating HuggingFace API credentials")
+
+	// Make a simple API call to validate credentials
+	apiURL := h.baseURL + "/api/whoami-v2"
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create validation request: %w", err)
+	}
+
+	if h.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+h.apiKey)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to validate HuggingFace credentials: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("invalid HuggingFace API credentials")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HuggingFace API validation failed with status: %d", resp.StatusCode)
+	}
+
+	glog.Infof("HuggingFace credentials validated successfully")
+	return nil
+}
+
+// newHfCatalog creates a new HuggingFace catalog source
+func newHfCatalog(source *CatalogSourceConfig) (CatalogSourceProvider, error) {
+	apiKey, ok := source.Properties["apiKey"].(string)
+	if !ok || apiKey == "" {
+		return nil, fmt.Errorf("missing or invalid 'apiKey' property for HuggingFace catalog")
+	}
+
+	baseURL := defaultHuggingFaceURL
+	if url, ok := source.Properties["url"].(string); ok && url != "" {
+		baseURL = strings.TrimSuffix(url, "/")
+	}
+
+	// Optional model limit for future implementation
+	modelLimit := 100
+	if limit, ok := source.Properties["modelLimit"].(int); ok && limit > 0 {
+		modelLimit = limit
+	}
+
+	glog.Infof("Configuring HuggingFace catalog with URL: %s, modelLimit: %d", baseURL, modelLimit)
+
+	h := &hfCatalogImpl{
+		client:  &http.Client{Timeout: 30 * time.Second},
+		apiKey:  apiKey,
+		baseURL: baseURL,
+	}
+
+	// Validate credentials during initialization (as required by Jira ticket)
+	ctx := context.Background()
+	if err := h.validateCredentials(ctx); err != nil {
+		glog.Errorf("HuggingFace catalog credential validation failed: %v", err)
+		return nil, fmt.Errorf("failed to validate HuggingFace catalog credentials: %w", err)
+	}
+
+	glog.Infof("HuggingFace catalog source configured successfully")
+	return h, nil
+}
+
+func init() {
+	if err := RegisterCatalogType("hf", newHfCatalog); err != nil {
+		panic(err)
+	}
+}

--- a/catalog/internal/catalog/hf_catalog_test.go
+++ b/catalog/internal/catalog/hf_catalog_test.go
@@ -1,0 +1,174 @@
+package catalog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubeflow/model-registry/catalog/pkg/openapi"
+)
+
+func TestNewHfCatalog_MissingAPIKey(t *testing.T) {
+	source := &CatalogSourceConfig{
+		CatalogSource: openapi.CatalogSource{
+			Id:   "test_hf",
+			Name: "Test HF",
+		},
+		Type: "hf",
+		Properties: map[string]any{
+			"url": "https://huggingface.co",
+		},
+	}
+
+	_, err := newHfCatalog(source)
+	if err == nil {
+		t.Fatal("Expected error for missing API key, got nil")
+	}
+	if err.Error() != "missing or invalid 'apiKey' property for HuggingFace catalog" {
+		t.Fatalf("Expected specific error message, got: %s", err.Error())
+	}
+}
+
+func TestNewHfCatalog_WithValidCredentials(t *testing.T) {
+	// Create mock server that returns valid response for credential validation
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check for authorization header
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-api-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/api/whoami-v2":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"name": "test-user", "type": "user"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	source := &CatalogSourceConfig{
+		CatalogSource: openapi.CatalogSource{
+			Id:   "test_hf",
+			Name: "Test HF",
+		},
+		Type: "hf",
+		Properties: map[string]any{
+			"apiKey":     "test-api-key",
+			"url":        server.URL,
+			"modelLimit": 10,
+		},
+	}
+
+	catalog, err := newHfCatalog(source)
+	if err != nil {
+		t.Fatalf("Failed to create HF catalog: %v", err)
+	}
+
+	hfCatalog := catalog.(*hfCatalogImpl)
+
+	// Test that methods return appropriate responses for stub implementation
+	ctx := context.Background()
+
+	// Test GetModel - should return not implemented error
+	model, err := hfCatalog.GetModel(ctx, "test-model")
+	if err == nil {
+		t.Fatal("Expected not implemented error, got nil")
+	}
+	if model != nil {
+		t.Fatal("Expected nil model, got non-nil")
+	}
+
+	// Test ListModels - should return empty list
+	listParams := ListModelsParams{
+		Query:     "",
+		OrderBy:   openapi.ORDERBYFIELD_NAME,
+		SortOrder: openapi.SORTORDER_ASC,
+	}
+	modelList, err := hfCatalog.ListModels(ctx, listParams)
+	if err != nil {
+		t.Fatalf("Failed to list models: %v", err)
+	}
+	if len(modelList.Items) != 0 {
+		t.Fatalf("Expected 0 models, got %d", len(modelList.Items))
+	}
+
+	// Test GetArtifacts - should return empty list
+	artifacts, err := hfCatalog.GetArtifacts(ctx, "test-model")
+	if err != nil {
+		t.Fatalf("Failed to get artifacts: %v", err)
+	}
+	if artifacts == nil {
+		t.Fatal("Expected artifacts list, got nil")
+	}
+	if len(artifacts.Items) != 0 {
+		t.Fatalf("Expected 0 artifacts, got %d", len(artifacts.Items))
+	}
+}
+
+func TestNewHfCatalog_InvalidCredentials(t *testing.T) {
+	// Create mock server that returns 401
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	source := &CatalogSourceConfig{
+		CatalogSource: openapi.CatalogSource{
+			Id:   "test_hf",
+			Name: "Test HF",
+		},
+		Type: "hf",
+		Properties: map[string]any{
+			"apiKey": "invalid-key",
+			"url":    server.URL,
+		},
+	}
+
+	_, err := newHfCatalog(source)
+	if err == nil {
+		t.Fatal("Expected error for invalid credentials, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid HuggingFace API credentials") {
+		t.Fatalf("Expected credential validation error, got: %s", err.Error())
+	}
+}
+
+func TestNewHfCatalog_DefaultConfiguration(t *testing.T) {
+	// Create mock server for default HuggingFace URL
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"name": "test-user"}`))
+	}))
+	defer server.Close()
+
+	source := &CatalogSourceConfig{
+		CatalogSource: openapi.CatalogSource{
+			Id:   "test_hf",
+			Name: "Test HF",
+		},
+		Type: "hf",
+		Properties: map[string]any{
+			"apiKey": "test-key",
+			"url":    server.URL, // Override default for testing
+		},
+	}
+
+	catalog, err := newHfCatalog(source)
+	if err != nil {
+		t.Fatalf("Failed to create HF catalog with defaults: %v", err)
+	}
+
+	hfCatalog := catalog.(*hfCatalogImpl)
+	if hfCatalog.apiKey != "test-key" {
+		t.Fatalf("Expected apiKey 'test-key', got '%s'", hfCatalog.apiKey)
+	}
+	if hfCatalog.baseURL != server.URL {
+		t.Fatalf("Expected baseURL '%s', got '%s'", server.URL, hfCatalog.baseURL)
+	}
+}

--- a/catalog/internal/catalog/testdata/test-hf-catalog-sources.yaml
+++ b/catalog/internal/catalog/testdata/test-hf-catalog-sources.yaml
@@ -1,0 +1,17 @@
+catalogs:
+  - name: "HuggingFace Test Catalog"
+    id: hf_test
+    type: hf
+    enabled: true
+    properties:
+      apiKey: "hf_test_api_key_here"
+      url: "https://huggingface.co"
+      modelLimit: 50
+  - name: "HuggingFace Invalid Credentials"
+    id: hf_invalid
+    type: hf
+    enabled: false # disabled so it doesn't cause startup failures in tests
+    properties:
+      apiKey: "invalid_key"
+      url: "https://huggingface.co"
+      modelLimit: 10

--- a/manifests/kustomize/options/catalog/hf-sources-example.yaml
+++ b/manifests/kustomize/options/catalog/hf-sources-example.yaml
@@ -1,0 +1,26 @@
+catalogs:
+  - name: Sample Catalog
+    id: sample_catalog
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: sample-catalog.yaml
+  - name: Red Hat Ecosystem Catalog
+    id: rhec
+    type: rhec
+    enabled: true
+    properties:
+      models:
+        - repository: rhelai1/modelcar-granite-7b-starter
+  - name: HuggingFace Hub
+    id: huggingface
+    type: hf
+    enabled: true
+    properties:
+      # HuggingFace API key - should be stored in a Kubernetes secret
+      # and referenced here, or set via environment variable
+      apiKey: "${HUGGINGFACE_API_KEY}"
+      # Optional: Custom HuggingFace URL (defaults to https://huggingface.co)
+      url: "https://huggingface.co"
+      # Optional: Limit the number of models to fetch (defaults to 100)
+      modelLimit: 200


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the skeleton for the HuggingFace Catalog Source implementation.

This follows a similar pattern to the RHEL catalog source, of course expecting hugging face credentials.

An extra validation added that the RHEL source does not have is to perform a call to the [`whoami-v2`](https://huggingface.co/docs/hub/en/api#get-apiwhoami-v2) endpoint to validate the provided credentials are associated to a user (note, the response of this api call is dropped, only checking for status codes 401 and 200 in the response)

## How Has This Been Tested?
Locally be executing the unit tests provided as well as performing cURL requests with the catalog running:

```
I0805 13:37:09.928347   39035 catalog.go:148] reading config type hf...
I0805 13:37:09.929045   39035 hf_catalog.go:102] Configuring HuggingFace catalog with URL: https://huggingface.co, modelLimit: 100
I0805 13:37:09.929049   39035 hf_catalog.go:54] Validating HuggingFace API credentials
I0805 13:37:10.001605   39035 hf_catalog.go:80] HuggingFace credentials validated successfully
I0805 13:37:10.001625   39035 hf_catalog.go:117] HuggingFace catalog source configured successfully
I0805 13:37:10.001630   39035 catalog.go:170] loaded config hf_test of type hf
I0805 13:37:10.001654   39035 catalog.go:42] Catalog API server listening on localhost:8082
```

...

```bash
curl -s "http://localhost:8082/api/model_catalog/v1alpha1/sources" | jq .              
{
  "items": [
    {
      "enabled": true,
      "id": "hf_test",
      "name": "HuggingFace Test Catalog"
    }
  ],
  "nextPageToken": "",
  "pageSize": 10,
  "size": 1
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
