### PR TITLE
feat(catalog): rename the model-catalog service

### DIFF
--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -127,12 +127,12 @@ func setupMock(mockK8sClient kubernetes.Interface, ctx context.Context) error {
 		return err
 	}
 
-	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog-service", "kubeflow", "10.0.0.15")
+	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog", "kubeflow", "10.0.0.15")
 	if err != nil {
 		return err
 	}
 
-	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog-service", "bella-namespace", "10.0.0.16")
+	err = createModelCatalogService(mockK8sClient, ctx, "model-catalog", "bella-namespace", "10.0.0.16")
 	if err != nil {
 		return err
 	}
@@ -412,7 +412,7 @@ func createModelCatalogService(k8sClient kubernetes.Interface, ctx context.Conte
 				"app":                         "model-catalog-service",
 				"app.kubernetes.io/component": "model-catalog",
 				"app.kubernetes.io/instance":  "model-catalog-service",
-				"app.kubernetes.io/name":      "model-catalog-service",
+				"app.kubernetes.io/name":      "model-catalog",
 				"app.kubernetes.io/part-of":   "model-catalog",
 				"component":                   "model-catalog",
 			},

--- a/clients/ui/bff/internal/repositories/model_catalog.go
+++ b/clients/ui/bff/internal/repositories/model_catalog.go
@@ -11,7 +11,7 @@ import (
 type ModelCatalogRepository struct {
 }
 
-const ModelCatalogServiceName = "model-catalog-service"
+const ModelCatalogServiceName = "model-catalog"
 
 func NewCatalogRepository() *ModelCatalogRepository {
 	return &ModelCatalogRepository{}

--- a/manifests/kustomize/options/catalog/base/deployment.yaml
+++ b/manifests/kustomize/options/catalog/base/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: server
+  name: model-catalog-server
   labels:
     component: model-catalog-server
 spec:

--- a/manifests/kustomize/options/catalog/base/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/base/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namePrefix: model-catalog-
-
 resources:
 - deployment.yaml
 - service.yaml
@@ -12,6 +10,6 @@ configMapGenerator:
   files:
   - sources.yaml=sources.yaml
   - sample-catalog.yaml=sample-catalog.yaml
-  name: sources
+  name: model-catalog-sources
   options:
     disableNameSuffixHash: true

--- a/manifests/kustomize/options/catalog/base/service.yaml
+++ b/manifests/kustomize/options/catalog/base/service.yaml
@@ -5,10 +5,10 @@ metadata:
     app: model-catalog-service
     app.kubernetes.io/component: model-catalog
     app.kubernetes.io/instance: model-catalog-service
-    app.kubernetes.io/name: model-catalog-service
+    app.kubernetes.io/name: model-catalog
     app.kubernetes.io/part-of: model-catalog
     component: model-catalog
-  name: service
+  name: model-catalog
 spec:
   selector:
     component: model-catalog-server

--- a/manifests/kustomize/options/catalog/overlay/destination-rule.yaml
+++ b/manifests/kustomize/options/catalog/overlay/destination-rule.yaml
@@ -3,7 +3,7 @@ kind: DestinationRule
 metadata:
   name: model-catalog-service
 spec:
-  host: model-catalog-service.kubeflow.svc.cluster.local
+  host: model-catalog.kubeflow.svc.cluster.local
   trafficPolicy:
     tls:
       mode: ISTIO_MUTUAL

--- a/manifests/kustomize/options/catalog/overlay/virtual-service.yaml
+++ b/manifests/kustomize/options/catalog/overlay/virtual-service.yaml
@@ -13,6 +13,6 @@ spec:
             prefix: /api/model_catalog/
       route:
         - destination:
-            host: model-catalog-service.kubeflow.svc.cluster.local
+            host: model-catalog.kubeflow.svc.cluster.local
             port:
               number: 8080


### PR DESCRIPTION
## Description

Rename `model-catalog-service` to just `model-catalog`.

## How Has This Been Tested?
Local cluster and unit tests.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
