### PR TITLE
chore(bff): handle SIGINT gracefully in development make targets

### DIFF
--- a/clients/ui/Makefile
+++ b/clients/ui/Makefile
@@ -32,6 +32,7 @@ dev-install-dependencies:
 
 .PHONY: dev-bff
 dev-bff:
+	trap 'exit 0' INT; \
 	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true MOCK_MR_CATALOG_CLIENT=true DEV_MODE=true DEPLOYMENT_MODE=standalone 
 
 .PHONY: dev-frontend
@@ -39,12 +40,14 @@ dev-frontend:
 	cd frontend && DEPLOYMENT_MODE=standalone STYLE_THEME=mui-theme npm run start:dev
 
 .PHONY: dev-start
-dev-start: 
+dev-start:
+	@trap 'exit 0' INT; \
 	make -j 2 dev-bff dev-frontend
 
 ########### Dev Kubeflow ############
 .PHONY: dev-start-kubeflow
-dev-start-kubeflow: 
+dev-start-kubeflow:
+	@trap 'exit 0' INT; \
 	make -j 2 dev-bff-kubeflow dev-frontend-kubeflow
 
 .PHONY: dev-frontend-kubeflow
@@ -57,7 +60,8 @@ dev-bff-kubeflow:
 
 ########### Dev Federated ###########
 .PHONY: dev-start-federated
-dev-start-federated: 
+dev-start-federated:
+	@trap 'exit 0' INT; \
 	make -j 2 dev-bff-federated dev-frontend-federated
 
 .PHONY: dev-frontend-federated

--- a/clients/ui/bff/Makefile
+++ b/clients/ui/bff/Makefile
@@ -61,6 +61,7 @@ endif
 
 .PHONY: run
 run: fmt vet envtest ## Runs the project.
+	trap 'exit 0' INT; \
 	ENVTEST_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	go run ./cmd --port=$(PORT) --auth-method=${AUTH_METHOD} --auth-token-header=$(AUTH_TOKEN_HEADER) --auth-token-prefix="$(AUTH_TOKEN_PREFIX)" --static-assets-dir=$(STATIC_ASSETS_DIR) --mock-k8s-client=$(MOCK_K8S_CLIENT) --mock-mr-client=$(MOCK_MR_CLIENT) --mock-mr-catalog-client=$(MOCK_MR_CATALOG_CLIENT)  --dev-mode=$(DEV_MODE) --dev-mode-model-registry-port=$(DEV_MODE_MODEL_REGISTRY_PORT) --dev-mode-catalog-port=$(DEV_MODE_CATALOG_PORT)  --deployment-mode=$(DEPLOYMENT_MODE) --log-level=$(LOG_LEVEL) --allowed-origins=$(ALLOWED_ORIGINS) --insecure-skip-verify=$(INSECURE_SKIP_VERIFY)
 


### PR DESCRIPTION
## Description
Previously, stopping the dev server with Ctrl-C caused make to report an error even though the Go process shut down cleanly.

This happens because:

- Ctrl-C sends SIGINT (signal 2) to the foreground process group.
- By default, the shell encodes this as exit code 130 (128 + 2).
- make interprets any non-zero exit code as an error, so it printed *** [target] Error 1.

This PR adds:

```shell
trap 'exit 0' INT; \
```

to the relevant make targets. This overrides the shell’s default behavior on SIGINT, replacing the exit 130 with exit 0. As a result:

- Hitting Ctrl-C still delivers SIGINT to the Go process, which shuts down gracefully.
- The shell now exits successfully (0), so make no longer reports a false error.
- Other non-zero exit codes (real failures) are still preserved and reported correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

 
