### PR TITLE
[Rebase of abandoned #1396] changes to the version details page format

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
-import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
-import { PlusCircleIcon } from '@patternfly/react-icons';
-import text from '@patternfly/react-styles/css/utilities/Text/text';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { DashboardDescriptionListGroup } from 'mod-arch-shared';
-import { getProperties, mergeUpdatedProperty } from '~/app/pages/modelRegistry/screens/utils';
+import { DescriptionListGroup, DescriptionListDescription } from '@patternfly/react-core';
 import { ModelRegistryCustomProperties } from '~/app/types';
-import ModelPropertiesTableRow from '~/app/pages/modelRegistry/screens/components/ModelPropertiesTableRow';
+import ModelPropertiesExpandableSection from '~/app/pages/modelRegistry/screens/components/ModelPropertiesExpandableSection';
 
 type ModelPropertiesDescriptionListGroupProps = {
   customProperties: ModelRegistryCustomProperties;
@@ -19,120 +13,17 @@ const ModelPropertiesDescriptionListGroup: React.FC<ModelPropertiesDescriptionLi
   customProperties = {},
   isArchive,
   saveEditedCustomProperties,
-}) => {
-  const [editingPropertyKeys, setEditingPropertyKeys] = React.useState<string[]>([]);
-  const setIsEditingKey = (key: string, isEditing: boolean) =>
-    setEditingPropertyKeys([
-      ...editingPropertyKeys.filter((k) => k !== key),
-      ...(isEditing ? [key] : []),
-    ]);
-  const [isAdding, setIsAdding] = React.useState(false);
-  const isEditingSomeRow = isAdding || editingPropertyKeys.length > 0;
-
-  const [isSavingEdits, setIsSavingEdits] = React.useState(false);
-
-  // We only show string properties with a defined value (no labels or other property types)
-  const filteredProperties = getProperties(customProperties);
-
-  const [isShowingMoreProperties, setIsShowingMoreProperties] = React.useState(false);
-  const keys = Object.keys(filteredProperties);
-  const needExpandControl = keys.length > 5;
-  const shownKeys = isShowingMoreProperties ? keys : keys.slice(0, 5);
-  const numHiddenKeys = keys.length - shownKeys.length;
-
-  // Includes keys reserved by non-string properties and labels
-  const allExistingKeys = Object.keys(customProperties);
-
-  const requiredAsterisk = (
-    <span aria-hidden="true" className={text.textColorStatusDanger}>
-      {' *'}
-    </span>
-  );
-
-  return (
-    <DashboardDescriptionListGroup
-      title="Properties"
-      action={
-        !isArchive && (
-          <Button
-            variant="link"
-            data-testid="add-property-button"
-            icon={<PlusCircleIcon />}
-            iconPosition="start"
-            isDisabled={isAdding || isSavingEdits}
-            onClick={() => {
-              setIsShowingMoreProperties(true);
-              setIsAdding(true);
-            }}
-          >
-            Add property
-          </Button>
-        )
-      }
-      isEmpty={!isAdding && keys.length === 0}
-      contentWhenEmpty="No properties"
-    >
-      <Table aria-label="Properties table" data-testid="properties-table" variant="compact">
-        <Thead>
-          <Tr>
-            <Th>Key {isEditingSomeRow && requiredAsterisk}</Th>
-            <Th>Value {isEditingSomeRow && requiredAsterisk}</Th>
-            <Th screenReaderText="Actions" />
-          </Tr>
-        </Thead>
-        <Tbody>
-          {shownKeys.map((key) => (
-            <ModelPropertiesTableRow
-              key={key}
-              isArchive={isArchive}
-              keyValuePair={{ key, value: filteredProperties[key].string_value }}
-              allExistingKeys={allExistingKeys}
-              isEditing={editingPropertyKeys.includes(key)}
-              setIsEditing={(isEditing) => setIsEditingKey(key, isEditing)}
-              isSavingEdits={isSavingEdits}
-              setIsSavingEdits={setIsSavingEdits}
-              saveEditedProperty={(oldKey, newPair) =>
-                saveEditedCustomProperties(
-                  mergeUpdatedProperty({ customProperties, op: 'update', oldKey, newPair }),
-                )
-              }
-              deleteProperty={(oldKey) =>
-                saveEditedCustomProperties(
-                  mergeUpdatedProperty({ customProperties, op: 'delete', oldKey }),
-                )
-              }
-            />
-          ))}
-          {isAdding && (
-            <ModelPropertiesTableRow
-              isAddRow
-              allExistingKeys={allExistingKeys}
-              setIsEditing={setIsAdding}
-              isSavingEdits={isSavingEdits}
-              setIsSavingEdits={setIsSavingEdits}
-              saveEditedProperty={(_oldKey, newPair) =>
-                saveEditedCustomProperties(
-                  mergeUpdatedProperty({ customProperties, op: 'create', newPair }),
-                )
-              }
-            />
-          )}
-        </Tbody>
-      </Table>
-      {needExpandControl && (
-        <Button
-          variant="link"
-          className={spacing.mtSm}
-          data-testid="expand-control-button"
-          onClick={() => setIsShowingMoreProperties(!isShowingMoreProperties)}
-        >
-          {isShowingMoreProperties
-            ? 'Show fewer properties'
-            : `Show ${numHiddenKeys} more ${numHiddenKeys === 1 ? 'property' : 'properties'}`}
-        </Button>
-      )}
-    </DashboardDescriptionListGroup>
-  );
-};
+}) => (
+  <DescriptionListGroup>
+    <DescriptionListDescription>
+      <ModelPropertiesExpandableSection
+        customProperties={customProperties}
+        isArchive={isArchive}
+        saveEditedCustomProperties={saveEditedCustomProperties}
+        isExpandedByDefault
+      />
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+);
 
 export default ModelPropertiesDescriptionListGroup;

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -11,6 +11,9 @@ import {
   Alert,
   StackItem,
   Stack,
+  Card,
+  CardHeader,
+  CardBody,
 } from '@patternfly/react-core';
 import {
   EditableLabelsDescriptionListGroup,
@@ -96,201 +99,206 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
         </StackItem>
       )}
       <StackItem>
-        <Flex
-          direction={{ default: 'column', md: 'row' }}
-          columnGap={{ default: 'columnGap4xl' }}
-          rowGap={{ default: 'rowGapLg' }}
-        >
-          <FlexItem flex={{ default: 'flex_1' }}>
-            <DescriptionList isFillColumns>
-              <EditableTextDescriptionListGroup
-                editableVariant="TextArea"
-                baseTestId="model-version-description"
-                isArchive={isArchiveVersion}
-                title="Description"
-                contentWhenEmpty="No description"
-                value={mv.description || ''}
-                saveEditedValue={(value) =>
-                  handleVersionUpdate(
-                    apiState.api.patchModelVersion({}, { description: value }, mv.id),
-                  )
-                }
-              />
-              <EditableLabelsDescriptionListGroup
-                labels={getLabels(mv.customProperties)}
-                isArchive={isArchiveVersion}
-                allExistingKeys={Object.keys(mv.customProperties)}
-                title="Labels"
-                contentWhenEmpty="No labels"
-                onLabelsChange={(editedLabels) =>
-                  handleVersionUpdate(
-                    apiState.api.patchModelVersion(
-                      {},
-                      { customProperties: mergeUpdatedLabels(mv.customProperties, editedLabels) },
-                      mv.id,
-                    ),
-                  )
-                }
-                data-testid="model-version-labels"
-              />
-              <ModelPropertiesDescriptionListGroup
-                isArchive={isArchiveVersion}
-                customProperties={mv.customProperties}
-                saveEditedCustomProperties={(editedProperties) =>
-                  apiState.api
-                    .patchModelVersion({}, { customProperties: editedProperties }, mv.id)
-                    .then(refresh)
-                }
-              />
-            </DescriptionList>
-          </FlexItem>
-          <FlexItem flex={{ default: 'flex_1' }}>
-            <DescriptionList isFillColumns>
-              <DashboardDescriptionListGroup
-                title="Version ID"
-                isEmpty={!mv.id}
-                contentWhenEmpty="No model ID"
-              >
-                <InlineTruncatedClipboardCopy testId="model-version-id" textToCopy={mv.id} />
-              </DashboardDescriptionListGroup>
-            </DescriptionList>
-
-            <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>
-              Model location
-            </Title>
-            {loadError ? (
-              <Alert variant="danger" isInline title={loadError.name}>
-                {loadError.message}
-              </Alert>
-            ) : (
-              <>
-                <DescriptionList>
-                  {storageFields?.s3Fields && (
-                    <>
-                      <DashboardDescriptionListGroup
-                        title="Endpoint"
-                        isEmpty={!storageFields.s3Fields.endpoint}
-                        contentWhenEmpty="No endpoint"
-                      >
-                        <InlineTruncatedClipboardCopy
-                          testId="storage-endpoint"
-                          textToCopy={storageFields.s3Fields.endpoint}
-                        />
-                      </DashboardDescriptionListGroup>
-                      <DashboardDescriptionListGroup
-                        title="Region"
-                        isEmpty={!storageFields.s3Fields.region}
-                        contentWhenEmpty="No region"
-                      >
-                        <InlineTruncatedClipboardCopy
-                          testId="storage-region"
-                          textToCopy={storageFields.s3Fields.region || ''}
-                        />
-                      </DashboardDescriptionListGroup>
-                      <DashboardDescriptionListGroup
-                        title="Bucket"
-                        isEmpty={!storageFields.s3Fields.bucket}
-                        contentWhenEmpty="No bucket"
-                      >
-                        <InlineTruncatedClipboardCopy
-                          testId="storage-bucket"
-                          textToCopy={storageFields.s3Fields.bucket}
-                        />
-                      </DashboardDescriptionListGroup>
-                      <DashboardDescriptionListGroup
-                        title="Path"
-                        isEmpty={!storageFields.s3Fields.path}
-                        contentWhenEmpty="No path"
-                      >
-                        <InlineTruncatedClipboardCopy
-                          testId="storage-path"
-                          textToCopy={storageFields.s3Fields.path}
-                        />
-                      </DashboardDescriptionListGroup>
-                    </>
-                  )}
-                  {(storageFields?.uri || storageFields?.ociUri) && (
-                    <>
-                      <DashboardDescriptionListGroup
-                        title="URI"
-                        isEmpty={!modelArtifact?.uri}
-                        contentWhenEmpty="No URI"
-                      >
-                        <InlineTruncatedClipboardCopy
-                          testId="storage-uri"
-                          textToCopy={modelArtifact?.uri || ''}
-                        />
-                      </DashboardDescriptionListGroup>
-                    </>
-                  )}
-                </DescriptionList>
-                <Divider style={{ marginTop: '1em' }} />
-                <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>
-                  Source model format
-                </Title>
-                <DescriptionList>
-                  <EditableTextDescriptionListGroup
-                    editableVariant="TextInput"
-                    baseTestId="source-model-format"
+        <Card>
+          <CardHeader>
+            <Title headingLevel="h2">Version details</Title>
+          </CardHeader>
+          <CardBody>
+            <Flex
+              direction={{ default: 'column', md: 'row' }}
+              columnGap={{ default: 'columnGap4xl' }}
+              rowGap={{ default: 'rowGapLg' }}
+            >
+              <FlexItem flex={{ default: 'flex_1' }}>
+                <DescriptionList isFillColumns>
+                  <EditableLabelsDescriptionListGroup
+                    labels={getLabels(mv.customProperties)}
                     isArchive={isArchiveVersion}
-                    value={modelArtifact?.modelFormatName || ''}
+                    allExistingKeys={Object.keys(mv.customProperties)}
+                    title="Labels"
+                    contentWhenEmpty="No labels"
+                    labelProps={{ variant: 'outline' }}
+                    onLabelsChange={(editedLabels) =>
+                      handleVersionUpdate(
+                        apiState.api.patchModelVersion(
+                          {},
+                          {
+                            customProperties: mergeUpdatedLabels(mv.customProperties, editedLabels),
+                          },
+                          mv.id,
+                        ),
+                      )
+                    }
+                    data-testid="model-version-labels"
+                  />
+                  <EditableTextDescriptionListGroup
+                    editableVariant="TextArea"
+                    baseTestId="model-version-description"
+                    isArchive={isArchiveVersion}
+                    title="Description"
+                    contentWhenEmpty="No description"
+                    value={mv.description || ''}
                     saveEditedValue={(value) =>
-                      handleArtifactUpdate(
-                        apiState.api.patchModelArtifact(
-                          {},
-                          { modelFormatName: value },
-                          modelArtifact?.id || '',
-                        ),
+                      handleVersionUpdate(
+                        apiState.api.patchModelVersion({}, { description: value }, mv.id),
                       )
                     }
-                    title="Model Format"
-                    contentWhenEmpty="No model format specified"
                   />
-                  <EditableTextDescriptionListGroup
-                    editableVariant="TextInput"
-                    baseTestId="source-model-version"
-                    value={modelArtifact?.modelFormatVersion || ''}
+                  <ModelPropertiesDescriptionListGroup
                     isArchive={isArchiveVersion}
-                    saveEditedValue={(newVersion) =>
-                      handleArtifactUpdate(
-                        apiState.api.patchModelArtifact(
-                          {},
-                          { modelFormatVersion: newVersion },
-                          modelArtifact?.id || '',
-                        ),
-                      )
+                    customProperties={mv.customProperties}
+                    saveEditedCustomProperties={(editedProperties) =>
+                      apiState.api
+                        .patchModelVersion({}, { customProperties: editedProperties }, mv.id)
+                        .then(refresh)
                     }
-                    title="Version"
-                    contentWhenEmpty="No source model format version"
                   />
                 </DescriptionList>
-              </>
-            )}
-            <Divider style={{ marginTop: '1em' }} />
-            <DescriptionList isFillColumns style={{ marginTop: '1em' }}>
-              <DashboardDescriptionListGroup
-                title="Author"
-                popover="The author is the user who registered the model version."
-              >
-                {mv.author}
-              </DashboardDescriptionListGroup>
-              <DashboardDescriptionListGroup
-                title="Last modified"
-                isEmpty={!mv.lastUpdateTimeSinceEpoch}
-                contentWhenEmpty="Unknown"
-              >
-                <ModelTimestamp timeSinceEpoch={mv.lastUpdateTimeSinceEpoch} />
-              </DashboardDescriptionListGroup>
-              <DashboardDescriptionListGroup
-                title="Created"
-                isEmpty={!mv.createTimeSinceEpoch}
-                contentWhenEmpty="Unknown"
-              >
-                <ModelTimestamp timeSinceEpoch={mv.createTimeSinceEpoch} />
-              </DashboardDescriptionListGroup>
-            </DescriptionList>
-          </FlexItem>
-        </Flex>
+              </FlexItem>
+              <Divider orientation={{ default: 'vertical' }} />
+              <FlexItem flex={{ default: 'flex_1' }}>
+                <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>
+                  Model location
+                </Title>
+                {loadError ? (
+                  <Alert variant="danger" isInline title={loadError.name}>
+                    {loadError.message}
+                  </Alert>
+                ) : (
+                  <>
+                    <DescriptionList>
+                      {storageFields?.s3Fields && (
+                        <>
+                          <DashboardDescriptionListGroup
+                            title="Endpoint"
+                            isEmpty={!storageFields.s3Fields.endpoint}
+                            contentWhenEmpty="No endpoint"
+                          >
+                            <InlineTruncatedClipboardCopy
+                              testId="storage-endpoint"
+                              textToCopy={storageFields.s3Fields.endpoint}
+                            />
+                          </DashboardDescriptionListGroup>
+                          <DashboardDescriptionListGroup
+                            title="Region"
+                            isEmpty={!storageFields.s3Fields.region}
+                            contentWhenEmpty="No region"
+                          >
+                            <InlineTruncatedClipboardCopy
+                              testId="storage-region"
+                              textToCopy={storageFields.s3Fields.region || ''}
+                            />
+                          </DashboardDescriptionListGroup>
+                          <DashboardDescriptionListGroup
+                            title="Bucket"
+                            isEmpty={!storageFields.s3Fields.bucket}
+                            contentWhenEmpty="No bucket"
+                          >
+                            <InlineTruncatedClipboardCopy
+                              testId="storage-bucket"
+                              textToCopy={storageFields.s3Fields.bucket}
+                            />
+                          </DashboardDescriptionListGroup>
+                          <DashboardDescriptionListGroup
+                            title="Path"
+                            isEmpty={!storageFields.s3Fields.path}
+                            contentWhenEmpty="No path"
+                          >
+                            <InlineTruncatedClipboardCopy
+                              testId="storage-path"
+                              textToCopy={storageFields.s3Fields.path}
+                            />
+                          </DashboardDescriptionListGroup>
+                        </>
+                      )}
+                      {(storageFields?.uri || storageFields?.ociUri) && (
+                        <>
+                          <DashboardDescriptionListGroup
+                            title="URI"
+                            isEmpty={!modelArtifact?.uri}
+                            contentWhenEmpty="No URI"
+                          >
+                            <InlineTruncatedClipboardCopy
+                              testId="storage-uri"
+                              textToCopy={modelArtifact?.uri || ''}
+                            />
+                          </DashboardDescriptionListGroup>
+                        </>
+                      )}
+                    </DescriptionList>
+                    <Divider style={{ marginTop: '1em' }} />
+                    <DescriptionList>
+                      <EditableTextDescriptionListGroup
+                        editableVariant="TextInput"
+                        baseTestId="source-model-format"
+                        isArchive={isArchiveVersion}
+                        value={modelArtifact?.modelFormatName || ''}
+                        saveEditedValue={(value) =>
+                          handleArtifactUpdate(
+                            apiState.api.patchModelArtifact(
+                              {},
+                              { modelFormatName: value },
+                              modelArtifact?.id || '',
+                            ),
+                          )
+                        }
+                        title="Model format"
+                        contentWhenEmpty="No model format specified"
+                      />
+                      <EditableTextDescriptionListGroup
+                        editableVariant="TextInput"
+                        baseTestId="source-model-version"
+                        value={modelArtifact?.modelFormatVersion || ''}
+                        isArchive={isArchiveVersion}
+                        saveEditedValue={(newVersion) =>
+                          handleArtifactUpdate(
+                            apiState.api.patchModelArtifact(
+                              {},
+                              { modelFormatVersion: newVersion },
+                              modelArtifact?.id || '',
+                            ),
+                          )
+                        }
+                        title="Model format version"
+                        contentWhenEmpty="No model format version"
+                      />
+                    </DescriptionList>
+                  </>
+                )}
+                <Divider style={{ marginTop: '1em' }} />
+                <DescriptionList isFillColumns style={{ marginTop: '1em' }}>
+                  <DashboardDescriptionListGroup
+                    title="Author"
+                    popover="The author is the user who registered the model version."
+                  >
+                    {mv.author}
+                  </DashboardDescriptionListGroup>
+                  <DashboardDescriptionListGroup
+                    title="Version ID"
+                    isEmpty={!mv.id}
+                    contentWhenEmpty="No model ID"
+                  >
+                    <InlineTruncatedClipboardCopy testId="model-version-id" textToCopy={mv.id} />
+                  </DashboardDescriptionListGroup>
+                  <DashboardDescriptionListGroup
+                    title="Last modified"
+                    isEmpty={!mv.lastUpdateTimeSinceEpoch}
+                    contentWhenEmpty="Unknown"
+                  >
+                    <ModelTimestamp timeSinceEpoch={mv.lastUpdateTimeSinceEpoch} />
+                  </DashboardDescriptionListGroup>
+                  <DashboardDescriptionListGroup
+                    title="Registered"
+                    isEmpty={!mv.createTimeSinceEpoch}
+                    contentWhenEmpty="Unknown"
+                  >
+                    <ModelTimestamp timeSinceEpoch={mv.createTimeSinceEpoch} />
+                  </DashboardDescriptionListGroup>
+                </DescriptionList>
+              </FlexItem>
+            </Flex>
+          </CardBody>
+        </Card>
       </StackItem>
     </Stack>
   );

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ModelPropertiesExpandableSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ModelPropertiesExpandableSection.tsx
@@ -12,12 +12,14 @@ type ModelPropertiesExpandableSectionProps = {
   customProperties?: ModelRegistryCustomProperties;
   isArchive?: boolean;
   saveEditedCustomProperties: (properties: ModelRegistryCustomProperties) => Promise<unknown>;
+  isExpandedByDefault?: boolean;
 };
 
 const ModelPropertiesExpandableSection: React.FC<ModelPropertiesExpandableSectionProps> = ({
   customProperties = {},
   isArchive,
   saveEditedCustomProperties,
+  isExpandedByDefault = false,
 }) => {
   const [editingPropertyKeys, setEditingPropertyKeys] = React.useState<string[]>([]);
   const setIsEditingKey = (key: string, isEditing: boolean) =>
@@ -48,8 +50,12 @@ const ModelPropertiesExpandableSection: React.FC<ModelPropertiesExpandableSectio
     </span>
   );
 
+  const [isExpanded, setIsExpanded] = React.useState(isExpandedByDefault);
+
   return (
     <ExpandableSection
+      isExpanded={isExpanded}
+      onToggle={() => setIsExpanded(!isExpanded)}
       toggleContent={
         <>
           Properties <Badge isRead>{keys.length}</Badge>


### PR DESCRIPTION
## Description

#1396 was closed as its contributor is no longer available. It had numerous conflicts upon a rebase (it refactors the same area refactored by other changes), so this PR replaces it in order to squash and cherry-pick its changes onto main.

I followed this process to identify the changes to preserve:
* Compared the changes on kubeflow/main since the old PR's base, ignoring whitespace changes. I did this a lazy way by pushing a copy of that old base to my fork and opening a [PR against my own fork](https://github.com/mturley/model-registry-midstream/pull/1) so I could use GitHub's "hide whitespace changes" feature. This revealed that the only changes in the base in this conflicting area were to wrap existing things in a Stack/StackItem layout.
<img width="1357" height="697" alt="Screenshot 2025-08-15 at 3 42 24 PM" src="https://github.com/user-attachments/assets/5bad18e3-844a-4341-b3db-87402f679a17" />

* Checked out the original branch from #1396 and squashed its 5 commits to 1 with an interactive rebase.
* Checked out the latest main and cherry-picked the new squashed commit onto it to start conflict resolution.
* Git was particularly confused in the file with conflicts (ModelVersionDetailsView.tsx), so it was easier to reset it to the version from main and then manually repeat the changes I saw from the #1396 diff.
* Tested the changes and saw that they match the screenshots from the original PR, with the exception of the new Model Details card above this section.

### Original PR description below (with my updated screenshot):

------

The layout and styling of the Version Details page were updated

* Content is now structured into a card layout with title "Version details"
* Fields have been repositioned for better organization (The description field is moved below the labels field)(moved the version id below the author)
* A vertical divider was added for clearer separation
* The description below the page name and "Source Model Format" title was removed
* Labels now use the grey outlined style
* Properties section is now expandable, with a badge count with "Add Property" button moved below the section

The new versions details page looks like:
<img width="1320" height="954" alt="Screenshot 2025-08-15 at 3 33 04 PM" src="https://github.com/user-attachments/assets/d2052827-3cf9-4731-b5a4-83e9df84eac1" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It is manually tested by ensuring the changes are visible on the website.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
