### PR TITLE
feat: replace sed with Python regex in OpenAPI generator script

### DIFF
--- a/catalog/scripts/gen_openapi_server.sh
+++ b/catalog/scripts/gen_openapi_server.sh
@@ -15,24 +15,31 @@ DST="$PROJECT_ROOT/${2:-internal/server/openapi}"
     --ignore-file-override "$PROJECT_ROOT"/.openapi-generator-ignore --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true,featureCORS=true \
     --template-dir "$PROJECT_ROOT"/../templates/go-server
 
-function sed_inplace() {
-    if [[ $(uname) == "Darwin" ]]; then
-        # introduce -i parameter for Mac OSX sed compatibility
-        sed -E -i '' "$@"
-    else
-        sed -E -i "$@"
-    fi
+# Python-based regex replace function
+# Usage: py-re-replace <count> <pattern> <replacement> <file1> [file2...]
+# count=0: replace all occurrences (like sed with /g flag)
+# count=1: replace first occurrence only (like sed without /g flag)
+# count=N: replace first N occurrences
+py-re-replace() {
+  python -c "
+import fileinput, re, sys
+count, pattern, replacement, filepaths = int(sys.argv[1]), sys.argv[2], sys.argv[3], sys.argv[4:]
+for filepath in filepaths:
+    for line in fileinput.FileInput(filepath, inplace=True, backup=''):
+        sys.stdout.write(re.sub(pattern, replacement, line, count=count))
+" "$@"
 }
 
-sed_inplace 's/, orderByParam/, model.OrderByField(orderByParam)/g' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
-sed_inplace 's/, sortOrderParam/, model.SortOrder(sortOrderParam)/g' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
+py-re-replace 0 ', orderByParam' ', model.OrderByField(orderByParam)' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
+py-re-replace 0 ', sortOrderParam' ', model.SortOrder(sortOrderParam)' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
 
-sed_inplace 's/"encoding\/json"//' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
+py-re-replace 1 '"encoding/json"' '' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
 
-sed_inplace 's/github.com\/kubeflow\/model-registry\/pkg\/openapi/github.com\/kubeflow\/model-registry\/catalog\/pkg\/openapi/' \
+py-re-replace 1 'github\.com/kubeflow/model-registry/pkg/openapi' 'github.com/kubeflow/model-registry/catalog/pkg/openapi' \
     "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go \
     "$PROJECT_ROOT"/internal/server/openapi/api.go
-sed_inplace 's/\{?model_name\+\}?/*/' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
+
+py-re-replace 1 '\{model_name\+\}|model_name\+' '*' "$PROJECT_ROOT"/internal/server/openapi/api_model_catalog_service.go
 
 echo "Applying patches to generated code"
 (


### PR DESCRIPTION
Replaced all sed_inplace invocations with py-re-replace function that uses Python's re module. The new function supports:
- count=0: replace all occurrences (equivalent to sed /g flag)
- count=1: replace first occurrence only (equivalent to sed without /g flag)
- count=N: replace first N occurrences
- Multiple file processing in single call
- Cross-platform compatibility with consistent regex behavior

AI-assisted: Claude Code 2.0.15 (claude-sonnet-4@20250514)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
