### PR TITLE
Makefile: Replace old DEV_MODE_PORT in federated commands with correct variables

### DIFF
--- a/clients/ui/Makefile
+++ b/clients/ui/Makefile
@@ -53,7 +53,7 @@ dev-frontend-kubeflow:
 
 .PHONY: dev-bff-kubeflow
 dev-bff-kubeflow:
-	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=kubeflow DEV_MODE_PORT=8085
+	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=kubeflow DEV_MODE_MODEL_REGISTRY_PORT=8085 DEV_MODE_CATALOG_PORT=8086
 
 ########### Dev Federated ###########
 .PHONY: dev-start-federated
@@ -66,7 +66,7 @@ dev-frontend-federated:
 
 .PHONY: dev-bff-federated
 dev-bff-federated:
-	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=federated DEV_MODE_PORT=8085 AUTH_METHOD=user_token AUTH_TOKEN_HEADER=x-forwarded-access-token AUTH_TOKEN_PREFIX=""
+	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false MOCK_MR_CATALOG_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=federated DEV_MODE_MODEL_REGISTRY_PORT=8085 DEV_MODE_CATALOG_PORT=8086 AUTH_METHOD=user_token AUTH_TOKEN_HEADER=x-forwarded-access-token AUTH_TOKEN_PREFIX=""
 
 ############ Build ############
 

--- a/clients/ui/docs/local-deployment-guide.md
+++ b/clients/ui/docs/local-deployment-guide.md
@@ -128,5 +128,5 @@ make run DEV_MODE=true
 You can also specify the port you are forwarding to if it is something other than 8080:
 
 ```shell
-make run DEV_MODE=true DEV_MODE_PORT=8081
+make run DEV_MODE=true DEV_MODE_MODEL_REGISTRY_PORT=8081
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

As discussed with @ederign - the DEV_MODE_PORT environment variable is outdated and replaced by the DEV_MODE_MODEL_REGISTRY_PORT and DEV_MODE_CATALOG_PORT variables, but it was not updated in the Makefile commands `dev-bff-kubeflow` and `dev-bff-federated`. The latter also included MOCK_MR_CLIENT=false but not MOCK_MR_CATALOG_CLIENT=false so this adds the latter for consistency.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using k9s to port forward the model registry and model catalog services to ports 8085 and 8086, running the BFF with `make dev-bff-kubeflow` or `make dev-bff-federated` and attempting to curl BFF endpoints for each of those services.
```sh
curl -i -H "X-Forwarded-Access-Token: $TOKEN" "localhost:4000/api/v1/model_registry/modelregistry-sample/registered_models?namespace=kubeflow"
```

Note that the model catalog version is not working yet in this mode due to related issues to be addressed in a separate PR. cc @ederign @lucferbux 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
