### PR TITLE
fix(catalog): default labels to an empty slice

### DIFF
--- a/catalog/internal/catalog/loader.go
+++ b/catalog/internal/catalog/loader.go
@@ -156,6 +156,12 @@ func (l *Loader) read(path string) (*sourceConfig, error) {
 		}
 		// If not explicitly set, default to enabled
 		source.CatalogSource.Enabled = apiutils.Of(true)
+
+		// Default to an empty labels list
+		if source.Labels == nil {
+			source.Labels = []string{}
+		}
+
 		enabledSources = append(enabledSources, source)
 	}
 	config.Catalogs = enabledSources


### PR DESCRIPTION
## Description
When loading sources, default labels to an empty slice so that the sources endpoint never outputs `null` labels.

## How Has This Been Tested?
Local dev environment and unit tests.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
