### PR TITLE
chore(catalog): disable monitor tests by default

### DIFF
--- a/catalog/internal/catalog/monitor_test.go
+++ b/catalog/internal/catalog/monitor_test.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var enableMonitorTests = flag.Bool("monitor-tests", false, "Enable flaky monitor tests (disabled by default)")
+
+// skipFlaky checks if flaky monitor tests should be skipped.
+// These tests are disabled by default due to timing sensitivity in CI environments.
+// Run with -monitor-tests flag to enable them.
+func skipFlaky(t *testing.T) {
+	t.Helper()
+	if !*enableMonitorTests {
+		t.Skip("Skipping flaky monitor test. Run with -monitor-tests flag to enable.")
+	}
+}
+
 func TestMonitor(t *testing.T) {
+	skipFlaky(t)
 	assert := assert.New(t)
 
 	mon, err := newMonitor()
@@ -72,6 +86,7 @@ func TestMonitor(t *testing.T) {
 }
 
 func TestMonitorSymlinks(t *testing.T) {
+	skipFlaky(t)
 	assert := assert.New(t)
 
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Description
Disable to monitor tests until they can pass them more reliably in GA.

## How Has This Been Tested?
Run locally.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
