### PR TITLE
fix(catalog): ensure platform-consistent OpenAPI code generation

### DIFF
--- a/catalog/scripts/gen_openapi_server.sh
+++ b/catalog/scripts/gen_openapi_server.sh
@@ -32,7 +32,10 @@ sed_inplace 's/"encoding\/json"//' "$PROJECT_ROOT"/internal/server/openapi/api_m
 sed_inplace 's/github.com\/kubeflow\/model-registry\/pkg\/openapi/github.com\/kubeflow\/model-registry\/catalog\/pkg\/openapi/' \
     "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go \
     "$PROJECT_ROOT"/internal/server/openapi/api.go
-sed_inplace 's/{\?model_name+}\?/*/' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
+# Replace {model_name+} path parameters with wildcard patterns
+sed_inplace 's/{model_name\+}/*/g' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
+# Replace quoted "model_name+" parameter names with "*" 
+sed_inplace 's/"model_name\+"/"*"/g' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
 
 echo "Applying patches to generated code"
 (


### PR DESCRIPTION
## Description
OpenAPI Generator v7.0.1 behaves differently on macOS vs Linux when processing {model_name+} path parameters, causing platform-specific generated code differences.

Root cause:
- macOS: Preserves {model_name+} patterns in generated code
- Linux: Converts {model_name+} to wildcard * patterns directly

This fix implements targeted sed replacements to normalize the output:
- Replace {model_name+} path parameters with * wildcards
- Replace "model_name+" parameter names with "*"
- Use proper regex escaping for + character

The fix is surgical and safe, only targeting specific patterns while preserving legitimate uses of model_name in comments and other contexts.

Fixes #1748
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make clean gen` produces no differences

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
