### PR TITLE
feat(ci): introduce first step to sbom

### DIFF
--- a/.github/workflows/build-and-push-async-upload.yml
+++ b/.github/workflows/build-and-push-async-upload.yml
@@ -13,6 +13,7 @@ on:
       - '!**.gitignore'
       - '!**.md'
       - '!**.txt'
+      - '.github/workflows/build-and-push-async-upload.yml' # self
 
 permissions: # set contents: read at top-level, per OpenSSF ScoreCard rule TokenPermissionsID
   contents: read
@@ -67,3 +68,5 @@ jobs:
           ${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_NAME }}:main
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        provenance: mode=max # pay attention no secrets are passed as build arguments: https://docs.docker.com/build/ci/github-actions/attestations/#default-provenance:~:text=don%27t%20support%20attestations.-,Warning,-If%20you%27re%20using
+        sbom: true

--- a/.github/workflows/build-and-push-csi-image.yml
+++ b/.github/workflows/build-and-push-csi-image.yml
@@ -13,7 +13,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/dependabot.yml'
       - 'docs/**'
-permissions: # set contents: read at top-level, per OpenSSF ScoreCard rule TokenPermissionsID
+permissions: # set contents: read at top-level, per OpenSSF ScoreCard rule TokenPermissionsID\
   contents: read
 env:
   IMG_REGISTRY: ghcr.io
@@ -26,7 +26,8 @@ jobs:
   build-csi-image:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      actions: read # anchore/sbom-action for syft
+      contents: write # anchore/sbom-action for syft
       packages: write
     steps:
       # Assign context variable for various action contexts (tag, main, CI)
@@ -68,6 +69,18 @@ jobs:
         env:
           IMG: "${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}"
         run: IMG=${{ env.IMG }} IMG_VERSION=${{ env.VERSION }} make image/push
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: "${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ env.VERSION }}"
+          format: spdx-json # default, but making sure of the format
+          artifact-name: "model-registry-server-${{ env.VERSION }}-sbom.spdx.json"
+          output-file: "model-registry-server-${{ env.VERSION }}-sbom.spdx.json" # pin the file to use it later below
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Attach SBOM to Image
+        run: |
+          cosign attach sbom --sbom model-registry-server-${{ env.VERSION }}-sbom.spdx.json "${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ env.VERSION }}"
       # Tag latest and main
       - name: Tag Latest
         if: env.BUILD_CONTEXT == 'main' && env.PUSH_IMAGE == 'true'

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -29,7 +29,8 @@ jobs:
     uses: ./.github/workflows/prepare.yml
   build-image:
     permissions:
-      contents: read
+      actions: read # anchore/sbom-action for syft
+      contents: write # anchore/sbom-action for syft
       packages: write
     runs-on: ubuntu-latest
     needs: prepare
@@ -57,6 +58,18 @@ jobs:
       - name: Build and Push Image
         shell: bash
         run: ./scripts/build_deploy.sh
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: "${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ env.VERSION }}"
+          format: spdx-json # default, but making sure of the format
+          artifact-name: "model-registry-server-${{ env.VERSION }}-sbom.spdx.json"
+          output-file: "model-registry-server-${{ env.VERSION }}-sbom.spdx.json" # pin the file to use it later below
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Attach SBOM to Image
+        run: |
+          cosign attach sbom --sbom model-registry-server-${{ env.VERSION }}-sbom.spdx.json "${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ env.VERSION }}"
       - name: Tag Latest
         if: env.BUILD_CONTEXT == 'main'
         shell: bash

--- a/.github/workflows/build-and-push-ui-images-standalone.yml
+++ b/.github/workflows/build-and-push-ui-images-standalone.yml
@@ -79,3 +79,5 @@ jobs:
           STYLE_THEME=mui-theme
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        provenance: mode=max # pay attention no secrets are passed as build arguments: https://docs.docker.com/build/ci/github-actions/attestations/#default-provenance:~:text=don%27t%20support%20attestations.-,Warning,-If%20you%27re%20using
+        sbom: true

--- a/.github/workflows/build-and-push-ui-images.yml
+++ b/.github/workflows/build-and-push-ui-images.yml
@@ -79,3 +79,5 @@ jobs:
           STYLE_THEME=mui-theme
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        provenance: mode=max # pay attention no secrets are passed as build arguments: https://docs.docker.com/build/ci/github-actions/attestations/#default-provenance:~:text=don%27t%20support%20attestations.-,Warning,-If%20you%27re%20using
+        sbom: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've tested in my fork to generate SBOM at least for our main container images, based on related discussions for graduation.

This provides and attach a spdx sbom to the images, albeit with some limitations:
- when using `docker/build-push-action` it uses the Docker format, so it's not recognized by cosign ootb and it's not signed
- when using docker/podman/container-engine manually, it's not signed

in other words:

| image                              | generates SBOM? | cosign-compatible format? | signed? |
|------------------------------------|-----------------|---------------------------|---------|
| model-registry/job/async-upload    | ✅               | no                        | no      |
| model-registry/storage-initializer | ✅               | ✅                         | no      |
| model-registry/server              | ✅               | ✅                         | no      |
| model-registry/ui-standalone       | ✅               | no                        | no      |
| model-registry/ui                  | ✅               | no                        | no      |

I believe this could be a valid _fist step_ forward, where a _next step_ would be to standardize on:
1. using the anchore/sbom-action to produce the spdx sbom
2. Attest, not Attach, the sbom with cosign along with image signature (this would ensure also the sbom is signed)

## How Has This Been Tested?
on my own fork,

example for `model-registry/job/async-upload`:

<img width="1390" height="1183" alt="image" src="https://github.com/user-attachments/assets/484a4d99-4c43-40a0-b338-6b5b9a6ec892" />


example for `model-registry/server`:
<img width="1390" height="665" alt="image" src="https://github.com/user-attachments/assets/afa7aa46-eeca-4975-bbe2-e63ccf816398" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
