### PR TITLE
feat(client): add K8s SA token fallback for user authn

### DIFF
--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -128,10 +128,13 @@ class ModelRegistry:
             # /var/run/secrets/kubernetes.io/serviceaccount/token
             if sa_token := os.environ.get(user_token_envvar):
                 if user_token_envvar == DEFAULT_USER_TOKEN_ENVVAR:
-                    logger.warning(
+                    logger.info(
                         f"Sourcing user token from default envvar: {DEFAULT_USER_TOKEN_ENVVAR}"
                     )
                 user_token = Path(sa_token).read_text()
+            elif Path("/var/run/secrets/kubernetes.io/serviceaccount/token").exists():
+                user_token = Path("/var/run/secrets/kubernetes.io/serviceaccount/token").read_text()
+                logger.info("Sourced user token from K8s default path: /var/run/secrets/kubernetes.io/serviceaccount/token.")
             else:
                 warn("User access token is missing", stacklevel=2)
 

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -72,6 +72,7 @@ logging.basicConfig(
 logger = logging.getLogger("model-registry")
 
 DEFAULT_USER_TOKEN_ENVVAR = "KF_PIPELINES_SA_TOKEN_PATH"  # noqa: S105
+DEFAULT_K8S_SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token" # noqa: S105
 
 
 class ModelRegistry:
@@ -132,9 +133,9 @@ class ModelRegistry:
                         f"Sourcing user token from default envvar: {DEFAULT_USER_TOKEN_ENVVAR}"
                     )
                 user_token = Path(sa_token).read_text()
-            elif Path("/var/run/secrets/kubernetes.io/serviceaccount/token").exists():
-                user_token = Path("/var/run/secrets/kubernetes.io/serviceaccount/token").read_text()
-                logger.info("Sourced user token from K8s default path: /var/run/secrets/kubernetes.io/serviceaccount/token.")
+            elif Path(DEFAULT_K8S_SA_TOKEN_PATH).exists():
+                user_token = Path(DEFAULT_K8S_SA_TOKEN_PATH).read_text()
+                logger.info("Sourced user token from K8s default path: %s.", DEFAULT_K8S_SA_TOKEN_PATH)
             else:
                 warn("User access token is missing", stacklevel=2)
 

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from itertools import islice
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 import requests

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1210,25 +1210,6 @@ async def test_as_mlops_engineer_i_would_like_to_store_a_longer_documentation_fo
     assert da.uri == "https://README.md"
 
 
-class MockPath:
-    def __init__(self, path_arg, file_contents=None):
-        self.path_arg = str(path_arg)
-        self.file_contents = file_contents or {}
-
-    def exists(self):
-        print("exists", self.path_arg)
-        return self.path_arg in self.file_contents
-
-    def read_text(self):
-        return self.file_contents.get(self.path_arg, "<wrong, returning arbitrary string>")
-
-    def __str__(self):
-        return self.path_arg
-
-    def __repr__(self):
-        return f"MockPath('{self.path_arg}', file_contents={self.file_contents})"
-
-
 @pytest.fixture
 def mock_get_registered_models(monkeypatch):
     """Mock the get_registered_models method to avoid server calls."""

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1234,7 +1234,7 @@ class TestUserToken:
     def test_user_token_from_envvar(self, mock_get_registered_models):
         """Test for user not providing explicitly user_token,
         reading user token from environment variable."""
-        test_token = "test-token-from-envvar"
+        test_token = "test-token-from-envvar" # noqa: S105
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as token_file:
             token_file.write(test_token)
@@ -1258,8 +1258,8 @@ class TestUserToken:
     def test_user_token_from_k8s_file(self, mock_get_registered_models):
         """Test for user not providing explicitly user_token,
         reading user token from Kubernetes service account token file."""
-        test_token = "test-token-from-k8s-file"
-        k8s_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        test_token = "test-token-from-k8s-file" # noqa: S105
+        k8s_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token" # noqa: S105
 
         with patch("model_registry._client.Path") as mock_path_class, \
                 patch.dict(os.environ, {}, clear=True):  # Clear env vars to force K8s fallback
@@ -1283,9 +1283,9 @@ class TestUserToken:
         """Test for user not providing explicitly user_token,
         reading user token from environment variable,
         taking precedence over K8s file for Service Account token."""
-        env_token = "test-token-from-envvar"
-        k8s_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        k8s_token = "test-token-from-k8s-file"
+        env_token = "test-token-from-envvar" # noqa: S105
+        k8s_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token" # noqa: S105
+        k8s_token = "test-token-from-k8s-file" # noqa: S105
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_token_file:
             env_token_file.write(env_token)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from itertools import islice
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -1229,108 +1229,115 @@ class MockPath:
         return f"MockPath('{self.path_arg}', file_contents={self.file_contents})"
 
 
-class TestUserToken:
-    @patch.object(ModelRegistry, "get_registered_models")
-    def test_user_token_from_envvar(self, mock_get_registered_models):
-        """Test for user not providing explicitly user_token,
-        reading user token from environment variable."""
-        test_token = "test-token-from-envvar" # noqa: S105
+@pytest.fixture
+def mock_get_registered_models(monkeypatch):
+    """Mock the get_registered_models method to avoid server calls."""
+    mock_get_registered_models = MagicMock()
+    mock_get_registered_models.return_value.page_size.return_value._next_page.return_value = None
+    monkeypatch.setattr(ModelRegistry, "get_registered_models", mock_get_registered_models)
+    return mock_get_registered_models
 
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as token_file:
-            token_file.write(test_token)
-            token_file_path = token_file.name
 
-        try:
-            with patch.dict(os.environ, {"KF_PIPELINES_SA_TOKEN_PATH": token_file_path}):
-                client = ModelRegistry(
-                    server_address="http://localhost",
-                    port=8080,
-                    author="test_author",
-                    is_secure=False,
-                    # user_token=None -> ... Let it read from Env var
-                )
-                assert client is not None
-                assert client._api.config.access_token == test_token
-        finally:
-            os.unlink(token_file_path)
+def test_user_token_from_envvar(monkeypatch, mock_get_registered_models):
+    """Test for user not providing explicitly user_token,
+    reading user token from environment variable."""
+    test_token = "test-token-from-envvar" # noqa: S105
 
-    @patch.object(ModelRegistry, "get_registered_models")
-    def test_user_token_from_k8s_file(self, mock_get_registered_models):
-        """Test for user not providing explicitly user_token,
-        reading user token from Kubernetes service account token file."""
-        test_token = "test-token-from-k8s-file" # noqa: S105
-        k8s_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token" # noqa: S105
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as token_file:
+        token_file.write(test_token)
+        token_file_path = token_file.name
 
-        with patch("model_registry._client.Path") as mock_path_class, \
-                patch.dict(os.environ, {}, clear=True):  # Clear env vars to force K8s fallback
-            def path_side_effect(path_arg):
-                return MockPath(path_arg, file_contents={k8s_token_path: test_token})
+    monkeypatch.setenv("KF_PIPELINES_SA_TOKEN_PATH", token_file_path)
+    print(os.environ)
+    print(os.environ.get("KF_PIPELINES_SA_TOKEN_PATH"))
+    client = ModelRegistry(
+        server_address="http://localhost",
+        port=8080,
+        author="test_author",
+        is_secure=False,
+        # user_token=None -> ... Let it read from Env var
+    )
+    assert client is not None
+    assert client._api.config.access_token == test_token
 
-            mock_path_class.side_effect = path_side_effect
+    os.unlink(token_file_path)
 
-            client = ModelRegistry(
-                server_address="http://localhost",
-                port=8080,
-                author="test_author",
-                is_secure=False,
-                # user_token=None -> ... Let it read from K8s file
-            )
-            assert client is not None
-            assert client._api.config.access_token == test_token
 
-    @patch.object(ModelRegistry, "get_registered_models")
-    def test_user_token_envvar_priority_over_k8s(self, mock_get_registered_models):
-        """Test for user not providing explicitly user_token,
-        reading user token from environment variable,
-        taking precedence over K8s file for Service Account token."""
-        env_token = "test-token-from-envvar" # noqa: S105
-        k8s_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token" # noqa: S105
-        k8s_token = "test-token-from-k8s-file" # noqa: S105
+def test_user_token_from_k8s_file(monkeypatch, mock_get_registered_models):
+    """Test for user not providing explicitly user_token,
+    reading user token from Kubernetes service account token file."""
+    test_token = "test-token-from-k8s-file" # noqa: S105
+    k8s_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token" # noqa: S105
 
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_token_file:
-            env_token_file.write(env_token)
-            env_token_path = env_token_file.name
+    monkeypatch.delenv("KF_PIPELINES_SA_TOKEN_PATH", raising=False)
+    with patch("model_registry._client.Path") as mock_path_class:
+        def path_side_effect(path_arg):
+            return MockPath(path_arg, file_contents={k8s_token_path: test_token})
 
-        try:
-            with patch("model_registry._client.Path") as mock_path_class, \
-                    patch.dict(os.environ, {"KF_PIPELINES_SA_TOKEN_PATH": env_token_path}):
-                def path_side_effect(path_arg):
-                    return MockPath(path_arg, file_contents={k8s_token_path: k8s_token, env_token_path: env_token})
+        mock_path_class.side_effect = path_side_effect
 
-                mock_path_class.side_effect = path_side_effect
+        client = ModelRegistry(
+            server_address="http://localhost",
+            port=8080,
+            author="test_author",
+            is_secure=False,
+            # user_token=None -> ... Let it read from K8s file
+        )
+        assert client is not None
+        assert client._api.config.access_token == test_token
 
-                client = ModelRegistry(
-                    server_address="http://localhost",
-                    port=8080,
-                    author="test_author",
-                    is_secure=False,
-                    # user_token=None -> ... Let it read from Env var (and not from K8s file, given that Env var is set)
-                )
-                assert client is not None
-                assert client._api.config.access_token == env_token
-        finally:
-            os.unlink(env_token_path)
 
-    @patch.object(ModelRegistry, "get_registered_models")
-    def test_user_token_missing_warning(self, mock_get_registered_models):
-        """Test for user not providing explicitly user_token,
-        after trying to read from envvar and K8s file for Service Account token but both are missing,
-        it will emit a warning."""
-        with patch("model_registry._client.Path") as mock_path_class, \
-             patch("model_registry._client.warn") as mock_warn, \
-             patch.dict(os.environ, {}, clear=True):  # Clear env vars
-            def path_side_effect(path_arg):
-                return MockPath(path_arg, file_contents={})  # No files exist
+def test_user_token_envvar_priority_over_k8s(monkeypatch, mock_get_registered_models):
+    """Test for user not providing explicitly user_token,
+    reading user token from environment variable,
+    taking precedence over K8s file for Service Account token."""
+    env_token = "test-token-from-envvar" # noqa: S105
+    k8s_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token" # noqa: S105
+    k8s_token = "test-token-from-k8s-file" # noqa: S105
 
-            mock_path_class.side_effect = path_side_effect
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_token_file:
+        env_token_file.write(env_token)
+        env_token_path = env_token_file.name
 
-            client = ModelRegistry(
-                server_address="http://localhost",
-                port=8080,
-                author="test_author",
-                is_secure=False,
-                # user_token=None -> ... Let it try to read, but missing Env var and K8s file, it will emit a warning
-            )
-            assert client is not None
-            mock_warn.assert_called_with("User access token is missing", stacklevel=2)
+    monkeypatch.setenv("KF_PIPELINES_SA_TOKEN_PATH", env_token_path)
+    with patch("model_registry._client.Path") as mock_path_class:
+        def path_side_effect(path_arg):
+            return MockPath(path_arg, file_contents={k8s_token_path: k8s_token, env_token_path: env_token})
+
+        mock_path_class.side_effect = path_side_effect
+
+        client = ModelRegistry(
+            server_address="http://localhost",
+            port=8080,
+            author="test_author",
+            is_secure=False,
+            # user_token=None -> ... Let it read from Env var (and not from K8s file, given that Env var is set)
+        )
+        assert client is not None
+        assert client._api.config.access_token == env_token
+
+    os.unlink(env_token_path)
+
+
+def test_user_token_missing_warning(monkeypatch, mock_get_registered_models):
+    """Test for user not providing explicitly user_token,
+    after trying to read from envvar and K8s file for Service Account token but both are missing,
+    it will emit a warning."""
+    monkeypatch.delenv("KF_PIPELINES_SA_TOKEN_PATH", raising=False)
+    with patch("model_registry._client.Path") as mock_path_class, \
+            patch("model_registry._client.warn") as mock_warn:
+        def path_side_effect(path_arg):
+            return MockPath(path_arg, file_contents={})  # No files exist
+
+        mock_path_class.side_effect = path_side_effect
+
+        client = ModelRegistry(
+            server_address="http://localhost",
+            port=8080,
+            author="test_author",
+            is_secure=False,
+            # user_token=None -> ... Let it try to read, but missing Env var and K8s file, it will emit a warning
+        )
+        assert client is not None
+        mock_warn.assert_called_with("User access token is missing", stacklevel=2)
 


### PR DESCRIPTION
## Description

- When user do not supply explicitly user_token=, add fallback to read from K8s SA token file when envvar `KF_PIPELINES_SA_TOKEN_PATH` is not set
- Change token from envvar log level from warning to info for consistency
- Add test coverage for token source priority and fallback logic
- Ensure envvar `KF_PIPELINES_SA_TOKEN_PATH` token takes precedence over K8s file token when both are available

### Details

In a simple Notebook, typically we rely on envvar `KF_PIPELINES_SA_TOKEN_PATH` to point to the path containing a SA token, since in most environment we faced this envvar is set into the Notebook with the KFP SA token (and we refer to that, not necessarily the SA token of the Jupyter Notebook itself).

Instead, in a simple example of K8s workload (eg KFP, or simply a Pod), I typically resort to something like the following:

```py
@dsl.component(base_image="registry.redhat.io/ubi9/python-311", packages_to_install=["model-registry"])
def my_component(run_id: str = None, run_name: str = None) -> str:
    import os
    try:
        with open("/var/run/secrets/kubernetes.io/serviceaccount/token", "r") as f:
            user_token = f.read().strip()
        print("Token loaded successfully")
    except FileNotFoundError:
        raise ValueError("Service account token file not found")
    except Exception as e:
        raise ValueError("Couldn't read the token", e)
    
    from model_registry import ModelRegistry
    registry = ModelRegistry(
        server_address="https://my-registry-rest.apps.rosa.mmortari-rosa2.otuf.p3.openshiftapps.com",
        author="pipeline-author",
        user_token=user_token
    )
    print("Connected to ModelRegistry")
```

that is, just source the standard K8s SA token and feed it into the client initialization, per documented API.

However, I've received the following comment:

> I think one of your examples had some magic around service account tokens

This PR fallback into attempting with a lower priority to source the K8s SA token when no user_token is provided and when the Notebook envvar is not set (ie inside a KFP or inside a simple Pod).

## How Has This Been Tested?

Pytest suite are added.

In addition to pytests, I've manually tested inside a barebone Pod, by loading the locally build .whl and:

<img width="1599" height="280" alt="Screenshot 2025-09-05 at 14 39 23" src="https://github.com/user-attachments/assets/b3e09798-f638-4104-9eef-9591a491d5c5" />

to confirm the envvar `KF_PIPELINES_SA_TOKEN_PATH` is not present on this barebone pod:

<img width="401" height="235" alt="Screenshot 2025-09-05 at 14 41 24" src="https://github.com/user-attachments/assets/9167871b-7459-4b77-b92f-586c3e44b996" />

overriding the default log_level show the intended messages:

<img width="1598" height="452" alt="Screenshot 2025-09-05 at 14 44 35" src="https://github.com/user-attachments/assets/1909ccdd-3f42-439d-b6ed-54cede63ece7" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
