### PR TITLE
Fixed Model Catalog Cards wrapping issue

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/CatalogCategorySection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/CatalogCategorySection.tsx
@@ -105,7 +105,14 @@ const CatalogCategorySection: React.FC<CategorySectionProps> = ({
         ) : (
           <Grid hasGutter>
             {itemsToDisplay.map((model) => (
-              <GridItem key={`${model.name}/${model.source_id}`} sm={6} md={6} lg={6} xl={6} xl2={3}>
+              <GridItem
+                key={`${model.name}/${model.source_id}`}
+                sm={6}
+                md={6}
+                lg={6}
+                xl={6}
+                xl2={3}
+              >
                 <ModelCatalogCard
                   model={model}
                   source={getSourceFromSourceId(model.source_id || '', catalogSources)}


### PR DESCRIPTION
## Description

Fixed a responsive layout issue on the catalog landing page's "All models" tab. At certain screen widths, cards wrapped to 3 per row with 1 on the next row (3+1) instead of staying in 4 columns.
## How Has This Been Tested?

https://github.com/user-attachments/assets/da7907cf-841d-436f-b9de-62f875752323



**Manual Testing:**
- Resized the browser window horizontally from very large to very small
- Verified that 4 cards remain in one row at all screen sizes where they fit
- Confirmed cards wrap appropriately only when the screen is too narrow

## Merge criteria:

- All the commits have been signed-off (To pass the `DCO` check)

- [x] The commits have meaningful messages

- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).

- [x] The developer has manually tested the changes and verified that the changes work.

- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.

- [ ] Included any necessary screenshots or gifs if it was a UI change.

- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.