### PR TITLE
feat(ui): add multi-arch Docker image support for arm64 and amd64 on UI Images

### DIFF
--- a/.github/workflows/build-and-push-ui-images-standalone.yml
+++ b/.github/workflows/build-and-push-ui-images-standalone.yml
@@ -21,6 +21,7 @@ env:
   IMG_UI_REPO: model-registry/ui-standalone # this image is intended for local development, not production
   DOCKER_USER: ${{ github.actor }}
   DOCKER_PWD: ${{ secrets.GITHUB_TOKEN }}
+  PLATFORMS: linux/arm64,linux/amd64
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -30,6 +31,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6.0.1
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -72,6 +76,7 @@ jobs:
       with:
         context: ./clients/ui
         push: true
+        platforms: ${{ env.PLATFORMS }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/.github/workflows/build-and-push-ui-images.yml
+++ b/.github/workflows/build-and-push-ui-images.yml
@@ -21,6 +21,7 @@ env:
   IMG_UI_REPO: model-registry/ui # this image is intended for local development, not production
   DOCKER_USER: ${{ github.actor }}
   DOCKER_PWD: ${{ secrets.GITHUB_TOKEN }}
+  PLATFORMS: linux/arm64,linux/amd64
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -30,6 +31,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6.0.1
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -72,6 +76,7 @@ jobs:
       with:
         context: ./clients/ui
         push: true
+        platforms: ${{ env.PLATFORMS }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/clients/ui/.env
+++ b/clients/ui/.env
@@ -4,6 +4,6 @@ CONTAINER_TOOL=docker
 IMG_UI=ghcr.io/kubeflow/model-registry/ui:latest
 IMG_UI_STANDALONE=ghcr.io/kubeflow/model-registry/ui-standalone:latest
 IMG_UI_FEDERATED=ghcr.io/kubeflow/model-registry/ui-federated:latest
-PLATFORM=linux/amd64
+PLATFORM=linux/arm64,linux/amd64
 STYLE_THEME=mui-theme
 DEPLOYMENT_MODE=kubeflow


### PR DESCRIPTION
Probably it's a overlap with: https://github.com/kubeflow/model-registry/pull/2032

## Description
Adds multi-architecture (arm64/amd64) support for the Model Registry UI Docker images. This follows the pattern from #1790.

This PR closes https://github.com/kubeflow/model-registry/issues/2057 and should be merged after https://github.com/kubeflow/model-registry/pull/2056 (just to make sure we test if multi arch works with docker compose).

## Changes

- **`.github/workflows/build-and-push-ui-images.yml`**: Added QEMU setup, PLATFORMS env var, and platforms parameter to build-push-action
- **`.github/workflows/build-and-push-ui-images-standalone.yml`**: Added QEMU setup, PLATFORMS env var, and platforms parameter to build-push-action
- **`clients/ui/.env`**: Updated PLATFORM to `linux/arm64,linux/amd64`

> **Note:** The `.env` change only affects local builds when using Makefile targets (`make docker-buildx`, `make docker-buildx-standalone`, `make docker-buildx-federated`). The GitHub Actions workflows define their own `PLATFORMS` env var directly in the workflow YAML files and do not use the `.env` file.

## How Has This Been Tested?
- Successfully built multi-arch images locally for both `model-registry/ui` and `model-registry/ui-standalone`>
- Hoping for the best in GHA 🤞 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
 