### PR TITLE
docs: py `--pre` on install no longer required

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -18,7 +18,7 @@ This library provides a high level interface for interacting with a model regist
 In your Python environment, you can install the latest version of the Model Registry Python client with:
 
 ```
-pip install --pre model-registry
+pip install model-registry
 ```
 
 ### Installing extras
@@ -30,7 +30,7 @@ By [installing an extra variant](https://packaging.python.org/en/latest/tutorial
 the additional dependencies will be managed for you automatically, for instance with:
 
 ```
-pip install --pre "model-registry[hf]"
+pip install "model-registry[hf]"
 ```
 
 This step is not required if you already installed the additional dependencies already, for instance with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
the `--pre` on `pip install ...` was required for pre-release alpha versions:

<img width="790" height="640" alt="image" src="https://github.com/user-attachments/assets/08d7834f-b210-4540-91e1-376897e5fd42" />

but it's no longer required since `0.2.9` Oct 18, 2024.

Currently latest is also `0.3.3` Nov 10, 2025

## How Has This Been Tested?
tested manually in jupyter

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
