### PR TITLE
chore: restore apparmor in github actions

### DIFF
--- a/.github/workflows/async-upload-test.yml
+++ b/.github/workflows/async-upload-test.yml
@@ -53,10 +53,6 @@ jobs:
       - name: Run tests
         run: |
           make test
-      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
-        run: |
-          set -x
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Run E2E tests
         run: |
           make test-e2e
@@ -74,10 +70,6 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install poetry
-      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
-        run: |
-          set -x
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Execute Sample Job E2E test
         run: |
           make test-integration

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -42,10 +42,6 @@ jobs:
         uses: helm/kind-action@v1.13.0
         with:
           node_image: "kindest/node:v1.27.11"
-      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
-        run: |
-          set -x
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Load Local Registry Test Image
         env:
           IMG: "${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"

--- a/.github/workflows/csi-test.yml
+++ b/.github/workflows/csi-test.yml
@@ -73,11 +73,6 @@ jobs:
         with:
           node_image: "kindest/node:v1.31.0"
 
-      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
-        run: |
-          set -x
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-
       - name: Install kustomize
         run: ./test/scripts/install_kustomize.sh
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -202,10 +202,6 @@ jobs:
           node_image: kindest/node:${{ matrix.kubernetes-version }}
           cluster_name: chart-testing-py-${{ matrix.python }}
           kubectl_version: ${{ matrix.kubernetes-version }}
-      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
-        run: |
-          set -x
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Load Local Registry Test Image
         env:
           IMG: "${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_REPO }}:${{ steps.tags.outputs.tag }}"

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -72,11 +72,6 @@ jobs:
           cluster_name: py-fuzz-${{ matrix.kubernetes-version }}
           kubectl_version: ${{ matrix.kubernetes-version }}
 
-      - name: Remove AppArmor profile for mysql in KinD on GHA # https://github.com/kubeflow/manifests/issues/2507
-        run: |
-          set -x
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-
       - name: Generate Tag
         shell: bash
         id: tags

--- a/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
+++ b/manifests/kustomize/overlays/db/model-registry-db-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "mysql -D $$MYSQL_DATABASE -u$$MYSQL_USER_NAME -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+            - "mysql -h 127.0.0.1 -D $$MYSQL_DATABASE -u$$MYSQL_USER_NAME -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 1

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -61,7 +61,7 @@ else
 
     kubectl exec -n "$MR_NAMESPACE" \
         "$(kubectl get pods -l component=db -o jsonpath="{.items[0].metadata.name}" -n "$MR_NAMESPACE")" \
-        -- mysql -u "$MYSQL_USER_NAME" -p"$MYSQL_ROOT_PASSWORD" -D "$TEST_DB_NAME" -e "START TRANSACTION; $PARTIAL_SQL_CMD; COMMIT;"
+        -- mysql -h 127.0.0.1 -u "$MYSQL_USER_NAME" -p"$MYSQL_ROOT_PASSWORD" -D "$TEST_DB_NAME" -e "START TRANSACTION; $PARTIAL_SQL_CMD; COMMIT;"
 
     echo -n 'Done cleaning up kubernetes MySQL DB'
 fi


### PR DESCRIPTION
## Description

Remove the commands that clear the mysql apparmor profile in the github actions. The profile prevents accessing mysql through the socket, so when running mysql in `kubectl exec` on the pod we need to specify the local IP address.

## How Has This Been Tested?
Through github actions on this PR.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
