### PR TITLE
[WIP] Clean up some type assertions and code reuse with the latency filter

### DIFF
--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -6,6 +6,7 @@ import {
   AllLanguageCode,
   ModelCatalogStringFilterKey,
   ModelCatalogNumberFilterKey,
+  LatencyMetricFieldName,
 } from '~/concepts/modelCatalog/const';
 import {
   ModelRegistryCustomProperties,
@@ -84,26 +85,6 @@ export type PerformanceMetricsCustomProperties = {
   hardware?: ModelRegistryCustomPropertyString;
   hardware_count?: ModelRegistryCustomPropertyInt;
   requests_per_second?: ModelRegistryCustomPropertyDouble;
-  // TTFT (Time To First Token) latency metrics
-  ttft_mean?: ModelRegistryCustomPropertyDouble;
-  ttft_p90?: ModelRegistryCustomPropertyDouble;
-  ttft_p95?: ModelRegistryCustomPropertyDouble;
-  ttft_p99?: ModelRegistryCustomPropertyDouble;
-  // E2E (End-to-End) latency metrics
-  e2e_mean?: ModelRegistryCustomPropertyDouble;
-  e2e_p90?: ModelRegistryCustomPropertyDouble;
-  e2e_p95?: ModelRegistryCustomPropertyDouble;
-  e2e_p99?: ModelRegistryCustomPropertyDouble;
-  // TPS (Tokens Per Second) latency metrics
-  tps_mean?: ModelRegistryCustomPropertyDouble;
-  tps_p90?: ModelRegistryCustomPropertyDouble;
-  tps_p95?: ModelRegistryCustomPropertyDouble;
-  tps_p99?: ModelRegistryCustomPropertyDouble;
-  // ITL (Inter-Token Latency) metrics
-  itl_mean?: ModelRegistryCustomPropertyDouble;
-  itl_p90?: ModelRegistryCustomPropertyDouble;
-  itl_p95?: ModelRegistryCustomPropertyDouble;
-  itl_p99?: ModelRegistryCustomPropertyDouble;
   // Token metrics
   max_input_tokens?: ModelRegistryCustomPropertyDouble;
   max_output_tokens?: ModelRegistryCustomPropertyDouble;
@@ -120,7 +101,7 @@ export type PerformanceMetricsCustomProperties = {
   updated_at?: ModelRegistryCustomPropertyString;
   model_hf_repo_name?: ModelRegistryCustomPropertyString;
   scenario_id?: ModelRegistryCustomPropertyString;
-};
+} & Partial<Record<LatencyMetricFieldName, ModelRegistryCustomPropertyDouble>>;
 
 export type AccuracyMetricsCustomProperties = {
   overall_average?: ModelRegistryCustomPropertyDouble;

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/WorkloadTypeFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/WorkloadTypeFilter.tsx
@@ -9,6 +9,7 @@ import {
   SelectOption,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
+import { asEnumMember } from 'mod-arch-core';
 import {
   ModelCatalogNumberFilterKey,
   WorkloadTypeOptionValue,
@@ -54,8 +55,10 @@ const WorkloadTypeFilter: React.FC = () => {
         isOpen={isOpen}
         selected={selectedWorkloadType}
         onSelect={(_, selectedVal) => {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          const workloadType = selectedVal as WorkloadTypeOptionValue;
+          const workloadType = asEnumMember(selectedVal, WorkloadTypeOptionValue);
+          if (!workloadType) {
+            return;
+          }
           const tokenValues = workloadTypeToMaxInputOutputTokens(workloadType);
 
           if (tokenValues) {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/hardwareConfigurationFilterUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/hardwareConfigurationFilterUtils.ts
@@ -1,42 +1,58 @@
 import {
   CatalogPerformanceMetricsArtifact,
   ModelCatalogFilterStates,
-  PerformanceMetricsCustomProperties,
 } from '~/app/modelCatalogTypes';
 import { getDoubleValue, getStringValue } from '~/app/utils';
 import {
   ModelCatalogStringFilterKey,
   ModelCatalogNumberFilterKey,
-  LatencyMetricKey,
+  LatencyMetricFieldName,
+  LatencyPercentile,
+  LatencyMetric,
 } from '~/concepts/modelCatalog/const';
 import { getTotalRps } from './performanceMetricsUtils';
 
 // Type for storing complex latency filter configuration
 export type LatencyFilterConfig = {
-  metric: 'E2E' | 'TTFT' | 'TPS' | 'ITL';
-  percentile: 'Mean' | 'P90' | 'P95' | 'P99';
+  metric: LatencyMetric;
+  percentile: LatencyPercentile;
   value: number;
 };
+
+const isMetricLowercase = (str: string): str is Lowercase<LatencyMetric> =>
+  Object.values(LatencyMetric)
+    .map((value) => value.toLowerCase())
+    .includes(str);
+const isPercentileLowercase = (str: string): str is Lowercase<LatencyPercentile> =>
+  Object.values(LatencyPercentile)
+    .map((value) => value.toLowerCase())
+    .includes(str);
 
 /**
  * Maps metric and percentile combination to the corresponding artifact field
  */
-const getLatencyFieldName = (
-  metric: string,
-  percentile: string,
-): keyof PerformanceMetricsCustomProperties => {
+export const getLatencyFieldName = (
+  metric: LatencyMetric,
+  percentile: LatencyPercentile,
+): LatencyMetricFieldName => {
   const metricPrefix = metric.toLowerCase();
-  const percentileSuffix = percentile === 'Mean' ? '_mean' : `_${percentile.toLowerCase()}`;
-  const fieldName = `${metricPrefix}${percentileSuffix}`;
+  const percentileSuffix = percentile.toLowerCase();
+  if (!isMetricLowercase(metricPrefix) || !isPercentileLowercase(percentileSuffix)) {
+    return 'ttft_mean'; // Default fallback
+  }
+  return `${metricPrefix}_${percentileSuffix}`;
+};
 
-  // Validate that the field exists in PerformanceMetricsCustomProperties
-  // Get latency fields from LatencyMetricKey enum
-  const validFields = Object.values(LatencyMetricKey);
-
-  return validFields.some((field) => field === fieldName)
-    ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      (fieldName as keyof PerformanceMetricsCustomProperties)
-    : LatencyMetricKey.TTFT_MEAN; // Default fallback
+/**
+ * Inverse of getLatencyFieldName
+ */
+export const parseLatencyFieldName = (
+  fieldName: LatencyMetricFieldName,
+): { metric: LatencyMetric; percentile: LatencyPercentile } | null => {
+  const [prefix, suffix] = fieldName.split('_');
+  const metric = Object.values(LatencyMetric).find((m) => m.toLowerCase() === prefix);
+  const percentile = Object.values(LatencyPercentile).find((p) => p.toLowerCase() === suffix);
+  return metric && percentile ? { metric, percentile } : null;
 };
 
 /**
@@ -101,8 +117,8 @@ export const filterHardwareConfigurationArtifacts = (
     const maxLatencyFilter = filterState[ModelCatalogNumberFilterKey.MAX_LATENCY];
     if (maxLatencyFilter !== undefined) {
       const defaultConfig: LatencyFilterConfig = {
-        metric: 'TTFT',
-        percentile: 'Mean',
+        metric: LatencyMetric.TTFT,
+        percentile: LatencyPercentile.Mean,
         value: maxLatencyFilter,
       };
 

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -13,29 +13,22 @@ export enum ModelCatalogNumberFilterKey {
   MAX_OUTPUT_TOKENS = 'max_output_tokens',
 }
 
-// Separate enum for all latency metrics used in validation and filtering
-export enum LatencyMetricKey {
-  // TTFT (Time To First Token)
-  TTFT_MEAN = 'ttft_mean',
-  TTFT_P90 = 'ttft_p90',
-  TTFT_P95 = 'ttft_p95',
-  TTFT_P99 = 'ttft_p99',
-  // E2E (End-to-End)
-  E2E_MEAN = 'e2e_mean',
-  E2E_P90 = 'e2e_p90',
-  E2E_P95 = 'e2e_p95',
-  E2E_P99 = 'e2e_p99',
-  // TPS (Tokens Per Second)
-  TPS_MEAN = 'tps_mean',
-  TPS_P90 = 'tps_p90',
-  TPS_P95 = 'tps_p95',
-  TPS_P99 = 'tps_p99',
-  // ITL (Inter-Token Latency)
-  ITL_MEAN = 'itl_mean',
-  ITL_P90 = 'itl_p90',
-  ITL_P95 = 'itl_p95',
-  ITL_P99 = 'itl_p99',
+export enum LatencyMetric {
+  E2E = 'E2E', // End to End
+  TTFT = 'TTFT', // Time To First Token
+  TPS = 'TPS', // Tokens Per Second
+  ITL = 'ITL', // Inter Token Latency
 }
+
+export enum LatencyPercentile {
+  Mean = 'Mean',
+  P90 = 'P90',
+  P95 = 'P95',
+  P99 = 'P99',
+}
+
+// Use getLatencyFieldName util to get values of this type
+export type LatencyMetricFieldName = `${Lowercase<LatencyMetric>}_${Lowercase<LatencyPercentile>}`;
 
 export enum WorkloadTypeOptionValue {
   CHAT = 'chat',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Small followup to https://github.com/kubeflow/model-registry/pull/1725

- Splits the `LatencyMetricKey` enum into two separate enums based on the metric and percentile. The new enums can be used as display names (they have proper upper/lower case for that) and you can derive the API key for a combination of the two using `getLatencyFieldName`.
- The `LatencyMetricFieldName` type uses TypeScript [Template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) to derive the `_`-concatenated lowercase values in a way that TypeScript can check against strings that combine the other enums. This type is used to reduce duplication in the `PerformanceMetricsCustomProperties` type, and as a result values of this type are assignable to that type.
- Adds a `parseLatencyFieldName` function as an inverse to `getLatencyFieldName`, not currently used but we can use it if we need logic checking a field name against the separated enums.
- Misc other cleanup surrounding these types and use of the `asEnumMember` util to avoid type assertions and duplicated code.

WIP because I don't want to block @manaswinidas from other followups to #1725 - feel free to cherrypick this commit to a branch and build on it without waiting for it to merge!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
