### PR TITLE
feat(catalog): return all sources regardless of enabled field value

### DIFF
--- a/catalog/internal/catalog/sources.go
+++ b/catalog/internal/catalog/sources.go
@@ -159,21 +159,19 @@ func (sc *SourceCollection) merged() map[string]Source {
 
 // AllSources returns all merged sources including Type and Properties.
 // This is used by the loader to get complete source information.
-// Only enabled sources are returned.
+// All sources are returned regardless of enabled status.
 func (sc *SourceCollection) AllSources() map[string]Source {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
 
 	result := map[string]Source{}
 	for id, source := range sc.merged() {
-		if source.Enabled != nil && *source.Enabled {
-			result[id] = source
-		}
+		result[id] = source
 	}
 	return result
 }
 
-// All returns all enabled sources as CatalogSource (for the API).
+// All returns all sources as CatalogSource (for the API).
 // This excludes internal fields like Type and Properties.
 func (sc *SourceCollection) All() map[string]model.CatalogSource {
 	result := map[string]model.CatalogSource{}

--- a/catalog/internal/catalog/sources_test.go
+++ b/catalog/internal/catalog/sources_test.go
@@ -412,7 +412,7 @@ func TestSourceCollection_MergeOverride(t *testing.T) {
 			},
 		},
 		{
-			name:        "user can disable a source from default - disabled sources not returned",
+			name:        "user can disable a source from default - disabled sources ARE returned",
 			originOrder: []string{"default.yaml", "user.yaml"},
 			mergeSequence: []struct {
 				origin  string
@@ -441,8 +441,15 @@ func TestSourceCollection_MergeOverride(t *testing.T) {
 					},
 				},
 			},
-			// Disabled sources are not returned by All()
-			expectedSources: map[string]model.CatalogSource{},
+			// Disabled sources ARE returned by All() - with enabled field showing false
+			expectedSources: map[string]model.CatalogSource{
+				"hf": {
+					Id:      "hf",
+					Name:    "Hugging Face",
+					Enabled: apiutils.Of(false),
+					Labels:  []string{},
+				},
+			},
 		},
 		{
 			name:        "sparse override: user enables disabled source with just id and enabled",


### PR DESCRIPTION
## Description
Implements - Sources endpoint should return all sources regardless of the enabled field's value

Related: https://issues.redhat.com/browse/RHOAIENG-41243

## How Has This Been Tested?
Unit tests -  `TESTCONTAINERS_RYUK_DISABLED=true make test`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
