### PR TITLE
ci: dependabot prefers requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
       - "/jobs/async-upload"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      - "/jobs/async-upload/requirements.txt"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

in /jobs/async-upload we use Poetry pyproject.toml we also export the dependencies via Poetry export plugin into requirements.txt for hermetic builds.

Due to the way dependabot works atm however, this leads to PRs from dependabot which only updates requirements.txt and ignore pyproject.toml and importantly ignore poetry.lock bumps

We need the opposite. We need to the Dependabot to update our lock file governed by Poetry, and in second instance we need to (manually) update the requirements.txt via makefile

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
I can't see practical ways to test this beyond merging this PR and waiting the next cycle.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
