### PR TITLE
feat(async-job): support URI connection resource mount

### DIFF
--- a/jobs/async-upload/README.md
+++ b/jobs/async-upload/README.md
@@ -43,6 +43,8 @@ See asterisks below table for details
 | MODEL_SYNC_SOURCE_TYPE                       | --source-type                       | s3                | ✅       |                                                                                         |
 | MODEL_SYNC_SOURCE_S3_CREDENTIALS_PATH        | --source-s3-credentials-path        |                   |          |                                                                                         |
 | MODEL_SYNC_SOURCE_OCI_CREDENTIALS_PATH       | --source-oci-credentials-path       |                   |          |                                                                                         |
+| MODEL_SYNC_SOURCE_URI_CREDENTIALS_PATH       | --source-uri-credentials-path       |                   |          |                                                                                         |
+| MODEL_SYNC_SOURCE_URI                        | --source-uri                        |                   | ✅\#     | When --source-type is "uri". The URI to download from                                   |
 | MODEL_SYNC_SOURCE_AWS_BUCKET                 | --source-aws-bucket                 |                   | ✅\*     | When --source-type is "s3"                                                              |
 | MODEL_SYNC_SOURCE_AWS_KEY                    | --source-aws-key                    |                   | ✅\*     | "                                                                                       |
 | MODEL_SYNC_SOURCE_AWS_REGION                 | --source-aws-region                 |                   |          | "                                                                                       |
@@ -85,6 +87,8 @@ See asterisks below table for details
 ✅\*: Must be present in some form when the source/destination is `s3`. This might be from the parameter in the table, or from the credentials file(s) that was specified/provided.
 
 ✅\+: Must be present in some from when the source/destination is `oci`. This might be from the parameter in the table, or from the credentials file(s) that was specified/provided.
+
+✅\#: Must be present in some form when the source is `uri`. This might be from the parameter in the table, or from the credentials file(s) that was specified/provided.
 
 ## References
 

--- a/jobs/async-upload/job/models.py
+++ b/jobs/async-upload/job/models.py
@@ -76,20 +76,24 @@ class OCIStorageConfig(BaseStorageConfig, OCIConfig):
         return self
 
 
-class URISourceConfig(BaseStorageConfig):
-    """URI source configuration - only used for sources, not destinations."""
-    uri: str
+class URISourceConfig(BaseModel):
+    """Basic URI source configuration. To be used as an intermediary model for the URISourceStorageConfig, allowing for additional values to be overlaid until the final config is created and validated via the URISourceStorageConfig model."""
+    uri: str | None = None
+
+
+class URISourceStorageConfig(BaseStorageConfig, URISourceConfig):
+    """URI source storage configuration with validation - only used for sources, not destinations."""
     
     @model_validator(mode='after')
-    def validate_uri_source(self) -> 'URISourceConfig':
-        """Validate that URI is present."""
+    def validate_uri_storage(self) -> 'URISourceStorageConfig':
+        """Validate that required URI field is present."""
         if not self.uri:
             raise ValueError("URI must be set for URI type sources")
         return self
 
 
 # Union types for source and destination configurations - this enables isinstance() checks
-SourceConfig = Union[S3StorageConfig, OCIStorageConfig, URISourceConfig]
+SourceConfig = Union[S3StorageConfig, OCIStorageConfig, URISourceStorageConfig]
 DestinationConfig = Union[S3StorageConfig, OCIStorageConfig]
 
 


### PR DESCRIPTION
This adds support for a URI connection resource (secret) containing the key "URI" to be used as the source for the async job. This was already possible for S3 and OCI connection types, but missing for URI.

AI-assisted: Cursor (claude-4-sonnet)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
