### PR TITLE
Populate defaults in filter_options endpoint

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -2205,6 +2205,19 @@ components:
               items:
                 $ref: "#/components/schemas/CatalogSource"
         - $ref: "#/components/schemas/BaseResourceList"
+    FieldFilter:
+      type: object
+      required:
+        - operator
+        - value
+      properties:
+        operator:
+          type: string
+          description: Filter operator (e.g., '<', '=', '>', 'IN')
+          example: "<"
+        value:
+          description: Filter value (can be number, string, or array)
+          example: 70
     FilterOption:
       type: object
       required:
@@ -2238,6 +2251,13 @@ components:
           description: A single filter option.
           additionalProperties:
             $ref: "#/components/schemas/FilterOption"
+        namedQueries:
+          type: object
+          description: Predefined named queries for common filtering scenarios
+          additionalProperties:
+            type: object
+            additionalProperties:
+              $ref: "#/components/schemas/FieldFilter"
     CatalogSourcePreviewRequest:
       description: Request to preview catalog source configuration effects.
       type: object

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -1349,11 +1349,28 @@ func GetFilterOptionMocks() map[string]models.FilterOption {
 	return filterOptions
 }
 
+func GetNamedQueriesMocks() map[string]map[string]models.FieldFilter {
+	namedQuries := make(map[string]map[string]models.FieldFilter)
+	namedQuries["validation-default"] = map[string]models.FieldFilter{
+		"ttft_p90": {
+			Operator: "<",
+			Value:    float64(70),
+		},
+		"workload_type": {
+			Operator: "=",
+			Value:    "Chat",
+		},
+	}
+	return namedQuries
+}
+
 func GetFilterOptionsListMock() models.FilterOptionsList {
 	filterOptions := GetFilterOptionMocks()
+	namedQueries := GetNamedQueriesMocks()
 
 	return models.FilterOptionsList{
-		Filters: &filterOptions,
+		Filters:      &filterOptions,
+		NamedQueries: &namedQueries,
 	}
 }
 

--- a/clients/ui/bff/internal/models/catalog_model_list.go
+++ b/clients/ui/bff/internal/models/catalog_model_list.go
@@ -40,8 +40,14 @@ type FilterOption struct {
 	Values []interface{}    `json:"values,omitempty"`
 }
 
+type FieldFilter struct {
+	Operator string      `json:"operator"`
+	Value    interface{} `json:"value"`
+}
+
 type FilterOptionType string
 
 type FilterOptionsList struct {
-	Filters *map[string]FilterOption `json:"filters,omitempty"`
+	Filters      *map[string]FilterOption           `json:"filters,omitempty"`
+	NamedQueries *map[string]map[string]FieldFilter `json:"namedQueries,omitempty"`
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to update the filter_options endpoint to populate the defaults. I have updated the types and mocks.

## How Has This Been Tested?
Run the application in mock mode -
and see now the filter_options endpoint have namedQueries in the top level as filters

<img width="1505" height="674" alt="Screenshot 2025-12-23 at 7 39 36 PM" src="https://github.com/user-attachments/assets/63ddaa03-e816-4538-8d9c-13f126022b38" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
