### PR TITLE
ci/GHA: on OpenAPI changes, run Fuzz with Schemathesis automatically

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -13,7 +13,7 @@ paths:
   /api/model_registry/v1alpha3/artifact:
     summary: Path used to search for an artifact.
     description: >-
-      The REST endpoint/path used to search for an `Artifact` entity.  This path contains a `GET` operation to perform the find task..
+      The REST endpoint/path used to search for an `Artifact` entity.  This path contains a `GET` operation to perform the find task.
     get:
       tags:
         - ModelRegistryService

--- a/api/openapi/src/model-registry.yaml
+++ b/api/openapi/src/model-registry.yaml
@@ -13,7 +13,7 @@ paths:
   /api/model_registry/v1alpha3/artifact:
     summary: Path used to search for an artifact.
     description: >-
-      The REST endpoint/path used to search for an `Artifact` entity.  This path contains a `GET` operation to perform the find task..
+      The REST endpoint/path used to search for an `Artifact` entity.  This path contains a `GET` operation to perform the find task.
     get:
       tags:
         - ModelRegistryService


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a question from @fege whether the changes to the OpenAPI with the PR https://github.com/kubeflow/model-registry/pull/1789 introduced Fuzzing regressions with Schemathesis.

To my assessment it's not the case:
<img width="1840" height="1147" alt="Screenshot 2025-11-04 at 10 07 24" src="https://github.com/user-attachments/assets/a5ec1f6e-939b-4f9d-b548-00c60edb1640" />

 as on the merge (last in the bottom) all 38 of 38 passed.

It seems to me the regression happened with the bump of schemathesis >4.3.6 : 

<img width="746" height="154" alt="Screenshot 2025-11-04 at 10 07 57" src="https://github.com/user-attachments/assets/efc2a68f-84ad-47ef-bfb7-d68063d13843" />

On further discussion with @fege pointed out whether we could run fuzzing on all PRs.
Inspired by that discussion, I think it is worthy at least to run it automatically each time we change the OpenAPI.
So to exclude PR such as:
- https://github.com/kubeflow/model-registry/pull/1789

to be introducing regressions during API Fuzzing.

This change would not detect issues of dependency bumps, but I think worthy to evaluate for the reason above.

## How Has This Been Tested?
As this change pertains to the ci/GHA, will use to demonstrate the changes are effective (below).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
