### PR TITLE
fix: readinessprobe bug

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -167,13 +167,14 @@ func runProxyServer(cmd *cobra.Command, args []string) error {
 			return
 		}
 
-		// Set the model registry service in the holder for health checks
-		serviceHolder.Set(conn)
-
 		ModelRegistryServiceAPIService := openapi.NewModelRegistryServiceAPIService(conn)
 		ModelRegistryServiceAPIController := openapi.NewModelRegistryServiceAPIController(ModelRegistryServiceAPIService)
 
 		router.SetRouter(middleware.WrapWithValidation(ModelRegistryServiceAPIController))
+
+		// Set the model registry service in the holder for health checks AFTER router is ready
+		// This ensures the readiness probe only passes when the router can serve actual requests
+		serviceHolder.Set(conn)
 	}()
 
 	// Start the proxy server in a separate goroutine so that we can handle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The readiness probe (/readyz/health) was passing before the HTTP router was fully configured, causing the pod to be marked as Ready while still returning 503 Service Unavailable for several seconds.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in a kind cluster

- Verified the readiness probe now correctly reflects actual service availability
- Pod only becomes Ready when it can serve real traffic


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
