### PR TITLE
Add new performance endpoint 

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -849,6 +849,81 @@ paths:
           $ref: "#/components/responses/InternalServerError"
       operationId: getAllModelArtifacts
 
+  /api/v1/model_catalog/sources/{sourceId}/performance_artifacts/{CatalogModelName+}:
+    description: >-
+      The REST endpoint/path used to list `CatalogModelPerformanceArtifacts`.
+    get:
+      summary: List CatalogModelPerformanceArtifacts.
+      tags:
+        - ModelCatalogService
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+        - name: sourceId
+          description: A unique identifier for a `CatalogSource`.
+          schema:
+            type: string
+          in: path
+          required: true
+        - name: CatalogModelName+
+          description: A unique identifier for the model.
+          schema:
+            type: string
+          in: path
+          required: true
+        - name: targetRPS
+          description: |-
+            Target requests per second. If specified, values for `replicas` and
+            `total_requests_per_second` will be calculated and returned as custom
+            properties.
+          schema:
+            type: integer
+          in: query
+        - name: recommendations
+          description: Filter records that are less optimal based on approximate cost to run and latency.
+          schema:
+            type: boolean
+            default: false
+          in: query
+        - name: rpsProperty
+          description: Custom property name for requests per second metric.
+          schema:
+            type: string
+            default: "requests_per_second"
+          in: query
+        - name: latencyProperty
+          description: Custom property name for latency metric (e.g., ttft_p90, p90_latency).
+          schema:
+            type: string
+            default: "ttft_p90"
+          in: query
+        - name: hardwareCountProperty
+          description: Custom property name for hardware count metric.
+          schema:
+            type: string
+            default: "hardware_count"
+          in: query
+        - name: hardwareTypeProperty
+          description: Custom property name for hardware type grouping.
+          schema:
+            type: string
+            default: "hardware_type"
+          in: query
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/artifactOrderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogModelArtifactListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getPerformanceArtifacts
+
   # Model catalog settings endpoints
   /api/v1/settings/model_catalog/source_configs:
     summary: Path used to managae Model catalog sources.
@@ -2001,6 +2076,7 @@ components:
         - type: object
           required:
             - artifactType
+            - metricsType
           properties:
             artifactType:
               type: string
@@ -2037,6 +2113,7 @@ components:
         - type: object
           required:
             - artifactType
+            - uri
           properties:
             artifactType:
               type: string
@@ -2787,6 +2864,58 @@ components:
       description: Specifies the order by criteria for listing entities.
       schema:
         $ref: "#/components/schemas/OrderByField"
+      in: query
+      required: false
+    artifactOrderBy:
+      style: form
+      explode: true
+      examples:
+        standardField:
+          value: ID
+          summary: Order by standard field
+        customPropertyDouble:
+          value: mmlu.double_value
+          summary: Order by custom double property
+        customPropertyString:
+          value: framework_type.string_value
+          summary: Order by custom string property
+        customPropertyInt:
+          value: hardware_count.int_value
+          summary: Order by custom integer property
+      name: orderBy
+      description: |
+        Specifies the order by criteria for listing artifacts.
+
+        **Standard Fields:**
+        - `ID` - Order by artifact ID
+        - `NAME` - Order by artifact name
+        - `CREATE_TIME` - Order by creation timestamp
+        - `LAST_UPDATE_TIME` - Order by last update timestamp
+
+        **Custom Property Ordering:**
+
+        Artifacts can be ordered by custom properties using the format: `<property_name>.<value_type>`
+
+        Supported value types:
+        - `double_value` - For numeric (floating-point) properties
+        - `int_value` - For integer properties
+        - `string_value` - For string properties
+
+        Examples:
+        - `mmlu.double_value` - Order by the 'mmlu' benchmark score
+        - `accuracy.double_value` - Order by accuracy metric
+        - `framework_type.string_value` - Order by framework type
+        - `hardware_count.int_value` - Order by hardware count
+        - `ttft_mean.double_value` - Order by time-to-first-token mean
+
+        **Behavior:**
+        - If an invalid value type is specified (e.g., `accuracy.invalid_type`), an error is returned
+        - If an invalid format is used (e.g., `accuracy` without `.value_type`), it falls back to ID ordering
+        - If a property doesn't exist, it falls back to ID ordering
+        - Artifacts with the specified property are ordered first (by the property value), followed by artifacts without the property (ordered by ID)
+        - Empty property names (e.g., `.double_value`) return an error
+      schema:
+        type: string
       in: query
       required: false
     sortOrder:

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -68,6 +68,7 @@ const (
 	CatalogSourceListPath               = CatalogPathPrefix + "/sources"
 	CatalogSourceModelCatchAllPath      = CatalogPathPrefix + "/sources/:" + CatalogSourceId + "/models/*" + CatalogModelName
 	CatalogSourceModelArtifactsCatchAll = CatalogPathPrefix + "/sources/:" + CatalogSourceId + "/artifacts/*" + CatalogModelName
+	CatalogModelPerformanceArtifacts    = CatalogPathPrefix + "/sources/:" + CatalogSourceId + "/performance_artifacts/*" + CatalogModelName
 
 	ModelCatalogSettingsPathPrefix           = SettingsPath + "/model_catalog"
 	ModelCatalogSettingsSourceConfigListPath = ModelCatalogSettingsPathPrefix + "/source_configs"
@@ -236,6 +237,7 @@ func (app *App) Routes() http.Handler {
 	apiRouter.GET(CatalogFilterOptionListPath, app.AttachNamespace(app.AttachModelCatalogRESTClient(app.GetCatalogFilterListHandler)))
 	apiRouter.GET(CatalogSourceModelCatchAllPath, app.AttachNamespace(app.AttachModelCatalogRESTClient(app.GetCatalogSourceModelHandler)))
 	apiRouter.GET(CatalogSourceModelArtifactsCatchAll, app.AttachNamespace(app.AttachModelCatalogRESTClient(app.GetCatalogSourceModelArtifactsHandler)))
+	apiRouter.GET(CatalogModelPerformanceArtifacts, app.AttachNamespace(app.AttachModelCatalogRESTClient(app.GetCatalogModelPerformanceArtifactsHandler)))
 	// Kubernetes routes
 	apiRouter.GET(UserPath, app.UserHandler)
 	apiRouter.GET(ModelRegistryListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetAllModelRegistriesHandler)))

--- a/clients/ui/bff/internal/api/catalog_sources_handler.go
+++ b/clients/ui/bff/internal/api/catalog_sources_handler.go
@@ -81,7 +81,7 @@ func (app *App) GetCatalogSourceModelArtifactsHandler(w http.ResponseWriter, r *
 
 	newModelName := url.PathEscape(modelName)
 
-	catalogModelArtifacts, err := app.repositories.ModelCatalogClient.GetCatalogSourceModelArtifacts(client, ps.ByName(CatalogSourceId), newModelName)
+	catalogModelArtifacts, err := app.repositories.ModelCatalogClient.GetCatalogSourceModelArtifacts(client, ps.ByName(CatalogSourceId), newModelName, r.URL.Query())
 
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
@@ -90,6 +90,34 @@ func (app *App) GetCatalogSourceModelArtifactsHandler(w http.ResponseWriter, r *
 
 	catalogModelArtifactList := catalogModelArtifactsListEnvelope{
 		Data: catalogModelArtifacts,
+	}
+
+	err = app.WriteJSON(w, http.StatusOK, catalogModelArtifactList, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetCatalogModelPerformanceArtifactsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	modelName := strings.TrimPrefix(ps.ByName(CatalogModelName), "/")
+
+	newModelName := url.PathEscape(modelName)
+
+	catalogModelPerformanceArtifacts, err := app.repositories.ModelCatalogClient.GetCatalogModelPerformanceArtifacts(client, ps.ByName(CatalogSourceId), newModelName, r.URL.Query())
+
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	catalogModelArtifactList := catalogModelArtifactsListEnvelope{
+		Data: catalogModelPerformanceArtifacts,
 	}
 
 	err = app.WriteJSON(w, http.StatusOK, catalogModelArtifactList, nil)

--- a/clients/ui/bff/internal/api/catalog_sources_handler_test.go
+++ b/clients/ui/bff/internal/api/catalog_sources_handler_test.go
@@ -84,5 +84,29 @@ var _ = Describe("TestGetAllCatalogSourcesHandler", func() {
 			Expect(actual.Data.Items).To(Equal(expected.Data.Items))
 		})
 
+		It("should retrieve the performance artifacts", func() {
+			By("fetching the catalog performance artifacts")
+			data := mocks.GetCatalogPerformanceMetricsArtifactListMock(4)
+			requestIdentity := kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			}
+
+			expected := catalogModelArtifactsListEnvelope{Data: &data}
+			actual, rs, err := setupApiTest[catalogModelArtifactsListEnvelope](http.MethodGet, "/api/v1/model_catalog/sources/source/performance_artifacts/model-name?namespace=kubeflow&name=dora", nil, kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("should fetch the expected performance artifacts")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Size).To(Equal(expected.Data.Size))
+			Expect(actual.Data.PageSize).To(Equal(expected.Data.PageSize))
+			Expect(actual.Data.NextPageToken).To(Equal(expected.Data.NextPageToken))
+			Expect(len(actual.Data.Items)).To(Equal(len(expected.Data.Items)))
+			for i := range expected.Data.Items {
+				Expect(actual.Data.Items[i].ArtifactType).To(Equal(expected.Data.Items[i].ArtifactType))
+				Expect(actual.Data.Items[i].MetricsType).To(Equal(expected.Data.Items[i].MetricsType))
+				Expect(actual.Data.Items[i].CreateTimeSinceEpoch).To(Equal(expected.Data.Items[i].CreateTimeSinceEpoch))
+			}
+		})
+
 	})
 })

--- a/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
+++ b/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
@@ -168,7 +168,7 @@ func (m *ModelCatalogClientMock) GetAllCatalogSources(client httpclient.HTTPClie
 	return &catalogSourceList, nil
 }
 
-func (m *ModelCatalogClientMock) GetCatalogSourceModelArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string) (*models.CatalogModelArtifactList, error) {
+func (m *ModelCatalogClientMock) GetCatalogSourceModelArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string, pageValues url.Values) (*models.CatalogModelArtifactList, error) {
 	var allMockModelArtifacts models.CatalogModelArtifactList
 
 	if sourceId == "sample-source" && modelName == "repo1%2Fgranite-8b-code-instruct" {
@@ -200,6 +200,12 @@ func (m *ModelCatalogClientMock) GetCatalogSourceModelArtifacts(client httpclien
 	}
 
 	return &allMockModelArtifacts, nil
+}
+
+func (m *ModelCatalogClientMock) GetCatalogModelPerformanceArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string, pageValues url.Values) (*models.CatalogModelArtifactList, error) {
+	allMockModelPerformanceArtifacts := GetCatalogPerformanceMetricsArtifactListMock(4)
+	return &allMockModelPerformanceArtifacts, nil
+
 }
 
 func (m *ModelCatalogClientMock) GetCatalogFilterOptions(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error) {

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -891,6 +891,12 @@ func performanceMetricsCustomProperties(customProperties map[string]openapi.Meta
 				MetadataType: "MetadataStringValue",
 			},
 		},
+		"totalRPS": {
+			MetadataDoubleValue: &openapi.MetadataDoubleValue{
+				DoubleValue:  30,
+				MetadataType: "MetadataDoubleValue",
+			},
+		},
 		"ttft_mean": {
 			MetadataDoubleValue: &openapi.MetadataDoubleValue{
 				DoubleValue:  35.48818160947744,

--- a/clients/ui/bff/internal/repositories/catalog_sources.go
+++ b/clients/ui/bff/internal/repositories/catalog_sources.go
@@ -15,8 +15,9 @@ const filterOptionPath = "/models/filter_options"
 type CatalogSourcesInterface interface {
 	GetAllCatalogSources(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.CatalogSourceList, error)
 	GetCatalogSourceModel(client httpclient.HTTPClientInterface, sourceId string, modelName string) (*models.CatalogModel, error)
-	GetCatalogSourceModelArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string) (*models.CatalogModelArtifactList, error)
+	GetCatalogSourceModelArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string, pageValues url.Values) (*models.CatalogModelArtifactList, error)
 	GetCatalogFilterOptions(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error)
+	GetCatalogModelPerformanceArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string, pageValues url.Values) (*models.CatalogModelArtifactList, error)
 }
 
 type CatalogSources struct {
@@ -58,12 +59,12 @@ func (a CatalogSources) GetCatalogSourceModel(client httpclient.HTTPClientInterf
 	return &catalogModel, nil
 }
 
-func (a CatalogSources) GetCatalogSourceModelArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string) (*models.CatalogModelArtifactList, error) {
+func (a CatalogSources) GetCatalogSourceModelArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string, pageValues url.Values) (*models.CatalogModelArtifactList, error) {
 	path, err := url.JoinPath(sourcesPath, sourceId, "models", modelName, "artifacts")
 	if err != nil {
 		return nil, err
 	}
-	responseData, err := client.GET(path)
+	responseData, err := client.GET(UrlWithPageParams(path, pageValues))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching sourcesPath: %w", err)
 	}
@@ -90,4 +91,22 @@ func (a CatalogSources) GetCatalogFilterOptions(client httpclient.HTTPClientInte
 	}
 
 	return &sources, nil
+}
+
+func (a CatalogSources) GetCatalogModelPerformanceArtifacts(client httpclient.HTTPClientInterface, sourceId string, modelName string, pageValues url.Values) (*models.CatalogModelArtifactList, error) {
+	path, err := url.JoinPath(sourcesPath, sourceId, "models", modelName, "artifacts", "performance")
+	if err != nil {
+		return nil, err
+	}
+	responseData, err := client.GET(UrlWithPageParams(path, pageValues))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching sourcesPath: %w", err)
+	}
+
+	var catalogModelArtifacts models.CatalogModelArtifactList
+
+	if err := json.Unmarshal(responseData, &catalogModelArtifacts); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+	return &catalogModelArtifacts, nil
 }

--- a/clients/ui/bff/internal/repositories/helpers.go
+++ b/clients/ui/bff/internal/repositories/helpers.go
@@ -41,6 +41,24 @@ func FilterPageValues(values url.Values) url.Values {
 	if v := values.Get("artifactType"); v != "" {
 		result.Set("artifactType", v)
 	}
+	if v := values.Get("targetRPS"); v != "" {
+		result.Set("targetRPS", v)
+	}
+	if v := values.Get("recommendations"); v != "" {
+		result.Set("recommendations", v)
+	}
+	if v := values.Get("rpsProperty"); v != "" {
+		result.Set("rpsProperty", v)
+	}
+	if v := values.Get("latencyProperty"); v != "" {
+		result.Set("latencyProperty", v)
+	}
+	if v := values.Get("hardwareCountProperty"); v != "" {
+		result.Set("hardwareCountProperty", v)
+	}
+	if v := values.Get("hardwareTypeProperty"); v != "" {
+		result.Set("hardwareTypeProperty", v)
+	}
 
 	return result
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to add new performance filter to the BFF. 

## How Has This Been Tested?
1. Run the application in mock model

```
curl -s -H "kubeflow-userid: user@example.com" \
  "http://localhost:4000/api/v1/model_catalog/sources/sample-source/performance_artifacts/repo1%2Fgranite-8b-code-instruct?namespace=kubeflow" 
```

2. With kind cluster and port-forwarding, we might have to have performance data to get a response.
run the above curl cmd with respective sourceID and modelName

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
