### PR TITLE
chore: don't welcome dependabot

### DIFF
--- a/.github/workflows/first-time-contributor-pr.yml
+++ b/.github/workflows/first-time-contributor-pr.yml
@@ -15,6 +15,7 @@ permissions: # set contents: read at top-level, per OpenSSF ScoreCard rule Token
 
 jobs:
   welcome:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Description

In general, we welcome our robot overlords, but in this case it's getting excessive on every dependabot PR.

## How Has This Been Tested?
I can't test this until it's been merged and dependabot opens a PR. Though the negative case will run in this PR.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
