### PR TITLE
feat: add hint_server_address_port method with tests

### DIFF
--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -135,6 +135,7 @@ class ModelRegistry:
             else:
                 warn("User access token is missing", stacklevel=2)
 
+        self.hint_server_address_port(server_address, port)
         if is_secure:
             if (
                 not custom_ca
@@ -161,6 +162,20 @@ class ModelRegistry:
             )
         self._active_experiment_context = ThreadSafeVariable(value=RunContext())
         self.get_registered_models().page_size(1)._next_page()
+
+
+    @staticmethod
+    def hint_server_address_port(server_address: str, port: int) -> None:
+        """Hint based on server_address protocol if the port may not be the correct one."""
+        if server_address.startswith("https://") and not str(port).endswith("443"):
+            logger.warning(
+                "Server address protocol is https://, but port is not 443 or ending with 443. You may want to verify the configuration is correct."
+            )
+        if server_address.startswith("http://") and not str(port).endswith("80"):
+            logger.warning(
+                "Server address protocol is http://, but port is not 80 or ending with 80. You may want to verify the configuration is correct."
+            )
+
 
     def async_runner(self, coro: Awaitable[TModel]) -> TModel:
         if hasattr(self, "_user_async_runner"):

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,5 +1,7 @@
+import logging
 import os
 from itertools import islice
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -1206,3 +1208,75 @@ async def test_as_mlops_engineer_i_would_like_to_store_a_longer_documentation_fo
     )
     assert da
     assert da.uri == "https://README.md"
+
+
+class TestHintServerAddressPort:
+    """Test cases for the hint_server_address_port method via ModelRegistry constructor."""
+
+    @patch.object(ModelRegistry, 'get_registered_models')
+    def test_https_with_standard_port_no_warning(self, mock_get_registered_models, caplog):
+        """Test that no warning is issued when using HTTPS with port 443."""
+        mock_get_registered_models.return_value.page_size.return_value._next_page.return_value = None # Mock the method chain that's called in the constructor
+
+        with caplog.at_level(logging.WARNING):
+            ModelRegistry(server_address="https://example.com", port=443, author="test", user_token="test")
+
+        assert len(caplog.records) == 0
+
+
+    @patch.object(ModelRegistry, 'get_registered_models')
+    def test_https_with_port_ending_443_no_warning(self, mock_get_registered_models, caplog):
+        """Test that no warning is issued when using HTTPS with port ending in 443."""
+        mock_get_registered_models.return_value.page_size.return_value._next_page.return_value = None # Mock the method chain that's called in the constructor
+
+        with caplog.at_level(logging.WARNING):
+            ModelRegistry(server_address="https://example.com", port=8443, author="test", user_token="test")
+
+        assert len(caplog.records) == 0
+
+
+    @patch.object(ModelRegistry, 'get_registered_models')
+    def test_https_with_non_443_port_warning(self, mock_get_registered_models, caplog):
+        """Test that a warning is issued when using HTTPS with non-443 port."""
+        mock_get_registered_models.return_value.page_size.return_value._next_page.return_value = None # Mock the method chain that's called in the constructor
+
+        with caplog.at_level(logging.WARNING):
+            ModelRegistry(server_address="https://example.com", port=8080, author="test", user_token="test")
+
+        assert len(caplog.records) == 1
+        assert "Server address protocol is https://, but port is not 443 or ending with 443" in caplog.records[0].message
+
+
+    @patch.object(ModelRegistry, 'get_registered_models')
+    def test_http_with_standard_port_no_warning(self, mock_get_registered_models, caplog):
+        """Test that no warning is issued when using HTTP with port 80."""
+        mock_get_registered_models.return_value.page_size.return_value._next_page.return_value = None # Mock the method chain that's called in the constructor
+        
+        with caplog.at_level(logging.WARNING):
+            ModelRegistry(server_address="http://example.com", port=80, author="test", is_secure=False)
+        
+        assert len(caplog.records) == 0
+
+
+    @patch.object(ModelRegistry, 'get_registered_models')
+    def test_http_with_port_ending_80_no_warning(self, mock_get_registered_models, caplog):
+        """Test that no warning is issued when using HTTP with port ending in 80."""
+        mock_get_registered_models.return_value.page_size.return_value._next_page.return_value = None # Mock the method chain that's called in the constructor
+
+        with caplog.at_level(logging.WARNING):
+            ModelRegistry(server_address="http://example.com", port=8080, author="test", is_secure=False)
+
+        assert len(caplog.records) == 0
+
+
+    @patch.object(ModelRegistry, 'get_registered_models')
+    def test_http_with_non_80_port_warning(self, mock_get_registered_models, caplog):
+        """Test that a warning is issued when using HTTP with non-80 port."""
+        mock_get_registered_models.return_value.page_size.return_value._next_page.return_value = None # Mock the method chain that's called in the constructor
+
+        with caplog.at_level(logging.WARNING):
+            ModelRegistry(server_address="http://example.com", port=8443, author="test", is_secure=False)
+
+        assert len(caplog.records) == 1
+        assert "Server address protocol is http://, but port is not 80 or ending with 80" in caplog.records[0].message
+


### PR DESCRIPTION
Add static method to ModelRegistry client
that inspect server address protocol against port numbers, issuing warnings for potentially mismatched HTTPS/HTTP configurations. Method is called during ModelRegistry initialization to hint users to verify their setup.

For example, it took me a while to realize when copying a snippet from an example

```py
ModelRegistry("http://...",
    8080,
    author="myself",
    is_secure=False)
```

to another cluster where https:// had to be used,

```py
ModelRegistry("https://...",
    8080,
    author="myself")
```

as the error was a timeout error after several seconds, and not an immediate connection error when invoked on that cluster.

Sometimes user might overlook this as it happened to me so at this point emitting a warning could be beneficial.

This PR includes test suite covering different scenarios.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
