### PR TITLE
bff(chore): clamp int values before casting to int32 in pagination

### DIFF
--- a/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
+++ b/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"net/url"
 	"strconv"
 	"strings"
@@ -101,10 +102,19 @@ func (m *ModelCatalogClientMock) GetAllCatalogModelsAcrossSources(client httpcli
 		nextPageToken = strconv.Itoa(endIndex)
 	}
 
+	size := len(pagedModels)
+	if size > math.MaxInt32 {
+		size = math.MaxInt32
+	}
+	ps := pageSize
+	if ps > math.MaxInt32 {
+		ps = math.MaxInt32
+	}
+
 	catalogModelList := openapi.CatalogModelList{
 		Items:         pagedModels,
-		Size:          int32(len(pagedModels)),
-		PageSize:      int32(pageSize),
+		Size:          int32(size),
+		PageSize:      int32(ps),
 		NextPageToken: nextPageToken,
 	}
 


### PR DESCRIPTION
## Description
Incorrect conversion of an integer with architecture-dependent bit size from strconv.Atoi to a
lower bit size type int32 without an upper bound check.

## How Has This Been Tested?
make build

## Merge criteria:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [X] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [NA] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.