### PR TITLE
fix(catalog): remove the duplicated model-catalog prefix from the service name

### DIFF
--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -127,7 +127,7 @@ func setupMock(mockK8sClient kubernetes.Interface, ctx context.Context) error {
 		return err
 	}
 
-	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog-model-catalog-service", "kubeflow", "10.0.0.15")
+	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog-service", "kubeflow", "10.0.0.15")
 	if err != nil {
 		return err
 	}

--- a/clients/ui/bff/internal/repositories/model_catalog.go
+++ b/clients/ui/bff/internal/repositories/model_catalog.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+
 	k8s "github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
 	"github.com/kubeflow/model-registry/ui/bff/internal/models"
 )
@@ -10,7 +11,7 @@ import (
 type ModelCatalogRepository struct {
 }
 
-const ModelCatalogServiceName = "model-catalog-model-catalog-service"
+const ModelCatalogServiceName = "model-catalog-service"
 
 func NewCatalogRepository() *ModelCatalogRepository {
 	return &ModelCatalogRepository{}

--- a/manifests/kustomize/options/catalog/base/service.yaml
+++ b/manifests/kustomize/options/catalog/base/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: model-catalog-service
     app.kubernetes.io/part-of: model-catalog
     component: model-catalog
-  name: model-catalog-service
+  name: service
 spec:
   selector:
     component: model-catalog-server


### PR DESCRIPTION
## Description

Name the model-catalog service `model-catalog-service` instead of `model-catalog-model-catalog-service`.

## How Has This Been Tested?
Applied to a dev cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
