### PR TITLE
ADA-KUBEFL-12: remove pprof from "production code"

### DIFF
--- a/internal/tls/config_test.go
+++ b/internal/tls/config_test.go
@@ -149,10 +149,12 @@ func TestBuildTLSConfig_Basic(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("BuildTLSConfig() error = %v", err)
+		return
 	}
 
 	if tlsConf == nil {
 		t.Fatal("BuildTLSConfig() returned nil config")
+		return
 	}
 
 	if !tlsConf.InsecureSkipVerify {

--- a/main.go
+++ b/main.go
@@ -3,18 +3,16 @@ package main
 import (
 	"github.com/golang/glog"
 	"github.com/kubeflow/model-registry/cmd"
-	"log"
-	"net/http"
-	_ "net/http/pprof"
 )
 
 func main() {
 	defer glog.Flush()
 
-	// start pprof server on 6060
-	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil))
-	}()
+	// ADA-KUBEFL-12: commented-out to ease opt-in when doing local development, while not shipping it in the container image ("production code")
+	// // start pprof server on 6060
+	// go func() {
+	// 	log.Println(http.ListenAndServe("localhost:6060", nil))
+	// }()
 
 	cmd.Execute()
 }


### PR DESCRIPTION
## Description

We have received the following report:

```
ID: ADA-KUBEFL-12
Type: Vulnerability
Severity: Moderate
Vulnerable Component: Model Registry main function
```

While the default configuration of Model Registry do not expose port 6060: https://github.com/kubeflow/model-registry/blob/d8744430a18c186b3d3330708a835f302c801016/manifests/kustomize/base/model-registry-deployment.yaml#L59-L61

it is not considered ideal anyway as a misconfiguration may lead to expose pprof endpoint in production.

Allegedly, this endpoint was used _once_ for local testing of some goroutine refactor; so instead of simply removing it, we're commenting it away with reference to the report ID; this should allow a contributor to easily re-enable it if needed, while providing a reminder to not commit it in the effective code path.

Some references:
- https://www.cve.org/CVERecord?id=CVE-2019-11248
- https://medium.com/@tvii/continuous-profiling-and-go-6c0ab4d2504b
- https://www.aquasec.com/blog/300000-prometheus-servers-and-exporters-exposed-to-dos-attacks/

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
just commenting out the endpoint binding and all tests are still passing.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
