### PR TITLE
fix(catalog): prefix applied to absolute paths

### DIFF
--- a/catalog/internal/catalog/yaml_catalog.go
+++ b/catalog/internal/catalog/yaml_catalog.go
@@ -398,7 +398,11 @@ func newYamlModelProvider(ctx context.Context, source *Source, reldir string) (<
 		return nil, fmt.Errorf("missing %s string property", yamlCatalogPathKey)
 	}
 
-	p.path = filepath.Join(reldir, path)
+	if filepath.IsAbs(path) {
+		p.path = path
+	} else {
+		p.path = filepath.Join(reldir, path)
+	}
 
 	// Excluded models is an optional source property.
 	if _, exists := source.Properties[excludedModelsKey]; exists {


### PR DESCRIPTION
## Description
The YAML loader was incorrectly applying a directory prefix to absolute
paths.


## How Has This Been Tested?
Reproduced with the unit test.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
