### PR TITLE
Removed Average accuracy from validated cards

### DIFF
--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -123,7 +123,7 @@ export type PerformanceMetricsCustomProperties = {
 };
 
 export type AccuracyMetricsCustomProperties = {
-  overall_average?: ModelRegistryCustomPropertyDouble;
+  // overall_average?: ModelRegistryCustomPropertyDouble; // NOTE: overall_average is currently omitted from the API and will be restored
   arc_v1?: ModelRegistryCustomPropertyDouble;
 } & Record<string, ModelRegistryCustomPropertyDouble>;
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -4,7 +4,7 @@ import {
   Button,
   Content,
   ContentVariants,
-  Divider,
+  // Divider, // NOTE: overall_average is currently omitted from the API and will be restored
   Flex,
   List,
   ListItem,
@@ -14,7 +14,11 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { MonitoringIcon, HelpIcon, AngleLeftIcon, AngleRightIcon } from '@patternfly/react-icons';
+import {
+  /* MonitoringIcon, */ HelpIcon,
+  AngleLeftIcon,
+  AngleRightIcon,
+} from '@patternfly/react-icons'; // NOTE: MonitoringIcon - overall_average is currently omitted from the API and will be restored
 import {
   CatalogModel,
   CatalogSource,
@@ -90,6 +94,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
 
     return (
       <Stack hasGutter>
+        {/* NOTE: overall_average is currently omitted from the API and will be restored
         <StackItem>
           <Flex
             alignItems={{ default: 'alignItemsCenter' }}
@@ -125,6 +130,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
         </StackItem>
 
         <Divider />
+        */}
 
         <StackItem>
           <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/mocks/accuracyMetricsMock.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/mocks/accuracyMetricsMock.ts
@@ -10,7 +10,7 @@ const MOCK_TIMESTAMP = '1739210683000';
 
 const createAccuracyMetricsArtifact = (
   id: string,
-  overallAverage: number,
+  // overallAverage: number, // NOTE: overall_average is currently omitted from the API and will be restored
   arcV1: number,
 ): CatalogAccuracyMetricsArtifact => ({
   artifactType: CatalogArtifactType.metricsArtifact,
@@ -18,10 +18,10 @@ const createAccuracyMetricsArtifact = (
   createTimeSinceEpoch: MOCK_TIMESTAMP,
   lastUpdateTimeSinceEpoch: MOCK_TIMESTAMP,
   customProperties: {
-    overall_average: {
-      metadataType: ModelRegistryMetadataType.DOUBLE,
-      double_value: overallAverage,
-    },
+    // overall_average: { // NOTE: overall_average is currently omitted from the API and will be restored
+    //   metadataType: ModelRegistryMetadataType.DOUBLE,
+    //   double_value: overallAverage,
+    // },
     arc_v1: {
       metadataType: ModelRegistryMetadataType.DOUBLE,
       double_value: arcV1,
@@ -30,10 +30,10 @@ const createAccuracyMetricsArtifact = (
 });
 
 export const mockAccuracyMetricsArtifacts: CatalogAccuracyMetricsArtifact[] = [
-  createAccuracyMetricsArtifact('1', 53.9, 45.2),
-  createAccuracyMetricsArtifact('2', 67.3, 58.1),
-  createAccuracyMetricsArtifact('3', 42.1, 38.7),
-  createAccuracyMetricsArtifact('4', 78.5, 72.3),
-  createAccuracyMetricsArtifact('5', 61.2, 55.8),
-  createAccuracyMetricsArtifact('6', 49.7, 43.9),
+  createAccuracyMetricsArtifact('1', /* 53.9, */ 45.2),
+  createAccuracyMetricsArtifact('2', /* 67.3, */ 58.1),
+  createAccuracyMetricsArtifact('3', /* 42.1, */ 38.7),
+  createAccuracyMetricsArtifact('4', /* 78.5, */ 72.3),
+  createAccuracyMetricsArtifact('5', /* 61.2, */ 55.8),
+  createAccuracyMetricsArtifact('6', /* 49.7, */ 43.9),
 ];

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/validatedModelUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/validatedModelUtils.spec.ts
@@ -8,7 +8,7 @@ import {
 import { ModelRegistryMetadataType } from '~/app/types';
 import {
   extractPerformanceMetrics,
-  calculateAverageAccuracy,
+  // calculateAverageAccuracy, // NOTE: overall_average is currently omitted from the API and will be restored
   extractValidatedModelMetrics,
 } from '~/app/pages/modelCatalog/utils/validatedModelUtils';
 
@@ -43,18 +43,20 @@ describe('validatedModelUtils', () => {
     },
   });
 
-  const createMockAccuracyArtifact = (overallAverage: number): CatalogAccuracyMetricsArtifact => ({
-    artifactType: CatalogArtifactType.metricsArtifact,
-    metricsType: MetricsType.accuracyMetrics,
-    createTimeSinceEpoch: '1739210683000',
-    lastUpdateTimeSinceEpoch: '1739210683000',
-    customProperties: {
-      overall_average: {
-        metadataType: ModelRegistryMetadataType.DOUBLE,
-        double_value: overallAverage,
+  const createMockAccuracyArtifact =
+    () // overallAverage: number, // NOTE: overall_average is currently omitted from the API and will be restored
+    : CatalogAccuracyMetricsArtifact => ({
+      artifactType: CatalogArtifactType.metricsArtifact,
+      metricsType: MetricsType.accuracyMetrics,
+      createTimeSinceEpoch: '1739210683000',
+      lastUpdateTimeSinceEpoch: '1739210683000',
+      customProperties: {
+        // overall_average: { // NOTE: overall_average is currently omitted from the API and will be restored
+        //   metadataType: ModelRegistryMetadataType.DOUBLE,
+        //   double_value: overallAverage,
+        // },
       },
-    },
-  });
+    });
 
   describe('extractPerformanceMetrics', () => {
     it('should extract performance metrics from a single artifact', () => {
@@ -90,61 +92,62 @@ describe('validatedModelUtils', () => {
     });
   });
 
-  describe('calculateAverageAccuracy', () => {
-    it('should calculate average accuracy from multiple artifacts', () => {
-      const artifacts = [
-        createMockAccuracyArtifact(50.0),
-        createMockAccuracyArtifact(60.0),
-        createMockAccuracyArtifact(70.0),
-      ];
-
-      const result = calculateAverageAccuracy(artifacts);
-
-      expect(result).toBe(60.0);
-    });
-
-    it('should handle single artifact', () => {
-      const artifacts = [createMockAccuracyArtifact(75.5)];
-
-      const result = calculateAverageAccuracy(artifacts);
-
-      expect(result).toBe(75.5);
-    });
-
-    it('should handle empty array with default fallback', () => {
-      const result = calculateAverageAccuracy([]);
-
-      expect(result).toBe(53.9);
-    });
-
-    it('should round to 1 decimal place', () => {
-      const artifacts = [
-        createMockAccuracyArtifact(50.0),
-        createMockAccuracyArtifact(60.0),
-        createMockAccuracyArtifact(70.0),
-        createMockAccuracyArtifact(80.0),
-      ];
-
-      const result = calculateAverageAccuracy(artifacts);
-
-      expect(result).toBe(65.0);
-    });
-
-    it('should handle artifacts with missing accuracy values', () => {
-      const artifacts = [
-        createMockAccuracyArtifact(50.0),
-        {
-          ...createMockAccuracyArtifact(0),
-          customProperties: {},
-        },
-        createMockAccuracyArtifact(70.0),
-      ];
-
-      const result = calculateAverageAccuracy(artifacts);
-
-      expect(result).toBe(40.0); // (50 + 0 + 70) / 3
-    });
-  });
+  // NOTE: overall_average is currently omitted from the API and will be restored
+  // describe('calculateAverageAccuracy', () => {
+  //   it('should calculate average accuracy from multiple artifacts', () => {
+  //     const artifacts = [
+  //       createMockAccuracyArtifact(50.0),
+  //       createMockAccuracyArtifact(60.0),
+  //       createMockAccuracyArtifact(70.0),
+  //     ];
+  //
+  //     const result = calculateAverageAccuracy(artifacts);
+  //
+  //     expect(result).toBe(60.0);
+  //   });
+  //
+  //   it('should handle single artifact', () => {
+  //     const artifacts = [createMockAccuracyArtifact(75.5)];
+  //
+  //     const result = calculateAverageAccuracy(artifacts);
+  //
+  //     expect(result).toBe(75.5);
+  //   });
+  //
+  //   it('should handle empty array with default fallback', () => {
+  //     const result = calculateAverageAccuracy([]);
+  //
+  //     expect(result).toBe(53.9);
+  //   });
+  //
+  //   it('should round to 1 decimal place', () => {
+  //     const artifacts = [
+  //       createMockAccuracyArtifact(50.0),
+  //       createMockAccuracyArtifact(60.0),
+  //       createMockAccuracyArtifact(70.0),
+  //       createMockAccuracyArtifact(80.0),
+  //     ];
+  //
+  //     const result = calculateAverageAccuracy(artifacts);
+  //
+  //     expect(result).toBe(65.0);
+  //   });
+  //
+  //   it('should handle artifacts with missing accuracy values', () => {
+  //     const artifacts = [
+  //       createMockAccuracyArtifact(50.0),
+  //       {
+  //         ...createMockAccuracyArtifact(0),
+  //         customProperties: {},
+  //       },
+  //       createMockAccuracyArtifact(70.0),
+  //     ];
+  //
+  //     const result = calculateAverageAccuracy(artifacts);
+  //
+  //     expect(result).toBe(40.0); // (50 + 0 + 70) / 3
+  //   });
+  // });
 
   describe('extractValidatedModelMetrics', () => {
     it('should extract metrics from arrays of artifacts with specific performance index', () => {
@@ -155,15 +158,15 @@ describe('validatedModelUtils', () => {
       ];
 
       const accuracyArtifacts = [
-        createMockAccuracyArtifact(50.0),
-        createMockAccuracyArtifact(60.0),
-        createMockAccuracyArtifact(70.0),
+        createMockAccuracyArtifact(/* 50.0 */),
+        createMockAccuracyArtifact(/* 60.0 */),
+        createMockAccuracyArtifact(/* 70.0 */),
       ];
 
       const result = extractValidatedModelMetrics(performanceArtifacts, accuracyArtifacts, 1);
 
       expect(result).toEqual({
-        accuracy: 60.0,
+        // accuracy: 60.0, // NOTE: overall_average is currently omitted from the API and will be restored
         hardwareType: 'H100-80',
         hardwareCount: '2',
         rpsPerReplica: 3.5,
@@ -177,12 +180,12 @@ describe('validatedModelUtils', () => {
         createMockPerformanceArtifact('H100-80', 2, 3.5, 1200),
       ];
 
-      const accuracyArtifacts = [createMockAccuracyArtifact(75.0)];
+      const accuracyArtifacts = [createMockAccuracyArtifact(/* 75.0 */)];
 
       const result = extractValidatedModelMetrics(performanceArtifacts, accuracyArtifacts);
 
       expect(result).toEqual({
-        accuracy: 75.0,
+        // accuracy: 75.0, // NOTE: overall_average is currently omitted from the API and will be restored
         hardwareType: 'A100-80',
         hardwareCount: '1',
         rpsPerReplica: 2.0,
@@ -192,12 +195,12 @@ describe('validatedModelUtils', () => {
 
     it('should handle empty performance artifacts array with defaults', () => {
       const performanceArtifacts: CatalogPerformanceMetricsArtifact[] = [];
-      const accuracyArtifacts = [createMockAccuracyArtifact(80.0)];
+      const accuracyArtifacts = [createMockAccuracyArtifact(/* 80.0 */)];
 
       const result = extractValidatedModelMetrics(performanceArtifacts, accuracyArtifacts);
 
       expect(result).toEqual({
-        accuracy: 80.0,
+        // accuracy: 80.0, // NOTE: overall_average is currently omitted from the API and will be restored
         hardwareType: 'H100-80',
         hardwareCount: '1',
         rpsPerReplica: 1,
@@ -207,12 +210,12 @@ describe('validatedModelUtils', () => {
 
     it('should handle invalid performance index with defaults', () => {
       const performanceArtifacts = [createMockPerformanceArtifact('A100-80', 1, 2.0, 1000)];
-      const accuracyArtifacts = [createMockAccuracyArtifact(90.0)];
+      const accuracyArtifacts = [createMockAccuracyArtifact(/* 90.0 */)];
 
       const result = extractValidatedModelMetrics(performanceArtifacts, accuracyArtifacts, 5);
 
       expect(result).toEqual({
-        accuracy: 90.0,
+        // accuracy: 90.0, // NOTE: overall_average is currently omitted from the API and will be restored
         hardwareType: 'H100-80',
         hardwareCount: '1',
         rpsPerReplica: 1,

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/validatedModelUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/validatedModelUtils.ts
@@ -4,7 +4,7 @@ import {
 } from '~/app/modelCatalogTypes';
 
 export type ValidatedModelMetrics = {
-  accuracy: number;
+  // accuracy: number; // NOTE: overall_average is currently omitted from the API and will be restored
   hardwareType: string;
   hardwareCount: string;
   rpsPerReplica: number;
@@ -27,20 +27,21 @@ export const extractPerformanceMetrics = (
   ttftMean: performanceMetrics.customProperties.ttft_mean?.double_value || 1428,
 });
 
-export const calculateAverageAccuracy = (
-  accuracyMetrics: CatalogAccuracyMetricsArtifact[],
-): number => {
-  if (accuracyMetrics.length === 0) {
-    return 53.9; // Default fallback
-  }
-
-  const totalAccuracy = accuracyMetrics.reduce((sum, artifact) => {
-    const accuracy = artifact.customProperties.overall_average?.double_value || 0;
-    return sum + accuracy;
-  }, 0);
-
-  return Math.round((totalAccuracy / accuracyMetrics.length) * 10) / 10; // Round to 1 decimal place
-};
+// NOTE: overall_average is currently omitted from the API and will be restored
+// export const calculateAverageAccuracy = (
+//   accuracyMetrics: CatalogAccuracyMetricsArtifact[],
+// ): number => {
+//   if (accuracyMetrics.length === 0) {
+//     return 53.9; // Default fallback
+//   }
+//
+//   const totalAccuracy = accuracyMetrics.reduce((sum, artifact) => {
+//     const accuracy = artifact.customProperties.overall_average?.double_value || 0;
+//     return sum + accuracy;
+//   }, 0);
+//
+//   return Math.round((totalAccuracy / accuracyMetrics.length) * 10) / 10; // Round to 1 decimal place
+// };
 
 export const extractValidatedModelMetrics = (
   performanceMetrics: CatalogPerformanceMetricsArtifact[],
@@ -59,7 +60,7 @@ export const extractValidatedModelMetrics = (
       };
 
   return {
-    accuracy: calculateAverageAccuracy(accuracyMetrics),
+    // accuracy: calculateAverageAccuracy(accuracyMetrics), // NOTE: overall_average is currently omitted from the API and will be restored
     ...performance,
   };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Commenting out the usage of Average Accuracy for now. 
<img width="1312" height="842" alt="Screenshot 2025-10-16 at 11 34 07 AM" src="https://github.com/user-attachments/assets/27c89cdc-ea7a-46e8-a0fe-9fca3b5ccb04" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running the code locally and seeing that the Average Accuracy is not present on validated model cards anymore

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
