### PR TITLE
Setup initial structure for loading performance data

### DIFF
--- a/catalog/internal/catalog/performance_metrics.go
+++ b/catalog/internal/catalog/performance_metrics.go
@@ -1,0 +1,89 @@
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	dbmodels "github.com/kubeflow/model-registry/catalog/internal/db/models"
+	"github.com/kubeflow/model-registry/catalog/internal/db/service"
+	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
+)
+
+// LoadPerformanceMetricsData loads performance metrics data from the specified directory
+// into the database using the catalog model and artifact repositories.
+func LoadPerformanceMetricsData(path []string, modelRepo dbmodels.CatalogModelRepository, metricsArtifactRepo dbmodels.CatalogMetricsArtifactRepository, typeMap map[string]int64) (map[string]*model.CatalogModel, error) {
+	if len(path) == 0 {
+		glog.Info("No performance metrics path provided, skipping performance metrics loading")
+		return nil, nil
+	}
+
+	// Check if path exists
+	for _, p := range path {
+		if _, err := os.Stat(p); os.IsNotExist(err) {
+			glog.Warningf("Performance metrics path %s does not exist, skipping performance metrics loading", p)
+			return nil, nil
+		}
+	}
+
+	glog.Infof("Loading performance metrics data from %s", path)
+
+	// Get the TypeID for CatalogModel from the type map
+	modelTypeIDInt64, exists := typeMap[service.CatalogModelTypeName]
+	if !exists {
+		return nil, fmt.Errorf("CatalogModel type not found in type map")
+	}
+	modelTypeID := int32(modelTypeIDInt64)
+	glog.V(2).Infof("Using catalog model type ID: %d", modelTypeID)
+
+	// Get the TypeID for CatalogMetricsArtifact from the type map
+	metricsArtifactTypeIDInt64, exists := typeMap[service.CatalogMetricsArtifactTypeName]
+	if !exists {
+		return nil, fmt.Errorf("CatalogMetricsArtifact type not found in type map")
+	}
+	metricsArtifactTypeID := int32(metricsArtifactTypeIDInt64)
+	glog.V(2).Infof("Using metrics artifact type ID: %d", metricsArtifactTypeID)
+
+	loadedModels := make(map[string]*model.CatalogModel)
+	processedCount := 0
+
+	// Walk through the directory structure to find model directories
+	for _, rootPath := range path {
+		err := filepath.Walk(rootPath, func(dirPath string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// Skip if not a directory
+			if !info.IsDir() {
+				return nil
+			}
+
+			// Check if this directory contains metadata.json
+			metadataPath := filepath.Join(dirPath, "metadata.json")
+			if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
+				return nil // Skip directories without metadata.json
+			}
+
+			glog.Infof("Processing model directory: %s", dirPath)
+
+			// Process the model directory
+			// if err := processModelDirectory(dirPath, modelRepo, metricsArtifactRepo, modelTypeID, metricsArtifactTypeID, loadedModels); err != nil {
+			// 	glog.Errorf("Failed to process model directory %s: %v", dirPath, err)
+			// 	// Continue processing other directories
+			// 	return nil
+			// }
+
+			processedCount++
+			return nil
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to walk performance metrics directory %s: %v", rootPath, err)
+		}
+	}
+
+	glog.Infof("Successfully processed %d model directories and loaded %d models into database", processedCount, len(loadedModels))
+	return loadedModels, nil
+}

--- a/catalog/internal/catalog/performance_metrics.go
+++ b/catalog/internal/catalog/performance_metrics.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -34,6 +35,10 @@ func LoadPerformanceMetricsData(path []string, modelRepo dbmodels.CatalogModelRe
 	if !exists {
 		return nil, fmt.Errorf("CatalogModel type not found in type map")
 	}
+	// Bounds check for int64 to int32 conversion
+	if modelTypeIDInt64 > math.MaxInt32 || modelTypeIDInt64 < math.MinInt32 {
+		return nil, fmt.Errorf("CatalogModel type ID %d is out of int32 range", modelTypeIDInt64)
+	}
 	modelTypeID := int32(modelTypeIDInt64)
 	glog.V(2).Infof("Using catalog model type ID: %d", modelTypeID)
 
@@ -41,6 +46,10 @@ func LoadPerformanceMetricsData(path []string, modelRepo dbmodels.CatalogModelRe
 	metricsArtifactTypeIDInt64, exists := typeMap[service.CatalogMetricsArtifactTypeName]
 	if !exists {
 		return nil, fmt.Errorf("CatalogMetricsArtifact type not found in type map")
+	}
+	// Bounds check for int64 to int32 conversion
+	if metricsArtifactTypeIDInt64 > math.MaxInt32 || metricsArtifactTypeIDInt64 < math.MinInt32 {
+		return nil, fmt.Errorf("CatalogMetricsArtifact type ID %d is out of int32 range", metricsArtifactTypeIDInt64)
 	}
 	metricsArtifactTypeID := int32(metricsArtifactTypeIDInt64)
 	glog.V(2).Infof("Using metrics artifact type ID: %d", metricsArtifactTypeID)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the initial structure for loading the performance metrics data from a filepath into the database. Currently this is just setting up the configuration and the initial checks to validate that the data is present and can be loaded.

This is the first part of a series of PRs to actually load this performance metric data into the database, there will be additional PRs that build off of this one.

## How Has This Been Tested?

Locally using docker/docker-compose

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
