### PR TITLE
fix: warn on invalid custom properties

### DIFF
--- a/internal/converter/embdemd_openapi_converter_util.go
+++ b/internal/converter/embdemd_openapi_converter_util.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/kubeflow/model-registry/internal/apiutils"
 	"github.com/kubeflow/model-registry/internal/db/models"
 	"github.com/kubeflow/model-registry/pkg/api"
@@ -59,7 +60,8 @@ func MapEmbedMDCustomProperties(source []models.Properties) (map[string]openapi.
 			b64 := base64.StdEncoding.EncodeToString(asJSON)
 			customValue.MetadataStructValue = NewMetadataStructValue(b64)
 		} else {
-			return nil, fmt.Errorf("%w: metadataType not found for %s: %v", api.ErrBadRequest, v.Name, v)
+			glog.Warningf("metadataType not found for %s: %v", v.Name, v)
+			continue
 		}
 
 		data[v.Name] = customValue

--- a/internal/converter/embdemd_openapi_converter_util_test.go
+++ b/internal/converter/embdemd_openapi_converter_util_test.go
@@ -56,8 +56,8 @@ func TestMapEmbedMDCustomProperties(t *testing.T) {
 					IntValue: nil,
 				},
 			},
-			expected: nil,
-			wantErr:  true,
+			expected: map[string]openapi.MetadataValue{},
+			wantErr:  false,
 		},
 		{
 			name: "test string value",
@@ -82,8 +82,8 @@ func TestMapEmbedMDCustomProperties(t *testing.T) {
 					StringValue: nil,
 				},
 			},
-			expected: nil,
-			wantErr:  true,
+			expected: map[string]openapi.MetadataValue{},
+			wantErr:  false,
 		},
 		{
 			name: "test string value with mlmd struct prefix",
@@ -123,8 +123,8 @@ func TestMapEmbedMDCustomProperties(t *testing.T) {
 					BoolValue: nil,
 				},
 			},
-			expected: nil,
-			wantErr:  true,
+			expected: map[string]openapi.MetadataValue{},
+			wantErr:  false,
 		},
 		{
 			name: "test double value",
@@ -149,8 +149,8 @@ func TestMapEmbedMDCustomProperties(t *testing.T) {
 					DoubleValue: nil,
 				},
 			},
-			expected: nil,
-			wantErr:  true,
+			expected: map[string]openapi.MetadataValue{},
+			wantErr:  false,
 		},
 		{
 			name: "test byte value",
@@ -175,8 +175,8 @@ func TestMapEmbedMDCustomProperties(t *testing.T) {
 					ByteValue: nil,
 				},
 			},
-			expected: nil,
-			wantErr:  true,
+			expected: map[string]openapi.MetadataValue{},
+			wantErr:  false,
 		},
 	}
 


### PR DESCRIPTION
## Description

When a custom property is encountered without a type warn about it, but
don't return an error.

This was an issue because metrics artifacts were being created with an
`updated_at` custom property that had no value set in any column. This
also prevents those properties from being created (they shouldn't have
been custom properties).

## How Has This Been Tested?
On a local dev environment.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
