### PR TITLE
feat: modify async upload job tests to check custom_properties

### DIFF
--- a/jobs/async-upload/tests/integration/test_integration_async_upload.py
+++ b/jobs/async-upload/tests/integration/test_integration_async_upload.py
@@ -545,15 +545,25 @@ def test_create_model_integration(
     assert created_rm, f"RegisteredModel '{config_model_name}' was not created"
     print(f"✅ RegisteredModel created: {created_rm.name} (ID: {created_rm.id})")
 
+    assert created_rm.custom_properties == json.loads(configmap_data["RegisteredModel.custom_properties"])
+    print(f"✅ RegisteredModel custom properties validated: {created_rm.custom_properties}")
+
     created_mv = model_registry_client.get_model_version(config_model_name, "v1.0.0")
     assert created_mv, "ModelVersion 'v1.0.0' was not created"
     print(f"✅ ModelVersion created: {created_mv.name} (ID: {created_mv.id})")
+
+    assert created_mv.custom_properties == json.loads(configmap_data["ModelVersion.custom_properties"])
+    print(f"✅ ModelVersion custom properties validated: {created_mv.custom_properties}")
 
     created_ma = model_registry_client.get_model_artifact(config_model_name, "v1.0.0")
     assert created_ma, "ModelArtifact was not created"
     assert created_ma.state == ArtifactState.LIVE, f"Artifact state should be LIVE: {created_ma.state}"
     print(f"✅ ModelArtifact created: {created_ma.name} (ID: {created_ma.id})")
     print(f"✅ Artifact URI: {created_ma.uri}")
+
+    assert created_ma.custom_properties == json.loads(configmap_data["ModelArtifact.custom_properties"])
+    print(f"✅ ModelArtifact custom properties validated: {created_ma.custom_properties}")
+
     print("Integration test completed successfully!")
 
 
@@ -602,9 +612,16 @@ def test_create_version_integration(
     assert created_mv, "ModelVersion 'v1.0.0' was not created"
     print(f"✅ ModelVersion created: {created_mv.name} (ID: {created_mv.id})")
 
+    assert created_mv.custom_properties == json.loads(configmap_data["ModelVersion.custom_properties"])
+    print(f"✅ ModelVersion custom properties validated: {created_mv.custom_properties}")
+
     created_ma = model_registry_client.get_model_artifact(unique_model_name, "v1.0.0")
     assert created_ma, "ModelArtifact was not created"
     assert created_ma.state == ArtifactState.LIVE, f"Artifact state should be LIVE: {created_ma.state}"
     print(f"✅ ModelArtifact created: {created_ma.name} (ID: {created_ma.id})")
     print(f"✅ Artifact URI: {created_ma.uri}")
+
+    assert created_ma.custom_properties == json.loads(configmap_data["ModelArtifact.custom_properties"])
+    print(f"✅ ModelArtifact custom properties validated: {created_ma.custom_properties}")
+
     print("Integration test completed successfully!")


### PR DESCRIPTION
This ensures that when we pass custom_properties to the async upload job via config map, that they are added to the model.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
