### PR TITLE
Make access token optional and update help text in catalog settings

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -101,7 +101,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
         )}
       </FormGroup>
 
-      <FormGroup label={FORM_LABELS.ACCESS_TOKEN} isRequired fieldId="access-token">
+      <FormGroup label={FORM_LABELS.ACCESS_TOKEN} fieldId="access-token">
         <FormHelperText>
           <HelperText>
             <HelperTextItem>{HELP_TEXT.ACCESS_TOKEN}</HelperTextItem>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.ts
@@ -32,7 +32,7 @@ export const VALIDATION_MESSAGES = {
 
 export const HELP_TEXT = {
   ACCESS_TOKEN:
-    'Enter your fine-grained Hugging Face access token. The token must have the following permissions: read repos in your namespace, read public repos that you can access, access webhooks, and create webhooks.',
+    'Enter your fine-grained Hugging Face access token. Public models can be pulled into catalog without an access token. For private/gated models, a token is recommended to ensure full metadata is displayed, otherwise only limited metadata may be available. The token must have the following permissions: read repos in your namespace, read public repos that you can access.',
   ORGANIZATION:
     'Limiting each Hugging Face source to a single organization helps prevent performance issues when loading large model sets.',
   YAML: 'Upload or paste a YAML string.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
<img width="486" height="185" alt="Screenshot 2025-12-16 at 3 24 04 PM" src="https://github.com/user-attachments/assets/cb5e530a-3ecc-4f58-9855-6f6e8842d7a0" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to catalog settings and check the access token field - it should be optional and the help text updated

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
