### PR TITLE
fix: prevent page reload on "View versions" link clicks

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -426,10 +426,6 @@ describe('Model version details', () => {
         .and('contain.text', 'View all')
         .and('contain.text', 'versions');
 
-      cy.findByTestId('versions-route-link')
-        .should('have.attr', 'href')
-        .and('include', '/model-registry/modelregistry-sample/registeredModels/1/versions');
-
       // Click the link and verify navigation
       cy.findByTestId('versions-route-link').click();
 

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsCard.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsCard.tsx
@@ -13,6 +13,7 @@ import {
   Divider,
   Truncate,
 } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import { TruncatedText } from 'mod-arch-shared';
 import { RegisteredModel } from '~/app/types';
 import useModelVersionsByRegisteredModel from '~/app/hooks/useModelVersionsByRegisteredModel';
@@ -55,11 +56,8 @@ const ModelVersionsCard: React.FC<ModelVersionsCardProps> = ({ rm, isArchiveMode
               >
                 <Flex spaceItems={{ default: 'spaceItemsXs' }} direction={{ default: 'column' }}>
                   <FlexItem>
-                    <Button
-                      component="a"
-                      isInline
-                      data-testid={`model-version-${mv.id}-link`}
-                      href={
+                    <Link
+                      to={
                         isArchiveModel
                           ? archiveModelVersionDetailsUrl(
                               mv.id,
@@ -68,10 +66,12 @@ const ModelVersionsCard: React.FC<ModelVersionsCardProps> = ({ rm, isArchiveMode
                             )
                           : modelVersionUrl(mv.id, rm.id, preferredModelRegistry?.name)
                       }
-                      variant="link"
+                      style={{ textDecoration: 'none' }}
                     >
-                      <Truncate content={mv.name} />
-                    </Button>
+                      <Button isInline data-testid={`model-version-${mv.id}-link`} variant="link">
+                        <Truncate content={mv.name} />
+                      </Button>
+                    </Link>
                   </FlexItem>
                   <FlexItem>
                     <TruncatedText content={mv.description} maxLines={1} />

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ViewAllVersionsButton.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ViewAllVersionsButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
 import {
   modelVersionListUrl,
   archiveModelVersionListUrl,
@@ -23,21 +24,24 @@ const ViewAllVersionsButton: React.FC<ViewAllVersionsButtonProps> = ({
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
 
   return (
-    <Button
-      component="a"
-      isInline
-      data-testid="versions-route-link"
-      href={
+    <Link
+      to={
         isArchiveModel
           ? archiveModelVersionListUrl(rmId, preferredModelRegistry?.name)
           : modelVersionListUrl(rmId, preferredModelRegistry?.name)
       }
-      variant="link"
-      icon={showIcon ? <ArrowRightIcon /> : undefined}
-      iconPosition={showIcon ? 'right' : undefined}
+      style={{ textDecoration: 'none' }}
     >
-      {`View all ${totalVersions} versions`}
-    </Button>
+      <Button
+        isInline
+        data-testid="versions-route-link"
+        variant="link"
+        icon={showIcon ? <ArrowRightIcon /> : undefined}
+        iconPosition={showIcon ? 'right' : undefined}
+      >
+        {`View all ${totalVersions} versions`}
+      </Button>
+    </Link>
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
"View versions" links now don't trigger a page reload and fixed related Cypress tests. Fixed the same for versions links in the "Latest versions" card

https://github.com/user-attachments/assets/2b8eaddb-2313-4615-b2ce-545977cd3aea


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Click on the "View versions" links in the Version dropdown link and the latest versions card - this shouldn't trigger a page reload 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
