### PR TITLE
Unescape catalog model names / publish catalog openapi client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests and workspace file
 COPY ["go.mod", "go.sum", "go.work", "go.work.sum", "./"]
 COPY ["pkg/openapi/go.mod", "pkg/openapi/"]
+COPY ["catalog/pkg/openapi/go.mod", "catalog/pkg/openapi/"]
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -25,6 +26,10 @@ func (m *ModelCatalogServiceAPIService) GetAllModelArtifacts(ctx context.Context
 	source, ok := m.sources.Get(sourceID)
 	if !ok {
 		return notFound("Unknown source"), nil
+	}
+
+	if newName, err := url.PathUnescape(name); err == nil {
+		name = newName
 	}
 
 	artifacts, err := source.Provider.GetArtifacts(ctx, name)
@@ -74,6 +79,10 @@ func (m *ModelCatalogServiceAPIService) GetModel(ctx context.Context, sourceID s
 	source, ok := m.sources.Get(sourceID)
 	if !ok {
 		return notFound("Unknown source"), nil
+	}
+
+	if newName, err := url.PathUnescape(name); err == nil {
+		name = newName
 	}
 
 	model, err := source.Provider.GetModel(ctx, name)

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -829,6 +829,27 @@ func TestGetModel(t *testing.T) {
 			expectedStatus: http.StatusNotFound,
 			expectedModel:  nil,
 		},
+		{
+			name: "Model name with an escaped slash and version",
+			sources: map[string]catalog.CatalogSource{
+				"source1": {
+					Metadata: model.CatalogSource{Id: "source1", Name: "Test Source"},
+					Provider: &mockModelProvider{
+						models: map[string]*model.CatalogModel{
+							"some/model:v1.0.0": {
+								Name: "some/model:v1.0.0",
+							},
+						},
+					},
+				},
+			},
+			sourceID:       "source1",
+			modelName:      "some%2Fmodel%3Av1.0.0",
+			expectedStatus: http.StatusOK,
+			expectedModel: &model.CatalogModel{
+				Name: "some/model:v1.0.0",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/catalog/pkg/openapi/go.mod
+++ b/catalog/pkg/openapi/go.mod
@@ -1,0 +1,3 @@
+module github.com/kubeflow/model-registry/catalog/pkg/openapi
+
+go 1.24

--- a/cmd/csi/Dockerfile.csi
+++ b/cmd/csi/Dockerfile.csi
@@ -7,6 +7,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY ["go.mod", "go.sum", "go.work", "./"]
 COPY ["pkg/openapi/go.mod", "pkg/openapi/"]
+COPY ["catalog/pkg/openapi/go.mod", "catalog/pkg/openapi/"]
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/glog v1.2.5
 	github.com/google/go-cmp v0.7.0
 	github.com/kserve/kserve v0.15.2
+	github.com/kubeflow/model-registry/catalog/pkg/openapi v0.0.0-00010101000000-000000000000
 	github.com/kubeflow/model-registry/pkg/openapi v0.0.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.25.2
@@ -216,3 +217,5 @@ require (
 )
 
 replace github.com/kubeflow/model-registry/pkg/openapi => ./pkg/openapi
+
+replace github.com/kubeflow/model-registry/catalog/pkg/openapi => ./catalog/pkg/openapi

--- a/go.work
+++ b/go.work
@@ -3,4 +3,5 @@ go 1.24.4
 use (
 	.
 	./pkg/openapi
+	./catalog/pkg/openapi
 )


### PR DESCRIPTION
## Description

* Unescape model names in model catalog's model endpoints (fixes #1554)
- Publish the catalog's generated Go client as a package

## How Has This Been Tested?

See steps in #1554

## Merge criteria:

- [x] All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).