### PR TITLE
fix user token handling

### DIFF
--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -13,9 +13,9 @@ from model_registry.types import ModelArtifact
 from model_registry.types.artifacts import DocArtifact
 
 
-def test_secure_client():
-    os.environ["CERT"] = ""
-    os.environ["KF_PIPELINES_SA_TOKEN_PATH"] = ""
+def test_secure_client(monkeypatch):
+    monkeypatch.delenv("CERT", raising=False)
+    monkeypatch.delenv("KF_PIPELINES_SA_TOKEN_PATH", raising=False)
     with pytest.raises(StoreError) as e:
         ModelRegistry("anything", author="test_author")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Previously the user_token_envvar kwarg for ModelRegistry.__init__ was given an explicit default string value, so passing in None or another falsy value would override the default. With this change, passing a falsy value results in the default being tried. This also errors when the user passes a non-empty string value but the env var is not set.

This allows the async-job to automatically use the default value as expected. Previously, we had to explicitly specify a value like this:
```
- name: MODEL_SYNC_REGISTRY_USER_TOKEN_ENVVAR
  value: KF_PIPELINES_SA_TOKEN_PATH
```
because failing to do so sets user_token_envvar to None.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
