### PR TITLE
fix: parse validated_on as JSON array instead of comma-separated string

### DIFF
--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -257,7 +257,7 @@ func catalogCustomProperties() *map[string]openapi.MetadataValue {
 		},
 		"validated_on": {
 			MetadataStringValue: &openapi.MetadataStringValue{
-				StringValue:  "RHOAI 2.20,RHAIIS 3.0,RHELAI 1.5",
+				StringValue:  "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]",
 				MetadataType: "MetadataStringValue",
 			},
 		},

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/__tests__/utils.test.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/__tests__/utils.test.ts
@@ -38,7 +38,7 @@ describe('getValidatedOnPlatforms', () => {
   it('should return single platform when validated_on has one platform', () => {
     const customProperties: ModelRegistryCustomProperties = {
       validated_on: {
-        string_value: 'OpenShift',
+        string_value: '["OpenShift"]',
         metadataType: ModelRegistryMetadataType.STRING,
       },
     };
@@ -46,10 +46,10 @@ describe('getValidatedOnPlatforms', () => {
     expect(result).toEqual(['OpenShift']);
   });
 
-  it('should return multiple platforms when validated_on has comma-separated platforms', () => {
+  it('should return multiple platforms when validated_on has JSON array of platforms', () => {
     const customProperties: ModelRegistryCustomProperties = {
       validated_on: {
-        string_value: 'OpenShift,Kubernetes,Docker',
+        string_value: '["OpenShift","Kubernetes","Docker"]',
         metadataType: ModelRegistryMetadataType.STRING,
       },
     };
@@ -60,7 +60,7 @@ describe('getValidatedOnPlatforms', () => {
   it('should trim whitespace from platform names', () => {
     const customProperties: ModelRegistryCustomProperties = {
       validated_on: {
-        string_value: ' OpenShift , Kubernetes , Docker ',
+        string_value: '[" OpenShift "," Kubernetes "," Docker "]',
         metadataType: ModelRegistryMetadataType.STRING,
       },
     };
@@ -71,7 +71,7 @@ describe('getValidatedOnPlatforms', () => {
   it('should filter out empty platform names after trimming', () => {
     const customProperties: ModelRegistryCustomProperties = {
       validated_on: {
-        string_value: 'OpenShift, ,Kubernetes,  ,Docker',
+        string_value: '["OpenShift","","Kubernetes","  ","Docker"]',
         metadataType: ModelRegistryMetadataType.STRING,
       },
     };
@@ -82,7 +82,7 @@ describe('getValidatedOnPlatforms', () => {
   it('should handle platforms with special characters', () => {
     const customProperties: ModelRegistryCustomProperties = {
       validated_on: {
-        string_value: 'OpenShift 4.x,Kubernetes 1.28,Red Hat Enterprise Linux',
+        string_value: '["OpenShift 4.x","Kubernetes 1.28","Red Hat Enterprise Linux"]',
         metadataType: ModelRegistryMetadataType.STRING,
       },
     };
@@ -93,7 +93,7 @@ describe('getValidatedOnPlatforms', () => {
   it('should handle mixed case platform names', () => {
     const customProperties: ModelRegistryCustomProperties = {
       validated_on: {
-        string_value: 'openshift,KUBERNETES,Docker',
+        string_value: '["openshift","KUBERNETES","Docker"]',
         metadataType: ModelRegistryMetadataType.STRING,
       },
     };
@@ -119,11 +119,44 @@ describe('getValidatedOnPlatforms', () => {
         metadataType: ModelRegistryMetadataType.STRING,
       },
       validated_on: {
-        string_value: 'OpenShift,Kubernetes',
+        string_value: '["OpenShift","Kubernetes"]',
         metadataType: ModelRegistryMetadataType.STRING,
       },
       license: {
         string_value: 'Apache 2.0',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedOnPlatforms(customProperties);
+    expect(result).toEqual(['OpenShift', 'Kubernetes']);
+  });
+
+  it('should return empty array when validated_on contains invalid JSON', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: 'not valid json',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedOnPlatforms(customProperties);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when validated_on JSON is not an array', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: '{"platform": "OpenShift"}',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedOnPlatforms(customProperties);
+    expect(result).toEqual([]);
+  });
+
+  it('should filter out non-string items from JSON array', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: '["OpenShift",123,null,"Kubernetes",true]',
         metadataType: ModelRegistryMetadataType.STRING,
       },
     };

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -215,8 +215,16 @@ export const getValidatedOnPlatforms = <T extends ModelRegistryCustomProperties>
     return [];
   }
 
-  return validatedOnString
-    .split(',')
-    .map((platform) => platform.trim())
-    .filter((platform) => platform.length > 0);
+  try {
+    const parsed = JSON.parse(validatedOnString);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((item) => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0);
+    }
+    return [];
+  } catch {
+    return [];
+  }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Updates the `validated_on` custom property handling to match the backend format change from comma-separated string to JSON array string.

### Changes

#### BFF Mock Data
- Updated `catalogCustomProperties()` in `static_data_mock.go`
- Changed `validated_on` from `"RHOAI 2.20,RHAIIS 3.0,RHELAI 1.5"` to `"[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"`

#### Frontend Utility
- Refactored `getValidatedOnPlatforms()` in `utils.ts` to parse JSON arrays instead of splitting by comma
- Added proper error handling for invalid JSON
- Validates that parsed value is an array
- Filters out non-string items from the array
- Trims whitespace from each platform name
- Filters out empty strings

#### Tests
- Updated all existing test cases to use JSON array string format
- Added 3 new test cases for edge cases:
  - Invalid JSON returns empty array
  - Non-array JSON returns empty array  
  - Non-string items are filtered out from array

### Testing

All 15 unit tests pass:
```bash
npm run test:unit -- utils.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran in mock mode and verified new parsing behavior works as expected

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
