### PR TITLE
Fix ManageSourceForm validation to not require HF access token

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -274,10 +274,6 @@ class ManageSourcePage {
     return cy.findByTestId('access-token-input');
   }
 
-  findAccessTokenError() {
-    return cy.findByTestId('access-token-error');
-  }
-
   findOrganizationInput() {
     return cy.findByTestId('organization-input');
   }

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -657,11 +657,8 @@ describe('Manage Source Page', () => {
       manageSourcePage.findPreviewButton().should('not.be.disabled');
     });
 
-    it('should show validation errors for HF fields when touched', () => {
+    it('should show validation errors for HF organization when touched', () => {
       manageSourcePage.visitAddSource();
-      manageSourcePage.findAccessTokenInput().focus().blur();
-      manageSourcePage.findAccessTokenError().should('exist');
-      manageSourcePage.findAccessTokenError().should('contain', 'Access token is required');
 
       manageSourcePage.findOrganizationInput().focus().blur();
       manageSourcePage.findOrganizationError().should('exist');
@@ -723,21 +720,17 @@ describe('Manage Source Page', () => {
 
       // Trigger validation errors
       manageSourcePage.findNameInput().focus().blur();
-      manageSourcePage.findAccessTokenInput().focus().blur();
       manageSourcePage.findOrganizationInput().focus().blur();
 
       manageSourcePage.findNameError().should('exist');
-      manageSourcePage.findAccessTokenError().should('exist');
       manageSourcePage.findOrganizationError().should('exist');
 
       // Fill fields
       manageSourcePage.fillSourceName('Test Source');
-      manageSourcePage.fillAccessToken('test-token');
       manageSourcePage.fillOrganization('Google');
 
       // Errors should be cleared
       manageSourcePage.findNameError().should('not.exist');
-      manageSourcePage.findAccessTokenError().should('not.exist');
       manageSourcePage.findOrganizationError().should('not.exist');
     });
 

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -15,10 +15,7 @@ import PasswordInput from '~/app/shared/components/PasswordInput';
 import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
-import {
-  validateOrganization,
-  validateAccessToken,
-} from '~/app/pages/modelCatalogSettings/utils/validation';
+import { validateOrganization } from '~/app/pages/modelCatalogSettings/utils/validation';
 import {
   FORM_LABELS,
   VALIDATION_MESSAGES,
@@ -46,10 +43,8 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
   onClearValidationSuccess,
 }) => {
   const [isOrganizationTouched, setIsOrganizationTouched] = React.useState(false);
-  const [isAccessTokenTouched, setIsAccessTokenTouched] = React.useState(false);
 
   const isOrganizationValid = validateOrganization(formData.organization);
-  const isAccessTokenValid = validateAccessToken(formData.accessToken);
 
   const organizationInput = (
     <TextInput
@@ -74,8 +69,6 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
       data-testid="access-token-input"
       value={formData.accessToken}
       onChange={(_event, value) => setData('accessToken', value)}
-      onBlur={() => setIsAccessTokenTouched(true)}
-      validated={isAccessTokenTouched && !isAccessTokenValid ? 'error' : 'default'}
       ariaLabelShow="Show access token"
       ariaLabelHide="Hide access token"
     />
@@ -108,15 +101,6 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
           </HelperText>
         </FormHelperText>
         <FormFieldset component={accessTokenInput} field="Access token" />
-        {isAccessTokenTouched && !isAccessTokenValid && (
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem variant="error" data-testid="access-token-error">
-                {VALIDATION_MESSAGES.ACCESS_TOKEN_REQUIRED}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        )}
       </FormGroup>
       {validationError && (
         <Alert isInline variant="danger" title="Validation failed" className="pf-v5-u-mt-md">
@@ -137,7 +121,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
 
       <ActionList className="pf-v5-u-mt-md">
         <Button
-          isDisabled={!isAccessTokenValid || !isOrganizationValid || isValidating}
+          isDisabled={!isOrganizationValid || isValidating}
           variant="link"
           onClick={onValidate}
           isLoading={isValidating}

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.ts
@@ -26,7 +26,6 @@ export const SOURCE_TYPE_LABELS = {
 export const VALIDATION_MESSAGES = {
   NAME_REQUIRED: 'Name is required',
   ORGANIZATION_REQUIRED: 'Organization is required',
-  ACCESS_TOKEN_REQUIRED: 'Access token is required',
   YAML_CONTENT_REQUIRED: 'YAML content is required',
 } as const;
 

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/validation.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/validation.ts
@@ -8,15 +8,13 @@ export const validateSourceName = (name: string): boolean => isNonEmptyString(na
 export const validateOrganization = (organization: string): boolean =>
   isNonEmptyString(organization);
 
-export const validateAccessToken = (accessToken: string): boolean => isNonEmptyString(accessToken);
-
 export const validateYamlContent = (yamlContent: string): boolean => isNonEmptyString(yamlContent);
 
 export const validateHuggingFaceCredentials = (data: ManageSourceFormData): boolean => {
   if (data.sourceType !== CatalogSourceType.HUGGING_FACE) {
     return true;
   }
-  return validateOrganization(data.organization) && validateAccessToken(data.accessToken);
+  return validateOrganization(data.organization);
 };
 
 export const validateYamlMode = (data: ManageSourceFormData): boolean => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

🤖 Description generated in part by Claude Code

Followup to https://github.com/kubeflow/model-registry/pull/2010.

Makes the HuggingFace access token field truly optional by removing it from form validation requirements and UI validation states.

### Changes
- **Validation logic** (`validation.ts`):
  - Removed `validateAccessToken()` function
  - Updated `validateHuggingFaceCredentials()` to only validate organization field
  
- **UI components** (`CredentialsSection.tsx`):
  - Removed access token field validation state (`isAccessTokenTouched`)
  - Removed `onBlur` and `validated` props from access token input
  - Removed validation error message display for access token
  - Updated "Validate credentials" button to only require organization field
  
- **Constants** (`constants.ts`):
  - Removed `ACCESS_TOKEN_REQUIRED` validation message
  
- **Cypress tests** (`modelCatalogSettings.cy.ts`):
  - Renamed test to "should show validation errors for HF organization when touched"
  - Removed access token validation assertions from multiple tests
  - Updated "should clear validation errors when fields are filled" test
  
- **Test utilities** (`modelCatalogSettings.ts` page object):
  - Removed `findAccessTokenError()` helper method

### Context
The access token field was designed to be optional for HuggingFace sources, but the validation logic and UI state management were still treating it as required. This caused the form to block submission when the access token was left empty, despite the field not having visual required indicators.

### Test Plan
- ✅ Form can be submitted with only organization field filled (access token empty)
- ✅ Preview and validation work with only organization field filled
- ✅ No validation errors shown for empty access token field
- ✅ "Validate credentials" button enabled when only organization is filled
- ✅ All updated Cypress tests pass

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
