### PR TITLE
ci: dependabot prefers requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "weekly"
     exclude-paths:
-      - "/jobs/async-upload/requirements.txt"
+      - "jobs/async-upload/requirements.txt"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION

## Description

followup to #1658

given the following error:
```
Dependabot encountered the following error when parsing your .github/dependabot.yml:
The property '#/updates/1/exclude-paths/0' should be relative to the repository root.
Please update the config file to conform with Dependabot's specification.
```

<!--- Provide a general summary of your changes in the Title above -->



## How Has This Been Tested?
see https://github.com/kubeflow/model-registry/pull/1647/checks?check_run_id=51682822596

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
