### PR TITLE
Fix status column edge cases

### DIFF
--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -74,7 +74,7 @@ export enum SourceLabel {
 
 export enum CatalogSourceType {
   YAML = 'yaml',
-  HUGGING_FACE = 'huggingface',
+  HUGGING_FACE = 'hf',
 }
 
 export type CatalogArtifactBase = {

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CatalogSourceStatus.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CatalogSourceStatus.tsx
@@ -21,11 +21,6 @@ const CatalogSourceStatus: React.FC<CatalogSourceStatusProps> = ({ catalogSource
     return <>-</>;
   }
 
-  // If source is disabled, render "-"
-  if (!catalogSourceConfig.enabled) {
-    return <>-</>;
-  }
-
   // Show loading spinner while fetching sources
   if (!catalogSourcesLoaded) {
     return <Spinner size="md" data-testid={`source-status-loading-${catalogSourceConfig.id}`} />;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We are now show "-" only for default sources on the model catalog setting status column. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Na change in functionality 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [X] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [X] The developer has added tests or explained why testing cannot be added.
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
