### PR TITLE
chore(catalog): set invalid updated and created timestamps to current time

### DIFF
--- a/catalog/internal/catalog/performance_metrics.go
+++ b/catalog/internal/catalog/performance_metrics.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	dbmodels "github.com/kubeflow/model-registry/catalog/internal/db/models"
 	"github.com/kubeflow/model-registry/catalog/internal/db/service"
+	"github.com/kubeflow/model-registry/internal/apiutils"
 	"github.com/kubeflow/model-registry/internal/db/models"
 )
 
@@ -566,6 +568,10 @@ func createPerformanceArtifact(perfRecord performanceRecord, modelID int32, type
 			}
 		}
 	}
+	if createTime == nil {
+		createTime = apiutils.Of(time.Now().UnixMilli())
+	}
+
 	if updatedAtNum, ok := perfRecord.CustomProperties["updated_at"].(json.Number); ok {
 		updatedAt, err := updatedAtNum.Int64()
 		if err == nil {
@@ -573,6 +579,9 @@ func createPerformanceArtifact(perfRecord performanceRecord, modelID int32, type
 		} else {
 			glog.Warningf("%s: invalid updated_at value: %v", artifactName, err)
 		}
+	}
+	if updateTime == nil {
+		updateTime = apiutils.Of(time.Now().UnixMilli())
 	}
 	delete(perfRecord.CustomProperties, "updated_at")
 	delete(perfRecord.CustomProperties, "created_at")


### PR DESCRIPTION
## Description
Follow up to [PR #1771](https://github.com/kubeflow/model-registry/pull/1771#discussion_r2444903033).

## How Has This Been Tested?
Local dev environment

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
