### PR TITLE
fix filterQuery IN operator

### DIFF
--- a/internal/core/experiment_test.go
+++ b/internal/core/experiment_test.go
@@ -596,6 +596,37 @@ func TestGetExperimentsWithFilterQuery(t *testing.T) {
 			expectedCount: 2,
 			expectedNames: []string{"cv-experiment-2", "nlp-experiment-2"},
 		},
+		{
+			name:          "Filter using IN operator with string values",
+			filterQuery:   "project IN ('nlp', 'vision')",
+			expectedCount: 3,
+			expectedNames: []string{"nlp-experiment-1", "cv-experiment-2", "nlp-experiment-2"},
+		},
+		{
+			name:          "Filter using IN operator with integer values",
+			filterQuery:   "priority.int_value IN (1, 2)",
+			expectedCount: 2,
+			expectedNames: []string{"nlp-experiment-1", "cv-experiment-2"},
+		},
+		{
+			name:          "Filter using IN operator with double values",
+			filterQuery:   "budget.double_value IN (10000.0, 25000.0)",
+			expectedCount: 2,
+			expectedNames: []string{"nlp-experiment-1", "cv-experiment-2"},
+		},
+		{
+			name:          "Filter using IN operator with single value",
+			filterQuery:   "owner IN ('charlie')",
+			expectedCount: 1,
+			expectedNames: []string{"rl-experiment"},
+		},
+
+		{
+			name:          "Filter using IN operator with mixed quoted strings",
+			filterQuery:   "team IN ('research', \"engineering\")",
+			expectedCount: 4,
+			expectedNames: []string{"nlp-experiment-1", "cv-experiment-2", "nlp-experiment-2", "rl-experiment"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/core/experiment_test.go
+++ b/internal/core/experiment_test.go
@@ -620,7 +620,12 @@ func TestGetExperimentsWithFilterQuery(t *testing.T) {
 			expectedCount: 1,
 			expectedNames: []string{"rl-experiment"},
 		},
-
+		{
+			name:          "Filter using IN operator with empty list",
+			filterQuery:   "project IN ()",
+			expectedCount: 0,
+			expectedNames: []string{},
+		},
 		{
 			name:          "Filter using IN operator with mixed quoted strings",
 			filterQuery:   "team IN ('research', \"engineering\")",

--- a/internal/db/filter/parser.go
+++ b/internal/db/filter/parser.go
@@ -107,7 +107,7 @@ type Value struct {
 
 //nolint:govet
 type ValueList struct {
-	Values []*SingleValue `"(" @@ ("," @@)* ")"`
+	Values []*SingleValue `"(" (@@  ("," @@)*)? ")"`
 }
 
 //nolint:govet

--- a/internal/db/filter/parser.go
+++ b/internal/db/filter/parser.go
@@ -98,6 +98,20 @@ type PropertyRef struct {
 
 //nolint:govet
 type Value struct {
+	String    *string    `@String`
+	Integer   *int64     `| @Int`
+	Float     *float64   `| @Float`
+	Boolean   *string    `| @("true" | "false" | "TRUE" | "FALSE")`
+	ValueList *ValueList `| @@`
+}
+
+//nolint:govet
+type ValueList struct {
+	Values []*SingleValue `"(" @@ ("," @@)* ")"`
+}
+
+//nolint:govet
+type SingleValue struct {
 	String  *string  `@String`
 	Integer *int64   `| @Int`
 	Float   *float64 `| @Float`
@@ -243,14 +257,36 @@ func convertPropertyRef(prop *PropertyRef, value *Value) *PropertyReference {
 
 func convertValue(val *Value) interface{} {
 	if val.String != nil {
-		// Remove quotes from string
-		str := *val.String
-		str = strings.Trim(str, `"'`)
-		// Handle escape sequences
-		str = strings.ReplaceAll(str, `\"`, `"`)
-		str = strings.ReplaceAll(str, `\'`, `'`)
-		str = strings.ReplaceAll(str, `\\`, `\`)
-		return str
+		return processStringValue(*val.String)
+	}
+
+	if val.Integer != nil {
+		return *val.Integer
+	}
+
+	if val.Float != nil {
+		return *val.Float
+	}
+
+	if val.Boolean != nil {
+		return strings.ToLower(*val.Boolean) == "true"
+	}
+
+	if val.ValueList != nil {
+		// Convert list of values to slice
+		var values []interface{}
+		for _, singleVal := range val.ValueList.Values {
+			values = append(values, convertSingleValue(singleVal))
+		}
+		return values
+	}
+
+	return nil
+}
+
+func convertSingleValue(val *SingleValue) interface{} {
+	if val.String != nil {
+		return processStringValue(*val.String)
 	}
 
 	if val.Integer != nil {
@@ -268,8 +304,40 @@ func convertValue(val *Value) interface{} {
 	return nil
 }
 
+// processStringValue removes quotes and handles escape sequences
+func processStringValue(str string) string {
+	// Remove quotes from string
+	result := strings.Trim(str, `"'`)
+	// Handle escape sequences
+	result = strings.ReplaceAll(result, `\"`, `"`)
+	result = strings.ReplaceAll(result, `\'`, `'`)
+	result = strings.ReplaceAll(result, `\\`, `\`)
+	return result
+}
+
 // inferValueType determines the appropriate value type based on the actual value
 func inferValueType(val *Value) string {
+	if val.String != nil {
+		return StringValueType
+	}
+	if val.Integer != nil {
+		return IntValueType
+	}
+	if val.Float != nil {
+		return DoubleValueType
+	}
+	if val.Boolean != nil {
+		return BoolValueType
+	}
+	if val.ValueList != nil && len(val.ValueList.Values) > 0 {
+		// For lists, infer type from the first value
+		return inferSingleValueType(val.ValueList.Values[0])
+	}
+	return StringValueType // default to string
+}
+
+// inferSingleValueType determines the appropriate value type for a SingleValue
+func inferSingleValueType(val *SingleValue) string {
 	if val.String != nil {
 		return StringValueType
 	}

--- a/internal/db/filter/query_builder.go
+++ b/internal/db/filter/query_builder.go
@@ -392,11 +392,7 @@ func (qb *QueryBuilder) buildOperatorCondition(column string, operator string, v
 				return conditionResult{condition: "1 = 0", args: []any{}}
 			}
 			// Create placeholders for each value
-			placeholders := make([]string, len(valueSlice))
-			for i := range placeholders {
-				placeholders[i] = "?"
-			}
-			condition := fmt.Sprintf("%s IN (%s)", column, strings.Join(placeholders, ","))
+			condition := fmt.Sprintf("%s IN (?%s)", column, strings.Repeat(",?", len(valueSlice)-1))
 			return conditionResult{condition: condition, args: valueSlice}
 		}
 		// Fallback to single value (shouldn't normally happen with proper parsing)


### PR DESCRIPTION
This adds handling of array values so we can do something like `id IN (6,7,8)` to filterQuery:

  curl 'http://localhost:8080/api/model_registry/v1alpha3/experiment_runs?filterQuery=id+IN+(6,7,8)'

AI-assisted: Cursor (claude-4-sonnet)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
