### PR TITLE
Update test to use user_token and update setup_env_user_token to use token when possible

### DIFF
--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -178,9 +178,10 @@ def client_attrs() -> dict[str, any]:
 
 
 @pytest.fixture(scope="module")
-def setup_env_user_token():
+def setup_env_user_token(user_token: str) -> str:
+    token_bytes = (user_token or "Token").encode("utf-8")
     with tempfile.NamedTemporaryFile(delete=False) as token_file:
-        token_file.write(b"Token")
+        token_file.write(token_bytes)
     old_token_path = os.getenv("KF_PIPELINES_SA_TOKEN_PATH")
     os.environ["KF_PIPELINES_SA_TOKEN_PATH"] = token_file.name
 

--- a/clients/python/tests/fuzz_api/conftest.py
+++ b/clients/python/tests/fuzz_api/conftest.py
@@ -29,11 +29,11 @@ def generated_schema(request: pytest.FixtureRequest, pytestconfig: pytest.Config
     return schema
 
 @pytest.fixture
-def auth_headers(setup_env_user_token):
+def auth_headers(user_token: str) -> dict[str, str]:
     """Provides authorization headers for API requests."""
     return {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {setup_env_user_token}"
+        "Authorization": f"Bearer {user_token}",
     }
 
 @pytest.fixture

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -862,7 +862,7 @@ def test_nested_recursive_store_in_s3(
 
 @pytest.mark.e2e
 def test_custom_async_runner_with_ray(
-    client_attrs: dict[str, any], client: ModelRegistry, monkeypatch
+    client_attrs: dict[str, any], client: ModelRegistry, user_token: str, monkeypatch
 ):
     """Test Ray integration with uvloop event loop policy"""
     import asyncio
@@ -901,6 +901,7 @@ def test_custom_async_runner_with_ray(
                     author=client_attrs["author"],
                     is_secure=client_attrs["ssl"],
                     async_runner=atr.run,
+                    user_token=user_token,
                 )
                 client.register_model(
                     name="test_model",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
