### PR TITLE
fix: return 404 in artifact creation on non existing model version

### DIFF
--- a/clients/python/tests/fuzz_api/model_registry/test_mr_stateless.py
+++ b/clients/python/tests/fuzz_api/model_registry/test_mr_stateless.py
@@ -87,7 +87,7 @@ def build_artifact_payload(artifact_type: str, uri_prefix: str, state: str, name
     return payload
 
 
-def validate_artifact_response(response: requests.Response, expected_payload: dict[str, Any]) -> str:
+def validate_artifact_response(response: requests.Response, expected_payload: dict[str, Any]) -> str | None:
     """Validate artifact creation response and return the artifact ID.
 
     Args:
@@ -104,6 +104,15 @@ def validate_artifact_response(response: requests.Response, expected_payload: di
     assert response.status_code in {200, 201, 404}, f"Expected 200, 201, or 404, got {response.status_code}: {response.text}"
 
     response_json = response.json()
+
+    # Handle error responses (404)
+    if response.status_code == 404:
+        assert "message" in response_json, "Error response should contain 'message' field"
+        assert "not found" in response_json["message"].lower(), f"Error message should contain 'not found', got: {response_json['message']}"
+        # For 404 responses, we don't return an ID since the artifact wasn't created
+        return None
+
+    # Handle success responses (200, 201)
     assert response_json.get("id"), "Response body should contain 'id'"
 
     # Validate response matches payload
@@ -284,8 +293,9 @@ def test_post_model_version_artifacts(auth_headers: dict, artifact_type: str, ur
     # Validate response and get artifact ID
     artifact_id = validate_artifact_response(response, payload)
 
-    # Cleanup after successful creation
-    cleanup_artifacts(artifact_id)
+    # Cleanup after successful creation (only if artifact was created)
+    if artifact_id is not None:
+        cleanup_artifacts(artifact_id)
 
 
 @pytest.mark.fuzz
@@ -316,8 +326,9 @@ def test_post_experiment_run_artifacts(auth_headers: dict, artifact_type: str, u
     # Validate response and get artifact ID
     artifact_id = validate_artifact_response(response, payload)
 
-    # Cleanup artifacts
-    cleanup_artifacts(artifact_id)
+    # Cleanup artifacts (only if artifact was created)
+    if artifact_id is not None:
+        cleanup_artifacts(artifact_id)
 
     # Cleanup experiment and run
     cleanup_experiment_and_run(auth_headers=auth_headers, experiment_id=experiment_id, experiment_run_id=experiment_run_id, verify_tls=verify_ssl)

--- a/clients/python/tests/fuzz_api/model_registry/test_mr_stateless.py
+++ b/clients/python/tests/fuzz_api/model_registry/test_mr_stateless.py
@@ -101,7 +101,7 @@ def validate_artifact_response(response: requests.Response, expected_payload: di
         AssertionError: If validation fails
     """
     # Check response status
-    assert response.status_code in {200, 201}, f"Expected 200 or 201, got {response.status_code}: {response.text}"
+    assert response.status_code in {200, 201, 404}, f"Expected 200, 201, or 404, got {response.status_code}: {response.text}"
 
     response_json = response.json()
     assert response_json.get("id"), "Response body should contain 'id'"

--- a/clients/python/tests/fuzz_api/model_registry/test_mr_stateless.py
+++ b/clients/python/tests/fuzz_api/model_registry/test_mr_stateless.py
@@ -1,7 +1,7 @@
 import logging
 import secrets
 import time
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import pytest
 import requests
@@ -87,7 +87,7 @@ def build_artifact_payload(artifact_type: str, uri_prefix: str, state: str, name
     return payload
 
 
-def validate_artifact_response(response: requests.Response, expected_payload: dict[str, Any]) -> str | None:
+def validate_artifact_response(response: requests.Response, expected_payload: dict[str, Any]) -> Optional[str]:
     """Validate artifact creation response and return the artifact ID.
 
     Args:

--- a/internal/core/artifact.go
+++ b/internal/core/artifact.go
@@ -314,6 +314,12 @@ func (b *ModelRegistryService) upsertArtifact(artifact *openapi.Artifact, parent
 }
 
 func (b *ModelRegistryService) UpsertModelVersionArtifact(artifact *openapi.Artifact, parentResourceId string) (*openapi.Artifact, error) {
+	// Validate that the ModelVersion exists before creating the artifact
+	_, err := b.GetModelVersionById(parentResourceId)
+	if err != nil {
+		return nil, err
+	}
+
 	return b.upsertArtifact(artifact, &parentResourceId)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR fixes current main CI failures on fuzz tests (e.g. https://github.com/kubeflow/model-registry/actions/runs/18311924976/job/52142359445)

API now returns 404 when trying to create an artifact on a non existing model version at endpoint `/api/model_registry/v1alpha3/model_versions/{model_version_id}/artifacts`

going from

(status 500)
```
 {
   "code":"Internal Server Error",
   "message":"error creating attribution: violates foreign key constraint"
}
```

to

(status 404)
```
{
  "code": "Not Found",
  "message": "no model version found for id 2: not found"
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
