### PR TITLE
chore(catalog): allow empty sources list

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -533,6 +533,8 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/CatalogSource"
+          required:
+            - items
         - $ref: "#/components/schemas/BaseResourceList"
     Error:
       description: Error code and message.

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -416,6 +416,8 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/CatalogSource"
+          required:
+            - items
         - $ref: "#/components/schemas/BaseResourceList"
     FilterOption:
       type: object

--- a/catalog/internal/server/openapi/type_asserts.go
+++ b/catalog/internal/server/openapi/type_asserts.go
@@ -262,6 +262,7 @@ func AssertCatalogSourceListRequired(obj model.CatalogSourceList) error {
 		"nextPageToken": obj.NextPageToken,
 		"pageSize":      obj.PageSize,
 		"size":          obj.Size,
+		"items":         obj.Items,
 	}
 	for name, el := range elements {
 		if isZero := IsZeroValue(el); isZero {

--- a/catalog/pkg/openapi/model_catalog_source_list.go
+++ b/catalog/pkg/openapi/model_catalog_source_list.go
@@ -26,7 +26,7 @@ type CatalogSourceList struct {
 	// Number of items in result list.
 	Size int32 `json:"size"`
 	// Array of `CatalogSource` entities.
-	Items []CatalogSource `json:"items,omitempty"`
+	Items []CatalogSource `json:"items"`
 }
 
 type _CatalogSourceList CatalogSourceList
@@ -35,11 +35,12 @@ type _CatalogSourceList CatalogSourceList
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCatalogSourceList(nextPageToken string, pageSize int32, size int32) *CatalogSourceList {
+func NewCatalogSourceList(nextPageToken string, pageSize int32, size int32, items []CatalogSource) *CatalogSourceList {
 	this := CatalogSourceList{}
 	this.NextPageToken = nextPageToken
 	this.PageSize = pageSize
 	this.Size = size
+	this.Items = items
 	return &this
 }
 
@@ -123,34 +124,26 @@ func (o *CatalogSourceList) SetSize(v int32) {
 	o.Size = v
 }
 
-// GetItems returns the Items field value if set, zero value otherwise.
+// GetItems returns the Items field value
 func (o *CatalogSourceList) GetItems() []CatalogSource {
-	if o == nil || IsNil(o.Items) {
+	if o == nil {
 		var ret []CatalogSource
 		return ret
 	}
+
 	return o.Items
 }
 
-// GetItemsOk returns a tuple with the Items field value if set, nil otherwise
+// GetItemsOk returns a tuple with the Items field value
 // and a boolean to check if the value has been set.
 func (o *CatalogSourceList) GetItemsOk() ([]CatalogSource, bool) {
-	if o == nil || IsNil(o.Items) {
+	if o == nil {
 		return nil, false
 	}
 	return o.Items, true
 }
 
-// HasItems returns a boolean if a field has been set.
-func (o *CatalogSourceList) HasItems() bool {
-	if o != nil && !IsNil(o.Items) {
-		return true
-	}
-
-	return false
-}
-
-// SetItems gets a reference to the given []CatalogSource and assigns it to the Items field.
+// SetItems sets field value
 func (o *CatalogSourceList) SetItems(v []CatalogSource) {
 	o.Items = v
 }
@@ -168,9 +161,7 @@ func (o CatalogSourceList) ToMap() (map[string]interface{}, error) {
 	toSerialize["nextPageToken"] = o.NextPageToken
 	toSerialize["pageSize"] = o.PageSize
 	toSerialize["size"] = o.Size
-	if !IsNil(o.Items) {
-		toSerialize["items"] = o.Items
-	}
+	toSerialize["items"] = o.Items
 	return toSerialize, nil
 }
 


### PR DESCRIPTION
## Description

Always return items from the sources endpoint, even if it's an empty list.

## How Has This Been Tested?
On a local dev environment.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
