### PR TITLE
fix: use the external names in the error from GET model_version

### DIFF
--- a/internal/core/model_version.go
+++ b/internal/core/model_version.go
@@ -139,22 +139,22 @@ func (b *ModelRegistryService) GetModelVersionByInferenceService(inferenceServic
 	return &versions.Items[0], nil
 }
 
-func (b *ModelRegistryService) GetModelVersionByParams(versionName *string, registeredModelId *string, externalId *string) (*openapi.ModelVersion, error) {
-	if (versionName == nil || registeredModelId == nil) && externalId == nil {
-		return nil, fmt.Errorf("invalid parameters call, supply either (versionName and registeredModelId), or externalId: %w", api.ErrBadRequest)
+func (b *ModelRegistryService) GetModelVersionByParams(name *string, parentResourceId *string, externalId *string) (*openapi.ModelVersion, error) {
+	if (name == nil || parentResourceId == nil) && externalId == nil {
+		return nil, fmt.Errorf("invalid parameters call, supply either (name and parentResourceId), or externalId: %w", api.ErrBadRequest)
 	}
 
 	var parentResourceID *int32
-	if registeredModelId != nil {
+	if parentResourceId != nil {
 		var err error
-		parentResourceID, err = apiutils.ValidateIDAsInt32Ptr(registeredModelId, "registered model")
+		parentResourceID, err = apiutils.ValidateIDAsInt32Ptr(parentResourceId, "registered model")
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	versionsList, err := b.modelVersionRepository.List(models.ModelVersionListOptions{
-		Name:             versionName,
+		Name:             name,
 		ExternalID:       externalId,
 		ParentResourceID: parentResourceID,
 	})
@@ -163,11 +163,11 @@ func (b *ModelRegistryService) GetModelVersionByParams(versionName *string, regi
 	}
 
 	if len(versionsList.Items) > 1 {
-		return nil, fmt.Errorf("multiple model versions found for versionName=%v, registeredModelId=%v, externalId=%v: %w", apiutils.ZeroIfNil(versionName), apiutils.ZeroIfNil(registeredModelId), apiutils.ZeroIfNil(externalId), api.ErrNotFound)
+		return nil, fmt.Errorf("multiple model versions found for name=%v, parentResourceId=%v, externalId=%v: %w", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId), api.ErrNotFound)
 	}
 
 	if len(versionsList.Items) == 0 {
-		return nil, fmt.Errorf("no model versions found for versionName=%v, registeredModelId=%v, externalId=%v: %w", apiutils.ZeroIfNil(versionName), apiutils.ZeroIfNil(registeredModelId), apiutils.ZeroIfNil(externalId), api.ErrNotFound)
+		return nil, fmt.Errorf("no model versions found for name=%v, parentResourceId=%v, externalId=%v: %w", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId), api.ErrNotFound)
 	}
 
 	toReturn, err := b.mapper.MapToModelVersion(versionsList.Items[0])


### PR DESCRIPTION
## Description

`GET /api/model_registry/v1alpha3/model_version` returned errors using its internal variable names which were returned to the user. Renaming the variables so that the internal and external names are the same.

Fixes #2009

## How Has This Been Tested?
On a local dev environment.

Before:
```
$ curl http://localhost:8080/api/model_registry/v1alpha3/model_version
{"code":"Bad Request","message":"invalid parameters call, supply either (versionName and registeredModelId), or externalId: bad request"}
```

After:
```
$ curl http://localhost:8080/api/model_registry/v1alpha3/model_version
{"code":"Bad Request","message":"invalid parameters call, supply either (name and parentResourceId), or externalId: bad request"}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
