### PR TITLE
feat(async-job): refactor model config validation

### DIFF
--- a/jobs/async-upload/job/config.py
+++ b/jobs/async-upload/job/config.py
@@ -8,11 +8,12 @@ from pathlib import Path
 from .models import (
     AsyncUploadConfig,
     OCIStorageConfig,
-    S3StorageConfig, 
-    SourceConfig, 
-    DestinationConfig, 
-    ModelConfig, 
-    StorageConfig, 
+    S3StorageConfig,
+    SourceConfig,
+    DestinationConfig,
+    ModelConfig,
+    ModelInputArgs,
+    StorageConfig,
     RegistryConfig,
     S3Config,
     OCIConfig,
@@ -20,7 +21,10 @@ from .models import (
     SourceType,
     DestinationType,
     URISourceStorageConfig,
-    UploadIntent
+    UploadIntent,
+    CreateModelIntent,
+    CreateVersionIntent,
+    UpdateArtifactIntent,
 )
 
 logger = logging.getLogger(__name__)
@@ -363,16 +367,18 @@ def get_config(argv: list[str] | None = None) -> AsyncUploadConfig:
     else:
         raise ValueError(f"Unsupported destination type: {args.destination_type}")
 
-    # Create model instances
+    model_args = ModelInputArgs(
+        intent_type=args.model_upload_intent,
+        id=args.model_id,
+        version_id=args.model_version_id,
+        artifact_id=args.model_artifact_id,
+    )
     try:
         config = AsyncUploadConfig(
             source=source_config,
             destination=destination_config,
             model=ModelConfig(
-                upload_intent=args.model_upload_intent,
-                id=args.model_id,
-                version_id=args.model_version_id,
-                artifact_id=args.model_artifact_id,
+                intent=model_args.model_dump(exclude_none=True),
             ),
             storage=StorageConfig(
                 path=args.storage_path,

--- a/jobs/async-upload/job/models.py
+++ b/jobs/async-upload/job/models.py
@@ -4,7 +4,7 @@ Configuration models for the async upload job using Pydantic for type safety and
 from __future__ import annotations
 from enum import StrEnum
 import logging
-from typing import Union
+from typing import Union, Annotated, Literal
 from pydantic import BaseModel, Field, model_validator, ConfigDict
 
 
@@ -101,31 +101,36 @@ class UploadIntent(StrEnum):
     create_version = "create_version"
     update_artifact = "update_artifact"
 
-class ModelConfig(BaseModel):
-    """Model registry model information."""
-    upload_intent: UploadIntent = Field(UploadIntent.update_artifact, description="Model upload intent")
-    id: str | None = Field(None, description="Model ID")
-    version_id: str | None = Field(None, description="Model version ID")
-    artifact_id: str | None = Field(None, description="Model artifact ID")
 
-    @model_validator(mode='after')
-    def validate_model_ids(self) -> 'ModelConfig':
-        """Validate that all model IDs are provided."""
-        if self.upload_intent == UploadIntent.create_model:
-            # No ids should be set when intent is create_model
-            if any([self.id, self.version_id, self.artifact_id]):
-                raise ValueError("Model ID, Model Version ID and Model Artifact ID cannot be set when intent is create_model")
-        elif self.upload_intent == UploadIntent.create_version:
-            if not self.id:
-                raise ValueError("Model ID must be set when intent is create_version")
-            elif any([self.version_id, self.artifact_id]):
-                raise ValueError("Model Version ID and Model Artifact ID cannot be set when intent is create_version")
-        elif self.upload_intent == UploadIntent.update_artifact:
-            if not self.artifact_id:
-                raise ValueError("Model Artifact ID must be set when intent is update_artifact")
-            elif any([self.id, self.version_id]):
-                raise ValueError("Model ID and Model Version ID cannot be set when intent is update_artifact")
-        return self
+class ModelInputArgs(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    intent_type: UploadIntent = Field(description="Upload intent type")
+    id: str | None = Field(description="Registered model ID")
+    version_id: str | None = Field(description="Model version ID")
+    artifact_id: str | None = Field(description="Model artifact ID")
+
+
+class CreateModelIntent(BaseModel):
+    intent_type: Literal[UploadIntent.create_model] = UploadIntent.create_model
+
+
+class CreateVersionIntent(BaseModel):
+    intent_type: Literal[UploadIntent.create_version] = UploadIntent.create_version
+    model_id: str = Field(..., description="Registered model ID for the existing model")
+
+
+class UpdateArtifactIntent(BaseModel):
+    intent_type: Literal[UploadIntent.update_artifact] = UploadIntent.update_artifact
+    artifact_id: str = Field(..., description="Model artifact ID to update")
+
+
+IntentConfig = Union[CreateModelIntent, CreateVersionIntent, UpdateArtifactIntent]
+
+
+class ModelConfig(BaseModel):
+    """Model registry model information with intent-specific configuration."""
+    intent: IntentConfig = Field(..., description="Model upload intent configuration", discriminator='intent_type')
 
 
 class StorageConfig(BaseModel):

--- a/jobs/async-upload/job/mr_client.py
+++ b/jobs/async-upload/job/mr_client.py
@@ -1,6 +1,6 @@
 import logging
 
-from job.models import ModelConfig, RegistryConfig
+from job.models import ModelConfig, RegistryConfig, UpdateArtifactIntent
 from model_registry import ModelRegistry
 from mr_openapi import ArtifactState
 
@@ -20,26 +20,34 @@ async def set_artifact_pending(
     """
     Sets the model artifact to pending.
     """
-    logger.debug("🔍 Setting artifact to pending: %s", config.artifact_id)
-    artifact = await client._api.get_model_artifact_by_id(config.artifact_id)
+    if not isinstance(config.intent, UpdateArtifactIntent):
+        raise ValueError("set_artifact_pending can only be used with UpdateArtifactIntent")
+    
+    artifact_id = config.intent.artifact_id
+    logger.debug("🔍 Setting artifact to pending: %s", artifact_id)
+    artifact = await client._api.get_model_artifact_by_id(artifact_id)
 
     if artifact is None:
-        raise ValueError(f"Artifact {config.artifact_id} not found")
+        raise ValueError(f"Artifact {artifact_id} not found")
     
     artifact.state = ArtifactState.PENDING
     await client._api.upsert_model_artifact(artifact)
-    logger.debug("✅ Artifact set to pending: %s", config.artifact_id)
+    logger.debug("✅ Artifact set to pending: %s", artifact_id)
 
 
 
 async def update_model_artifact_uri(
     uri: str, client: ModelRegistry, config: ModelConfig
 ) -> None:
+    if not isinstance(config.intent, UpdateArtifactIntent):
+        raise ValueError("update_model_artifact_uri can only be used with UpdateArtifactIntent")
+    
+    artifact_id = config.intent.artifact_id
     logger.debug("🔍 Updating model artifact URI: %s", uri)
-    artifact = await client._api.get_model_artifact_by_id(config.artifact_id)
+    artifact = await client._api.get_model_artifact_by_id(artifact_id)
 
     if artifact is None:
-        raise ValueError(f"Artifact {config.artifact_id} not found")
+        raise ValueError(f"Artifact {artifact_id} not found")
     
 
     # Set the state of the artifact to LIVE and set the URI

--- a/jobs/async-upload/pyproject.toml
+++ b/jobs/async-upload/pyproject.toml
@@ -33,8 +33,6 @@ markers = [
     "integration: marks tests as integration tests"
 ]
 
-[tool.poetry.scripts]
-debug-test = "debugpy:main --listen 5678 --wait-for-client -m pytest jobs/async-upload/tests/test_config.py -v"
 
 [tool.ruff]
 line-length = 119

--- a/jobs/async-upload/tests/test_config.py
+++ b/jobs/async-upload/tests/test_config.py
@@ -188,7 +188,7 @@ def test_env_based_s3_to_oci_config(
     assert config.destination.username == destination_oci_env_vars["oci_username"]
     assert config.destination.password == destination_oci_env_vars["oci_password"]
 
-    assert config.model.artifact_id == update_artifact_intent_env_vars["model_artifact_id"]
+    assert config.model.intent.artifact_id == update_artifact_intent_env_vars["model_artifact_id"]
     assert config.registry.server_address == update_artifact_intent_env_vars["registry_server_address"]
 
 

--- a/jobs/async-upload/tests/test_models.py
+++ b/jobs/async-upload/tests/test_models.py
@@ -4,108 +4,97 @@ Unit tests for models.py - specifically testing model validation logic.
 import pytest
 from pydantic import ValidationError
 
-from job.models import ModelConfig, UploadIntent
+from job.models import ModelConfig, UploadIntent, CreateModelIntent, CreateVersionIntent, UpdateArtifactIntent
 
 
-class TestModelConfigValidateModelIds:
-    """Test cases for ModelConfig.validate_model_ids method"""
+class TestModelConfigIntentTypes:
+    """Test cases for ModelConfig intent types using discriminated union"""
 
     def test_create_model_intent_with_no_ids_succeeds(self):
         """Test that create_model intent succeeds when no ids are provided"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.create_model,
-        )
+        intent = CreateModelIntent()
+        config = ModelConfig(intent=intent)
         
         # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.create_model
+        assert config.intent.intent_type == UploadIntent.create_model
+        assert isinstance(config.intent, CreateModelIntent)
 
-    def test_create_model_intent_with_any_id_fails(self):
-        """Test that create_model intent fails when any id is provided"""
-        expected_error_message = "Model ID, Model Version ID and Model Artifact ID cannot be set when intent is create_model"
+    def test_create_model_intent_structure(self):
+        """Test that CreateModelIntent only has the intent_type field"""
+        intent = CreateModelIntent()
+        config = ModelConfig(intent=intent)
         
-        with pytest.raises(ValidationError) as exc_info:
-            ModelConfig(
-                upload_intent=UploadIntent.create_model,
-                id="fail",
-            )
-        assert expected_error_message in str(exc_info.value)
-
-        with pytest.raises(ValidationError) as exc_info:
-            ModelConfig(
-                upload_intent=UploadIntent.create_model,
-                version_id="fail",
-            )
-        assert expected_error_message in str(exc_info.value)
-
-        with pytest.raises(ValidationError) as exc_info:
-            ModelConfig(
-                upload_intent=UploadIntent.create_model,
-                artifact_id="fail",
-            )
-        assert expected_error_message in str(exc_info.value)
+        # CreateModelIntent should only have intent_type field
+        assert config.intent.intent_type == UploadIntent.create_model
+        assert not hasattr(config.intent, 'model_id')
+        assert not hasattr(config.intent, 'artifact_id')
 
     def test_create_version_intent_with_required_ids_succeeds(self):
-        """Test that create_version intent succeeds when model ID and version ID are provided"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.create_version,
-            id="test-model-id",
-        )
+        """Test that create_version intent succeeds when model ID is provided"""
+        intent = CreateVersionIntent(model_id="test-model-id")
+        config = ModelConfig(intent=intent)
         
         # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.create_version
-        assert config.id == "test-model-id"
+        assert config.intent.intent_type == UploadIntent.create_version
+        assert isinstance(config.intent, CreateVersionIntent)
+        assert config.intent.model_id == "test-model-id"
 
     def test_create_version_intent_missing_model_id_fails(self):
         """Test that create_version intent fails when model ID is missing"""
         with pytest.raises(ValidationError) as exc_info:
-            ModelConfig(
-                upload_intent=UploadIntent.create_version,
-                # model id is missing
-            )
+            CreateVersionIntent()
+            # model_id is a required field
         
         error_message = str(exc_info.value)
-        assert "Model ID must be set when intent is create_version" in error_message
+        assert "Field required" in error_message
 
     def test_update_artifact_intent_with_artifact_id_succeeds(self):
         """Test that update_artifact intent succeeds when artifact ID is provided"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.update_artifact,
-            artifact_id="test-artifact-id"
-        )
+        intent = UpdateArtifactIntent(artifact_id="test-artifact-id")
+        config = ModelConfig(intent=intent)
         
         # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.update_artifact
-        assert config.artifact_id == "test-artifact-id"
+        assert config.intent.intent_type == UploadIntent.update_artifact
+        assert isinstance(config.intent, UpdateArtifactIntent)
+        assert config.intent.artifact_id == "test-artifact-id"
 
-    def test_update_artifact_intent_without_model_and_version_ids_succeeds(self):
-        """Test that update_artifact intent succeeds without model ID and version ID"""
-        config = ModelConfig(
-            upload_intent=UploadIntent.update_artifact,
-            # no model id or version id
-            artifact_id="test-artifact-id"
-        )
+    def test_update_artifact_intent_structure(self):
+        """Test that UpdateArtifactIntent only has the required fields"""
+        intent = UpdateArtifactIntent(artifact_id="test-artifact-id")
+        config = ModelConfig(intent=intent)
         
-        # Should not raise any validation errors
-        assert config.upload_intent == UploadIntent.update_artifact
-        assert config.artifact_id == "test-artifact-id"
+        # UpdateArtifactIntent should only have intent_type and artifact_id fields
+        assert config.intent.intent_type == UploadIntent.update_artifact
+        assert config.intent.artifact_id == "test-artifact-id"
+        assert not hasattr(config.intent, 'model_id')
 
     def test_update_artifact_intent_missing_artifact_id_fails(self):
         """Test that update_artifact intent fails when artifact ID is missing"""
         with pytest.raises(ValidationError) as exc_info:
-            ModelConfig(
-                upload_intent=UploadIntent.update_artifact,
-                id="test-model-id",
-            )
+            UpdateArtifactIntent()
+            # artifact_id is a required field
         
         error_message = str(exc_info.value)
-        assert "Model Artifact ID must be set when intent is update_artifact" in error_message
+        assert "Field required" in error_message
 
-    def test_default_intent_is_update_artifact(self):
-        """Test that the default upload intent is update_artifact"""
-        config = ModelConfig(
-            # intent is not set
-            artifact_id="test-artifact-id"
-        )
+    def test_discriminated_union_serialization(self):
+        """Test that discriminated union serialization works correctly"""
+        # Test CreateModelIntent
+        create_intent = CreateModelIntent()
+        config = ModelConfig(intent=create_intent)
+        serialized = config.model_dump()
+        assert serialized['intent']['intent_type'] == 'create_model'
         
-        # Default should be update_artifact
-        assert config.upload_intent == UploadIntent.update_artifact
+        # Test CreateVersionIntent
+        version_intent = CreateVersionIntent(model_id="test-id")
+        config = ModelConfig(intent=version_intent)
+        serialized = config.model_dump()
+        assert serialized['intent']['intent_type'] == 'create_version'
+        assert serialized['intent']['model_id'] == 'test-id'
+        
+        # Test UpdateArtifactIntent
+        artifact_intent = UpdateArtifactIntent(artifact_id="artifact-id")
+        config = ModelConfig(intent=artifact_intent)
+        serialized = config.model_dump()
+        assert serialized['intent']['intent_type'] == 'update_artifact'
+        assert serialized['intent']['artifact_id'] == 'artifact-id'

--- a/jobs/async-upload/tests/test_upload.py
+++ b/jobs/async-upload/tests/test_upload.py
@@ -9,7 +9,8 @@ from job.models import (
     OCIStorageConfig,
     ModelConfig,
     StorageConfig,
-    RegistryConfig
+    RegistryConfig,
+    UpdateArtifactIntent
 )
 
 class TestGetUploadParams:
@@ -34,8 +35,7 @@ class TestGetUploadParams:
                 region="us-east-1"
             ),
             model=ModelConfig(
-                upload_intent="update_artifact",
-                artifact_id="test-artifact"
+                intent=UpdateArtifactIntent(artifact_id="test-artifact")
             ),
             storage=StorageConfig(path="/tmp/test"),
             registry=RegistryConfig(server_address="test-server")
@@ -71,8 +71,7 @@ class TestGetUploadParams:
                 credentials_path="/tmp/test-creds"
             ),
             model=ModelConfig(
-                upload_intent="update_artifact",
-                artifact_id="123"
+                intent=UpdateArtifactIntent(artifact_id="123")
             ),
             storage=StorageConfig(path="/tmp/test-model"),
             registry=RegistryConfig(server_address="test-server")
@@ -117,8 +116,7 @@ class TestGetUploadParams:
                 credentials_path=None
             ),
             model=ModelConfig(
-                upload_intent="update_artifact",
-                artifact_id="123"
+                intent=UpdateArtifactIntent(artifact_id="123")
             ),
             storage=StorageConfig(path="/tmp/test-model"),
             registry=RegistryConfig(server_address="test-server")
@@ -163,8 +161,7 @@ class TestPerformUpload:
                 credentials_path="/tmp/test-creds"
             ),
             model=ModelConfig(
-                upload_intent="update_artifact",
-                artifact_id="123"
+                intent=UpdateArtifactIntent(artifact_id="123")
             ),
             storage=StorageConfig(path="/tmp/test-model"),
             registry=RegistryConfig(server_address="test-server")
@@ -201,8 +198,7 @@ class TestPerformUpload:
                 region="us-east-1"
             ),
             model=ModelConfig(
-                upload_intent="update_artifact",
-                artifact_id="test-artifact"
+                intent=UpdateArtifactIntent(artifact_id="test-artifact")
             ),
             storage=StorageConfig(path="/tmp/test-model"),
             registry=RegistryConfig(server_address="test-server")
@@ -243,8 +239,7 @@ class TestPerformUpload:
                 credentials_path="/tmp/test-creds"
             ),
             model=ModelConfig(
-                upload_intent="update_artifact",
-                artifact_id="123"
+                intent=UpdateArtifactIntent(artifact_id="123")
             ),
             storage=StorageConfig(path="/tmp/test-model"),
             registry=RegistryConfig(server_address="test-server")


### PR DESCRIPTION
This simplifies the model config classes and validation logic to use separate pydantic models for each intent type.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
