### PR TITLE
feat(catalog): allow source label name to be null

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -383,7 +383,11 @@ components:
       properties:
         name:
           type: string
+          nullable: true
           description: The unique name identifier for the label.
+        displayName:
+          type: string
+          description: An optional human-readable name to show in place of `name`.
       additionalProperties:
         type: string
       example:

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -338,7 +338,11 @@ components:
       properties:
         name:
           type: string
+          nullable: true
           description: The unique name identifier for the label.
+        displayName:
+          type: string
+          description: An optional human-readable name to show in place of `name`.
       additionalProperties:
         type: string
       example:

--- a/catalog/internal/catalog/catalog_test.go
+++ b/catalog/internal/catalog/catalog_test.go
@@ -132,7 +132,7 @@ func TestLabelsValidation(t *testing.T) {
 			name: "valid labels with name field",
 			config: &sourceConfig{
 				Catalogs: []Source{},
-				Labels: []map[string]string{
+				Labels: []map[string]any{
 					{"name": "labelNameOne", "displayName": "Label Name One"},
 					{"name": "labelNameTwo", "displayName": "Label Name Two"},
 				},
@@ -143,7 +143,7 @@ func TestLabelsValidation(t *testing.T) {
 			name: "invalid label missing name field",
 			config: &sourceConfig{
 				Catalogs: []Source{},
-				Labels: []map[string]string{
+				Labels: []map[string]any{
 					{"name": "labelNameOne", "displayName": "Label Name One"},
 					{"displayName": "Label Name Two"}, // Missing "name"
 				},
@@ -155,7 +155,7 @@ func TestLabelsValidation(t *testing.T) {
 			name: "invalid label with empty name",
 			config: &sourceConfig{
 				Catalogs: []Source{},
-				Labels: []map[string]string{
+				Labels: []map[string]any{
 					{"name": "", "displayName": "Empty Name"},
 				},
 			},
@@ -166,7 +166,7 @@ func TestLabelsValidation(t *testing.T) {
 			name: "duplicate label names within same origin",
 			config: &sourceConfig{
 				Catalogs: []Source{},
-				Labels: []map[string]string{
+				Labels: []map[string]any{
 					{"name": "labelNameOne", "displayName": "Label Name One 1"},
 					{"name": "labelNameTwo", "displayName": "Label Name Two"},
 					{"name": "labelNameOne", "displayName": "Label Name One 2"},
@@ -187,7 +187,7 @@ func TestLabelsValidation(t *testing.T) {
 			name: "empty labels array should not error",
 			config: &sourceConfig{
 				Catalogs: []Source{},
-				Labels:   []map[string]string{},
+				Labels:   []map[string]any{},
 			},
 			wantErr: false,
 		},

--- a/catalog/internal/catalog/loader.go
+++ b/catalog/internal/catalog/loader.go
@@ -44,8 +44,8 @@ type LoaderEventHandler func(ctx context.Context, record ModelProviderRecord) er
 
 // sourceConfig is the structure for the catalog sources YAML file.
 type sourceConfig struct {
-	Catalogs []Source            `json:"catalogs"`
-	Labels   []map[string]string `json:"labels,omitempty"`
+	Catalogs []Source         `json:"catalogs"`
+	Labels   []map[string]any `json:"labels,omitempty"`
 }
 
 // Source is a single entry from the catalog sources YAML file.
@@ -206,7 +206,7 @@ func (l *Loader) updateLabels(path string, config *sourceConfig) error {
 	// Merge labels from config into the label collection
 	if config.Labels == nil {
 		// No labels in config, but we still need to clear any previous labels from this origin
-		return l.Labels.Merge(path, []map[string]string{})
+		return l.Labels.Merge(path, []map[string]any{})
 	}
 
 	// Validate that each label has a required "name" field

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -125,11 +125,16 @@ func (m *ModelCatalogServiceAPIService) FindLabels(ctx context.Context, pageSize
 			return ErrorResponse(http.StatusInternalServerError, err), err
 		}
 
-		// Create CatalogLabel with name
-		label := model.NewCatalogLabel(name)
+		// Create CatalogLabel with name (which may be null)
+		var label *model.CatalogLabel
+		if nameStr, ok := name.(string); ok {
+			label = model.NewCatalogLabel(*model.NewNullableString(&nameStr))
+		} else {
+			label = model.NewCatalogLabel(*model.NewNullableString(nil))
+		}
 
 		// Add all other properties to AdditionalProperties
-		label.AdditionalProperties = make(map[string]interface{})
+		label.AdditionalProperties = make(map[string]any)
 		for key, value := range sl.data {
 			if key != "name" {
 				label.AdditionalProperties[key] = value
@@ -297,7 +302,7 @@ func generateLabelID(index int) string {
 
 // sortableLabel wraps a label map to make it sortable
 type sortableLabel struct {
-	data  map[string]string
+	data  map[string]any
 	index int    // Original position for stable sort when key is missing
 	id    string // Stable ID for pagination
 }
@@ -335,8 +340,17 @@ func genLabelCmpFunc(orderByKey string, sortOrder model.SortOrder) func(sortable
 		}
 
 		// Get values for the orderBy key
-		aVal, aHasKey := a.data[orderByKey]
-		bVal, bHasKey := b.data[orderByKey]
+		aValRaw, aHasKey := a.data[orderByKey]
+		bValRaw, bHasKey := b.data[orderByKey]
+
+		var aVal string
+		if aHasKey {
+			aVal, aHasKey = aValRaw.(string)
+		}
+		var bVal string
+		if bHasKey {
+			bVal, bHasKey = bValRaw.(string)
+		}
 
 		// If both have the key, compare their values
 		if aHasKey && bHasKey {

--- a/catalog/pkg/openapi/model_catalog_label.go
+++ b/catalog/pkg/openapi/model_catalog_label.go
@@ -20,7 +20,9 @@ var _ MappedNullable = &CatalogLabel{}
 // CatalogLabel A catalog label. Labels are used to categorize catalog sources. Represented as a flexible map of string key-value pairs with a required 'name' field.
 type CatalogLabel struct {
 	// The unique name identifier for the label.
-	Name                 string `json:"name"`
+	Name NullableString `json:"name"`
+	// An optional human-readable name to show in place of `name`.
+	DisplayName          *string `json:"displayName,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -30,7 +32,7 @@ type _CatalogLabel CatalogLabel
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCatalogLabel(name string) *CatalogLabel {
+func NewCatalogLabel(name NullableString) *CatalogLabel {
 	this := CatalogLabel{}
 	this.Name = name
 	return &this
@@ -45,27 +47,61 @@ func NewCatalogLabelWithDefaults() *CatalogLabel {
 }
 
 // GetName returns the Name field value
+// If the value is explicit nil, the zero value for string will be returned
 func (o *CatalogLabel) GetName() string {
-	if o == nil {
+	if o == nil || o.Name.Get() == nil {
 		var ret string
 		return ret
 	}
 
-	return o.Name
+	return *o.Name.Get()
 }
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *CatalogLabel) GetNameOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name.Get(), o.Name.IsSet()
 }
 
 // SetName sets field value
 func (o *CatalogLabel) SetName(v string) {
-	o.Name = v
+	o.Name.Set(&v)
+}
+
+// GetDisplayName returns the DisplayName field value if set, zero value otherwise.
+func (o *CatalogLabel) GetDisplayName() string {
+	if o == nil || IsNil(o.DisplayName) {
+		var ret string
+		return ret
+	}
+	return *o.DisplayName
+}
+
+// GetDisplayNameOk returns a tuple with the DisplayName field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CatalogLabel) GetDisplayNameOk() (*string, bool) {
+	if o == nil || IsNil(o.DisplayName) {
+		return nil, false
+	}
+	return o.DisplayName, true
+}
+
+// HasDisplayName returns a boolean if a field has been set.
+func (o *CatalogLabel) HasDisplayName() bool {
+	if o != nil && !IsNil(o.DisplayName) {
+		return true
+	}
+
+	return false
+}
+
+// SetDisplayName gets a reference to the given string and assigns it to the DisplayName field.
+func (o *CatalogLabel) SetDisplayName(v string) {
+	o.DisplayName = &v
 }
 
 func (o CatalogLabel) MarshalJSON() ([]byte, error) {
@@ -78,7 +114,10 @@ func (o CatalogLabel) MarshalJSON() ([]byte, error) {
 
 func (o CatalogLabel) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["name"] = o.Name
+	toSerialize["name"] = o.Name.Get()
+	if !IsNil(o.DisplayName) {
+		toSerialize["displayName"] = o.DisplayName
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value


### PR DESCRIPTION
## Description

Allow one source label to exist with a null name that can be used for a
catch-all. Also adding an official displayName field that can be used to
override the name when displaying it.

## How Has This Been Tested?
Local dev environment and unit tests.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
