### PR TITLE
ci: add Trivy scan results to Security tab

### DIFF
--- a/.github/workflows/trivy-image-scanning.yaml
+++ b/.github/workflows/trivy-image-scanning.yaml
@@ -1,0 +1,44 @@
+name: Trivy image scanning
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1' # Every Monday at 00:00
+
+jobs:
+  image-scanning:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        IMAGE: [
+          'ghcr.io/kubeflow/model-registry/server:latest',
+          'ghcr.io/kubeflow/model-registry/ui:latest',
+          'ghcr.io/kubeflow/model-registry/storage-initializer:latest',
+          'ghcr.io/kubeflow/model-registry/ui-standalone:latest'
+        ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Sanitize image name for SARIF filename
+        run: |
+          # Replace special characters with hyphens and convert to lowercase
+          SANITIZED_NAME=$(echo "${{ matrix.IMAGE }}" | sed 's/[^a-zA-Z0-9._-]/-/g' | tr '[:upper:]' '[:lower:]')
+          echo "SANITIZED_IMAGE_NAME=${SANITIZED_NAME}" >> $GITHUB_ENV
+          echo "Sanitized image name: ${SANITIZED_NAME}"
+
+      - name: trivy scan for github security tab
+        uses: aquasecurity/trivy-action@0.32.0
+        with:
+          image-ref: '${{ matrix.IMAGE }}'
+          format: 'sarif'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          output: 'trivy-results-${{ env.SANITIZED_IMAGE_NAME }}.sarif'
+          timeout: 30m0s
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results-${{ env.SANITIZED_IMAGE_NAME }}.sarif'


### PR DESCRIPTION

## Description

implement Kubeflow Community guideline

make it similar to Spark Operator
for the published images by this Working Group, Model Registry execute the check weekly on the published images
and on-demand (helpful for testing, etc)

segregate result in individual files
in case of future debugging needs

thanks to discussion with @kramaranya.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
using from : https://github.com/kubeflow/spark-operator/blob/master/.github/workflows/trivy-image-scanning.yaml 
but making a matrix for the images which are published by this working group.

Since there is no easy way to effectively test this setup even with Act, relying on the GitHub Action workflow_dispatch and amending in future if needed

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
