### PR TITLE
fix(catalog): Catalog is broken on make compose/up #1590

### DIFF
--- a/catalog/internal/catalog/testdata/test-catalog-sources.yaml
+++ b/catalog/internal/catalog/testdata/test-catalog-sources.yaml
@@ -15,19 +15,3 @@ catalogs:
       privateProp21: 12345
       privateProp22: privateStringValue2
       yamlCatalogPath: test-yaml-catalog.yaml
-  - name: "Catalog 3"
-    id: catalog3
-    type: rhec
-    enabled: true
-    properties:
-      models:
-      - rhelai1/modelcar-granite-7b-starter
-  - name: "Catalog 4"
-    id: catalog4
-    type: rhec
-    enabled: true
-    properties:
-      models:
-      - rhelai1/modelcar-granite-7b-starter
-      excludedModels:
-      - rhelai1/modelcar-granite-7b-starter:latest


### PR DESCRIPTION
## Description
**Describe the bug**
As a part of https://github.com/kubeflow/model-registry/pull/1579/files, I believe we missed cleaning up rhec from test-catalog-sources.yaml, breaking make catalog on compose/up

Closes https://github.com/kubeflow/model-registry/issues/1590

**To Reproduce**
Steps to reproduce the behavior:
1. make compose/up
2. See error
```shell
 make compose/up                                                                                                                      (kind-kubeflow/default)
docker compose --profile mysql up
WARN[0000] /Users/ederign/src/kubeflow/model-registry/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Running 2/2
 ✔ model-catalog Pulled                                                                                                                                                              0.4s
 ✔ model-registry Pulled                                                                                                                                                             0.4s
[+] Running 3/0
 ✔ Container mysql           Created                                                                                                                                                 0.0s
 ✔ Container model-catalog   Created                                                                                                                                                 0.0s
 ✔ Container model-registry  Created                                                                                                                                                 0.0s
Attaching to model-catalog, model-registry, mysql
mysql           | 2025-09-12 17:19:20+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.3.0-1.el8 started.
model-catalog   | I0912 17:19:20.328780       1 catalog.go:148] reading config type yaml...
mysql           | 2025-09-12 17:19:20+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
model-catalog   | I0912 17:19:20.346887       1 catalog.go:170] loaded config catalog1 of type yaml
model-catalog   | I0912 17:19:20.346941       1 catalog.go:148] reading config type rhec...
model-catalog   | Error: error loading catalog sources: catalog type rhec not registered
mysql           | 2025-09-12 17:19:20+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.3.0-1.el8 started.
model-catalog   | Usage:
model-catalog   |   model-registry catalog [flags]
model-catalog   |
model-catalog   | Flags:
model-catalog   |       --catalogs-path string   Path to catalog source configuration file (default "sources.yaml")
model-catalog   |   -h, --help                   help for catalog
model-catalog   |   -l, --listen string          Address to listen on (default "0.0.0.0:8080")
model-catalog   |
model-catalog   | Global Flags:
model-catalog   |       --alsologtostderr                   log to standard error as well as files
model-catalog   |   -c, --config string                     config file (default is $HOME/.model-registry.yaml)
model-catalog   |       --log_backtrace_at traceLocations   when logging hits line file:N, emit a stack trace
model-catalog   |       --log_dir string                    If non-empty, write log files in this directory
model-catalog   |       --log_link string                   If non-empty, add symbolic links in this directory to the log files
model-catalog   |       --logbuflevel int                   Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
model-catalog   |       --logtostderr                       log to standard error instead of files (default true)
model-catalog   |       --stderrthreshold severityFlag      logs at or above this threshold go to stderr (default 2)
model-catalog   |   -v, --v Level                           log level for V logs
model-catalog   |       --vmodule vModuleFlag               comma-separated list of pattern=N settings for file-filtered logging
model-catalog   |
model-catalog   | F0912 17:19:20.350231       1 root.go:42] error: error loading catalog sources: catalog type rhec not registered
model-catalog exited with code 1
```
## How Has This Been Tested?
make compose/up

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [X] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [NA] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [NA] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [NA] The developer has added tests or explained why testing cannot be added.
- [NA] Included any necessary screenshots or gifs if it was a UI change.
- [NA] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
