### PR TITLE
Handle JSON arrays in filterQuery

### DIFF
--- a/catalog/internal/catalog/db_catalog_filterquery_test.go
+++ b/catalog/internal/catalog/db_catalog_filterquery_test.go
@@ -209,6 +209,36 @@ func TestFilterQueryToSQLGeneration(t *testing.T) {
 			description:  "Special characters should be properly escaped and parameterized",
 		},
 		{
+			name:        "Equals for a JSON array",
+			filterQuery: `language = "en"`,
+			expectedSQL: []string{
+				`prop_1.string_value IS JSON ARRAY`,
+				`prop_1.string_value::jsonb ?| array[$`,
+			},
+			expectedArgs: []any{"language", "en"},
+			description:  "Equals on JSON arrays should search inside the array",
+		},
+		{
+			name:        "Not equals for a JSON array",
+			filterQuery: `language != "en"`,
+			expectedSQL: []string{
+				`prop_1.string_value IS NOT JSON ARRAY`,
+				`NOT prop_1.string_value::jsonb ?| array[$`,
+			},
+			expectedArgs: []any{"language", "en"},
+			description:  "Not equals on JSON arrays should search inside the array",
+		},
+		{
+			name:        "IN for a JSON array",
+			filterQuery: `language IN ("en","it")`,
+			expectedSQL: []string{
+				`prop_1.string_value IS JSON ARRAY`,
+				`prop_1.string_value::jsonb ?| array[$`,
+			},
+			expectedArgs: []any{"language", "en", "it"},
+			description:  "IN on JSON arrays should search inside the array",
+		},
+		{
 			name:        "Invalid syntax should error",
 			filterQuery: `invalid syntax here`,
 			shouldError: true,

--- a/catalog/internal/db/filter/entity_mappings.go
+++ b/catalog/internal/db/filter/entity_mappings.go
@@ -61,7 +61,7 @@ var catalogModelProperties = map[string]filter.PropertyDefinition{
 	"description":  {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "description"},
 	"owner":        {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "owner"},
 	"state":        {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "state"},
-	"language":     {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "language"},
+	"language":     {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "language"},
 	"library_name": {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "library_name"},
 	"license_link": {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "license_link"},
 	"license":      {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "license"},
@@ -69,5 +69,5 @@ var catalogModelProperties = map[string]filter.PropertyDefinition{
 	"maturity":     {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "maturity"},
 	"provider":     {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "provider"},
 	"readme":       {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "readme"},
-	"tasks":        {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "tasks"},
+	"tasks":        {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "tasks"},
 }

--- a/internal/db/filter/parser.go
+++ b/internal/db/filter/parser.go
@@ -15,6 +15,7 @@ const (
 	DoubleValueType = "double_value"
 	IntValueType    = "int_value"
 	BoolValueType   = "bool_value"
+	ArrayValueType  = "array_value"
 )
 
 // Define the lexer for SQL WHERE clauses
@@ -42,7 +43,7 @@ func initParser() {
 		participle.Lexer(sqlLexer),
 		participle.Elide("whitespace", "Comment"),
 		participle.CaseInsensitive("OR", "AND", "LIKE", "ILIKE", "IN", "true", "false", "TRUE", "FALSE"),
-		participle.CaseInsensitive(StringValueType, DoubleValueType, IntValueType, BoolValueType),
+		participle.CaseInsensitive(StringValueType, DoubleValueType, IntValueType, BoolValueType, ArrayValueType),
 	)
 }
 
@@ -132,7 +133,7 @@ type FilterExpression struct {
 type PropertyReference struct {
 	Name      string
 	IsCustom  bool
-	ValueType string // StringValueType, DoubleValueType, IntValueType, BoolValueType
+	ValueType string // StringValueType, DoubleValueType, IntValueType, BoolValueType, ArrayValueType
 	IsEscaped bool   // whether the property name was escaped with backticks
 }
 


### PR DESCRIPTION
## Description

Handle `filterQuery` args for JSON array fields more like single-value fields. For instance, `language = 'en'` returns records where at least one entry in the language field is "en".

This only works on PostgreSQL right now, but it's only intended for the catalog.

## How Has This Been Tested?
Tested locally and added unit tests.

```
$ curl -s "http://localhost:8082/api/model_catalog/v1alpha1/models?pageSize=15&filterQuery=$(echo '"license IN (\"mit\",\"apache-2.0\") AND language IN (\"zh\",\"en\")"' | jq -r '@uri')" | jq -r '.items[] | .license + " - " + (.language | join(", "))'
apache-2.0 - en
apache-2.0 - en
apache-2.0 - en, de, es, fr, ja, pt, ar, cs, it, ko, nl, zh
apache-2.0 - en
apache-2.0 - en
apache-2.0 - en
apache-2.0 - en
apache-2.0 - en
apache-2.0 - en
apache-2.0 - en
mit - en
apache-2.0 - en, fr, de, es, it, pt, zh, ja, ru, ko
apache-2.0 - en, fr, de, es, it, pt, zh, ja, ru, ko
apache-2.0 - en, fr, de, es, it, pt, zh, ja, ru, ko
apache-2.0 - en, fr, de, es, it, pt, zh, ja, ru, ko
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
