### PR TITLE
fix: remove scrollbars from model cards and sort versions by date

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionSelector.tsx
@@ -49,6 +49,7 @@ const ModelVersionSelector: React.FC<ModelVersionSelectorProps> = ({
 
   const menuListItems = liveModelVersions
     .filter((item) => input === '' || item.name.toLowerCase().includes(input.toLowerCase()))
+    .toSorted((a, b) => Number(b.createTimeSinceEpoch) - Number(a.createTimeSinceEpoch)) // Sort by creation time, newest first
     .map((mv, index) => (
       <MenuItem isSelected={mv.id === selection.id} itemId={mv.id} key={index}>
         <Flex spaceItems={{ default: 'spaceItemsSm' }}>

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelDetailsCard.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelDetailsCard.tsx
@@ -173,7 +173,7 @@ const ModelDetailsCard: React.FC<ModelDetailsCardProps> = ({
   );
 
   return (
-    <Card isExpanded={isExpanded}>
+    <Card isExpanded={isExpanded} style={{ overflow: 'visible' }}>
       {isExpandable ? (
         <>
           <CardHeader


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Addressing UI feedback from community
- Remove unnecessary scrollbar from model card in Model version details and Model Overview tab

Before: 

<img width="1112" height="526" alt="Screenshot 2025-08-19 at 7 52 33 PM" src="https://github.com/user-attachments/assets/31ddc18c-4ec0-4939-a6d7-6045b08e7abc" />
<img width="1106" height="622" alt="Screenshot 2025-08-19 at 7 52 46 PM" src="https://github.com/user-attachments/assets/96349aae-f371-4186-b840-56d41ecb4df7" />

After:

<img width="1101" height="606" alt="Screenshot 2025-08-19 at 7 51 37 PM" src="https://github.com/user-attachments/assets/5e716519-ba5a-4607-b392-146e8a52c6b3" />
<img width="1111" height="519" alt="Screenshot 2025-08-19 at 7 51 59 PM" src="https://github.com/user-attachments/assets/e9dfd18e-8a47-413c-9ef9-5b39c7f78b3c" />

- Make sure the latest version is at the top of the dropdown

Before:

<img width="313" height="232" alt="Screenshot 2025-08-19 at 6 24 46 PM" src="https://github.com/user-attachments/assets/7b2e1502-e040-4ad7-82f2-d495865646a3" />

After:

<img width="209" height="225" alt="Screenshot 2025-08-19 at 7 51 45 PM" src="https://github.com/user-attachments/assets/53e2e08d-46e5-4373-a8f1-88bdb8ef6357" />

Just visual changes so tests not required

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to Model versions Details page and Model Overview tab and check for these changes

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
