### PR TITLE
Proposed OpenAPI spec changes for catalog administration

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -624,6 +624,15 @@ components:
           type: array
           items:
             type: string
+        status:
+          $ref: "#/components/schemas/CatalogSourceStatus"
+          description: Current operational status of the catalog source.
+        error:
+          description: |-
+            Detailed error information when the status is "Error".
+            This field is null or empty when the source is functioning normally.
+          type: string
+          nullable: true
         includedModels:
           description: |-
             Optional allow-list of models that are eligible for this source. Entries can be
@@ -726,6 +735,17 @@ components:
             - items
             - summary
         - $ref: "#/components/schemas/BaseResourceList"
+    CatalogSourceStatus:
+      description: |-
+        Operational status of a catalog source.
+        - `available`: The source is functioning correctly and models can be retrieved
+        - `error`: The source is experiencing issues and cannot provide models
+        - `disabled`: The source has been intentionally disabled
+      enum:
+        - available
+        - error
+        - disabled
+      type: string
     Error:
       description: Error code and message.
       required:

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -486,6 +486,17 @@ components:
           required:
             - items
         - $ref: "#/components/schemas/BaseResourceList"
+    CatalogSourceStatus:
+      description: |-
+        Operational status of a catalog source.
+        - `available`: The source is functioning correctly and models can be retrieved
+        - `error`: The source is experiencing issues and cannot provide models
+        - `disabled`: The source has been intentionally disabled
+      enum:
+        - available
+        - error
+        - disabled
+      type: string
     CatalogSource:
       description: A catalog source. A catalog source has CatalogModel children.
       required:
@@ -509,6 +520,15 @@ components:
           type: array
           items:
             type: string
+        status:
+          $ref: "#/components/schemas/CatalogSourceStatus"
+          description: Current operational status of the catalog source.
+        error:
+          description: |-
+            Detailed error information when the status is "Error".
+            This field is null or empty when the source is functioning normally.
+          type: string
+          nullable: true
         includedModels:
           description: |-
             Optional allow-list of models that are eligible for this source. Entries can be


### PR DESCRIPTION
## Description
These are proposed changes to the API spec for the model catalog to support admin functions from the dashboard. Specifically, it adds:

- A new endpoint to preview changes to a catalog source
- Unified fields for specifying models to include/exclude
- Status and error fields for sources

This is not intended to be merged, but we can take these changes as a starting point for implementation.

## How Has This Been Tested?
N/A

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
