### PR TITLE
chore: consistently use int32 for type IDs

### DIFF
--- a/catalog/internal/catalog/db_catalog_test.go
+++ b/catalog/internal/catalog/db_catalog_test.go
@@ -36,7 +36,7 @@ func TestDBCatalog(t *testing.T) {
 
 	// Create repositories
 	catalogModelRepo := service.NewCatalogModelRepository(sharedDB, catalogModelTypeID)
-	catalogArtifactRepo := service.NewCatalogArtifactRepository(sharedDB, map[string]int64{
+	catalogArtifactRepo := service.NewCatalogArtifactRepository(sharedDB, map[string]int32{
 		service.CatalogModelArtifactTypeName:   modelArtifactTypeID,
 		service.CatalogMetricsArtifactTypeName: metricsArtifactTypeID,
 	})
@@ -967,29 +967,29 @@ func TestDBCatalog(t *testing.T) {
 
 // Helper functions to get type IDs from database
 
-func getCatalogModelTypeIDForDBTest(t *testing.T, db *gorm.DB) int64 {
+func getCatalogModelTypeIDForDBTest(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", service.CatalogModelTypeName).First(&typeRecord).Error
 	if err != nil {
 		require.NoError(t, err, "Failed to query CatalogModel type")
 	}
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getCatalogModelArtifactTypeIDForDBTest(t *testing.T, db *gorm.DB) int64 {
+func getCatalogModelArtifactTypeIDForDBTest(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", service.CatalogModelArtifactTypeName).First(&typeRecord).Error
 	if err != nil {
 		require.NoError(t, err, "Failed to query CatalogModelArtifact type")
 	}
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getCatalogMetricsArtifactTypeIDForDBTest(t *testing.T, db *gorm.DB) int64 {
+func getCatalogMetricsArtifactTypeIDForDBTest(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", service.CatalogMetricsArtifactTypeName).First(&typeRecord).Error
 	if err != nil {
 		require.NoError(t, err, "Failed to query CatalogMetricsArtifact type")
 	}
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }

--- a/catalog/internal/catalog/performance_metrics.go
+++ b/catalog/internal/catalog/performance_metrics.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,7 +129,7 @@ type PerformanceMetricsLoader struct {
 	metricsArtifactTypeID int32
 }
 
-func NewPerformanceMetricsLoader(path []string, modelRepo dbmodels.CatalogModelRepository, metricsArtifactRepo dbmodels.CatalogMetricsArtifactRepository, typeMap map[string]int64) (*PerformanceMetricsLoader, error) {
+func NewPerformanceMetricsLoader(path []string, modelRepo dbmodels.CatalogModelRepository, metricsArtifactRepo dbmodels.CatalogMetricsArtifactRepository, typeMap map[string]int32) (*PerformanceMetricsLoader, error) {
 	if len(path) == 0 {
 		glog.Info("No performance metrics path provided, skipping performance metrics loading")
 		return nil, nil
@@ -147,27 +146,17 @@ func NewPerformanceMetricsLoader(path []string, modelRepo dbmodels.CatalogModelR
 	glog.Infof("Loading performance metrics data from %s", path)
 
 	// Get the TypeID for CatalogModel from the type map
-	modelTypeIDInt64, exists := typeMap[service.CatalogModelTypeName]
+	modelTypeID, exists := typeMap[service.CatalogModelTypeName]
 	if !exists {
 		return nil, fmt.Errorf("CatalogModel type not found in type map")
 	}
-	// Bounds check for int64 to int32 conversion
-	if modelTypeIDInt64 > math.MaxInt32 || modelTypeIDInt64 < math.MinInt32 {
-		return nil, fmt.Errorf("CatalogModel type ID %d is out of int32 range", modelTypeIDInt64)
-	}
-	modelTypeID := int32(modelTypeIDInt64)
 	glog.V(2).Infof("Using catalog model type ID: %d", modelTypeID)
 
 	// Get the TypeID for CatalogMetricsArtifact from the type map
-	metricsArtifactTypeIDInt64, exists := typeMap[service.CatalogMetricsArtifactTypeName]
+	metricsArtifactTypeID, exists := typeMap[service.CatalogMetricsArtifactTypeName]
 	if !exists {
 		return nil, fmt.Errorf("CatalogMetricsArtifact type not found in type map")
 	}
-	// Bounds check for int64 to int32 conversion
-	if metricsArtifactTypeIDInt64 > math.MaxInt32 || metricsArtifactTypeIDInt64 < math.MinInt32 {
-		return nil, fmt.Errorf("CatalogMetricsArtifact type ID %d is out of int32 range", metricsArtifactTypeIDInt64)
-	}
-	metricsArtifactTypeID := int32(metricsArtifactTypeIDInt64)
 	glog.V(2).Infof("Using metrics artifact type ID: %d", metricsArtifactTypeID)
 
 	return &PerformanceMetricsLoader{
@@ -192,9 +181,9 @@ func (pml *PerformanceMetricsLoader) Load(ctx context.Context, record ModelProvi
 	glog.Infof("Loading performance metrics for %s", *attrs.Name)
 
 	// Create a type map from the stored type IDs
-	typeMap := map[string]int64{
-		service.CatalogModelTypeName:           int64(pml.modelTypeID),
-		service.CatalogMetricsArtifactTypeName: int64(pml.metricsArtifactTypeID),
+	typeMap := map[string]int32{
+		service.CatalogModelTypeName:           pml.modelTypeID,
+		service.CatalogMetricsArtifactTypeName: pml.metricsArtifactTypeID,
 	}
 
 	// Call the existing LoadPerformanceMetricsData function
@@ -205,7 +194,7 @@ func (pml *PerformanceMetricsLoader) Load(ctx context.Context, record ModelProvi
 // into the database using the catalog model and artifact repositories.
 // Only loads metrics for models that already exist in the database and where
 // the metrics artifacts don't already exist.
-func LoadPerformanceMetricsData(path []string, modelRepo dbmodels.CatalogModelRepository, metricsArtifactRepo dbmodels.CatalogMetricsArtifactRepository, typeMap map[string]int64) error {
+func LoadPerformanceMetricsData(path []string, modelRepo dbmodels.CatalogModelRepository, metricsArtifactRepo dbmodels.CatalogMetricsArtifactRepository, typeMap map[string]int32) error {
 	if len(path) == 0 {
 		glog.Info("No performance metrics path provided, skipping performance metrics loading")
 		return nil
@@ -222,27 +211,17 @@ func LoadPerformanceMetricsData(path []string, modelRepo dbmodels.CatalogModelRe
 	glog.Infof("Loading performance metrics data from %s", path)
 
 	// Get the TypeID for CatalogModel from the type map
-	modelTypeIDInt64, exists := typeMap[service.CatalogModelTypeName]
+	modelTypeID, exists := typeMap[service.CatalogModelTypeName]
 	if !exists {
 		return fmt.Errorf("CatalogModel type not found in type map")
 	}
-	// Bounds check for int64 to int32 conversion
-	if modelTypeIDInt64 > math.MaxInt32 || modelTypeIDInt64 < math.MinInt32 {
-		return fmt.Errorf("CatalogModel type ID %d is out of int32 range", modelTypeIDInt64)
-	}
-	modelTypeID := int32(modelTypeIDInt64)
 	glog.V(2).Infof("Using catalog model type ID: %d", modelTypeID)
 
 	// Get the TypeID for CatalogMetricsArtifact from the type map
-	metricsArtifactTypeIDInt64, exists := typeMap[service.CatalogMetricsArtifactTypeName]
+	metricsArtifactTypeID, exists := typeMap[service.CatalogMetricsArtifactTypeName]
 	if !exists {
 		return fmt.Errorf("CatalogMetricsArtifact type not found in type map")
 	}
-	// Bounds check for int64 to int32 conversion
-	if metricsArtifactTypeIDInt64 > math.MaxInt32 || metricsArtifactTypeIDInt64 < math.MinInt32 {
-		return fmt.Errorf("CatalogMetricsArtifact type ID %d is out of int32 range", metricsArtifactTypeIDInt64)
-	}
-	metricsArtifactTypeID := int32(metricsArtifactTypeIDInt64)
 	glog.V(2).Infof("Using metrics artifact type ID: %d", metricsArtifactTypeID)
 
 	processedCount := 0

--- a/catalog/internal/db/service/catalog_artifact.go
+++ b/catalog/internal/db/service/catalog_artifact.go
@@ -17,12 +17,12 @@ var ErrCatalogArtifactNotFound = errors.New("catalog artifact by id not found")
 
 type CatalogArtifactRepositoryImpl struct {
 	db       *gorm.DB
-	idToName map[int64]string
+	idToName map[int32]string
 	nameToID datastore.ArtifactTypeMap
 }
 
 func NewCatalogArtifactRepository(db *gorm.DB, artifactTypes datastore.ArtifactTypeMap) models.CatalogArtifactRepository {
-	idToName := make(map[int64]string, len(artifactTypes))
+	idToName := make(map[int32]string, len(artifactTypes))
 	for name, id := range artifactTypes {
 		idToName[id] = name
 	}
@@ -86,7 +86,7 @@ func (r *CatalogArtifactRepositoryImpl) List(listOptions models.CatalogArtifactL
 		query = query.Where("type_id = ?", typeID)
 	} else {
 		// Only include catalog artifact types
-		catalogTypeIDs := []int64{}
+		catalogTypeIDs := []int32{}
 		for _, typeID := range r.nameToID {
 			catalogTypeIDs = append(catalogTypeIDs, typeID)
 		}
@@ -159,7 +159,7 @@ func (r *CatalogArtifactRepositoryImpl) List(listOptions models.CatalogArtifactL
 }
 
 // getTypeIDFromArtifactType maps catalog artifact type strings to their corresponding type IDs
-func (r *CatalogArtifactRepositoryImpl) getTypeIDFromArtifactType(artifactType string) (int64, error) {
+func (r *CatalogArtifactRepositoryImpl) getTypeIDFromArtifactType(artifactType string) (int32, error) {
 	switch artifactType {
 	case "model-artifact":
 		return r.nameToID[CatalogModelArtifactTypeName], nil
@@ -173,7 +173,7 @@ func (r *CatalogArtifactRepositoryImpl) getTypeIDFromArtifactType(artifactType s
 func (r *CatalogArtifactRepositoryImpl) mapDataLayerToCatalogArtifact(artifact schema.Artifact, properties []schema.ArtifactProperty) (models.CatalogArtifact, error) {
 	artToReturn := models.CatalogArtifact{}
 
-	typeName := r.idToName[int64(artifact.TypeID)]
+	typeName := r.idToName[artifact.TypeID]
 
 	switch typeName {
 	case CatalogModelArtifactTypeName:

--- a/catalog/internal/db/service/catalog_artifact_test.go
+++ b/catalog/internal/db/service/catalog_artifact_test.go
@@ -22,7 +22,7 @@ func TestCatalogArtifactRepository(t *testing.T) {
 	metricsArtifactTypeID := getCatalogMetricsArtifactTypeID(t, sharedDB)
 
 	// Create unified artifact repository with both types
-	artifactTypeMap := map[string]int64{
+	artifactTypeMap := map[string]int32{
 		service.CatalogModelArtifactTypeName:   modelArtifactTypeID,
 		service.CatalogMetricsArtifactTypeName: metricsArtifactTypeID,
 	}
@@ -351,7 +351,7 @@ func TestCatalogArtifactRepository(t *testing.T) {
 		// by temporarily modifying the repository's type mapping
 
 		// Create a repository with incomplete type mapping
-		incompleteTypeMap := map[string]int64{
+		incompleteTypeMap := map[string]int32{
 			service.CatalogModelArtifactTypeName: modelArtifactTypeID,
 			// Missing CatalogMetricsArtifactTypeName intentionally
 		}

--- a/catalog/internal/db/service/catalog_metrics_artifact.go
+++ b/catalog/internal/db/service/catalog_metrics_artifact.go
@@ -3,7 +3,6 @@ package service
 import (
 	"errors"
 	"fmt"
-	"math"
 
 	"github.com/kubeflow/model-registry/catalog/internal/db/models"
 	"github.com/kubeflow/model-registry/internal/apiutils"
@@ -20,7 +19,7 @@ type CatalogMetricsArtifactRepositoryImpl struct {
 	*service.GenericRepository[models.CatalogMetricsArtifact, schema.Artifact, schema.ArtifactProperty, *models.CatalogMetricsArtifactListOptions]
 }
 
-func NewCatalogMetricsArtifactRepository(db *gorm.DB, typeID int64) models.CatalogMetricsArtifactRepository {
+func NewCatalogMetricsArtifactRepository(db *gorm.DB, typeID int32) models.CatalogMetricsArtifactRepository {
 	config := service.GenericRepositoryConfig[models.CatalogMetricsArtifact, schema.Artifact, schema.ArtifactProperty, *models.CatalogMetricsArtifactListOptions]{
 		DB:                  db,
 		TypeID:              typeID,
@@ -47,8 +46,8 @@ func (r *CatalogMetricsArtifactRepositoryImpl) List(listOptions models.CatalogMe
 func (r *CatalogMetricsArtifactRepositoryImpl) Save(ma models.CatalogMetricsArtifact, parentResourceID *int32) (models.CatalogMetricsArtifact, error) {
 	config := r.GetConfig()
 	if ma.GetTypeID() == nil {
-		if config.TypeID > 0 && config.TypeID < math.MaxInt32 {
-			ma.SetTypeID(int32(config.TypeID))
+		if config.TypeID > 0 {
+			ma.SetTypeID(config.TypeID)
 		}
 	}
 

--- a/catalog/internal/db/service/catalog_metrics_artifact_test.go
+++ b/catalog/internal/db/service/catalog_metrics_artifact_test.go
@@ -629,12 +629,12 @@ func TestCatalogMetricsArtifactRepository(t *testing.T) {
 }
 
 // Helper function to get or create CatalogMetricsArtifact type ID
-func getCatalogMetricsArtifactTypeID(t *testing.T, db *gorm.DB) int64 {
+func getCatalogMetricsArtifactTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", service.CatalogMetricsArtifactTypeName).First(&typeRecord).Error
 	if err != nil {
 		require.NoError(t, err, "Failed to query CatalogMetricsArtifact type")
 	}
 
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }

--- a/catalog/internal/db/service/catalog_model.go
+++ b/catalog/internal/db/service/catalog_model.go
@@ -3,7 +3,6 @@ package service
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/kubeflow/model-registry/catalog/internal/db/filter"
@@ -22,7 +21,7 @@ type CatalogModelRepositoryImpl struct {
 	*service.GenericRepository[models.CatalogModel, schema.Context, schema.ContextProperty, *models.CatalogModelListOptions]
 }
 
-func NewCatalogModelRepository(db *gorm.DB, typeID int64) models.CatalogModelRepository {
+func NewCatalogModelRepository(db *gorm.DB, typeID int32) models.CatalogModelRepository {
 	r := &CatalogModelRepositoryImpl{}
 
 	r.GenericRepository = service.NewGenericRepository(service.GenericRepositoryConfig[models.CatalogModel, schema.Context, schema.ContextProperty, *models.CatalogModelListOptions]{
@@ -46,8 +45,8 @@ func NewCatalogModelRepository(db *gorm.DB, typeID int64) models.CatalogModelRep
 func (r *CatalogModelRepositoryImpl) Save(model models.CatalogModel) (models.CatalogModel, error) {
 	config := r.GetConfig()
 	if model.GetTypeID() == nil {
-		if config.TypeID > 0 && config.TypeID < math.MaxInt32 {
-			model.SetTypeID(int32(config.TypeID))
+		if config.TypeID > 0 {
+			model.SetTypeID(config.TypeID)
 		}
 	}
 

--- a/catalog/internal/db/service/catalog_model_artifact.go
+++ b/catalog/internal/db/service/catalog_model_artifact.go
@@ -3,7 +3,6 @@ package service
 import (
 	"errors"
 	"fmt"
-	"math"
 
 	"github.com/kubeflow/model-registry/catalog/internal/db/models"
 	"github.com/kubeflow/model-registry/internal/apiutils"
@@ -20,7 +19,7 @@ type CatalogModelArtifactRepositoryImpl struct {
 	*service.GenericRepository[models.CatalogModelArtifact, schema.Artifact, schema.ArtifactProperty, *models.CatalogModelArtifactListOptions]
 }
 
-func NewCatalogModelArtifactRepository(db *gorm.DB, typeID int64) models.CatalogModelArtifactRepository {
+func NewCatalogModelArtifactRepository(db *gorm.DB, typeID int32) models.CatalogModelArtifactRepository {
 	config := service.GenericRepositoryConfig[models.CatalogModelArtifact, schema.Artifact, schema.ArtifactProperty, *models.CatalogModelArtifactListOptions]{
 		DB:                  db,
 		TypeID:              typeID,
@@ -43,8 +42,8 @@ func NewCatalogModelArtifactRepository(db *gorm.DB, typeID int64) models.Catalog
 func (r *CatalogModelArtifactRepositoryImpl) Save(modelArtifact models.CatalogModelArtifact, parentResourceID *int32) (models.CatalogModelArtifact, error) {
 	config := r.GetConfig()
 	if modelArtifact.GetTypeID() == nil {
-		if config.TypeID > 0 && config.TypeID < math.MaxInt32 {
-			modelArtifact.SetTypeID(int32(config.TypeID))
+		if config.TypeID > 0 {
+			modelArtifact.SetTypeID(config.TypeID)
 		}
 	}
 

--- a/catalog/internal/db/service/catalog_model_artifact_test.go
+++ b/catalog/internal/db/service/catalog_model_artifact_test.go
@@ -631,12 +631,12 @@ func TestCatalogModelArtifactRepository(t *testing.T) {
 }
 
 // Helper function to get or create CatalogModelArtifact type ID
-func getCatalogModelArtifactTypeID(t *testing.T, db *gorm.DB) int64 {
+func getCatalogModelArtifactTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", service.CatalogModelArtifactTypeName).First(&typeRecord).Error
 	if err != nil {
 		require.NoError(t, err, "Failed to query CatalogModelArtifact type")
 	}
 
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }

--- a/catalog/internal/db/service/catalog_model_test.go
+++ b/catalog/internal/db/service/catalog_model_test.go
@@ -418,12 +418,12 @@ func TestCatalogModelRepository(t *testing.T) {
 }
 
 // Helper function to get or create CatalogModel type ID
-func getCatalogModelTypeID(t *testing.T, db *gorm.DB) int64 {
+func getCatalogModelTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", service.CatalogModelTypeName).First(&typeRecord).Error
 	if err != nil {
 		require.NoError(t, err, "Failed to query CatalogModel type")
 	}
 
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }

--- a/internal/converter/openapi_converter.go
+++ b/internal/converter/openapi_converter.go
@@ -15,7 +15,7 @@ type OpenAPIModelWrapper[
 	Model            *M
 	ParentResourceId *string
 	ModelName        *string
-	TypeId           int64
+	TypeId           int32
 }
 
 // goverter:converter

--- a/internal/converter/openapi_embedmd_converter_util.go
+++ b/internal/converter/openapi_embedmd_converter_util.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -27,19 +26,6 @@ func Int32ToString(id *int32) *string {
 	}
 	idAsString := strconv.FormatInt(int64(*id), 10)
 	return &idAsString
-}
-
-// Int64ToInt32 converts int64 to int32 if numeric, otherwise return error
-func Int64ToInt32(id *int64) (*int32, error) {
-	if id == nil {
-		return nil, nil
-	}
-	if *id > math.MaxInt32 || *id < math.MinInt32 {
-		return nil, fmt.Errorf("id is out of range of int32: %d", *id)
-	}
-
-	idInt32 := int32(*id)
-	return &idInt32, nil
 }
 
 // MapOpenAPICustomPropertiesEmbedMD maps OpenAPI custom properties model to embedmd one
@@ -100,7 +86,7 @@ func MapOpenAPICustomPropertiesEmbedMD(source *map[string]openapi.MetadataValue)
 
 // MapRegisteredModelTypeIDEmbedMD maps RegisteredModel type id to embedmd one
 func MapRegisteredModelTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.RegisteredModel]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 func encodeStruct(structValue *structpb.Struct) (string, error) {
@@ -272,7 +258,7 @@ func MapRegisteredModelAttributesEmbedMD(source *openapi.RegisteredModel) (*mode
 
 // MapModelVersionTypeIDEmbedMD maps ModelVersion type id to embedmd one
 func MapModelVersionTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.ModelVersion]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 // MapModelVersionPropertiesEmbedMD maps ModelVersion fields to specific embedmd properties
@@ -350,7 +336,7 @@ func MapModelVersionAttributesEmbedMD(source *OpenAPIModelWrapper[openapi.ModelV
 
 // MapServingEnvironmentTypeIDEmbedMD maps ServingEnvironment type id to embedmd one
 func MapServingEnvironmentTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.ServingEnvironment]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 // MapServingEnvironmentPropertiesEmbedMD maps ServingEnvironment fields to specific embedmd properties
@@ -396,7 +382,7 @@ func MapServingEnvironmentAttributesEmbedMD(source *openapi.ServingEnvironment) 
 }
 
 func MapInferenceServiceTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.InferenceService]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 func MapInferenceServicePropertiesEmbedMD(source *openapi.InferenceService) (*[]models.Properties, error) {
@@ -496,7 +482,7 @@ func MapInferenceServiceAttributesEmbedMD(source *OpenAPIModelWrapper[openapi.In
 }
 
 func MapModelArtifactTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.ModelArtifact]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 func MapModelArtifactPropertiesEmbedMD(source *openapi.ModelArtifact) (*[]models.Properties, error) {
@@ -623,7 +609,7 @@ func MapModelArtifactAttributesEmbedMD(source *OpenAPIModelWrapper[openapi.Model
 }
 
 func MapDocArtifactTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.DocArtifact]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 func MapDocArtifactPropertiesEmbedMD(source *openapi.DocArtifact) (*[]models.Properties, error) {
@@ -679,7 +665,7 @@ func MapDocArtifactAttributesEmbedMD(source *OpenAPIModelWrapper[openapi.DocArti
 }
 
 func MapServeModelTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.ServeModel]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 func MapServeModelPropertiesEmbedMD(source *openapi.ServeModel) (*[]models.Properties, error) {
@@ -748,7 +734,7 @@ func MapServeModelAttributesEmbedMD(source *OpenAPIModelWrapper[openapi.ServeMod
 
 // MapExperimentTypeIDEmbedMD maps Experiment type id to embedmd one
 func MapExperimentTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.Experiment]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 // MapExperimentPropertiesEmbedMD maps Experiment fields to specific embedmd properties
@@ -811,7 +797,7 @@ func MapExperimentAttributesEmbedMD(source *openapi.Experiment) (*models.Experim
 
 // MapExperimentRunTypeIDEmbedMD maps ExperimentRun type id to embedmd one
 func MapExperimentRunTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.ExperimentRun]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 // MapExperimentRunPropertiesEmbedMD maps ExperimentRun fields to specific embedmd properties
@@ -913,7 +899,7 @@ func MapExperimentRunAttributesEmbedMD(source *OpenAPIModelWrapper[openapi.Exper
 
 // MapDataSetTypeIDEmbedMD maps DataSet type id to embedmd one
 func MapDataSetTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.DataSet]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 // MapDataSetPropertiesEmbedMD maps DataSet fields to specific embedmd properties
@@ -1012,7 +998,7 @@ func MapDataSetAttributesEmbedMD(source *OpenAPIModelWrapper[openapi.DataSet]) (
 
 // MapMetricTypeIDEmbedMD maps Metric type id to embedmd one
 func MapMetricTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.Metric]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 // MapMetricPropertiesEmbedMD maps Metric fields to specific embedmd properties
@@ -1097,7 +1083,7 @@ func MapMetricAttributesEmbedMD(source *OpenAPIModelWrapper[openapi.Metric]) (*m
 
 // MapParameterTypeIDEmbedMD maps Parameter type id to embedmd one
 func MapParameterTypeIDEmbedMD(source *OpenAPIModelWrapper[openapi.Parameter]) (*int32, error) {
-	return Int64ToInt32(&source.TypeId)
+	return &source.TypeId, nil
 }
 
 // MapParameterPropertiesEmbedMD maps Parameter fields to specific embedmd properties

--- a/internal/converter/openapi_embedmd_converter_util_test.go
+++ b/internal/converter/openapi_embedmd_converter_util_test.go
@@ -157,7 +157,7 @@ func TestMapOpenAPICustomPropertiesEmbedMD(t *testing.T) {
 }
 
 func TestMapRegisteredModelTypeIDEmbedMD(t *testing.T) {
-	testId := int64(1)
+	testId := int32(1)
 	testId32 := int32(testId)
 
 	testCases := []struct {
@@ -351,7 +351,7 @@ func TestMapRegisteredModelAttributesEmbedMD(t *testing.T) {
 }
 
 func TestMapModelVersionTypeIDEmbedMD(t *testing.T) {
-	testId := int64(1)
+	testId := int32(1)
 	testId32 := int32(testId)
 
 	testCases := []struct {
@@ -501,7 +501,7 @@ func TestMapModelVersionAttributesEmbedMD(t *testing.T) {
 }
 
 func TestMapServingEnvironmentTypeIDEmbedMD(t *testing.T) {
-	testId := int64(1)
+	testId := int32(1)
 	testId32 := int32(testId)
 
 	testCases := []struct {
@@ -615,7 +615,7 @@ func TestMapServingEnvironmentAttributesEmbedMD(t *testing.T) {
 }
 
 func TestMapInferenceServiceTypeIDEmbedMD(t *testing.T) {
-	testId := int64(1)
+	testId := int32(1)
 	testId32 := int32(testId)
 
 	testCases := []struct {
@@ -783,7 +783,7 @@ func TestMapInferenceServiceAttributesEmbedMD(t *testing.T) {
 }
 
 func TestMapModelArtifactTypeIDEmbedMD(t *testing.T) {
-	testId := int64(1)
+	testId := int32(1)
 	testId32 := int32(testId)
 
 	testCases := []struct {
@@ -1001,7 +1001,7 @@ func TestMapModelArtifactAttributesEmbedMD(t *testing.T) {
 }
 
 func TestMapDocArtifactTypeIDEmbedMD(t *testing.T) {
-	testId := int64(1)
+	testId := int32(1)
 	testId32 := int32(testId)
 
 	testCases := []struct {
@@ -1149,7 +1149,7 @@ func TestMapDocArtifactAttributesEmbedMD(t *testing.T) {
 }
 
 func TestMapServeModelTypeIDEmbedMD(t *testing.T) {
-	testId := int64(1)
+	testId := int32(1)
 	testId32 := int32(testId)
 
 	testCases := []struct {

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -34,8 +34,8 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 }
 
 // getTypeIDs retrieves all type IDs from the database for testing
-func getTypeIDs(t *testing.T, db *gorm.DB) map[string]int64 {
-	typesMap := make(map[string]int64)
+func getTypeIDs(t *testing.T, db *gorm.DB) map[string]int32 {
+	typesMap := map[string]int32{}
 
 	typeNames := []string{
 		defaults.RegisteredModelTypeName,
@@ -57,7 +57,7 @@ func getTypeIDs(t *testing.T, db *gorm.DB) map[string]int64 {
 		var typeRecord schema.Type
 		err := db.Where("name = ?", typeName).First(&typeRecord).Error
 		require.NoError(t, err, "Failed to find type: %s", typeName)
-		typesMap[typeName] = int64(typeRecord.ID)
+		typesMap[typeName] = typeRecord.ID
 	}
 
 	return typesMap
@@ -69,7 +69,7 @@ func createModelRegistryService(t *testing.T, db *gorm.DB) *core.ModelRegistrySe
 	typesMap := getTypeIDs(t, db)
 
 	// Create all repositories
-	artifactRepo := service.NewArtifactRepository(db, map[string]int64{
+	artifactRepo := service.NewArtifactRepository(db, map[string]int32{
 		defaults.ModelArtifactTypeName: typesMap[defaults.ModelArtifactTypeName],
 		defaults.DocArtifactTypeName:   typesMap[defaults.DocArtifactTypeName],
 		defaults.DataSetTypeName:       typesMap[defaults.DataSetTypeName],

--- a/internal/core/modelregistry_service.go
+++ b/internal/core/modelregistry_service.go
@@ -25,7 +25,7 @@ type ModelRegistryService struct {
 	parameterRepository          models.ParameterRepository
 	metricHistoryRepository      models.MetricHistoryRepository
 	mapper                       mapper.EmbedMDMapper
-	typesMap                     map[string]int64
+	typesMap                     map[string]int32
 }
 
 func NewModelRegistryService(
@@ -43,7 +43,7 @@ func NewModelRegistryService(
 	metricRepository models.MetricRepository,
 	parameterRepository models.ParameterRepository,
 	metricHistoryRepository models.MetricHistoryRepository,
-	typesMap map[string]int64) *ModelRegistryService {
+	typesMap map[string]int32) *ModelRegistryService {
 	return &ModelRegistryService{
 		artifactRepository:           artifactRepository,
 		modelArtifactRepository:      modelArtifactRepository,

--- a/internal/datastore/embedmd/repos.go
+++ b/internal/datastore/embedmd/repos.go
@@ -15,7 +15,7 @@ var _ datastore.RepoSet = (*repoSetImpl)(nil)
 type repoSetImpl struct {
 	db        *gorm.DB
 	spec      *datastore.Spec
-	nameIDMap map[string]int64
+	nameIDMap map[string]int32
 	repos     map[reflect.Type]any
 }
 
@@ -29,9 +29,9 @@ func newRepoSet(db *gorm.DB, spec *datastore.Spec) (datastore.RepoSet, error) {
 		return nil, err
 	}
 
-	nameIDMap := make(map[string]int64, len(types))
+	nameIDMap := make(map[string]int32, len(types))
 	for _, t := range types {
-		nameIDMap[*t.GetAttributes().Name] = int64(*t.GetID())
+		nameIDMap[*t.GetAttributes().Name] = int32(*t.GetID())
 	}
 
 	glog.Infof("Types retrieved")
@@ -179,15 +179,15 @@ func (rs *repoSetImpl) Repository(t reflect.Type) (any, error) {
 	return nil, fmt.Errorf("unknown repository type: %s", t.Name())
 }
 
-func (rs *repoSetImpl) TypeMap() map[string]int64 {
-	clone := make(map[string]int64, len(rs.nameIDMap))
+func (rs *repoSetImpl) TypeMap() map[string]int32 {
+	clone := make(map[string]int32, len(rs.nameIDMap))
 	for k, v := range rs.nameIDMap {
 		clone[k] = v
 	}
 	return clone
 }
 
-func makeTypeMap[T ~map[string]int64](specMap map[string]*datastore.SpecType, nameIDMap map[string]int64) T {
+func makeTypeMap[T ~map[string]int32](specMap map[string]*datastore.SpecType, nameIDMap map[string]int32) T {
 	returnMap := make(T, len(specMap))
 	for k := range specMap {
 		returnMap[k] = nameIDMap[k]

--- a/internal/datastore/embedmd/repos_test.go
+++ b/internal/datastore/embedmd/repos_test.go
@@ -20,15 +20,15 @@ import (
 
 // Mock repository types for testing
 type mockArtifactRepo struct {
-	typeID int64
+	typeID int32
 }
 
 type mockContextRepo struct {
-	typeID int64
+	typeID int32
 }
 
 type mockExecutionRepo struct {
-	typeID int64
+	typeID int32
 }
 
 type mockOtherRepo struct {
@@ -36,15 +36,15 @@ type mockOtherRepo struct {
 }
 
 // Mock initializer functions
-func newMockArtifactRepo(db *gorm.DB, typeID int64) *mockArtifactRepo {
+func newMockArtifactRepo(db *gorm.DB, typeID int32) *mockArtifactRepo {
 	return &mockArtifactRepo{typeID: typeID}
 }
 
-func newMockContextRepo(db *gorm.DB, typeID int64) *mockContextRepo {
+func newMockContextRepo(db *gorm.DB, typeID int32) *mockContextRepo {
 	return &mockContextRepo{typeID: typeID}
 }
 
-func newMockExecutionRepo(db *gorm.DB, typeID int64) *mockExecutionRepo {
+func newMockExecutionRepo(db *gorm.DB, typeID int32) *mockExecutionRepo {
 	return &mockExecutionRepo{typeID: typeID}
 }
 
@@ -142,11 +142,11 @@ func TestNewRepoSet_Success(t *testing.T) {
 
 	// Verify TypeMap returns correct mappings
 	typeMap := repoSet.TypeMap()
-	assert.Equal(t, int64(1), typeMap["TestArtifact"])
-	assert.Equal(t, int64(2), typeMap["TestDoc"])
-	assert.Equal(t, int64(3), typeMap["TestContext"])
-	assert.Equal(t, int64(4), typeMap["TestModel"])
-	assert.Equal(t, int64(5), typeMap["TestExecution"])
+	assert.Equal(t, int32(1), typeMap["TestArtifact"])
+	assert.Equal(t, int32(2), typeMap["TestDoc"])
+	assert.Equal(t, int32(3), typeMap["TestContext"])
+	assert.Equal(t, int32(4), typeMap["TestModel"])
+	assert.Equal(t, int32(5), typeMap["TestExecution"])
 }
 
 func TestNewRepoSet_MissingType(t *testing.T) {
@@ -278,7 +278,7 @@ func TestRepoSetImpl_Call_ValidInitializers(t *testing.T) {
 
 	args := map[reflect.Type]any{
 		reflect.TypeOf(db):       db,
-		reflect.TypeOf(int64(0)): int64(42),
+		reflect.TypeOf(int32(0)): int32(42),
 	}
 
 	// Test function with one return value
@@ -293,7 +293,7 @@ func TestRepoSetImpl_Call_ValidInitializers(t *testing.T) {
 	assert.Equal(t, db, mockRepo.db)
 
 	// Test function with two return values (success case)
-	twoReturnSuccessFunc := func(db *gorm.DB, id int64) (*mockArtifactRepo, error) {
+	twoReturnSuccessFunc := func(db *gorm.DB, id int32) (*mockArtifactRepo, error) {
 		return &mockArtifactRepo{typeID: id}, nil
 	}
 	result, err = rs.call(twoReturnSuccessFunc, args)
@@ -301,7 +301,7 @@ func TestRepoSetImpl_Call_ValidInitializers(t *testing.T) {
 	assert.NotNil(t, result)
 	mockArtifact, ok := result.(*mockArtifactRepo)
 	assert.True(t, ok)
-	assert.Equal(t, int64(42), mockArtifact.typeID)
+	assert.Equal(t, int32(42), mockArtifact.typeID)
 
 	// Test function with two return values (error case)
 	twoReturnErrorFunc := func(db *gorm.DB) (*mockOtherRepo, error) {
@@ -320,7 +320,7 @@ func TestMakeTypeMap(t *testing.T) {
 		"type3": datastore.NewSpecType("func3"),
 	}
 
-	nameIDMap := map[string]int64{
+	nameIDMap := map[string]int32{
 		"type1": 10,
 		"type2": 20,
 		"type3": 30,

--- a/internal/datastore/repos.go
+++ b/internal/datastore/repos.go
@@ -148,17 +148,17 @@ func (st *SpecType) AddBoolean(name string) *SpecType {
 // RepoSet holds repository implementions.
 type RepoSet interface {
 	// TypeMap returns a map of type names to IDs
-	TypeMap() map[string]int64
+	TypeMap() map[string]int32
 
 	// Repository returns a repository instance of the specified type.
 	Repository(t reflect.Type) (any, error)
 }
 
 // ArtifactTypeMap maps artifact type names to IDs
-type ArtifactTypeMap map[string]int64
+type ArtifactTypeMap map[string]int32
 
 // ContextTypeMap maps context type names to IDs
-type ContextTypeMap map[string]int64
+type ContextTypeMap map[string]int32
 
 // ExecutionTypeMap maps execution type names to IDs
-type ExecutionTypeMap map[string]int64
+type ExecutionTypeMap map[string]int32

--- a/internal/db/service/artifact.go
+++ b/internal/db/service/artifact.go
@@ -19,12 +19,12 @@ var ErrArtifactNotFound = errors.New("artifact by id not found")
 
 type ArtifactRepositoryImpl struct {
 	db       *gorm.DB
-	idToName map[int64]string
+	idToName map[int32]string
 	nameToID datastore.ArtifactTypeMap
 }
 
 func NewArtifactRepository(db *gorm.DB, artifactTypes datastore.ArtifactTypeMap) models.ArtifactRepository {
-	idToName := make(map[int64]string, len(artifactTypes))
+	idToName := make(map[int32]string, len(artifactTypes))
 	for name, id := range artifactTypes {
 		idToName[id] = name
 	}
@@ -170,7 +170,7 @@ func (r *ArtifactRepositoryImpl) List(listOptions models.ArtifactListOptions) (*
 }
 
 // getTypeIDFromArtifactType maps artifact type strings to their corresponding type IDs
-func (r *ArtifactRepositoryImpl) getTypeIDFromArtifactType(artifactType string) (int64, error) {
+func (r *ArtifactRepositoryImpl) getTypeIDFromArtifactType(artifactType string) (int32, error) {
 	switch openapi.ArtifactTypeQueryParam(artifactType) {
 	case openapi.ARTIFACTTYPEQUERYPARAM_MODEL_ARTIFACT:
 		return r.nameToID[defaults.ModelArtifactTypeName], nil
@@ -190,7 +190,7 @@ func (r *ArtifactRepositoryImpl) getTypeIDFromArtifactType(artifactType string) 
 func (r *ArtifactRepositoryImpl) mapDataLayerToArtifact(artifact schema.Artifact, properties []schema.ArtifactProperty) (models.Artifact, error) {
 	artToReturn := models.Artifact{}
 
-	typeName := r.idToName[int64(artifact.TypeID)]
+	typeName := r.idToName[artifact.TypeID]
 
 	switch typeName {
 	case defaults.ModelArtifactTypeName:

--- a/internal/db/service/artifact_test.go
+++ b/internal/db/service/artifact_test.go
@@ -25,7 +25,7 @@ func TestArtifactRepository(t *testing.T) {
 	metricTypeID := getMetricTypeID(t, sharedDB)
 	parameterTypeID := getParameterTypeID(t, sharedDB)
 	metricHistoryTypeID := getMetricHistoryTypeID(t, sharedDB)
-	repo := service.NewArtifactRepository(sharedDB, map[string]int64{
+	repo := service.NewArtifactRepository(sharedDB, map[string]int32{
 		defaults.ModelArtifactTypeName: modelArtifactTypeID,
 		defaults.DocArtifactTypeName:   docArtifactTypeID,
 		defaults.DataSetTypeName:       dataSetTypeID,
@@ -43,7 +43,7 @@ func TestArtifactRepository(t *testing.T) {
 
 	// Create shared test data
 	registeredModel := &models.RegisteredModelImpl{
-		TypeID: apiutils.Of(int32(registeredModelTypeID)),
+		TypeID: apiutils.Of(registeredModelTypeID),
 		Attributes: &models.RegisteredModelAttributes{
 			Name: apiutils.Of("test-registered-model-for-artifacts"),
 		},
@@ -52,7 +52,7 @@ func TestArtifactRepository(t *testing.T) {
 	require.NoError(t, err)
 
 	modelVersion := &models.ModelVersionImpl{
-		TypeID: apiutils.Of(int32(modelVersionTypeID)),
+		TypeID: apiutils.Of(modelVersionTypeID),
 		Attributes: &models.ModelVersionAttributes{
 			Name: apiutils.Of("test-model-version-for-artifacts"),
 		},
@@ -70,7 +70,7 @@ func TestArtifactRepository(t *testing.T) {
 		// Create a model artifact using the model artifact repository
 		modelArtifactRepo := service.NewModelArtifactRepository(sharedDB, modelArtifactTypeID)
 		modelArtifact := &models.ModelArtifactImpl{
-			TypeID: apiutils.Of(int32(modelArtifactTypeID)),
+			TypeID: apiutils.Of(modelArtifactTypeID),
 			Attributes: &models.ModelArtifactAttributes{
 				Name:         apiutils.Of(fmt.Sprintf("%d:test-model-artifact-for-getbyid", *savedModelVersion.GetID())),
 				URI:          apiutils.Of("s3://bucket/model.pkl"),
@@ -84,7 +84,7 @@ func TestArtifactRepository(t *testing.T) {
 		// Create a doc artifact using the doc artifact repository
 		docArtifactRepo := service.NewDocArtifactRepository(sharedDB, docArtifactTypeID)
 		docArtifact := &models.DocArtifactImpl{
-			TypeID: apiutils.Of(int32(docArtifactTypeID)),
+			TypeID: apiutils.Of(docArtifactTypeID),
 			Attributes: &models.DocArtifactAttributes{
 				Name:         apiutils.Of(fmt.Sprintf("%d:unified-test-doc-artifact-for-getbyid", *savedModelVersion.GetID())),
 				URI:          apiutils.Of("s3://bucket/doc.pdf"),
@@ -126,7 +126,7 @@ func TestArtifactRepository(t *testing.T) {
 		// Create model artifacts
 		modelArtifacts := []*models.ModelArtifactImpl{
 			{
-				TypeID: apiutils.Of(int32(modelArtifactTypeID)),
+				TypeID: apiutils.Of(modelArtifactTypeID),
 				Attributes: &models.ModelArtifactAttributes{
 					Name:         apiutils.Of(fmt.Sprintf("%d:list-model-artifact-1", *savedModelVersion.GetID())),
 					ExternalID:   apiutils.Of("list-model-ext-1"),
@@ -136,7 +136,7 @@ func TestArtifactRepository(t *testing.T) {
 				},
 			},
 			{
-				TypeID: apiutils.Of(int32(modelArtifactTypeID)),
+				TypeID: apiutils.Of(modelArtifactTypeID),
 				Attributes: &models.ModelArtifactAttributes{
 					Name:         apiutils.Of(fmt.Sprintf("%d:list-model-artifact-2", *savedModelVersion.GetID())),
 					ExternalID:   apiutils.Of("list-model-ext-2"),
@@ -155,7 +155,7 @@ func TestArtifactRepository(t *testing.T) {
 		// Create doc artifacts
 		docArtifacts := []*models.DocArtifactImpl{
 			{
-				TypeID: apiutils.Of(int32(docArtifactTypeID)),
+				TypeID: apiutils.Of(docArtifactTypeID),
 				Attributes: &models.DocArtifactAttributes{
 					Name:         apiutils.Of(fmt.Sprintf("%d:unified-list-doc-artifact-1", *savedModelVersion.GetID())),
 					ExternalID:   apiutils.Of("unified-list-doc-ext-1"),
@@ -165,7 +165,7 @@ func TestArtifactRepository(t *testing.T) {
 				},
 			},
 			{
-				TypeID: apiutils.Of(int32(docArtifactTypeID)),
+				TypeID: apiutils.Of(docArtifactTypeID),
 				Attributes: &models.DocArtifactAttributes{
 					Name:         apiutils.Of(fmt.Sprintf("%d:unified-list-doc-artifact-2", *savedModelVersion.GetID())),
 					ExternalID:   apiutils.Of("unified-list-doc-ext-2"),
@@ -291,7 +291,7 @@ func TestArtifactRepository(t *testing.T) {
 
 		// Create first artifact (model artifact)
 		artifact1 := &models.ModelArtifactImpl{
-			TypeID: apiutils.Of(int32(modelArtifactTypeID)),
+			TypeID: apiutils.Of(modelArtifactTypeID),
 			Attributes: &models.ModelArtifactAttributes{
 				Name:         apiutils.Of("time-test-model-artifact-1"),
 				URI:          apiutils.Of("s3://bucket/time-model-1.pkl"),
@@ -307,7 +307,7 @@ func TestArtifactRepository(t *testing.T) {
 
 		// Create second artifact (doc artifact)
 		artifact2 := &models.DocArtifactImpl{
-			TypeID: apiutils.Of(int32(docArtifactTypeID)),
+			TypeID: apiutils.Of(docArtifactTypeID),
 			Attributes: &models.DocArtifactAttributes{
 				Name:         apiutils.Of("unified-time-test-doc-artifact-2"),
 				URI:          apiutils.Of("s3://bucket/time-doc-2.pdf"),
@@ -373,7 +373,7 @@ func TestArtifactRepository(t *testing.T) {
 
 		// Create artifacts with similar names but different types
 		modelArtifact := &models.ModelArtifactImpl{
-			TypeID: apiutils.Of(int32(modelArtifactTypeID)),
+			TypeID: apiutils.Of(modelArtifactTypeID),
 			Attributes: &models.ModelArtifactAttributes{
 				Name:         apiutils.Of("mixed-test-artifact"),
 				URI:          apiutils.Of("s3://bucket/mixed-model.pkl"),
@@ -385,7 +385,7 @@ func TestArtifactRepository(t *testing.T) {
 		require.NoError(t, err)
 
 		docArtifact := &models.DocArtifactImpl{
-			TypeID: apiutils.Of(int32(docArtifactTypeID)),
+			TypeID: apiutils.Of(docArtifactTypeID),
 			Attributes: &models.DocArtifactAttributes{
 				Name:         apiutils.Of("unified-mixed-test-doc"),
 				URI:          apiutils.Of("s3://bucket/mixed-doc.pdf"),
@@ -431,7 +431,7 @@ func TestArtifactRepository(t *testing.T) {
 
 		// Create standalone artifacts (without model version attribution)
 		standaloneModelArtifact := &models.ModelArtifactImpl{
-			TypeID: apiutils.Of(int32(modelArtifactTypeID)),
+			TypeID: apiutils.Of(modelArtifactTypeID),
 			Attributes: &models.ModelArtifactAttributes{
 				Name:         apiutils.Of("standalone-model-artifact"),
 				URI:          apiutils.Of("s3://bucket/standalone-model.pkl"),
@@ -443,7 +443,7 @@ func TestArtifactRepository(t *testing.T) {
 		require.NoError(t, err)
 
 		standaloneDocArtifact := &models.DocArtifactImpl{
-			TypeID: apiutils.Of(int32(docArtifactTypeID)),
+			TypeID: apiutils.Of(docArtifactTypeID),
 			Attributes: &models.DocArtifactAttributes{
 				Name:         apiutils.Of("unified-standalone-doc-artifact"),
 				URI:          apiutils.Of("s3://bucket/standalone-doc.pdf"),

--- a/internal/db/service/common_test.go
+++ b/internal/db/service/common_test.go
@@ -33,93 +33,93 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 }
 
 // Helper functions to get type IDs from the database
-func getRegisteredModelTypeID(t *testing.T, db *gorm.DB) int64 {
+func getRegisteredModelTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.RegisteredModelTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find RegisteredModel type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getModelVersionTypeID(t *testing.T, db *gorm.DB) int64 {
+func getModelVersionTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.ModelVersionTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find ModelVersion type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getModelArtifactTypeID(t *testing.T, db *gorm.DB) int64 {
+func getModelArtifactTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.ModelArtifactTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find ModelArtifact type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getDocArtifactTypeID(t *testing.T, db *gorm.DB) int64 {
+func getDocArtifactTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.DocArtifactTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find DocArtifact type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getServingEnvironmentTypeID(t *testing.T, db *gorm.DB) int64 {
+func getServingEnvironmentTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.ServingEnvironmentTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find ServingEnvironment type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getInferenceServiceTypeID(t *testing.T, db *gorm.DB) int64 {
+func getInferenceServiceTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.InferenceServiceTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find InferenceService type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getServeModelTypeID(t *testing.T, db *gorm.DB) int64 {
+func getServeModelTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.ServeModelTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find ServeModel type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getExperimentTypeID(t *testing.T, db *gorm.DB) int64 {
+func getExperimentTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.ExperimentTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find Experiment type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getExperimentRunTypeID(t *testing.T, db *gorm.DB) int64 {
+func getExperimentRunTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.ExperimentRunTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find ExperimentRun type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getDataSetTypeID(t *testing.T, db *gorm.DB) int64 {
+func getDataSetTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.DataSetTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find DataSet type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getMetricTypeID(t *testing.T, db *gorm.DB) int64 {
+func getMetricTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.MetricTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find Metric type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getParameterTypeID(t *testing.T, db *gorm.DB) int64 {
+func getParameterTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.ParameterTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find Parameter type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }
 
-func getMetricHistoryTypeID(t *testing.T, db *gorm.DB) int64 {
+func getMetricHistoryTypeID(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", defaults.MetricHistoryTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to find MetricHistory type")
-	return int64(typeRecord.ID)
+	return typeRecord.ID
 }

--- a/internal/db/service/dataset.go
+++ b/internal/db/service/dataset.go
@@ -17,7 +17,7 @@ type DataSetRepositoryImpl struct {
 	*GenericRepository[models.DataSet, schema.Artifact, schema.ArtifactProperty, *models.DataSetListOptions]
 }
 
-func NewDataSetRepository(db *gorm.DB, typeID int64) models.DataSetRepository {
+func NewDataSetRepository(db *gorm.DB, typeID int32) models.DataSetRepository {
 	config := GenericRepositoryConfig[models.DataSet, schema.Artifact, schema.ArtifactProperty, *models.DataSetListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/doc_artifact.go
+++ b/internal/db/service/doc_artifact.go
@@ -17,7 +17,7 @@ type DocArtifactRepositoryImpl struct {
 	*GenericRepository[models.DocArtifact, schema.Artifact, schema.ArtifactProperty, *models.DocArtifactListOptions]
 }
 
-func NewDocArtifactRepository(db *gorm.DB, typeID int64) models.DocArtifactRepository {
+func NewDocArtifactRepository(db *gorm.DB, typeID int32) models.DocArtifactRepository {
 	config := GenericRepositoryConfig[models.DocArtifact, schema.Artifact, schema.ArtifactProperty, *models.DocArtifactListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/experiment.go
+++ b/internal/db/service/experiment.go
@@ -14,7 +14,7 @@ type ExperimentRepositoryImpl struct {
 	*GenericRepository[models.Experiment, schema.Context, schema.ContextProperty, *models.ExperimentListOptions]
 }
 
-func NewExperimentRepository(db *gorm.DB, typeID int64) models.ExperimentRepository {
+func NewExperimentRepository(db *gorm.DB, typeID int32) models.ExperimentRepository {
 	config := GenericRepositoryConfig[models.Experiment, schema.Context, schema.ContextProperty, *models.ExperimentListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/experiment_run.go
+++ b/internal/db/service/experiment_run.go
@@ -16,7 +16,7 @@ type ExperimentRunRepositoryImpl struct {
 	*GenericRepository[models.ExperimentRun, schema.Context, schema.ContextProperty, *models.ExperimentRunListOptions]
 }
 
-func NewExperimentRunRepository(db *gorm.DB, typeID int64) models.ExperimentRunRepository {
+func NewExperimentRunRepository(db *gorm.DB, typeID int32) models.ExperimentRunRepository {
 	config := GenericRepositoryConfig[models.ExperimentRun, schema.Context, schema.ContextProperty, *models.ExperimentRunListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/generic_repository.go
+++ b/internal/db/service/generic_repository.go
@@ -66,7 +66,7 @@ func applyFilterQuery(query *gorm.DB, listOptions any, mappingFuncs filter.Entit
 // Generic repository configuration
 type GenericRepositoryConfig[TEntity any, TSchema SchemaEntity, TProp PropertyEntity, TListOpts BaseListOptions] struct {
 	DB                    *gorm.DB
-	TypeID                int64
+	TypeID                int32
 	EntityToSchema        EntityToSchemaMapper[TEntity, TSchema]
 	SchemaToEntity        SchemaToEntityMapper[TSchema, TProp, TEntity]
 	EntityToProperties    EntityToPropertiesMapper[TEntity, TProp]

--- a/internal/db/service/inference_service.go
+++ b/internal/db/service/inference_service.go
@@ -16,7 +16,7 @@ type InferenceServiceRepositoryImpl struct {
 	*GenericRepository[models.InferenceService, schema.Context, schema.ContextProperty, *models.InferenceServiceListOptions]
 }
 
-func NewInferenceServiceRepository(db *gorm.DB, typeID int64) models.InferenceServiceRepository {
+func NewInferenceServiceRepository(db *gorm.DB, typeID int32) models.InferenceServiceRepository {
 	config := GenericRepositoryConfig[models.InferenceService, schema.Context, schema.ContextProperty, *models.InferenceServiceListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/metric.go
+++ b/internal/db/service/metric.go
@@ -17,7 +17,7 @@ type MetricRepositoryImpl struct {
 	*GenericRepository[models.Metric, schema.Artifact, schema.ArtifactProperty, *models.MetricListOptions]
 }
 
-func NewMetricRepository(db *gorm.DB, typeID int64) models.MetricRepository {
+func NewMetricRepository(db *gorm.DB, typeID int32) models.MetricRepository {
 	config := GenericRepositoryConfig[models.Metric, schema.Artifact, schema.ArtifactProperty, *models.MetricListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/metric_history.go
+++ b/internal/db/service/metric_history.go
@@ -47,7 +47,7 @@ type MetricHistoryRepositoryImpl struct {
 	*GenericRepository[models.MetricHistory, schema.Artifact, schema.ArtifactProperty, *models.MetricHistoryListOptions]
 }
 
-func NewMetricHistoryRepository(db *gorm.DB, typeID int64) models.MetricHistoryRepository {
+func NewMetricHistoryRepository(db *gorm.DB, typeID int32) models.MetricHistoryRepository {
 	config := GenericRepositoryConfig[models.MetricHistory, schema.Artifact, schema.ArtifactProperty, *models.MetricHistoryListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/model_artifact.go
+++ b/internal/db/service/model_artifact.go
@@ -17,7 +17,7 @@ type ModelArtifactRepositoryImpl struct {
 	*GenericRepository[models.ModelArtifact, schema.Artifact, schema.ArtifactProperty, *models.ModelArtifactListOptions]
 }
 
-func NewModelArtifactRepository(db *gorm.DB, typeID int64) models.ModelArtifactRepository {
+func NewModelArtifactRepository(db *gorm.DB, typeID int32) models.ModelArtifactRepository {
 	config := GenericRepositoryConfig[models.ModelArtifact, schema.Artifact, schema.ArtifactProperty, *models.ModelArtifactListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/model_version.go
+++ b/internal/db/service/model_version.go
@@ -16,7 +16,7 @@ type ModelVersionRepositoryImpl struct {
 	*GenericRepository[models.ModelVersion, schema.Context, schema.ContextProperty, *models.ModelVersionListOptions]
 }
 
-func NewModelVersionRepository(db *gorm.DB, typeID int64) models.ModelVersionRepository {
+func NewModelVersionRepository(db *gorm.DB, typeID int32) models.ModelVersionRepository {
 	config := GenericRepositoryConfig[models.ModelVersion, schema.Context, schema.ContextProperty, *models.ModelVersionListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/parameter.go
+++ b/internal/db/service/parameter.go
@@ -17,7 +17,7 @@ type ParameterRepositoryImpl struct {
 	*GenericRepository[models.Parameter, schema.Artifact, schema.ArtifactProperty, *models.ParameterListOptions]
 }
 
-func NewParameterRepository(db *gorm.DB, typeID int64) models.ParameterRepository {
+func NewParameterRepository(db *gorm.DB, typeID int32) models.ParameterRepository {
 	config := GenericRepositoryConfig[models.Parameter, schema.Artifact, schema.ArtifactProperty, *models.ParameterListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/registered_model.go
+++ b/internal/db/service/registered_model.go
@@ -14,7 +14,7 @@ type RegisteredModelRepositoryImpl struct {
 	*GenericRepository[models.RegisteredModel, schema.Context, schema.ContextProperty, *models.RegisteredModelListOptions]
 }
 
-func NewRegisteredModelRepository(db *gorm.DB, typeID int64) models.RegisteredModelRepository {
+func NewRegisteredModelRepository(db *gorm.DB, typeID int32) models.RegisteredModelRepository {
 	config := GenericRepositoryConfig[models.RegisteredModel, schema.Context, schema.ContextProperty, *models.RegisteredModelListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/serve_model.go
+++ b/internal/db/service/serve_model.go
@@ -16,7 +16,7 @@ type ServeModelRepositoryImpl struct {
 	*GenericRepository[models.ServeModel, schema.Execution, schema.ExecutionProperty, *models.ServeModelListOptions]
 }
 
-func NewServeModelRepository(db *gorm.DB, typeID int64) models.ServeModelRepository {
+func NewServeModelRepository(db *gorm.DB, typeID int32) models.ServeModelRepository {
 	config := GenericRepositoryConfig[models.ServeModel, schema.Execution, schema.ExecutionProperty, *models.ServeModelListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/db/service/serving_environment.go
+++ b/internal/db/service/serving_environment.go
@@ -14,7 +14,7 @@ type ServingEnvironmentRepositoryImpl struct {
 	*GenericRepository[models.ServingEnvironment, schema.Context, schema.ContextProperty, *models.ServingEnvironmentListOptions]
 }
 
-func NewServingEnvironmentRepository(db *gorm.DB, typeID int64) models.ServingEnvironmentRepository {
+func NewServingEnvironmentRepository(db *gorm.DB, typeID int32) models.ServingEnvironmentRepository {
 	config := GenericRepositoryConfig[models.ServingEnvironment, schema.Context, schema.ContextProperty, *models.ServingEnvironmentListOptions]{
 		DB:                  db,
 		TypeID:              typeID,

--- a/internal/mapper/embedmd_mapper.go
+++ b/internal/mapper/embedmd_mapper.go
@@ -15,10 +15,10 @@ type EmbedMDMapper struct {
 	embedMDConverter converter.EmbedMDToOpenAPIConverter
 	*generated.OpenAPIConverterImpl
 	*generated.OpenAPIReconcilerImpl
-	typesMap map[string]int64
+	typesMap map[string]int32
 }
 
-func NewEmbedMDMapper(typesMap map[string]int64) *EmbedMDMapper {
+func NewEmbedMDMapper(typesMap map[string]int32) *EmbedMDMapper {
 	return &EmbedMDMapper{
 		openAPIConverter:      &generated.OpenAPIToEmbedMDConverterImpl{},
 		embedMDConverter:      &generated.EmbedMDToOpenAPIConverterImpl{},

--- a/internal/mapper/embedmd_mapper_test.go
+++ b/internal/mapper/embedmd_mapper_test.go
@@ -14,16 +14,16 @@ import (
 
 // Test constants for type IDs
 const (
-	testRegisteredModelTypeId    = int64(1)
-	testModelVersionTypeId       = int64(2)
-	testDocArtifactTypeId        = int64(3)
-	testModelArtifactTypeId      = int64(4)
-	testServingEnvironmentTypeId = int64(5)
-	testInferenceServiceTypeId   = int64(6)
-	testServeModelTypeId         = int64(7)
+	testRegisteredModelTypeId    = int32(1)
+	testModelVersionTypeId       = int32(2)
+	testDocArtifactTypeId        = int32(3)
+	testModelArtifactTypeId      = int32(4)
+	testServingEnvironmentTypeId = int32(5)
+	testInferenceServiceTypeId   = int32(6)
+	testServeModelTypeId         = int32(7)
 )
 
-var testTypesMap = map[string]int64{
+var testTypesMap = map[string]int32{
 	defaults.RegisteredModelTypeName:    testRegisteredModelTypeId,
 	defaults.ModelVersionTypeName:       testModelVersionTypeId,
 	defaults.DocArtifactTypeName:        testDocArtifactTypeId,

--- a/internal/proxy/readiness_test.go
+++ b/internal/proxy/readiness_test.go
@@ -39,8 +39,8 @@ func setupTestDB(t *testing.T) (*gorm.DB, string, api.ModelRegistryApi, func()) 
 }
 
 // getTypeIDs retrieves all type IDs from the database for testing
-func getTypeIDs(sharedDB *gorm.DB) map[string]int64 {
-	typesMap := make(map[string]int64)
+func getTypeIDs(sharedDB *gorm.DB) map[string]int32 {
+	typesMap := map[string]int32{}
 
 	typeNames := []string{
 		defaults.RegisteredModelTypeName,
@@ -64,7 +64,7 @@ func getTypeIDs(sharedDB *gorm.DB) map[string]int64 {
 		if err != nil {
 			panic("Failed to find type: " + typeName + ": " + err.Error())
 		}
-		typesMap[typeName] = int64(typeRecord.ID)
+		typesMap[typeName] = typeRecord.ID
 	}
 
 	return typesMap
@@ -76,7 +76,7 @@ func setupModelRegistryService(sharedDB *gorm.DB) api.ModelRegistryApi {
 	typesMap := getTypeIDs(sharedDB)
 
 	// Create all repositories
-	artifactRepo := service.NewArtifactRepository(sharedDB, map[string]int64{
+	artifactRepo := service.NewArtifactRepository(sharedDB, map[string]int32{
 		defaults.ModelArtifactTypeName: typesMap[defaults.ModelArtifactTypeName],
 		defaults.DocArtifactTypeName:   typesMap[defaults.DocArtifactTypeName],
 		defaults.DataSetTypeName:       typesMap[defaults.DataSetTypeName],


### PR DESCRIPTION
## Description
Type IDs are 32-bit integers in the database, but they were converted to
int64 in the code. This was causing unnecessary type conversions and
bounds checks.

## How Has This Been Tested?
Unit tests and on a local dev environment.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
