### PR TITLE
doc: more explicit comment for ADA-KUBEFL-11

### DIFF
--- a/internal/tls/config_test.go
+++ b/internal/tls/config_test.go
@@ -12,6 +12,8 @@ import (
 
 const (
 	// Test certificate and key (self-signed, for testing only)
+	// the following keys do not correspond to any system or live system
+	// and has been generated with self-signature locally
 	testCert = `-----BEGIN CERTIFICATE-----
 MIIDczCCAlugAwIBAgIUMF77xY8/4njgitPJbFfCpfdDYvYwDQYJKoZIhvcNAQEL
 BQAwSTELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx
@@ -32,7 +34,7 @@ f2c5eSbc8n/IGvbiHPGmq/iHtZyDSKw83GQyRxSsXdgM7ru7N0YcP7qAkA6aqjYq
 3/LbAvJOrPUMYlbpG7/+ZKareiMDy/1z8bWVFd3LiT12RhSJuqsCwMa3KePNAjaq
 QTYxfer470vq8Y9cBwlMid0+RNGOcuQxbr20QeexEpGN8wHyxC4sO5ByBbpnPUsN
 lcYEIoSHV3P8mTOqEVmCzBnDerbQfis=
------END CERTIFICATE-----`
+-----END CERTIFICATE-----` // notsecret
 
 	testKey = `-----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCzQdrfRQE7lmrl
@@ -61,7 +63,7 @@ mfAmq5zkixlBvq7+FwZ8BUTyviKEnaJZPCKQnIECgYEAt26lsdwbUtistx9isZ8/
 /NB4rd/GPQnBCyiQZy2mftYROuEonOHZq0XmuGhoU/Vvv0/9149eDCOED0BllBRy
 qaXDpxpd8DoJVEvJDXAQVPu9WqcrYieJDc9a40tBMaf3YvcaCuHPj6LywzXlH45f
 COUgUAV+r5AGr5R23tHluuQ=
------END PRIVATE KEY-----`
+-----END PRIVATE KEY-----` // notsecret
 
 	testRootCA = `-----BEGIN CERTIFICATE-----
 MIIDczCCAlugAwIBAgIUMF77xY8/4njgitPJbFfCpfdDYvYwDQYJKoZIhvcNAQEL
@@ -83,7 +85,7 @@ f2c5eSbc8n/IGvbiHPGmq/iHtZyDSKw83GQyRxSsXdgM7ru7N0YcP7qAkA6aqjYq
 3/LbAvJOrPUMYlbpG7/+ZKareiMDy/1z8bWVFd3LiT12RhSJuqsCwMa3KePNAjaq
 QTYxfer470vq8Y9cBwlMid0+RNGOcuQxbr20QeexEpGN8wHyxC4sO5ByBbpnPUsN
 lcYEIoSHV3P8mTOqEVmCzBnDerbQfis=
------END CERTIFICATE-----`
+-----END CERTIFICATE-----` // notsecret
 )
 
 func TestNewTLSConfig(t *testing.T) {


### PR DESCRIPTION
## Description

we have received the following report:

```
ID: ADA-KUBEFL-11
Type: Vulnerability
Severity: Informational
Vulnerable Component: Model Registry internal/tls
```

pertaining to
`internal/tls/config_test.go`

As the comment already present indicates,
these are just some self-signed certificates used for testing and do not correspond to access to any past system and do not correspond to access to any live system

To make it even more explicit, we are adding an expanded comment and marking with a placeholder comment typically used in other "leak detection system" for each variable.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
just adding code comment 🙃 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
