### PR TITLE
feat(catalog): add postgres for catalog dev

### DIFF
--- a/devenv/configs/tiltfiles/catalog.tiltfile
+++ b/devenv/configs/tiltfiles/catalog.tiltfile
@@ -1,4 +1,4 @@
-manifests = kustomize("../../../manifests/kustomize/options/catalog")
+manifests = kustomize("../../../manifests/kustomize/options/catalog/base")
 
 objects = decode_yaml_stream(manifests)
 
@@ -18,5 +18,14 @@ k8s_resource(
     labels="backend",
     resource_deps=["kubeflow-namespace"],
     port_forwards="8082:8080",
+    trigger_mode=TRIGGER_MODE_AUTO
+)
+
+k8s_resource(
+    workload="model-catalog-postgres",
+    new_name="catalog-db",
+    labels="backend",
+    resource_deps=["kubeflow-namespace"],
+    port_forwards="5432:5432",
     trigger_mode=TRIGGER_MODE_AUTO
 )

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -19,6 +19,15 @@ services:
       - "8081:8081"
     volumes:
       - ./catalog/internal/catalog/testdata:/testdata
+    depends_on:
+      - postgres
+    profiles:
+      - postgres
+    environment:
+      - PGHOST=postgres
+      - PGDATABASE=model_catalog
+      - PGUSER=postgres
+      - PGPASSWORD=demo
 
   model-registry:
     build:
@@ -82,7 +91,16 @@ services:
       start_period: 20s
     profiles:
       - postgres
+    configs:
+      - source: pginit
+        target: /docker-entrypoint-initdb.d/pginit.sql
 
 volumes:
   mysql_data:
   postgres_data:
+
+configs:
+  pginit:
+    content: |
+      CREATE DATABASE model_catalog;
+      GRANT ALL PRIVILEGES ON model_catalog TO postgres;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,15 @@ services:
       - "8081:8081"
     volumes:
       - ./catalog/internal/catalog/testdata:/testdata
+    depends_on:
+      - postgres
+    profiles:
+      - postgres
+    environment:
+      - PGHOST=postgres
+      - PGDATABASE=model_catalog
+      - PGUSER=postgres
+      - PGPASSWORD=demo
 
   model-registry:
     image: ghcr.io/kubeflow/model-registry/server:latest
@@ -80,7 +89,16 @@ services:
       start_period: 20s
     profiles:
       - postgres
+    configs:
+      - source: pginit
+        target: /docker-entrypoint-initdb.d/pginit.sql
 
 volumes:
   mysql_data:
   postgres_data:
+
+configs:
+  pginit:
+    content: |
+      CREATE DATABASE model_catalog;
+      GRANT ALL PRIVILEGES ON model_catalog TO postgres;


### PR DESCRIPTION
## Description

Adding postgres to tilt and docker compose for dev.

## How Has This Been Tested?
Locally

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
