### PR TITLE
Fix performance metrics loading custom property data

### DIFF
--- a/catalog/internal/catalog/performance_metrics.go
+++ b/catalog/internal/catalog/performance_metrics.go
@@ -88,6 +88,35 @@ type performanceRecord struct {
 	CustomProperties map[string]interface{} `json:"-"`
 }
 
+// UnmarshalJSON implements custom JSON unmarshaling to capture all undefined fields as CustomProperties
+func (pr *performanceRecord) UnmarshalJSON(data []byte) error {
+	// First unmarshal into a generic map to get all fields
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Extract the core fields
+	if id, ok := raw["id"].(string); ok {
+		pr.ID = id
+	}
+	if modelID, ok := raw["model_id"].(string); ok {
+		pr.ModelID = modelID
+	}
+
+	// Initialize CustomProperties if nil
+	if pr.CustomProperties == nil {
+		pr.CustomProperties = make(map[string]interface{})
+	}
+
+	// Copy all fields to CustomProperties, including the core ones
+	for key, value := range raw {
+		pr.CustomProperties[key] = value
+	}
+
+	return nil
+}
+
 type PerformanceMetricsLoader struct {
 	path                  []string
 	modelRepo             dbmodels.CatalogModelRepository


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For some reason the Unmarshal method was not committed in a previous PR. I think this was a result of extensive cherry-picking when attempting to do parallel development.

This adds the unmarshal method back, which will populate the custom_properties with values not defined on the artifact

## How Has This Been Tested?
Locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
