### PR TITLE
Performance metrics fixes

### DIFF
--- a/internal/db/models/registered_model.go
+++ b/internal/db/models/registered_model.go
@@ -1,6 +1,10 @@
 package models
 
-import "github.com/kubeflow/model-registry/internal/db/filter"
+import (
+	"math"
+
+	"github.com/kubeflow/model-registry/internal/db/filter"
+)
 
 type RegisteredModelListOptions struct {
 	Pagination
@@ -22,6 +26,15 @@ type Properties struct {
 	BoolValue        *bool
 	ByteValue        *[]byte
 	ProtoValue       *[]byte
+}
+
+func (p *Properties) SetInt64Value(n int64) {
+	if n >= math.MinInt32 && n <= math.MaxInt32 {
+		n32 := int32(n)
+		p.IntValue = &n32
+	} else {
+		p.IntValue = nil
+	}
 }
 
 // Constructor functions for Properties


### PR DESCRIPTION
## Description
Import integer values into the `int_value` field, instead of the `double_value` field.

~~Since the data changed, we also need to fix records created before, so also
adding the ability to replace existing artifacts with new data.~~

~~Unfortunately, it loaded every directory after every event. This was never
ideal, but it was quick before the change above. Now it was taking several
minutes to start with a modest data set. So switching it to only try to load
the data for the model we receive an event for.~~

(Dropped the second commit, but it still here: https://github.com/pboyd/model-registry/commit/cf3083325c70611f3a81c8a4a84090bb5f9c04a6)

## How Has This Been Tested?
Imported data locally and checked the resulting database records.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
