### PR TITLE
fix(catalog): preserve historical timestamps from YAML catalog imports

### DIFF
--- a/catalog/internal/db/service/catalog_metrics_artifact.go
+++ b/catalog/internal/db/service/catalog_metrics_artifact.go
@@ -22,17 +22,18 @@ type CatalogMetricsArtifactRepositoryImpl struct {
 
 func NewCatalogMetricsArtifactRepository(db *gorm.DB, typeID int32) models.CatalogMetricsArtifactRepository {
 	config := service.GenericRepositoryConfig[models.CatalogMetricsArtifact, schema.Artifact, schema.ArtifactProperty, *models.CatalogMetricsArtifactListOptions]{
-		DB:                  db,
-		TypeID:              typeID,
-		EntityToSchema:      mapCatalogMetricsArtifactToArtifact,
-		SchemaToEntity:      mapDataLayerToCatalogMetricsArtifact,
-		EntityToProperties:  mapCatalogMetricsArtifactToArtifactProperties,
-		NotFoundError:       ErrCatalogMetricsArtifactNotFound,
-		EntityName:          "catalog metrics artifact",
-		PropertyFieldName:   "artifact_id",
-		ApplyListFilters:    applyCatalogMetricsArtifactListFilters,
-		IsNewEntity:         func(entity models.CatalogMetricsArtifact) bool { return entity.GetID() == nil },
-		HasCustomProperties: func(entity models.CatalogMetricsArtifact) bool { return entity.GetCustomProperties() != nil },
+		DB:                      db,
+		TypeID:                  typeID,
+		EntityToSchema:          mapCatalogMetricsArtifactToArtifact,
+		SchemaToEntity:          mapDataLayerToCatalogMetricsArtifact,
+		EntityToProperties:      mapCatalogMetricsArtifactToArtifactProperties,
+		NotFoundError:           ErrCatalogMetricsArtifactNotFound,
+		EntityName:              "catalog metrics artifact",
+		PropertyFieldName:       "artifact_id",
+		ApplyListFilters:        applyCatalogMetricsArtifactListFilters,
+		IsNewEntity:             func(entity models.CatalogMetricsArtifact) bool { return entity.GetID() == nil },
+		HasCustomProperties:     func(entity models.CatalogMetricsArtifact) bool { return entity.GetCustomProperties() != nil },
+		PreserveHistoricalTimes: true, // Catalog preserves timestamps from YAML source data
 	}
 
 	return &CatalogMetricsArtifactRepositoryImpl{

--- a/catalog/internal/db/service/catalog_model.go
+++ b/catalog/internal/db/service/catalog_model.go
@@ -27,20 +27,21 @@ func NewCatalogModelRepository(db *gorm.DB, typeID int32) models.CatalogModelRep
 	r := &CatalogModelRepositoryImpl{}
 
 	r.GenericRepository = service.NewGenericRepository(service.GenericRepositoryConfig[models.CatalogModel, schema.Context, schema.ContextProperty, *models.CatalogModelListOptions]{
-		DB:                    db,
-		TypeID:                typeID,
-		EntityToSchema:        mapCatalogModelToContext,
-		SchemaToEntity:        mapDataLayerToCatalogModel,
-		EntityToProperties:    mapCatalogModelToContextProperties,
-		NotFoundError:         ErrCatalogModelNotFound,
-		EntityName:            "catalog model",
-		PropertyFieldName:     "context_id",
-		ApplyListFilters:      applyCatalogModelListFilters,
-		CreatePaginationToken: r.createPaginationToken,
-		ApplyCustomOrdering:   r.applyCustomOrdering,
-		IsNewEntity:           func(entity models.CatalogModel) bool { return entity.GetID() == nil },
-		HasCustomProperties:   func(entity models.CatalogModel) bool { return entity.GetCustomProperties() != nil },
-		EntityMappingFuncs:    filter.NewCatalogEntityMappings(),
+		DB:                      db,
+		TypeID:                  typeID,
+		EntityToSchema:          mapCatalogModelToContext,
+		SchemaToEntity:          mapDataLayerToCatalogModel,
+		EntityToProperties:      mapCatalogModelToContextProperties,
+		NotFoundError:           ErrCatalogModelNotFound,
+		EntityName:              "catalog model",
+		PropertyFieldName:       "context_id",
+		ApplyListFilters:        applyCatalogModelListFilters,
+		CreatePaginationToken:   r.createPaginationToken,
+		ApplyCustomOrdering:     r.applyCustomOrdering,
+		IsNewEntity:             func(entity models.CatalogModel) bool { return entity.GetID() == nil },
+		HasCustomProperties:     func(entity models.CatalogModel) bool { return entity.GetCustomProperties() != nil },
+		EntityMappingFuncs:      filter.NewCatalogEntityMappings(),
+		PreserveHistoricalTimes: true, // Catalog preserves timestamps from YAML source data
 	})
 
 	return r

--- a/catalog/internal/db/service/catalog_model_artifact.go
+++ b/catalog/internal/db/service/catalog_model_artifact.go
@@ -21,17 +21,18 @@ type CatalogModelArtifactRepositoryImpl struct {
 
 func NewCatalogModelArtifactRepository(db *gorm.DB, typeID int32) models.CatalogModelArtifactRepository {
 	config := service.GenericRepositoryConfig[models.CatalogModelArtifact, schema.Artifact, schema.ArtifactProperty, *models.CatalogModelArtifactListOptions]{
-		DB:                  db,
-		TypeID:              typeID,
-		EntityToSchema:      mapCatalogModelArtifactToArtifact,
-		SchemaToEntity:      mapDataLayerToCatalogModelArtifact,
-		EntityToProperties:  mapCatalogModelArtifactToArtifactProperties,
-		NotFoundError:       ErrCatalogModelArtifactNotFound,
-		EntityName:          "catalog model artifact",
-		PropertyFieldName:   "artifact_id",
-		ApplyListFilters:    applyCatalogModelArtifactListFilters,
-		IsNewEntity:         func(entity models.CatalogModelArtifact) bool { return entity.GetID() == nil },
-		HasCustomProperties: func(entity models.CatalogModelArtifact) bool { return entity.GetCustomProperties() != nil },
+		DB:                      db,
+		TypeID:                  typeID,
+		EntityToSchema:          mapCatalogModelArtifactToArtifact,
+		SchemaToEntity:          mapDataLayerToCatalogModelArtifact,
+		EntityToProperties:      mapCatalogModelArtifactToArtifactProperties,
+		NotFoundError:           ErrCatalogModelArtifactNotFound,
+		EntityName:              "catalog model artifact",
+		PropertyFieldName:       "artifact_id",
+		ApplyListFilters:        applyCatalogModelArtifactListFilters,
+		IsNewEntity:             func(entity models.CatalogModelArtifact) bool { return entity.GetID() == nil },
+		HasCustomProperties:     func(entity models.CatalogModelArtifact) bool { return entity.GetCustomProperties() != nil },
+		PreserveHistoricalTimes: true, // Catalog preserves timestamps from YAML source data
 	}
 
 	return &CatalogModelArtifactRepositoryImpl{


### PR DESCRIPTION
## Description
Modified the generic repository to preserve existing CreateTimeSinceEpoch and LastUpdateTimeSinceEpoch values when present, allowing catalog models loaded from YAML files to maintain their historical timestamps instead of being overwritten with current time.

Fixes: RHOAIENG-39336

## How Has This Been Tested?

- Passing unit tests
- Validated with docker-compose setup data

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
