### PR TITLE
[Async Upload] Add initial intent options for more usecases

### DIFF
--- a/jobs/async-upload/README.md
+++ b/jobs/async-upload/README.md
@@ -38,57 +38,60 @@ Below is a table of the configuration that can be passed into the job
 
 See asterisks below table for details
 
-| Environment Variable                         | Arg                                 | Default Value     | Required | Description                                                                             |
-| -------------------------------------------- | ----------------------------------- | ----------------- | -------- | --------------------------------------------------------------------------------------- |
-| MODEL_SYNC_SOURCE_TYPE                       | --source-type                       | s3                | ✅       |                                                                                         |
-| MODEL_SYNC_SOURCE_S3_CREDENTIALS_PATH        | --source-s3-credentials-path        |                   |          |                                                                                         |
-| MODEL_SYNC_SOURCE_OCI_CREDENTIALS_PATH       | --source-oci-credentials-path       |                   |          |                                                                                         |
-| MODEL_SYNC_SOURCE_URI_CREDENTIALS_PATH       | --source-uri-credentials-path       |                   |          |                                                                                         |
-| MODEL_SYNC_SOURCE_URI                        | --source-uri                        |                   | ✅\#     | When --source-type is "uri". The URI to download from                                   |
-| MODEL_SYNC_SOURCE_AWS_BUCKET                 | --source-aws-bucket                 |                   | ✅\*     | When --source-type is "s3"                                                              |
-| MODEL_SYNC_SOURCE_AWS_KEY                    | --source-aws-key                    |                   | ✅\*     | "                                                                                       |
-| MODEL_SYNC_SOURCE_AWS_REGION                 | --source-aws-region                 |                   |          | "                                                                                       |
-| MODEL_SYNC_SOURCE_AWS_ACCESS_KEY_ID          | --source-aws-access-key-id          |                   | ✅\*     | "                                                                                       |
-| MODEL_SYNC_SOURCE_AWS_SECRET_ACCESS_KEY      | --source-aws-secret-access-key      |                   | ✅\*     | "                                                                                       |
-| MODEL_SYNC_SOURCE_AWS_ENDPOINT               | --source-aws-endpoint               |                   |          | "                                                                                       |
-| MODEL_SYNC_SOURCE_OCI_URI                    | --source-oci-uri                    |                   | ✅\+     | When --source-type is "oci". The tag to use when pulling the image                      |
-| MODEL_SYNC_SOURCE_OCI_REGISTRY               | --source-oci-registry               |                   | ✅\+     | When --source-type is "oci". Indicates which registry the creds belong to               |
-| MODEL_SYNC_SOURCE_OCI_USERNAME               | --source-oci-username               |                   | ✅\+     | "                                                                                       |
-| MODEL_SYNC_SOURCE_OCI_PASSWORD               | --source-oci-password               |                   | ✅\+     | "                                                                                       |
-| MODEL_SYNC_DESTINATION_TYPE                  | --destination-type                  | oci               | ✅       |                                                                                         |
-| MODEL_SYNC_DESTINATION_S3_CREDENTIALS_PATH   | --destination-s3-credentials-path   |                   |          |                                                                                         |
-| MODEL_SYNC_DESTINATION_OCI_CREDENTIALS_PATH  | --destination-oci-credentials-path  |                   |          |                                                                                         |
-| MODEL_SYNC_DESTINATION_AWS_BUCKET            | --destination-aws-bucket            |                   | ✅\*     | When --destination-type is "s3"                                                         |
-| MODEL_SYNC_DESTINATION_AWS_KEY               | --destination-aws-key               |                   | ✅\*     | "                                                                                       |
-| MODEL_SYNC_DESTINATION_AWS_REGION            | --destination-aws-region            |                   |          | "                                                                                       |
-| MODEL_SYNC_DESTINATION_AWS_ACCESS_KEY_ID     | --destination-aws-access-key-id     |                   | ✅\*     | "                                                                                       |
-| MODEL_SYNC_DESTINATION_AWS_SECRET_ACCESS_KEY | --destination-aws-secret-access-key |                   | ✅\*     | "                                                                                       |
-| MODEL_SYNC_DESTINATION_AWS_ENDPOINT          | --destination-aws-endpoint          |                   |          | "                                                                                       |
-| MODEL_SYNC_DESTINATION_OCI_URI               | --destination-oci-uri               |                   | ✅\+     | When --destination-type is "oci". The tag to use when pushing the image                 |
-| MODEL_SYNC_DESTINATION_OCI_REGISTRY          | --destination-oci-registry          |                   | ✅\+     | When --destination-type is "oci". Indicates which registry the creds belong to          |
-| MODEL_SYNC_DESTINATION_OCI_USERNAME          | --destination-oci-username          |                   | ✅\+     | "                                                                                       |
-| MODEL_SYNC_DESTINATION_OCI_PASSWORD          | --destination-oci-password          |                   | ✅\+     | "                                                                                       |
-| MODEL_SYNC_DESTINATION_OCI_BASE_IMAGE        | --destination-oci-base-image        | busybox:latest    |          | When --destination-type is "oci". The image to use when pushing to an OCI registry      |
-| MODEL_SYNC_DESTINATION_OCI_ENABLE_TLS_VERIFY | --destination-oci-enable-tls-verify | true              |          | When --destination-type is "oci". Specifies whether to use TLS when pushing to registry |
-| MODEL_SYNC_MODEL_ID                          | --model-id                          |                   | ✅       | The `RegisteredModel.id`                                                                |
-| MODEL_SYNC_VERSION_ID                        | --model-version-id                  |                   | ✅       | The `ModelVersion.id`                                                                   |
-| MODEL_SYNC_ARTIFACT_ID                       | --model-artifact-id                 |                   | ✅       | The `ModelArtifact.id`                                                                  |
-| MODEL_SYNC_STORAGE_PATH                      | --storage-path                      | `/tmp/model-sync` | ✅       | Temporary storage, must be large enough to hold the entire model                        |
-| MODEL_SYNC_REGISTRY_SERVER_ADDRESS           | --registry-server-address           |                   | ✅       | Server address for the model-registry client to connect to                              |
-| MODEL_SYNC_REGISTRY_PORT                     | --registry-port                     | 443               |          |                                                                                         |
-| MODEL_SYNC_REGISTRY_IS_SECURE                | --registry-is-secure                | True              |          |                                                                                         |
-| MODEL_SYNC_REGISTRY_AUTHOR                   | --registry-author                   |                   |          |                                                                                         |
-| MODEL_SYNC_REGISTRY_USER_TOKEN               | --registry-user-token               |                   |          |                                                                                         |
-| MODEL_SYNC_REGISTRY_USER_TOKEN_ENVVAR        | --registry-user-token-envvar        |                   |          |                                                                                         |
-| MODEL_SYNC_REGISTRY_CUSTOM_CA                | --registry-custom-ca                |                   |          |                                                                                         |
-| MODEL_SYNC_REGISTRY_CUSTOM_CA_ENVVAR         | --registry-custom-ca-envvar         |                   |          |                                                                                         |
-| MODEL_SYNC_REGISTRY_LOG_LEVEL                | --registry-log-level                |                   |          |                                                                                         |
+| Environment Variable                         | Arg                                 | Default Value     | Required | Description                                                                                            |
+| -------------------------------------------- | ----------------------------------- | ----------------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| MODEL_SYNC_SOURCE_TYPE                       | --source-type                       | s3                | ✅       |                                                                                                        |
+| MODEL_SYNC_SOURCE_S3_CREDENTIALS_PATH        | --source-s3-credentials-path        |                   |          |                                                                                                        |
+| MODEL_SYNC_SOURCE_OCI_CREDENTIALS_PATH       | --source-oci-credentials-path       |                   |          |                                                                                                        |
+| MODEL_SYNC_SOURCE_URI_CREDENTIALS_PATH       | --source-uri-credentials-path       |                   |          |                                                                                                        |
+| MODEL_SYNC_SOURCE_URI                        | --source-uri                        |                   | ✅\#     | When --source-type is "uri". The URI to download from                                                  |
+| MODEL_SYNC_SOURCE_AWS_BUCKET                 | --source-aws-bucket                 |                   | ✅\*     | When --source-type is "s3"                                                                             |
+| MODEL_SYNC_SOURCE_AWS_KEY                    | --source-aws-key                    |                   | ✅\*     | "                                                                                                      |
+| MODEL_SYNC_SOURCE_AWS_REGION                 | --source-aws-region                 |                   |          | "                                                                                                      |
+| MODEL_SYNC_SOURCE_AWS_ACCESS_KEY_ID          | --source-aws-access-key-id          |                   | ✅\*     | "                                                                                                      |
+| MODEL_SYNC_SOURCE_AWS_SECRET_ACCESS_KEY      | --source-aws-secret-access-key      |                   | ✅\*     | "                                                                                                      |
+| MODEL_SYNC_SOURCE_AWS_ENDPOINT               | --source-aws-endpoint               |                   |          | "                                                                                                      |
+| MODEL_SYNC_SOURCE_OCI_URI                    | --source-oci-uri                    |                   | ✅\+     | When --source-type is "oci". The tag to use when pulling the image                                     |
+| MODEL_SYNC_SOURCE_OCI_REGISTRY               | --source-oci-registry               |                   | ✅\+     | When --source-type is "oci". Indicates which registry the creds belong to                              |
+| MODEL_SYNC_SOURCE_OCI_USERNAME               | --source-oci-username               |                   | ✅\+     | "                                                                                                      |
+| MODEL_SYNC_SOURCE_OCI_PASSWORD               | --source-oci-password               |                   | ✅\+     | "                                                                                                      |
+| MODEL_SYNC_DESTINATION_TYPE                  | --destination-type                  | oci               | ✅       |                                                                                                        |
+| MODEL_SYNC_DESTINATION_S3_CREDENTIALS_PATH   | --destination-s3-credentials-path   |                   |          |                                                                                                        |
+| MODEL_SYNC_DESTINATION_OCI_CREDENTIALS_PATH  | --destination-oci-credentials-path  |                   |          |                                                                                                        |
+| MODEL_SYNC_DESTINATION_AWS_BUCKET            | --destination-aws-bucket            |                   | ✅\*     | When --destination-type is "s3"                                                                        |
+| MODEL_SYNC_DESTINATION_AWS_KEY               | --destination-aws-key               |                   | ✅\*     | "                                                                                                      |
+| MODEL_SYNC_DESTINATION_AWS_REGION            | --destination-aws-region            |                   |          | "                                                                                                      |
+| MODEL_SYNC_DESTINATION_AWS_ACCESS_KEY_ID     | --destination-aws-access-key-id     |                   | ✅\*     | "                                                                                                      |
+| MODEL_SYNC_DESTINATION_AWS_SECRET_ACCESS_KEY | --destination-aws-secret-access-key |                   | ✅\*     | "                                                                                                      |
+| MODEL_SYNC_DESTINATION_AWS_ENDPOINT          | --destination-aws-endpoint          |                   |          | "                                                                                                      |
+| MODEL_SYNC_DESTINATION_OCI_URI               | --destination-oci-uri               |                   | ✅\+     | When --destination-type is "oci". The tag to use when pushing the image                                |
+| MODEL_SYNC_DESTINATION_OCI_REGISTRY          | --destination-oci-registry          |                   | ✅\+     | When --destination-type is "oci". Indicates which registry the creds belong to                         |
+| MODEL_SYNC_DESTINATION_OCI_USERNAME          | --destination-oci-username          |                   | ✅\+     | "                                                                                                      |
+| MODEL_SYNC_DESTINATION_OCI_PASSWORD          | --destination-oci-password          |                   | ✅\+     | "                                                                                                      |
+| MODEL_SYNC_DESTINATION_OCI_BASE_IMAGE        | --destination-oci-base-image        | busybox:latest    |          | When --destination-type is "oci". The image to use when pushing to an OCI registry                     |
+| MODEL_SYNC_DESTINATION_OCI_ENABLE_TLS_VERIFY | --destination-oci-enable-tls-verify | true              |          | When --destination-type is "oci". Specifies whether to use TLS when pushing to registry                |
+| MODEL_SYNC_UPLOAD_INTENT                     | --model-upload-intent               | update_artifact   |          | The intent of the upload job. Options include `["create_model", "create_version", "update_artifact"]`. |
+| MODEL_SYNC_MODEL_ID                          | --model-id                          |                   | ✅\%     | The `RegisteredModel.id`                                                                               |
+| MODEL_SYNC_VERSION_ID                        | --model-version-id                  |                   | ✅\%     | The `ModelVersion.id`                                                                                  |
+| MODEL_SYNC_ARTIFACT_ID                       | --model-artifact-id                 |                   | ✅\%     | The `ModelArtifact.id`                                                                                 |
+| MODEL_SYNC_STORAGE_PATH                      | --storage-path                      | `/tmp/model-sync` | ✅       | Temporary storage, must be large enough to hold the entire model                                       |
+| MODEL_SYNC_REGISTRY_SERVER_ADDRESS           | --registry-server-address           |                   | ✅       | Server address for the model-registry client to connect to                                             |
+| MODEL_SYNC_REGISTRY_PORT                     | --registry-port                     | 443               |          |                                                                                                        |
+| MODEL_SYNC_REGISTRY_IS_SECURE                | --registry-is-secure                | True              |          |                                                                                                        |
+| MODEL_SYNC_REGISTRY_AUTHOR                   | --registry-author                   |                   |          |                                                                                                        |
+| MODEL_SYNC_REGISTRY_USER_TOKEN               | --registry-user-token               |                   |          |                                                                                                        |
+| MODEL_SYNC_REGISTRY_USER_TOKEN_ENVVAR        | --registry-user-token-envvar        |                   |          |                                                                                                        |
+| MODEL_SYNC_REGISTRY_CUSTOM_CA                | --registry-custom-ca                |                   |          |                                                                                                        |
+| MODEL_SYNC_REGISTRY_CUSTOM_CA_ENVVAR         | --registry-custom-ca-envvar         |                   |          |                                                                                                        |
+| MODEL_SYNC_REGISTRY_LOG_LEVEL                | --registry-log-level                |                   |          |                                                                                                        |
 
 ✅\*: Must be present in some form when the source/destination is `s3`. This might be from the parameter in the table, or from the credentials file(s) that was specified/provided.
 
 ✅\+: Must be present in some from when the source/destination is `oci`. This might be from the parameter in the table, or from the credentials file(s) that was specified/provided.
 
 ✅\#: Must be present in some form when the source is `uri`. This might be from the parameter in the table, or from the credentials file(s) that was specified/provided.
+
+✅\%: Must be present in some form depending on what the `model-upload-intent` is set to.
 
 ## References
 

--- a/jobs/async-upload/job/config.py
+++ b/jobs/async-upload/job/config.py
@@ -76,7 +76,7 @@ def _parser() -> cap.ArgumentParser:
     p.add_argument(
         "--model-upload-intent", 
         type=UploadIntent, 
-        choices=[UploadIntent.create_model, UploadIntent.create_version, UploadIntent.update_artifact], 
+        choices=tuple(UploadIntent), 
         default=UploadIntent.update_artifact
     )
     p.add_argument("--model-id")

--- a/jobs/async-upload/job/config.py
+++ b/jobs/async-upload/job/config.py
@@ -19,7 +19,8 @@ from .models import (
     URISourceConfig,
     SourceType,
     DestinationType,
-    URISourceStorageConfig
+    URISourceStorageConfig,
+    UploadIntent
 )
 
 logger = logging.getLogger(__name__)
@@ -71,6 +72,13 @@ def _parser() -> cap.ArgumentParser:
     p.add_argument("--destination-oci-enable-tls-verify", default=True, type=str2bool)
 
     # --- model-registry model data ---
+    # This intent determines the action to take once the model has been uploaded to the destination.
+    p.add_argument(
+        "--model-upload-intent", 
+        type=UploadIntent, 
+        choices=[UploadIntent.create_model, UploadIntent.create_version, UploadIntent.update_artifact], 
+        default=UploadIntent.update_artifact
+    )
     p.add_argument("--model-id")
     p.add_argument("--model-version-id")
     p.add_argument("--model-artifact-id")
@@ -361,6 +369,7 @@ def get_config(argv: list[str] | None = None) -> AsyncUploadConfig:
             source=source_config,
             destination=destination_config,
             model=ModelConfig(
+                upload_intent=args.model_upload_intent,
                 id=args.model_id,
                 version_id=args.model_version_id,
                 artifact_id=args.model_artifact_id,

--- a/jobs/async-upload/job/models.py
+++ b/jobs/async-upload/job/models.py
@@ -4,7 +4,7 @@ Configuration models for the async upload job using Pydantic for type safety and
 from __future__ import annotations
 from enum import StrEnum
 import logging
-from typing import Any, Union
+from typing import Union
 from pydantic import BaseModel, Field, model_validator, ConfigDict
 
 
@@ -96,18 +96,29 @@ class URISourceStorageConfig(BaseStorageConfig, URISourceConfig):
 SourceConfig = Union[S3StorageConfig, OCIStorageConfig, URISourceStorageConfig]
 DestinationConfig = Union[S3StorageConfig, OCIStorageConfig]
 
+class UploadIntent(StrEnum):
+    create_model = "create_model"
+    create_version = "create_version"
+    update_artifact = "update_artifact"
 
 class ModelConfig(BaseModel):
     """Model registry model information."""
-    id: str = Field(..., description="Model ID")
-    version_id: str = Field(..., description="Model version ID")
-    artifact_id: str = Field(..., description="Model artifact ID")
+    upload_intent: UploadIntent = Field(UploadIntent.update_artifact, description="Model upload intent")
+    id: str | None = Field(..., description="Model ID")
+    version_id: str | None = Field(..., description="Model version ID")
+    artifact_id: str | None = Field(..., description="Model artifact ID")
 
     @model_validator(mode='after')
     def validate_model_ids(self) -> 'ModelConfig':
         """Validate that all model IDs are provided."""
-        if not all([self.id, self.version_id, self.artifact_id]):
-            raise ValueError("Model ID, version ID and artifact ID must be set")
+        if self.upload_intent == UploadIntent.create_model:
+            return self
+        elif self.upload_intent == UploadIntent.create_version:
+            if not self.id:
+                raise ValueError("Model ID must be set when intent is create_version")
+        elif self.upload_intent == UploadIntent.update_artifact:
+            if not self.artifact_id:
+                raise ValueError("Model Artifact ID must be set when intent is update_artifact")
         return self
 
 

--- a/jobs/async-upload/job/models.py
+++ b/jobs/async-upload/job/models.py
@@ -104,15 +104,17 @@ class UploadIntent(StrEnum):
 class ModelConfig(BaseModel):
     """Model registry model information."""
     upload_intent: UploadIntent = Field(UploadIntent.update_artifact, description="Model upload intent")
-    id: str | None = Field(..., description="Model ID")
-    version_id: str | None = Field(..., description="Model version ID")
-    artifact_id: str | None = Field(..., description="Model artifact ID")
+    id: str | None = Field(None, description="Model ID")
+    version_id: str | None = Field(None, description="Model version ID")
+    artifact_id: str | None = Field(None, description="Model artifact ID")
 
     @model_validator(mode='after')
     def validate_model_ids(self) -> 'ModelConfig':
         """Validate that all model IDs are provided."""
         if self.upload_intent == UploadIntent.create_model:
-            return self
+            # No ids should be set when intent is create_model
+            if any([self.id, self.version_id, self.artifact_id]):
+                raise ValueError("Model ID, Model Version ID and Model Artifact ID cannot be set when intent is create_model")
         elif self.upload_intent == UploadIntent.create_version:
             if not self.id:
                 raise ValueError("Model ID must be set when intent is create_version")

--- a/jobs/async-upload/job/models.py
+++ b/jobs/async-upload/job/models.py
@@ -118,9 +118,13 @@ class ModelConfig(BaseModel):
         elif self.upload_intent == UploadIntent.create_version:
             if not self.id:
                 raise ValueError("Model ID must be set when intent is create_version")
+            elif any([self.version_id, self.artifact_id]):
+                raise ValueError("Model Version ID and Model Artifact ID cannot be set when intent is create_version")
         elif self.upload_intent == UploadIntent.update_artifact:
             if not self.artifact_id:
                 raise ValueError("Model Artifact ID must be set when intent is update_artifact")
+            elif any([self.id, self.version_id]):
+                raise ValueError("Model ID and Model Version ID cannot be set when intent is update_artifact")
         return self
 
 

--- a/jobs/async-upload/samples/sample_job_s3_to_oci.yaml
+++ b/jobs/async-upload/samples/sample_job_s3_to_oci.yaml
@@ -117,10 +117,8 @@ spec:
               value: "false"
 
             # ---- Model Params ----
-            - name: MODEL_SYNC_MODEL_ID
-              value: "1"
-            - name: MODEL_SYNC_MODEL_VERSION_ID
-              value: "3"
+            - name: MODEL_SYNC_UPLOAD_INTENT
+              value: "update_artifact"
             - name: MODEL_SYNC_MODEL_ARTIFACT_ID
               value: "6"
 

--- a/jobs/async-upload/tests/integration/test_integration_async_upload.py
+++ b/jobs/async-upload/tests/integration/test_integration_async_upload.py
@@ -81,8 +81,7 @@ def apply_job_with_strategic_merge(
     import time
 
     patch_env = {
-        "MODEL_SYNC_MODEL_ID": rm_id,
-        "MODEL_SYNC_MODEL_VERSION_ID": mv_id,
+        "MODEL_SYNC_UPLOAD_INTENT": "update_artifact",
         "MODEL_SYNC_MODEL_ARTIFACT_ID": ma_id,
         **env,
     }

--- a/jobs/async-upload/tests/test_download.py
+++ b/jobs/async-upload/tests/test_download.py
@@ -19,7 +19,7 @@ DUMMY_FILE_DATA = {
 
 
 @pytest.fixture
-def minimal_env_source_dest_vars():
+def minimal_update_artifact_env_source_dest_vars():
     original_env = dict(os.environ)
 
     # Destination variables
@@ -49,8 +49,7 @@ def minimal_env_source_dest_vars():
 
     # Model and registry variables
     model_vars = {
-        "model_id": "abc",
-        "model_version_id": "def",
+        "model_upload_intent": "update_artifact",
         "model_artifact_id": "123",
         "registry_server_address": "http://localhost",
         "registry_port": "8080",
@@ -114,7 +113,7 @@ def test_unpack_archive_file(dummy_archive, tmp_path):
     assert result == DUMMY_FILE_DATA
 
 
-def test_download_from_s3(minimal_env_source_dest_vars):
+def test_download_from_s3(minimal_update_artifact_env_source_dest_vars):
     """Test download_from_s3 now that it pages through prefixes."""
 
     # load config from your fixture
@@ -202,7 +201,7 @@ def test_download_from_s3(minimal_env_source_dest_vars):
         )
 
 
-def test_download_from_s3_with_region(minimal_env_source_dest_vars):
+def test_download_from_s3_with_region(minimal_update_artifact_env_source_dest_vars):
     """Test download_from_s3 function with region specified"""
 
     # Set region in environment
@@ -250,7 +249,7 @@ def test_download_from_s3_with_region(minimal_env_source_dest_vars):
         )
 
 
-def test_download_from_s3_connection_error(minimal_env_source_dest_vars):
+def test_download_from_s3_connection_error(minimal_update_artifact_env_source_dest_vars):
     """Test download_from_s3 function when S3 connection fails"""
 
     config = get_config([])
@@ -270,7 +269,7 @@ def test_download_from_s3_connection_error(minimal_env_source_dest_vars):
                 download_from_s3(config.source, config.storage.path)
 
 
-def test_download_from_s3_download_error(minimal_env_source_dest_vars):
+def test_download_from_s3_download_error(minimal_update_artifact_env_source_dest_vars):
     """Test download_from_s3 function when file download fails"""
 
     config = get_config([])

--- a/jobs/async-upload/tests/test_models.py
+++ b/jobs/async-upload/tests/test_models.py
@@ -10,147 +10,57 @@ from job.models import ModelConfig, UploadIntent
 class TestModelConfigValidateModelIds:
     """Test cases for ModelConfig.validate_model_ids method"""
 
-    def test_create_model_intent_with_all_ids_succeeds(self):
-        """Test that create_model intent succeeds when all required IDs are provided"""
+    def test_create_model_intent_with_no_ids_succeeds(self):
+        """Test that create_model intent succeeds when no ids are provided"""
         config = ModelConfig(
             upload_intent=UploadIntent.create_model,
-            id="test-model-id",
-            version_id="test-version-id",
-            artifact_id="test-artifact-id"
         )
         
         # Should not raise any validation errors
         assert config.upload_intent == UploadIntent.create_model
-        assert config.id == "test-model-id"
-        assert config.version_id == "test-version-id"
-        assert config.artifact_id == "test-artifact-id"
 
-    def test_create_model_intent_no_validation(self):
-        """Test that create_model intent has no validation requirements"""
-        # Should succeed even with empty strings since create_model has no validation
-        config = ModelConfig(
-            upload_intent=UploadIntent.create_model,
-            id="",  # Empty string - should be fine
-            version_id="",  # Empty string - should be fine
-            artifact_id=""  # Empty string - should be fine
-        )
+    def test_create_model_intent_with_any_id_fails(self):
+        """Test that create_model intent fails when any id is provided"""
+        expected_error_message = "Model ID, Model Version ID and Model Artifact ID cannot be set when intent is create_model"
         
-        # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.create_model
-        assert config.id == ""
-        assert config.version_id == ""
-        assert config.artifact_id == ""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelConfig(
+                upload_intent=UploadIntent.create_model,
+                id="fail",
+            )
+        assert expected_error_message in str(exc_info.value)
 
-    def test_create_model_intent_with_partial_data_succeeds(self):
-        """Test that create_model intent succeeds with partial data"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.create_model,
-            id="test-model-id",
-            version_id="",  # Empty string - should be fine
-            artifact_id="test-artifact-id"
-        )
-        
-        # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.create_model
-        assert config.id == "test-model-id"
-        assert config.version_id == ""
-        assert config.artifact_id == "test-artifact-id"
+        with pytest.raises(ValidationError) as exc_info:
+            ModelConfig(
+                upload_intent=UploadIntent.create_model,
+                version_id="fail",
+            )
+        assert expected_error_message in str(exc_info.value)
 
-    def test_create_model_intent_with_mixed_data_succeeds(self):
-        """Test that create_model intent succeeds with mixed data"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.create_model,
-            id="test-model-id",
-            version_id="test-version-id",
-            artifact_id=""  # Empty string - should be fine
-        )
-        
-        # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.create_model
-        assert config.id == "test-model-id"
-        assert config.version_id == "test-version-id"
-        assert config.artifact_id == ""
-
-    def test_create_model_intent_allows_all_empty_ids(self):
-        """Test that create_model intent allows all empty IDs"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.create_model,
-            id="",
-            version_id="",
-            artifact_id=""
-        )
-        
-        # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.create_model
-        assert config.id == ""
-        assert config.version_id == ""
-        assert config.artifact_id == ""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelConfig(
+                upload_intent=UploadIntent.create_model,
+                artifact_id="fail",
+            )
+        assert expected_error_message in str(exc_info.value)
 
     def test_create_version_intent_with_required_ids_succeeds(self):
         """Test that create_version intent succeeds when model ID and version ID are provided"""
         config = ModelConfig(
             upload_intent=UploadIntent.create_version,
             id="test-model-id",
-            version_id="test-version-id",
-            artifact_id="test-artifact-id"  # Can be provided but not required
         )
         
         # Should not raise any validation errors
         assert config.upload_intent == UploadIntent.create_version
         assert config.id == "test-model-id"
-        assert config.version_id == "test-version-id"
-        assert config.artifact_id == "test-artifact-id"
-
-    def test_create_version_intent_without_artifact_id_succeeds(self):
-        """Test that create_version intent succeeds without artifact ID"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.create_version,
-            id="test-model-id",
-            version_id="test-version-id",
-            artifact_id="any-value"  # Not validated for create_version
-        )
-        
-        # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.create_version
-        assert config.id == "test-model-id"
-        assert config.version_id == "test-version-id"
 
     def test_create_version_intent_missing_model_id_fails(self):
         """Test that create_version intent fails when model ID is missing"""
         with pytest.raises(ValidationError) as exc_info:
             ModelConfig(
                 upload_intent=UploadIntent.create_version,
-                id="",  # Empty string
-                version_id="test-version-id",
-                artifact_id="test-artifact-id"
-            )
-        
-        error_message = str(exc_info.value)
-        assert "Model ID must be set when intent is create_version" in error_message
-
-    def test_create_version_intent_without_version_id_succeeds(self):
-        """Test that create_version intent succeeds without version ID (only model ID required)"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.create_version,
-            id="test-model-id",
-            version_id="",  # Empty string - should be fine
-            artifact_id="test-artifact-id"
-        )
-        
-        # Should not raise any validation errors since only model ID is required
-        assert config.upload_intent == UploadIntent.create_version
-        assert config.id == "test-model-id"
-        assert config.version_id == ""
-        assert config.artifact_id == "test-artifact-id"
-
-    def test_create_version_intent_missing_model_id_only_fails(self):
-        """Test that create_version intent fails only when model ID is missing"""
-        with pytest.raises(ValidationError) as exc_info:
-            ModelConfig(
-                upload_intent=UploadIntent.create_version,
-                id="",  # Empty string - this should fail
-                version_id="",  # Empty string - this is fine
-                artifact_id="test-artifact-id"
+                # model id is missing
             )
         
         error_message = str(exc_info.value)
@@ -167,16 +77,13 @@ class TestModelConfigValidateModelIds:
         
         # Should not raise any validation errors
         assert config.upload_intent == UploadIntent.update_artifact
-        assert config.id == "test-model-id"
-        assert config.version_id == "test-version-id"
         assert config.artifact_id == "test-artifact-id"
 
     def test_update_artifact_intent_without_model_and_version_ids_succeeds(self):
         """Test that update_artifact intent succeeds without model ID and version ID"""
         config = ModelConfig(
             upload_intent=UploadIntent.update_artifact,
-            id="any-value",  # Not validated for update_artifact
-            version_id="any-value",  # Not validated for update_artifact
+            # no model id or version id
             artifact_id="test-artifact-id"
         )
         
@@ -190,8 +97,6 @@ class TestModelConfigValidateModelIds:
             ModelConfig(
                 upload_intent=UploadIntent.update_artifact,
                 id="test-model-id",
-                version_id="test-version-id",
-                artifact_id=""  # Empty string
             )
         
         error_message = str(exc_info.value)
@@ -200,74 +105,9 @@ class TestModelConfigValidateModelIds:
     def test_default_intent_is_update_artifact(self):
         """Test that the default upload intent is update_artifact"""
         config = ModelConfig(
-            id="test-model-id",
-            version_id="test-version-id",
+            # intent is not set
             artifact_id="test-artifact-id"
         )
         
         # Default should be update_artifact
         assert config.upload_intent == UploadIntent.update_artifact
-
-    def test_default_intent_validation_with_valid_artifact_id(self):
-        """Test that default intent (update_artifact) validates correctly with artifact ID"""
-        config = ModelConfig(
-            id="test-model-id",
-            version_id="test-version-id",
-            artifact_id="test-artifact-id"
-        )
-        
-        # Should not raise any validation errors with default intent
-        assert config.upload_intent == UploadIntent.update_artifact
-        assert config.artifact_id == "test-artifact-id"
-
-    def test_default_intent_validation_fails_without_artifact_id(self):
-        """Test that default intent (update_artifact) validation fails without artifact ID"""
-        with pytest.raises(ValidationError) as exc_info:
-            ModelConfig(
-                id="test-model-id",
-                version_id="test-version-id",
-                artifact_id=""  # Empty string
-            )
-        
-        error_message = str(exc_info.value)
-        assert "Model Artifact ID must be set when intent is update_artifact" in error_message
-
-    def test_pydantic_field_validation_prevents_none_values(self):
-        """Test that Pydantic field validation prevents None values for required fields"""
-        # Pydantic should prevent None values due to Field(...) constraints
-        with pytest.raises(ValidationError):
-            ModelConfig(
-                upload_intent=UploadIntent.update_artifact,
-                id="test-model-id",
-                version_id="test-version-id",
-                artifact_id=None  # This should be caught by Pydantic field validation
-            )
-
-    def test_whitespace_only_strings_behavior(self):
-        """Test behavior with whitespace-only strings for different intents"""
-        # create_model: No validation, so whitespace is fine
-        config1 = ModelConfig(
-            upload_intent=UploadIntent.create_model,
-            id="   ",  # Whitespace only - fine for create_model
-            version_id="   ",
-            artifact_id="   "
-        )
-        assert config1.upload_intent == UploadIntent.create_model
-        
-        # create_version: Only validates model ID, whitespace-only string is truthy
-        config2 = ModelConfig(
-            upload_intent=UploadIntent.create_version,
-            id="   ",  # Whitespace only - truthy, so validation passes
-            version_id="",
-            artifact_id=""
-        )
-        assert config2.upload_intent == UploadIntent.create_version
-        
-        # update_artifact: Only validates artifact ID, whitespace-only string is truthy
-        config3 = ModelConfig(
-            upload_intent=UploadIntent.update_artifact,
-            id="",
-            version_id="",
-            artifact_id="   "  # Whitespace only - truthy, so validation passes
-        )
-        assert config3.upload_intent == UploadIntent.update_artifact

--- a/jobs/async-upload/tests/test_models.py
+++ b/jobs/async-upload/tests/test_models.py
@@ -70,8 +70,6 @@ class TestModelConfigValidateModelIds:
         """Test that update_artifact intent succeeds when artifact ID is provided"""
         config = ModelConfig(
             upload_intent=UploadIntent.update_artifact,
-            id="test-model-id",  # Can be provided but not required
-            version_id="test-version-id",  # Can be provided but not required
             artifact_id="test-artifact-id"
         )
         

--- a/jobs/async-upload/tests/test_models.py
+++ b/jobs/async-upload/tests/test_models.py
@@ -1,0 +1,273 @@
+"""
+Unit tests for models.py - specifically testing model validation logic.
+"""
+import pytest
+from pydantic import ValidationError
+
+from job.models import ModelConfig, UploadIntent
+
+
+class TestModelConfigValidateModelIds:
+    """Test cases for ModelConfig.validate_model_ids method"""
+
+    def test_create_model_intent_with_all_ids_succeeds(self):
+        """Test that create_model intent succeeds when all required IDs are provided"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.create_model,
+            id="test-model-id",
+            version_id="test-version-id",
+            artifact_id="test-artifact-id"
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.create_model
+        assert config.id == "test-model-id"
+        assert config.version_id == "test-version-id"
+        assert config.artifact_id == "test-artifact-id"
+
+    def test_create_model_intent_no_validation(self):
+        """Test that create_model intent has no validation requirements"""
+        # Should succeed even with empty strings since create_model has no validation
+        config = ModelConfig(
+            upload_intent=UploadIntent.create_model,
+            id="",  # Empty string - should be fine
+            version_id="",  # Empty string - should be fine
+            artifact_id=""  # Empty string - should be fine
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.create_model
+        assert config.id == ""
+        assert config.version_id == ""
+        assert config.artifact_id == ""
+
+    def test_create_model_intent_with_partial_data_succeeds(self):
+        """Test that create_model intent succeeds with partial data"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.create_model,
+            id="test-model-id",
+            version_id="",  # Empty string - should be fine
+            artifact_id="test-artifact-id"
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.create_model
+        assert config.id == "test-model-id"
+        assert config.version_id == ""
+        assert config.artifact_id == "test-artifact-id"
+
+    def test_create_model_intent_with_mixed_data_succeeds(self):
+        """Test that create_model intent succeeds with mixed data"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.create_model,
+            id="test-model-id",
+            version_id="test-version-id",
+            artifact_id=""  # Empty string - should be fine
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.create_model
+        assert config.id == "test-model-id"
+        assert config.version_id == "test-version-id"
+        assert config.artifact_id == ""
+
+    def test_create_model_intent_allows_all_empty_ids(self):
+        """Test that create_model intent allows all empty IDs"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.create_model,
+            id="",
+            version_id="",
+            artifact_id=""
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.create_model
+        assert config.id == ""
+        assert config.version_id == ""
+        assert config.artifact_id == ""
+
+    def test_create_version_intent_with_required_ids_succeeds(self):
+        """Test that create_version intent succeeds when model ID and version ID are provided"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.create_version,
+            id="test-model-id",
+            version_id="test-version-id",
+            artifact_id="test-artifact-id"  # Can be provided but not required
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.create_version
+        assert config.id == "test-model-id"
+        assert config.version_id == "test-version-id"
+        assert config.artifact_id == "test-artifact-id"
+
+    def test_create_version_intent_without_artifact_id_succeeds(self):
+        """Test that create_version intent succeeds without artifact ID"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.create_version,
+            id="test-model-id",
+            version_id="test-version-id",
+            artifact_id="any-value"  # Not validated for create_version
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.create_version
+        assert config.id == "test-model-id"
+        assert config.version_id == "test-version-id"
+
+    def test_create_version_intent_missing_model_id_fails(self):
+        """Test that create_version intent fails when model ID is missing"""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelConfig(
+                upload_intent=UploadIntent.create_version,
+                id="",  # Empty string
+                version_id="test-version-id",
+                artifact_id="test-artifact-id"
+            )
+        
+        error_message = str(exc_info.value)
+        assert "Model ID must be set when intent is create_version" in error_message
+
+    def test_create_version_intent_without_version_id_succeeds(self):
+        """Test that create_version intent succeeds without version ID (only model ID required)"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.create_version,
+            id="test-model-id",
+            version_id="",  # Empty string - should be fine
+            artifact_id="test-artifact-id"
+        )
+        
+        # Should not raise any validation errors since only model ID is required
+        assert config.upload_intent == UploadIntent.create_version
+        assert config.id == "test-model-id"
+        assert config.version_id == ""
+        assert config.artifact_id == "test-artifact-id"
+
+    def test_create_version_intent_missing_model_id_only_fails(self):
+        """Test that create_version intent fails only when model ID is missing"""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelConfig(
+                upload_intent=UploadIntent.create_version,
+                id="",  # Empty string - this should fail
+                version_id="",  # Empty string - this is fine
+                artifact_id="test-artifact-id"
+            )
+        
+        error_message = str(exc_info.value)
+        assert "Model ID must be set when intent is create_version" in error_message
+
+    def test_update_artifact_intent_with_artifact_id_succeeds(self):
+        """Test that update_artifact intent succeeds when artifact ID is provided"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.update_artifact,
+            id="test-model-id",  # Can be provided but not required
+            version_id="test-version-id",  # Can be provided but not required
+            artifact_id="test-artifact-id"
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.update_artifact
+        assert config.id == "test-model-id"
+        assert config.version_id == "test-version-id"
+        assert config.artifact_id == "test-artifact-id"
+
+    def test_update_artifact_intent_without_model_and_version_ids_succeeds(self):
+        """Test that update_artifact intent succeeds without model ID and version ID"""
+        config = ModelConfig(
+            upload_intent=UploadIntent.update_artifact,
+            id="any-value",  # Not validated for update_artifact
+            version_id="any-value",  # Not validated for update_artifact
+            artifact_id="test-artifact-id"
+        )
+        
+        # Should not raise any validation errors
+        assert config.upload_intent == UploadIntent.update_artifact
+        assert config.artifact_id == "test-artifact-id"
+
+    def test_update_artifact_intent_missing_artifact_id_fails(self):
+        """Test that update_artifact intent fails when artifact ID is missing"""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelConfig(
+                upload_intent=UploadIntent.update_artifact,
+                id="test-model-id",
+                version_id="test-version-id",
+                artifact_id=""  # Empty string
+            )
+        
+        error_message = str(exc_info.value)
+        assert "Model Artifact ID must be set when intent is update_artifact" in error_message
+
+    def test_default_intent_is_update_artifact(self):
+        """Test that the default upload intent is update_artifact"""
+        config = ModelConfig(
+            id="test-model-id",
+            version_id="test-version-id",
+            artifact_id="test-artifact-id"
+        )
+        
+        # Default should be update_artifact
+        assert config.upload_intent == UploadIntent.update_artifact
+
+    def test_default_intent_validation_with_valid_artifact_id(self):
+        """Test that default intent (update_artifact) validates correctly with artifact ID"""
+        config = ModelConfig(
+            id="test-model-id",
+            version_id="test-version-id",
+            artifact_id="test-artifact-id"
+        )
+        
+        # Should not raise any validation errors with default intent
+        assert config.upload_intent == UploadIntent.update_artifact
+        assert config.artifact_id == "test-artifact-id"
+
+    def test_default_intent_validation_fails_without_artifact_id(self):
+        """Test that default intent (update_artifact) validation fails without artifact ID"""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelConfig(
+                id="test-model-id",
+                version_id="test-version-id",
+                artifact_id=""  # Empty string
+            )
+        
+        error_message = str(exc_info.value)
+        assert "Model Artifact ID must be set when intent is update_artifact" in error_message
+
+    def test_pydantic_field_validation_prevents_none_values(self):
+        """Test that Pydantic field validation prevents None values for required fields"""
+        # Pydantic should prevent None values due to Field(...) constraints
+        with pytest.raises(ValidationError):
+            ModelConfig(
+                upload_intent=UploadIntent.update_artifact,
+                id="test-model-id",
+                version_id="test-version-id",
+                artifact_id=None  # This should be caught by Pydantic field validation
+            )
+
+    def test_whitespace_only_strings_behavior(self):
+        """Test behavior with whitespace-only strings for different intents"""
+        # create_model: No validation, so whitespace is fine
+        config1 = ModelConfig(
+            upload_intent=UploadIntent.create_model,
+            id="   ",  # Whitespace only - fine for create_model
+            version_id="   ",
+            artifact_id="   "
+        )
+        assert config1.upload_intent == UploadIntent.create_model
+        
+        # create_version: Only validates model ID, whitespace-only string is truthy
+        config2 = ModelConfig(
+            upload_intent=UploadIntent.create_version,
+            id="   ",  # Whitespace only - truthy, so validation passes
+            version_id="",
+            artifact_id=""
+        )
+        assert config2.upload_intent == UploadIntent.create_version
+        
+        # update_artifact: Only validates artifact ID, whitespace-only string is truthy
+        config3 = ModelConfig(
+            upload_intent=UploadIntent.update_artifact,
+            id="",
+            version_id="",
+            artifact_id="   "  # Whitespace only - truthy, so validation passes
+        )
+        assert config3.upload_intent == UploadIntent.update_artifact

--- a/jobs/async-upload/tests/test_mr_client.py
+++ b/jobs/async-upload/tests/test_mr_client.py
@@ -26,8 +26,7 @@ def minimal_env_source_dest_vars():
         os.environ[f"MODEL_SYNC_SOURCE_{key.upper()}"] = value
 
     vars = {
-        "model_id": "abc",
-        "model_version_id": "def",
+        "model_upload_intent": "update_artifact",
         "model_artifact_id": "123",
         "registry_server_address": "http://localhost",
         "registry_port": "8080",

--- a/jobs/async-upload/tests/test_upload.py
+++ b/jobs/async-upload/tests/test_upload.py
@@ -34,8 +34,7 @@ class TestGetUploadParams:
                 region="us-east-1"
             ),
             model=ModelConfig(
-                id="test-model",
-                version_id="test-version", 
+                upload_intent="update_artifact",
                 artifact_id="test-artifact"
             ),
             storage=StorageConfig(path="/tmp/test"),
@@ -72,8 +71,7 @@ class TestGetUploadParams:
                 credentials_path="/tmp/test-creds"
             ),
             model=ModelConfig(
-                id="abc",
-                version_id="def",
+                upload_intent="update_artifact",
                 artifact_id="123"
             ),
             storage=StorageConfig(path="/tmp/test-model"),
@@ -119,8 +117,7 @@ class TestGetUploadParams:
                 credentials_path=None
             ),
             model=ModelConfig(
-                id="abc",
-                version_id="def",
+                upload_intent="update_artifact",
                 artifact_id="123"
             ),
             storage=StorageConfig(path="/tmp/test-model"),
@@ -166,8 +163,7 @@ class TestPerformUpload:
                 credentials_path="/tmp/test-creds"
             ),
             model=ModelConfig(
-                id="abc",
-                version_id="def",
+                upload_intent="update_artifact",
                 artifact_id="123"
             ),
             storage=StorageConfig(path="/tmp/test-model"),
@@ -205,8 +201,7 @@ class TestPerformUpload:
                 region="us-east-1"
             ),
             model=ModelConfig(
-                id="test-model",
-                version_id="1.0.0",
+                upload_intent="update_artifact",
                 artifact_id="test-artifact"
             ),
             storage=StorageConfig(path="/tmp/test-model"),
@@ -248,8 +243,7 @@ class TestPerformUpload:
                 credentials_path="/tmp/test-creds"
             ),
             model=ModelConfig(
-                id="abc",
-                version_id="def",
+                upload_intent="update_artifact",
                 artifact_id="123"
             ),
             storage=StorageConfig(path="/tmp/test-model"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is the initial phase to expand the capability of the async upload job. There are usecases where a user might want to perform more than simply "updating an artifact" once the async job completes.

Additional use cases include (but may not be limited to): fully-registering the model in the model-registry (providing all metadata required to register a new model) and adding an additional version to an existing registered model (and the metadata required for that)

This PR will just add these upload-intents as options, with the default setting to "upload_artifact" (the initial functionality).

This will not change the behavior of the system as-is, but does enable the expansion of these other upload intents safely.

## How Has This Been Tested?
Unit tests ensuring the default config behavior is maintained

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
