### PR TITLE
feat(catalog): make the hf key optional in the preview endpoint

### DIFF
--- a/catalog/internal/catalog/hf_catalog.go
+++ b/catalog/internal/catalog/hf_catalog.go
@@ -732,14 +732,14 @@ func NewHFPreviewProvider(config *PreviewConfig) (*hfModelProvider, error) {
 		maxModels: defaultMaxModels,
 	}
 
-	// Parse API key from environment variable
+	// Parse API key from environment variable (optional - allows public model access without key)
 	apiKeyEnvVar := defaultAPIKeyEnvVar
 	if envVar, ok := config.Properties[apiKeyEnvVarKey].(string); ok && envVar != "" {
 		apiKeyEnvVar = envVar
 	}
 	apiKey := os.Getenv(apiKeyEnvVar)
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing %s environment variable for HuggingFace preview", apiKeyEnvVar)
+		glog.Infof("No API key configured for Hugging Face preview. Only public models and limited data for gated models will be available.")
 	}
 	p.apiKey = apiKey
 
@@ -975,9 +975,11 @@ func (p *hfModelProvider) FetchModelNamesForPreview(ctx context.Context, modelId
 		return nil, fmt.Errorf("includedModels is required for HuggingFace source preview")
 	}
 
-	// Validate credentials first
-	if err := p.validateCredentials(ctx); err != nil {
-		return nil, fmt.Errorf("failed to validate HuggingFace credentials: %w", err)
+	// Validate credentials only if API key is provided
+	if p.apiKey != "" {
+		if err := p.validateCredentials(ctx); err != nil {
+			return nil, fmt.Errorf("failed to validate HuggingFace credentials: %w", err)
+		}
 	}
 
 	names := make([]string, 0)

--- a/catalog/internal/catalog/preview_test.go
+++ b/catalog/internal/catalog/preview_test.go
@@ -573,8 +573,8 @@ func TestPreviewSourceModels_HuggingFace_Errors(t *testing.T) {
 		assert.Contains(t, err.Error(), "includedModels is required")
 	})
 
-	t.Run("hf preview without API key returns error", func(t *testing.T) {
-		// Ensure HF_API_KEY is not set
+	t.Run("hf preview without API key works for public models", func(t *testing.T) {
+		// Ensure HF_API_KEY is not set - should still work for public models
 		oldKey := os.Getenv("HF_API_KEY")
 		os.Unsetenv("HF_API_KEY")
 		defer func() {
@@ -586,13 +586,14 @@ func TestPreviewSourceModels_HuggingFace_Errors(t *testing.T) {
 		config := &PreviewConfig{
 			Type: "hf",
 			IncludedModels: []string{
-				"meta-llama/Llama-2-7b-chat",
+				"openai-community/gpt2", // public model that doesn't require auth
 			},
 		}
 
-		_, err := PreviewSourceModels(context.Background(), config, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "HF_API_KEY")
+		// Should not return an error - API key is optional
+		result, err := PreviewSourceModels(context.Background(), config, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
 	})
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Set the hf key as optional in the preview endpoint for model catalog

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local and unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

