### PR TITLE
Fix model-catalog service name

### DIFF
--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -109,8 +109,9 @@ func (app *App) AttachModelCatalogRESTClient(next func(http.ResponseWriter, *htt
 		modelCatalogBaseURL := modelCatalog.ServerAddress
 
 		// If we are in dev mode, we need to resolve the server address to the local host
-		// to allow the client to connect to the model catalog via port forwarded from the cluster to the local machine.
-		if app.config.DevMode {
+		// to allow the client to connect to the model registry via port forwarded from the cluster to the local machine.
+		// If you are in federated mode, we do not want to override the server address.
+		if app.config.DevMode && !app.config.DeploymentMode.IsFederatedMode() {
 			modelCatalogBaseURL = app.repositories.ModelCatalog.ResolveServerAddress("localhost", int32(app.config.DevModeCatalogPort), modelCatalog.IsHTTPS, "", app.config.DeploymentMode.IsFederatedMode())
 		}
 

--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -109,9 +109,8 @@ func (app *App) AttachModelCatalogRESTClient(next func(http.ResponseWriter, *htt
 		modelCatalogBaseURL := modelCatalog.ServerAddress
 
 		// If we are in dev mode, we need to resolve the server address to the local host
-		// to allow the client to connect to the model registry via port forwarded from the cluster to the local machine.
-		// If you are in federated mode, we do not want to override the server address.
-		if app.config.DevMode && !app.config.DeploymentMode.IsFederatedMode() {
+		// to allow the client to connect to the model catalog via port forwarded from the cluster to the local machine.
+		if app.config.DevMode {
 			modelCatalogBaseURL = app.repositories.ModelCatalog.ResolveServerAddress("localhost", int32(app.config.DevModeCatalogPort), modelCatalog.IsHTTPS, "", app.config.DeploymentMode.IsFederatedMode())
 		}
 

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -127,12 +127,12 @@ func setupMock(mockK8sClient kubernetes.Interface, ctx context.Context) error {
 		return err
 	}
 
-	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog-service", "kubeflow", "10.0.0.15")
+	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog", "kubeflow", "10.0.0.15")
 	if err != nil {
 		return err
 	}
 
-	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog-service", "bella-namespace", "10.0.0.16")
+	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog", "bella-namespace", "10.0.0.16")
 	if err != nil {
 		return err
 	}
@@ -409,10 +409,10 @@ func createModelCatalogService(k8sClient kubernetes.Interface, ctx context.Conte
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app":                         "model-catalog-service",
+				"app":                         "model-catalog",
 				"app.kubernetes.io/component": "model-catalog",
-				"app.kubernetes.io/instance":  "model-catalog-service",
-				"app.kubernetes.io/name":      "model-catalog-service",
+				"app.kubernetes.io/instance":  "model-catalog",
+				"app.kubernetes.io/name":      "model-catalog",
 				"app.kubernetes.io/part-of":   "model-catalog",
 				"component":                   "model-catalog",
 			},

--- a/clients/ui/bff/internal/repositories/model_catalog.go
+++ b/clients/ui/bff/internal/repositories/model_catalog.go
@@ -11,7 +11,7 @@ import (
 type ModelCatalogRepository struct {
 }
 
-const ModelCatalogServiceName = "model-catalog-service"
+const ModelCatalogServiceName = "model-catalog"
 
 func NewCatalogRepository() *ModelCatalogRepository {
 	return &ModelCatalogRepository{}

--- a/manifests/kustomize/options/catalog/base/service.yaml
+++ b/manifests/kustomize/options/catalog/base/service.yaml
@@ -2,10 +2,10 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: model-catalog-service
+    app: model-catalog
     app.kubernetes.io/component: model-catalog
-    app.kubernetes.io/instance: model-catalog-service
-    app.kubernetes.io/name: model-catalog-service
+    app.kubernetes.io/instance: model-catalog
+    app.kubernetes.io/name: model-catalog
     app.kubernetes.io/part-of: model-catalog
     component: model-catalog
   name: service

--- a/manifests/kustomize/options/catalog/overlay/destination-rule.yaml
+++ b/manifests/kustomize/options/catalog/overlay/destination-rule.yaml
@@ -1,9 +1,9 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: model-catalog-service
+  name: model-catalog
 spec:
-  host: model-catalog-service.kubeflow.svc.cluster.local
+  host: model-catalog.kubeflow.svc.cluster.local
   trafficPolicy:
     tls:
       mode: ISTIO_MUTUAL

--- a/manifests/kustomize/options/catalog/overlay/virtual-service.yaml
+++ b/manifests/kustomize/options/catalog/overlay/virtual-service.yaml
@@ -13,6 +13,6 @@ spec:
             prefix: /api/model_catalog/
       route:
         - destination:
-            host: model-catalog-service.kubeflow.svc.cluster.local
+            host: model-catalog.kubeflow.svc.cluster.local
             port:
               number: 8080


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Changes discussed with @ederign . We are working towards being able to properly run the BFF locally in federated mode in a way that can connect to the model catalog service on a cluster. @lucferbux is still working on issues with certificates.

Edit: This PR only renames the model-catalog service to its correct new name. The original change to middleware has been reverted and saved for another PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Need other fixes to finish testing this, will follow up in another PR. This feature is still in development.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
