### PR TITLE
feat: add labels field to catalog sources

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -298,6 +298,7 @@ components:
       required:
         - id
         - name
+        - labels
       type: object
       properties:
         id:
@@ -310,6 +311,11 @@ components:
           description: Whether the catalog source is enabled.
           type: boolean
           default: true
+        labels:
+          description: Labels for the catalog source.
+          type: array
+          items:
+            type: string
     CatalogSourceList:
       description: List of CatalogSource entities.
       allOf:

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -201,6 +201,7 @@ components:
       required:
         - id
         - name
+        - labels
       type: object
       properties:
         id:
@@ -213,6 +214,11 @@ components:
           description: Whether the catalog source is enabled.
           type: boolean
           default: true
+        labels:
+          description: Labels for the catalog source.
+          type: array
+          items:
+            type: string
     CatalogSourceList:
       description: List of CatalogSource entities.
       allOf:

--- a/catalog/internal/catalog/catalog.go
+++ b/catalog/internal/catalog/catalog.go
@@ -157,6 +157,11 @@ func (sc *SourceCollection) load(path string) error {
 		if _, exists := sources[id]; exists {
 			return fmt.Errorf("duplicate catalog id %s", id)
 		}
+		labels := make([]string, 0)
+		if catalogConfig.GetLabels() != nil {
+			labels = catalogConfig.GetLabels()
+		}
+		catalogConfig.CatalogSource.Labels = labels
 		provider, err := registerFunc(&catalogConfig)
 		if err != nil {
 			return fmt.Errorf("error reading catalog type %s with id %s: %v", catalogType, id, err)

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -327,6 +327,7 @@ func TestFindSources(t *testing.T) {
 		expectedSize   int32
 		expectedItems  int
 		checkSorting   bool
+		expectedLabels int
 	}{
 		{
 			name:           "Empty catalog list",
@@ -605,6 +606,29 @@ func TestFindSources(t *testing.T) {
 			expectedItems:  3,
 			checkSorting:   true,
 		},
+		{
+			name: "Labels should be returned if set",
+			catalogs: map[string]catalog.CatalogSource{
+				"catalog1": {
+					Metadata: model.CatalogSource{Id: "catalog1", Name: "Test Catalog 1", Labels: []string{"label1", "label2"}},
+				},
+				"catalog2": {
+					Metadata: model.CatalogSource{Id: "catalog2", Name: "Test Catalog 2", Labels: []string{"label3", "label4"}},
+				},
+				"catalog3": {
+					Metadata: model.CatalogSource{Id: "catalog3", Name: "Test Catalog 3", Labels: []string{"label5", "label6"}},
+				},
+			},
+			nameFilter:     "",
+			pageSize:       "10",
+			orderBy:        model.ORDERBYFIELD_ID,
+			sortOrder:      model.SORTORDER_ASC,
+			expectedStatus: http.StatusOK,
+			expectedSize:   1,
+			expectedItems:  1,
+			checkSorting:   true,
+			expectedLabels: 6,
+		},
 	}
 
 	// Run test cases
@@ -688,6 +712,12 @@ func TestFindSources(t *testing.T) {
 					}
 				}
 			}
+
+			labels := make([]string, 0)
+			for _, item := range sourceList.Items {
+				labels = append(labels, item.Labels...)
+			}
+			assert.Equal(t, tc.expectedLabels, len(labels))
 		})
 	}
 }

--- a/catalog/internal/server/openapi/type_asserts.go
+++ b/catalog/internal/server/openapi/type_asserts.go
@@ -193,8 +193,9 @@ func AssertCatalogSourceListRequired(obj model.CatalogSourceList) error {
 // AssertCatalogSourceRequired checks if the required fields are not zero-ed
 func AssertCatalogSourceRequired(obj model.CatalogSource) error {
 	elements := map[string]interface{}{
-		"id":   obj.Id,
-		"name": obj.Name,
+		"id":     obj.Id,
+		"name":   obj.Name,
+		"labels": obj.Labels,
 	}
 	for name, el := range elements {
 		if isZero := IsZeroValue(el); isZero {

--- a/catalog/pkg/openapi/model_catalog_source.go
+++ b/catalog/pkg/openapi/model_catalog_source.go
@@ -25,18 +25,21 @@ type CatalogSource struct {
 	Name string `json:"name"`
 	// Whether the catalog source is enabled.
 	Enabled *bool `json:"enabled,omitempty"`
+	// Labels for the catalog source.
+	Labels []string `json:"labels"`
 }
 
 // NewCatalogSource instantiates a new CatalogSource object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCatalogSource(id string, name string) *CatalogSource {
+func NewCatalogSource(id string, name string, labels []string) *CatalogSource {
 	this := CatalogSource{}
 	this.Id = id
 	this.Name = name
 	var enabled bool = true
 	this.Enabled = &enabled
+	this.Labels = labels
 	return &this
 }
 
@@ -130,6 +133,30 @@ func (o *CatalogSource) SetEnabled(v bool) {
 	o.Enabled = &v
 }
 
+// GetLabels returns the Labels field value
+func (o *CatalogSource) GetLabels() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+
+	return o.Labels
+}
+
+// GetLabelsOk returns a tuple with the Labels field value
+// and a boolean to check if the value has been set.
+func (o *CatalogSource) GetLabelsOk() ([]string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Labels, true
+}
+
+// SetLabels sets field value
+func (o *CatalogSource) SetLabels(v []string) {
+	o.Labels = v
+}
+
 func (o CatalogSource) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -145,6 +172,7 @@ func (o CatalogSource) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
+	toSerialize["labels"] = o.Labels
 	return toSerialize, nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

In this PR I added a labels field to CatalogSource entities in the Model Catalog API to support labeling and categorization of catalog sources.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### 1 - Labels field omitted in sources.yaml ###

```yaml
catalogs:
- name: Sample Catalog
  id: sample_custom_catalog
  type: yaml
  enabled: true
  properties:
    yamlCatalogPath: sample-catalog.yaml
```

```shell
curl --request GET -s  --url http://localhost:8080/api/model_catalog/v1alpha1/sources | jq
{
  "items": [
    {
      "enabled": true,
      "id": "sample_custom_catalog",
      "labels": [],
      "name": "Sample Catalog"
    }
  ],
  "nextPageToken": "",
  "pageSize": 10,
  "size": 1
}
```

### 2 - Labels is an empty array in sources.yaml ###

```yaml
catalogs:
- name: Sample Catalog
  id: sample_custom_catalog
  type: yaml
  enabled: true
  labels: []
  properties:
    yamlCatalogPath: sample-catalog.yaml
```

```shell
curl --request GET -s  --url http://localhost:8080/api/model_catalog/v1alpha1/sources | jq
{
  "items": [
    {
      "enabled": true,
      "id": "sample_custom_catalog",
      "labels": [],
      "name": "Sample Catalog"
    }
  ],
  "nextPageToken": "",
  "pageSize": 10,
  "size": 1
}
```

### 3 - Labels is populated in sources.yaml ###

```yaml
catalogs:
- name: Sample Catalog
  id: sample_custom_catalog
  type: yaml
  enabled: true
  labels:
  - sample-label
  - sample-label-2
  properties:
    yamlCatalogPath: sample-catalog.yaml
```

```shell
curl --request GET -s  --url http://localhost:8080/api/model_catalog/v1alpha1/sources | jq
{
  "items": [
    {
      "enabled": true,
      "id": "sample_custom_catalog",
      "labels": [
        "sample-label",
        "sample-label-2"
      ],
      "name": "Sample Catalog"
    }
  ],
  "nextPageToken": "",
  "pageSize": 10,
  "size": 1
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
