### PR TITLE
  feat(compose): add database profile support with MySQL and PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,15 +153,55 @@ The server listens on `localhost` by default, hence the `-n 0.0.0.0` option allo
 
 #### Running model registry
 
-> **NOTE:** Docker compose must be installed in your environment.
+> **NOTE:** Docker Compose or Podman Compose must be installed in your environment.
 
-There are two `docker-compose` files that make the startup of both model registry and a MySQL database easier, by simply running:
+There are two `docker-compose` files that make the startup easier:
+
+- `docker-compose.yaml` - Uses pre-built images from registry
+- `docker-compose-local.yaml` - Builds model registry from source  
+
+Both files support MySQL and PostgreSQL databases using profiles.
+
+#### Using Makefile targets (recommended)
+
+The easiest way to run the services is using the provided Makefile targets:
 
 ```shell
-docker compose -f docker-compose[-local].yaml up
+# Start with MySQL (using pre-built images)
+make compose/up
+
+# Start with PostgreSQL (using pre-built images)  
+make compose/up/postgres
+
+# Start with MySQL (builds from source)
+make compose/local/up
+
+# Start with PostgreSQL (builds from source)
+make compose/local/up/postgres
+
+# Stop services
+make compose/down  # or compose/local/down
+
+# Clean up all volumes and networks
+make compose/clean
 ```
 
-The main difference between the two docker compose files is that `-local` one build the model registry from source, the other one, instead, download the `latest` pushed [quay.io](https://quay.io/repository/opendatahub/model-registry?tab=tags) image.
+#### Manual docker-compose usage
+
+Alternatively, you can run the compose files directly:
+
+```shell
+# Using pre-built images with MySQL
+docker-compose --profile mysql up
+
+# Using pre-built images with PostgreSQL  
+DB_TYPE=postgres docker-compose --profile postgres up
+
+# Building from source with PostgreSQL
+DB_TYPE=postgres docker-compose -f docker-compose-local.yaml --profile postgres up
+```
+
+The Makefile automatically detects whether to use `docker-compose`, `podman-compose`, or `docker compose` based on what's available on your system.
 
 ### Testing architecture
 

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -1,21 +1,46 @@
 # Local development demo/example compose file
 # Composes:
 # - a MySQL database,
-# - a model-registry server built from source.
-version: '3.4'
+# - a model-registry server built from source connected to the MySQL database.
+# - a model-catalog server built from source.
+# or
+# - a PostgreSQL database,
+# - a model-registry server built from source connected to the PostgreSQL database.
+# - a model-catalog server built from source.
+version: '3.8'
 services:
+  model-catalog:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ["catalog", "--listen", "0.0.0.0:8081", "--catalogs-path", "/testdata/test-catalog-sources.yaml"]
+    container_name: model-catalog
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./catalog/internal/catalog/testdata:/testdata
+
   model-registry:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["proxy", "--hostname", "0.0.0.0", "--datastore-type", "embedmd", "--embedmd-database-dsn", "root:demo@tcp(mysql:3306)/model_registry?charset=utf8mb4"]
+    entrypoint: ["/bin/sh"]
+    command: 
+      - -c
+      - |
+        if [ "$$DB_TYPE" = "postgres" ]; then
+          exec /model-registry proxy --hostname 0.0.0.0 --datastore-type embedmd --embedmd-database-type postgres --embedmd-database-dsn "host=postgres port=5432 user=postgres password=demo dbname=model_registry sslmode=disable"
+        else
+          exec /model-registry proxy --hostname 0.0.0.0 --datastore-type embedmd --embedmd-database-dsn "root:demo@tcp(mysql:3306)/model_registry?charset=utf8mb4"
+        fi
     container_name: model-registry
     ports:
       - "8080:8080"
     depends_on:
-      mysql:
-        condition: service_healthy
-        required: true
+      - ${DB_TYPE:-mysql}
+    environment:
+      - DB_TYPE=${DB_TYPE:-mysql}
+
   mysql:
     image: mysql:8.3
     container_name: mysql
@@ -35,5 +60,29 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+    profiles:
+      - mysql
+
+  postgres:
+    image: postgres:15
+    container_name: postgres
+    environment:
+      - POSTGRES_DB=model_registry
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=demo
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d model_registry"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    profiles:
+      - postgres
+
 volumes:
   mysql_data:
+  postgres_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,19 +2,43 @@
 # Composes:
 # - a MySQL database,
 # - a model-registry server connected to the MySQL database.
-version: '3'
+# - a model-catalog server
+# or
+# - a PostgreSQL database,
+# - a model-registry server connected to the PostgreSQL database.
+# - a model-catalog server
+version: '3.8'
 services:
+  model-catalog:
+    image: ghcr.io/kubeflow/model-registry/server:latest
+    pull_policy: always
+    command: ["catalog", "--listen", "0.0.0.0:8081", "--catalogs-path", "/testdata/test-catalog-sources.yaml"]
+    container_name: model-catalog
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./catalog/internal/catalog/testdata:/testdata
+
   model-registry:
     image: ghcr.io/kubeflow/model-registry/server:latest
     pull_policy: always
-    command: ["proxy", "--hostname", "0.0.0.0", "--datastore-type", "embedmd", "--embedmd-database-dsn", "root:demo@tcp(mysql:3306)/model_registry?charset=utf8mb4"]
+    entrypoint: ["/bin/sh"]
+    command: 
+      - -c
+      - |
+        if [ "$$DB_TYPE" = "postgres" ]; then
+          exec /model-registry proxy --hostname 0.0.0.0 --datastore-type embedmd --embedmd-database-type postgres --embedmd-database-dsn "host=postgres port=5432 user=postgres password=demo dbname=model_registry sslmode=disable"
+        else
+          exec /model-registry proxy --hostname 0.0.0.0 --datastore-type embedmd --embedmd-database-dsn "root:demo@tcp(mysql:3306)/model_registry?charset=utf8mb4"
+        fi
     container_name: model-registry
     ports:
       - "8080:8080"
     depends_on:
-      mysql:
-        condition: service_healthy
-        required: true
+      - ${DB_TYPE:-mysql}
+    environment:
+      - DB_TYPE=${DB_TYPE:-mysql}
+
   mysql:
     image: mysql:8.3
     container_name: mysql
@@ -34,5 +58,29 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+    profiles:
+      - mysql
+
+  postgres:
+    image: postgres:15
+    container_name: postgres
+    environment:
+      - POSTGRES_DB=model_registry
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=demo
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d model_registry"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    profiles:
+      - postgres
+
 volumes:
   mysql_data:
+  postgres_data:


### PR DESCRIPTION
## Description
  - Add profile-based configuration to support both MySQL and PostgreSQL databases in docker-compose.yaml and docker-compose-local.yaml
  - Add comprehensive make targets for easy compose management with auto-detection of docker-compose vs podman-compose
  - Update README.md with complete documentation for database profiles and new make targets

  Changes:
  - docker-compose.yaml: Add mysql/postgres profiles with proper shell syntax
  - docker-compose-local.yaml: Add mysql/postgres profiles with proper shell syntax
  - Makefile: Add compose/* targets with automatic compose command detection
  - README.md: Document profile usage and new make targets

  Features:
  - Support for both MySQL and PostgreSQL via --profile flag
  - Environment variable DB_TYPE controls database selection
  - Make targets: compose/up, compose/up/postgres, compose/local/up, etc.
  - Automatic detection of docker-compose, podman-compose, or docker compose

  This enables flexible database backend selection for different deployment
  scenarios while maintaining backward compatibility.

## How Has This Been Tested?
Run the make targets described in the updated README file

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
