### PR TITLE
fix: default BRANCH to main in controller-test

### DIFF
--- a/.github/workflows/controller-test.yml
+++ b/.github/workflows/controller-test.yml
@@ -35,7 +35,7 @@ jobs:
         id: tags
         run: |
           commit_sha=${{ github.event.after }}
-          tag="$BRANCH"-${commit_sha:0:7}
+          tag="${BRANCH:-main}"-${commit_sha:0:7}
           echo "tag=${tag}" >> $GITHUB_OUTPUT
 
       - name: Clone the code


### PR DESCRIPTION
## Description
#1786 broke the controller build on `main` because `$BRANCH` isn't set there. Defaulting it to `main`.

## How Has This Been Tested?
In the PR workflow.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
