### PR TITLE
BFF: Fix model-catalog-default-sources configmap name

### DIFF
--- a/clients/ui/bff/internal/integrations/kubernetes/client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/client.go
@@ -10,7 +10,7 @@ const ComponentLabelValueCatalog = "model-catalog"
 
 // TODO ppadti double check if the config map key is indeed sources.yaml
 const CatalogSourceKey = "sources.yaml"
-const CatalogSourceDefaultConfigMapName = "model-catalog-source-config"
+const CatalogSourceDefaultConfigMapName = "model-catalog-default-sources"
 const CatalogSourceUserConfigMapName = "model-catalog-sources"
 
 type KubernetesClientInterface interface {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The BFF currently tries to find a configmap called model-catalog-source-config for the default sources, but the correct configmap name is model-catalog-default-sources. This causes a 500 error when running the ODH version of the catalog settings BFF endpoints.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the settings page BFF calls still work in mock mode. Will test e2e against real configmaps in ODH.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
