### PR TITLE
Apply filters and search

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -142,7 +142,10 @@ declare global {
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/:apiVersion/model_catalog/models',
-          options: { path: { apiVersion: string }; query: { source: string } },
+          options: {
+            path: { apiVersion: string };
+            query: { source: string; filterQuery?: string };
+          },
           response: ApiResponse<CatalogModelList>,
         ) => Cypress.Chainable<null>) &
         ((

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -34,7 +34,7 @@ const initIntercepts = ({
     mockCatalogModelList({
       items: [mockCatalogModel({})],
     }),
-  );
+  ).as('getCatalogModelsBySource');
 
   cy.interceptApi(
     `GET /api/:apiVersion/model_catalog/models/filter_options`,
@@ -106,14 +106,26 @@ describe('Model Catalog Page', () => {
     modelCatalog.findFilterCheckbox('Task', 'video-to-text').should('not.be.exist');
   });
 
-  // TODO: Add this test when the actual card filtering is implemented.
-  // it('checkbox should work', () => {
-  //   initIntercepts({});
-  //   modelCatalog.visit();
-  //   modelCatalog.navigate();
-  //   modelCatalog.findFilterCheckbox('Task', 'text-generation').click();
-  //   modelCatalog.findFirstModelCatalogCard().should('be.visible');
-  //   modelCatalog.findFilterCheckbox('Task', 'text-to-text').click();
-  //   modelCatalog.findModelCatalogEmptyState().should('be.visible');
-  // });
+  it('checkbox should work', () => {
+    initIntercepts({});
+    modelCatalog.visit();
+    modelCatalog.navigate();
+    modelCatalog.findFilterCheckbox('Task', 'text-generation').click();
+    modelCatalog.findFilterCheckbox('Task', 'text-to-text').click();
+    modelCatalog.findFilterCheckbox('Provider', 'Google').click();
+    cy.wait([
+      '@getCatalogModelsBySource',
+      '@getCatalogModelsBySource',
+      '@getCatalogModelsBySource',
+      '@getCatalogModelsBySource',
+      '@getCatalogModelsBySource',
+      '@getCatalogModelsBySource',
+      '@getCatalogModelsBySource',
+    ]).then((interceptions) => {
+      const lastInterception = interceptions[interceptions.length - 1];
+      expect(lastInterception.request.url).to.include(
+        'filterQuery%3Dtasks%2BIN%2B%28%27text-generation%27%2C%27text-to-text%27%29%2BAND%2Bprovider%2B%3D%2B%27Google%27',
+      );
+    });
+  });
 });

--- a/clients/ui/frontend/src/app/api/modelCatalog/service.ts
+++ b/clients/ui/frontend/src/app/api/modelCatalog/service.ts
@@ -5,7 +5,9 @@ import {
   CatalogModel,
   CatalogModelList,
   CatalogSourceList,
+  ModelCatalogFilterStates,
 } from '~/app/modelCatalogTypes';
+import { filtersToFilterQuery } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 
 export const getCatalogModelsBySource =
   (hostPath: string, queryParams: Record<string, unknown> = {}) =>
@@ -19,12 +21,16 @@ export const getCatalogModelsBySource =
       sortOrder?: string;
     },
     searchKeyword?: string,
+    filterData?: ModelCatalogFilterStates,
+    filterOptions?: CatalogFilterOptionsList | null,
   ): Promise<CatalogModelList> => {
     const allParams = {
       source: sourceId,
       ...paginationParams,
       ...(searchKeyword && { q: searchKeyword }),
       ...queryParams,
+      ...(filterData &&
+        filterOptions && { filterQuery: filtersToFilterQuery(filterData, filterOptions) }),
     };
     return handleRestFailures(restGET(hostPath, '/models', allParams, opts)).then((response) => {
       if (isModArchResponse<CatalogModelList>(response)) {

--- a/clients/ui/frontend/src/app/hooks/modelCatalog/useCatalogModelsBySource.ts
+++ b/clients/ui/frontend/src/app/hooks/modelCatalog/useCatalogModelsBySource.ts
@@ -1,6 +1,11 @@
 import { useFetchState, FetchStateCallbackPromise, NotReadyError } from 'mod-arch-core';
 import React from 'react';
-import { CatalogModel, CatalogModelList } from '~/app/modelCatalogTypes';
+import {
+  CatalogFilterOptionsList,
+  CatalogModel,
+  CatalogModelList,
+  ModelCatalogFilterStates,
+} from '~/app/modelCatalogTypes';
 import { useModelCatalogAPI } from './useModelCatalogAPI';
 
 type PaginatedCatalogModelList = {
@@ -25,6 +30,8 @@ export const useCatalogModelsBySources = (
   sourceId: string,
   pageSize = 10,
   searchQuery = '',
+  filterData?: ModelCatalogFilterStates,
+  filterOptions?: CatalogFilterOptionsList | null,
 ): ModelList => {
   const { api, apiAvailable } = useModelCatalogAPI();
 
@@ -47,9 +54,11 @@ export const useCatalogModelsBySources = (
         sourceId,
         { pageSize: pageSize.toString() },
         searchQuery.trim() || undefined,
+        filterData,
+        filterOptions,
       );
     },
-    [api, apiAvailable, sourceId, pageSize, searchQuery],
+    [api, apiAvailable, sourceId, pageSize, searchQuery, filterData, filterOptions],
   );
 
   const [firstPageData, loaded, error, refetch] = useFetchState(

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -161,6 +161,8 @@ export type GetCatalogModelsBySource = (
     sortOrder?: string;
   },
   searchKeyword?: string,
+  filterData?: ModelCatalogFilterStates,
+  filterOptions?: CatalogFilterOptionsList | null,
 ) => Promise<CatalogModelList>;
 
 export type GetListSources = (opts: APIOptions) => Promise<CatalogSourceList>;
@@ -219,5 +221,5 @@ export type CatalogFilterOptionsList = {
 export type ModelCatalogFilterStates = {
   [key in ModelCatalogStringFilterKey]: ModelCatalogStringFilterValueType[key][];
 } & {
-  [key in ModelCatalogNumberFilterKey]: number;
+  [key in ModelCatalogNumberFilterKey]: number | undefined;
 };

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogPage.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogPage.tsx
@@ -10,6 +10,7 @@ import {
 import { SearchIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
+import { useCatalogFilterOptionList } from '~/app/hooks/modelCatalog/useCatalogFilterOptionList';
 import { useCatalogModelsBySources } from '~/app/hooks/modelCatalog/useCatalogModelsBySource';
 import { CatalogModel } from '~/app/modelCatalogTypes';
 import ModelCatalogCard from '~/app/pages/modelCatalog/components/ModelCatalogCard';
@@ -20,11 +21,14 @@ type ModelCatalogPageProps = {
 };
 
 const ModelCatalogPage: React.FC<ModelCatalogPageProps> = ({ searchTerm }) => {
-  const { selectedSource } = React.useContext(ModelCatalogContext);
+  const { selectedSource, filterData, apiState } = React.useContext(ModelCatalogContext);
+  const [filterOptions] = useCatalogFilterOptionList(apiState);
   const { catalogModels, catalogModelsLoaded, catalogModelsLoadError } = useCatalogModelsBySources(
     selectedSource?.id || '',
     10,
     searchTerm,
+    filterData,
+    filterOptions,
   );
 
   if (catalogModelsLoadError) {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -1,0 +1,272 @@
+// Disabling camelcase for this file because the inherent property names are not camelcase
+/* eslint-disable camelcase */
+import { CatalogFilterOptionsList, ModelCatalogFilterStates } from '~/app/modelCatalogTypes';
+import {
+  AllLanguageCode,
+  ModelCatalogLicense,
+  ModelCatalogProvider,
+  ModelCatalogTask,
+} from '~/concepts/modelCatalog/const';
+import { filtersToFilterQuery } from '../modelCatalogUtils';
+
+// TODO: Implement performance filters.
+describe('filtersToFilterQuery', () => {
+  const mockFormData = ({
+    tasks = [],
+    license = [],
+    provider = [],
+    language = [],
+    // ttft_mean = undefined,
+    // rps_mean = undefined,
+  }: Partial<ModelCatalogFilterStates>): ModelCatalogFilterStates => ({
+    tasks,
+    provider,
+    license,
+    language,
+    // ttft_mean,
+    // rps_mean,
+  });
+
+  const mockFilterOptions: CatalogFilterOptionsList = {
+    filters: {
+      tasks: {
+        type: 'string',
+        values: [
+          ModelCatalogTask.AUDIO_TO_TEXT,
+          ModelCatalogTask.IMAGE_TEXT_TO_TEXT,
+          ModelCatalogTask.IMAGE_TO_TEXT,
+          ModelCatalogTask.TEXT_GENERATION,
+          ModelCatalogTask.TEXT_TO_TEXT,
+          ModelCatalogTask.VIDEO_TO_TEXT,
+        ],
+      },
+      provider: {
+        type: 'string',
+        values: [
+          ModelCatalogProvider.ALIBABA_CLOUD,
+          ModelCatalogProvider.DEEPSEEK,
+          ModelCatalogProvider.GOOGLE,
+          ModelCatalogProvider.IBM,
+          ModelCatalogProvider.META,
+          ModelCatalogProvider.MISTRAL_AI,
+          ModelCatalogProvider.MOONSHOT_AI,
+          ModelCatalogProvider.NEURAL_MAGIC,
+          ModelCatalogProvider.NVIDIA,
+          ModelCatalogProvider.NVIDIA_ALTERNATE,
+          ModelCatalogProvider.RED_HAT,
+        ],
+      },
+      license: {
+        type: 'string',
+        values: [
+          ModelCatalogLicense.APACHE_2_0,
+          ModelCatalogLicense.GEMMA,
+          ModelCatalogLicense.LLLAMA_3_3,
+          ModelCatalogLicense.LLLAMA_3_1,
+          ModelCatalogLicense.LLLAMA_3_3_ALTERNATE,
+          ModelCatalogLicense.LLLAMA_4,
+          ModelCatalogLicense.MIT,
+          ModelCatalogLicense.MODIFIED_MIT,
+        ],
+      },
+      language: {
+        type: 'string',
+        values: [
+          AllLanguageCode.BG,
+          AllLanguageCode.CA,
+          AllLanguageCode.CS,
+          AllLanguageCode.DA,
+          AllLanguageCode.DE,
+          AllLanguageCode.EL,
+          AllLanguageCode.EN,
+          AllLanguageCode.ES,
+          AllLanguageCode.FI,
+          AllLanguageCode.FR,
+          AllLanguageCode.HR,
+          AllLanguageCode.HU,
+          AllLanguageCode.IS,
+          AllLanguageCode.IT,
+          AllLanguageCode.NL,
+          AllLanguageCode.NLD,
+          AllLanguageCode.NO,
+          AllLanguageCode.PL,
+          AllLanguageCode.PT,
+          AllLanguageCode.RO,
+          AllLanguageCode.RU,
+          AllLanguageCode.SK,
+          AllLanguageCode.SL,
+          AllLanguageCode.SR,
+          AllLanguageCode.SV,
+          AllLanguageCode.UK,
+          AllLanguageCode.JA,
+          AllLanguageCode.KO,
+          AllLanguageCode.ZH,
+          AllLanguageCode.HI,
+          AllLanguageCode.TH,
+          AllLanguageCode.VI,
+          AllLanguageCode.ID,
+          AllLanguageCode.MS,
+          AllLanguageCode.ZSM,
+          AllLanguageCode.AR,
+          AllLanguageCode.FA,
+          AllLanguageCode.HE,
+          AllLanguageCode.TR,
+          AllLanguageCode.UR,
+          AllLanguageCode.TL,
+        ],
+      },
+      // TODO: Implement performance filters.
+      // ttft_mean: {
+      //   type: 'number',
+      //   range: {
+      //     min: 0,
+      //     max: 100,
+      //   },
+      // },
+      // TODO: Implement performance filters.
+      // rps_mean: {
+      //   type: 'number',
+      //   range: {
+      //     min: 0,
+      //     max: 10,
+      //   },
+      // },
+    },
+  };
+  /* eslint-enable camelcase */
+
+  describe('multi-selection values', () => {
+    it('handles no data', () => {
+      expect(filtersToFilterQuery(mockFormData({}), mockFilterOptions)).toBe('');
+    });
+
+    it('handles a single array of a single data point', () => {
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT] }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=tasks+=+'text-to-text'");
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ provider: [ModelCatalogProvider.GOOGLE] }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=provider+=+'Google'");
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ license: [ModelCatalogLicense.APACHE_2_0] }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=license+=+'apache-2.0'");
+      expect(
+        filtersToFilterQuery(mockFormData({ language: [AllLanguageCode.CA] }), mockFilterOptions),
+      ).toBe("filterQuery=language+=+'ca'");
+    });
+
+    it('handles multiple arrays of a single data point', () => {
+      expect(
+        filtersToFilterQuery(
+          mockFormData({
+            tasks: [ModelCatalogTask.TEXT_TO_TEXT],
+            license: [ModelCatalogLicense.APACHE_2_0],
+          }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=tasks+=+'text-to-text'+AND+license+=+'apache-2.0'");
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ provider: [ModelCatalogProvider.GOOGLE], language: [AllLanguageCode.CA] }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=provider+=+'Google'+AND+language+=+'ca'");
+    });
+
+    it('handles a single array with multiple data points', () => {
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT, ModelCatalogTask.IMAGE_TO_TEXT] }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=tasks+IN+('text-to-text','image-to-text')");
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ provider: [ModelCatalogProvider.GOOGLE, ModelCatalogProvider.DEEPSEEK] }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=provider+IN+('Google','DeepSeek')");
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ license: [ModelCatalogLicense.APACHE_2_0, ModelCatalogLicense.MIT] }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=license+IN+('apache-2.0','mit')");
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ language: [AllLanguageCode.CA, AllLanguageCode.PT] }),
+          mockFilterOptions,
+        ),
+      ).toBe("filterQuery=language+IN+('ca','pt')");
+    });
+
+    it('handles multiple arrays with mixed count of data points', () => {
+      expect(
+        filtersToFilterQuery(
+          mockFormData({
+            tasks: [ModelCatalogTask.TEXT_TO_TEXT, ModelCatalogTask.IMAGE_TO_TEXT],
+            provider: [ModelCatalogProvider.GOOGLE],
+            license: [ModelCatalogLicense.MIT],
+            language: [
+              AllLanguageCode.CA,
+              AllLanguageCode.PT,
+              AllLanguageCode.VI,
+              AllLanguageCode.ZSM,
+            ],
+          }),
+          mockFilterOptions,
+        ),
+      ).toBe(
+        "filterQuery=tasks+IN+('text-to-text','image-to-text')+AND+provider+=+'Google'+AND+license+=+'mit'+AND+language+IN+('ca','pt','vi','zsm')",
+      );
+    });
+  });
+
+  // TODO: Implement performance filters.
+  //   describe('less than values', () => {
+  //     it('handles TimeToFirstToken - ttft', () => {
+  //       // eslint-disable-next-line camelcase
+  //       expect(filtersToFilterQuery(mockFormData({ ttft_mean: 100 }), mockFilterOptions)).toBe(
+  //         'filterQuery=ttft_mean+<+100',
+  //       );
+  //     });
+  //   });
+
+  //   describe('greater than values', () => {
+  //     it('handles TimeToFirstToken - ttft', () => {
+  //       // eslint-disable-next-line camelcase
+  //       expect(filtersToFilterQuery(mockFormData({ rps_mean: 7 }), mockFilterOptions)).toBe(
+  //         'filterQuery=rps_mean+>+7',
+  //       );
+  //     });
+  //   });
+
+  //   describe('mixture of multiple types of values', () => {
+  //     it('handles TimeToFirstToken - ttft', () => {
+  //       expect(
+  //         filtersToFilterQuery(
+  //           mockFormData({
+  //             // eslint-disable-next-line camelcase
+  //             ttft_mean: 100,
+  //             tasks: [ModelCatalogTask.TEXT_TO_TEXT],
+  //             license: [ModelCatalogLicense.APACHE_2_0, ModelCatalogLicense.MIT],
+  //             // eslint-disable-next-line camelcase
+  //             rps_mean: 3,
+  //           }),
+  //           mockFilterOptions,
+  //         ),
+  //       ).toBe(
+  //         "filterQuery=tasks+=+'text-to-text'+AND+license+IN+('apache-2.0','mit')+AND+ttft_mean+<+100+AND+rps_mean+>+3",
+  //       );
+  //     });
+  //   });
+});

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -4,6 +4,8 @@ import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogCont
 import {
   CatalogArtifacts,
   CatalogArtifactType,
+  CatalogFilterOptions,
+  CatalogFilterOptionsList,
   CatalogModel,
   CatalogModelDetailsParams,
   CatalogSourceList,
@@ -110,4 +112,89 @@ export const useCatalogStringFilterState = (
     }
   };
   return { isSelected, setSelected };
+};
+
+const isArrayOfSelections = (
+  filterOption: CatalogFilterOptions[keyof CatalogFilterOptions],
+  data: unknown,
+): data is string[] =>
+  filterOption.type === 'string' && Array.isArray(filterOption.values) && Array.isArray(data);
+
+// TODO: Implement performance filters.
+// type FilterId = keyof CatalogFilterOptionsList['filters'];
+// const KNOWN_LESS_THAN_IDS: FilterId[] = [ModelCatalogNumberFilterKey.TTFT_MEAN]; // TODO: populate with filters that need to talk about "less" values
+// const isKnownLessThanValue = (
+//   filterOption: CatalogFilterOptions[keyof CatalogFilterOptions],
+//   filterId: FilterId,
+//   data: unknown,
+// ): data is number =>
+//   filterOption.type === 'number' &&
+//   KNOWN_LESS_THAN_IDS.includes(filterId) &&
+//   typeof data === 'number';
+
+// const KNOWN_MORE_THAN_IDS: FilterId[] = [ModelCatalogNumberFilterKey.RPS_MEAN]; // TODO: populate with filters that need to talk about "more" values
+// const isKnownMoreThanValue = (
+//   filterOption: CatalogFilterOptions[keyof CatalogFilterOptions],
+//   filterId: FilterId,
+//   data: unknown,
+// ): data is number =>
+//   filterOption.type === 'number' &&
+//   KNOWN_MORE_THAN_IDS.includes(filterId) &&
+//   typeof data === 'number';
+
+const isFilterIdInMap = (
+  filterId: unknown,
+  filters: CatalogFilterOptionsList['filters'],
+): filterId is keyof CatalogFilterOptionsList['filters'] =>
+  typeof filterId === 'string' && filterId in filters;
+
+const wrapInQuotes = (v: string): string => `'${v}'`;
+const inSpacer = `,`;
+
+export const filtersToFilterQuery = (
+  filterData: ModelCatalogFilterStates,
+  options: CatalogFilterOptionsList,
+): string => {
+  const filters = Object.entries(filterData).map(([filterId, data]) => {
+    if (!isFilterIdInMap(filterId, options.filters) || typeof data === 'undefined') {
+      // Unhandled key or no data
+      return '';
+    }
+
+    const filterOption = options.filters[filterId];
+
+    if (isArrayOfSelections(filterOption, data)) {
+      switch (data.length) {
+        case 0:
+          return '';
+        case 1:
+          return `${filterId} = ${wrapInQuotes(data[0])}`;
+        default:
+          // 2 or more
+          return `${filterId} IN (${data.map(wrapInQuotes).join(inSpacer)})`;
+      }
+    }
+
+    // TODO: Implement performance filters.
+    // if (isKnownLessThanValue(filterOption, filterId, data)) {
+    //   return `${filterId} < ${data}`;
+    // }
+
+    // if (isKnownMoreThanValue(filterOption, filterId, data)) {
+    //   return `${filterId} > ${data}`;
+    // }
+
+    // TODO: Implement more data transforms
+    // Shouldn't reach this far, but if it does, log & ignore the case
+    // eslint-disable-next-line no-console
+    console.warn('Unhandled option', filterId, data, filterOption);
+    return '';
+  });
+
+  const nonEmptyFilters = filters.filter((v) => !!v);
+
+  // eg. filterQuery=rps_mean+>1+AND+license+IN+('mit','apache-2.0')+AND+ttft_mean+<+10
+  return nonEmptyFilters.length === 0
+    ? ''
+    : `filterQuery=${nonEmptyFilters.join(' AND ')}`.replace(/\s/g, '+');
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Now, checking the filters will send a request with query parameters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Cypress and unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
