### PR TITLE
Wired the deletion prop to the bff

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTable.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTable.tsx
@@ -18,7 +18,7 @@ import CatalogSourceConfigsTableRow from './CatalogSourceConfigsTableRow';
 type CatalogSourceConfigsTableProps = {
   catalogSourceConfigs: CatalogSourceConfig[];
   onAddSource: () => void;
-  onDeleteSource?: (config: CatalogSourceConfig) => void;
+  onDeleteSource: (sourceId: string) => Promise<void>;
 };
 
 const CatalogSourceConfigsTable: React.FC<CatalogSourceConfigsTableProps> = ({
@@ -67,7 +67,7 @@ const CatalogSourceConfigsTable: React.FC<CatalogSourceConfigsTableProps> = ({
             <CatalogSourceConfigsTableRow
               key={config.id}
               catalogSourceConfig={config}
-              onDelete={onDeleteSource}
+              onDeleteSource={onDeleteSource}
             />
           )}
           variant="compact"

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableRow.tsx
@@ -9,22 +9,20 @@ import {
   ModelVisibilityBadgeColor,
 } from '~/concepts/modelCatalogSettings/const';
 import { hasSourceFilters, getOrganizationDisplay } from '~/concepts/modelCatalogSettings/utils';
-import { ModelCatalogSettingsContext } from '~/app/context/modelCatalogSettings/ModelCatalogSettingsContext';
 import DeleteModal from '~/app/shared/components/DeleteModal';
 import { useNotification } from '~/app/hooks/useNotification';
 import CatalogSourceStatus from '~/app/pages/modelCatalogSettings/components/CatalogSourceStatus';
 
 type CatalogSourceConfigsTableRowProps = {
   catalogSourceConfig: CatalogSourceConfig;
-  onDelete?: (config: CatalogSourceConfig) => void;
+  onDeleteSource: (sourceId: string) => Promise<void>;
 };
 
 const CatalogSourceConfigsTableRow: React.FC<CatalogSourceConfigsTableRowProps> = ({
   catalogSourceConfig,
-  onDelete,
+  onDeleteSource,
 }) => {
   const navigate = useNavigate();
-  const { apiState, refreshCatalogSourceConfigs } = React.useContext(ModelCatalogSettingsContext);
   const notification = useNotification();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
   const [isDeleting, setIsDeleting] = React.useState(false);
@@ -49,7 +47,7 @@ const CatalogSourceConfigsTableRow: React.FC<CatalogSourceConfigsTableRowProps> 
     navigate(manageSourceUrl(catalogSourceConfig.id));
   };
 
-  const handleDeleteSource = () => {
+  const handleDeleteClick = () => {
     setDeleteError(undefined);
     setIsDeleteModalOpen(true);
   };
@@ -59,11 +57,9 @@ const CatalogSourceConfigsTableRow: React.FC<CatalogSourceConfigsTableRowProps> 
     setDeleteError(undefined);
 
     try {
-      await apiState.api.deleteCatalogSourceConfig({}, catalogSourceConfig.id);
+      await onDeleteSource(catalogSourceConfig.id);
       setIsDeleteModalOpen(false);
-      refreshCatalogSourceConfigs();
       notification.success(`${catalogSourceConfig.name} deleted successfully`);
-      onDelete?.(catalogSourceConfig);
     } catch (error) {
       setDeleteError(error instanceof Error ? error : new Error('Failed to delete source'));
     } finally {
@@ -143,7 +139,7 @@ const CatalogSourceConfigsTableRow: React.FC<CatalogSourceConfigsTableRowProps> 
               items={[
                 {
                   title: 'Delete source',
-                  onClick: handleDeleteSource,
+                  onClick: handleDeleteClick,
                 },
               ]}
               data-testid={`source-actions-${catalogSourceConfig.id}`}

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/ModelCatalogSettings.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/ModelCatalogSettings.tsx
@@ -13,11 +13,27 @@ import CatalogSourceConfigsTable from './CatalogSourceConfigsTable';
 
 const ModelCatalogSettings: React.FC = () => {
   const navigate = useNavigate();
-  const { catalogSourceConfigs, catalogSourceConfigsLoaded, catalogSourceConfigsLoadError } =
-    React.useContext(ModelCatalogSettingsContext);
+  const {
+    catalogSourceConfigs,
+    catalogSourceConfigsLoaded,
+    catalogSourceConfigsLoadError,
+    apiState,
+    refreshCatalogSourceConfigs,
+  } = React.useContext(ModelCatalogSettingsContext);
 
   const configs = catalogSourceConfigs?.catalogs || [];
   const isEmpty = catalogSourceConfigsLoaded && configs.length === 0;
+
+  const handleDeleteSource = React.useCallback(
+    async (sourceId: string): Promise<void> => {
+      if (!apiState.apiAvailable) {
+        throw new Error('API not available');
+      }
+      await apiState.api.deleteCatalogSourceConfig({}, sourceId);
+      refreshCatalogSourceConfigs();
+    },
+    [apiState.api, apiState.apiAvailable, refreshCatalogSourceConfigs],
+  );
 
   return (
     <ApplicationsPage
@@ -58,6 +74,7 @@ const ModelCatalogSettings: React.FC = () => {
       <CatalogSourceConfigsTable
         catalogSourceConfigs={configs}
         onAddSource={() => navigate(addSourceUrl())}
+        onDeleteSource={handleDeleteSource}
       />
     </ApplicationsPage>
   );


### PR DESCRIPTION
## Description

This PR implements the delete functionality for catalog source configurations in the Model Catalog Settings page. The changes refactor the delete operation to wire to the actual BFF

<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The UI remains the same - users can delete catalog source configurations via the actions menu (kebab menu) in each table row. The delete operation shows a confirmation modal and displays success/error notifications.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->



## Merge criteria:

<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)



<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages

- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).

- [x] The developer has manually tested the changes and verified that the changes work.

- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.



If you have UI changes



<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->

- [x] The developer has added tests or explained why testing cannot be added.

- [x] Included any necessary screenshots or gifs if it was a UI change.

- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

