### PR TITLE
ci: ensure manual Fuzz Test use local built image

### DIFF
--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -70,7 +70,17 @@ jobs:
           set -x
           sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
 
+      - name: Generate Tag
+        shell: bash
+        id: tags
+        run: |
+          commit_sha=${{ fromJson(steps.pr.outputs.result).sha }}
+          tag=fuzz-${commit_sha:0:7}
+          echo "tag=${tag}" | tee -a $GITHUB_OUTPUT
+
       - name: Run Fuzz Tests
+        env:
+          IMG_VERSION: ${{ steps.tags.outputs.tag }}
         run: |
           echo "Starting fuzz tests..."
           make test-fuzz

--- a/main.go
+++ b/main.go
@@ -16,3 +16,4 @@ func main() {
 
 	cmd.Execute()
 }
+


### PR DESCRIPTION
## Description

a race condition happens if the fuzz test starts
the :latest image is loaded in KinD
but a more recent image is available on ghcr.io
container registry, for example by merging and
a new commit on main.

typically other ci/GHA workflow pinned the IMG_VERSION we are doing a tag containing a sha even tho it's not necessary, unless we will ever tag and image on ghcr.io with `:fuzz` but for consistency using the postfix sha

since the github event.after does not exists for
workflow_dispatch, using sha from the previously
existing step. so you might notice this is different from other ci/GHA which are looking up the sha via the PR event.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
aligned with PR strategy, but can't effectively be tested until merged.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
