### PR TITLE
Change column name of hw table from Target RPS to Total RPS

### DIFF
--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -903,12 +903,6 @@ func performanceMetricsCustomProperties(customProperties map[string]openapi.Meta
 				MetadataType: "MetadataStringValue",
 			},
 		},
-		"totalRPS": {
-			MetadataDoubleValue: &openapi.MetadataDoubleValue{
-				DoubleValue:  30,
-				MetadataType: "MetadataDoubleValue",
-			},
-		},
 		"ttft_mean": {
 			MetadataDoubleValue: &openapi.MetadataDoubleValue{
 				DoubleValue:  35.48818160947744,

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -72,7 +72,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
   },
   {
     field: 'total_requests_per_second',
-    label: `Target${NBSP}RPS`,
+    label: `Total${NBSP}RPS`,
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Small Fix for mocks - remove totalRPS(total_requests_per_second is already present) and change column name from Target RPS to Total RPS
<img width="1031" height="513" alt="Screenshot 2025-12-24 at 9 56 24 PM" src="https://github.com/user-attachments/assets/e5a21d7f-23f7-4307-b4cd-5483ed0b6003" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
