### PR TITLE
Move includedModels and excludedModels out of properties sub-object on catalog source configs

### DIFF
--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -253,11 +253,11 @@ catalogs:
     enabled: true
     properties:
       yamlCatalogPath: custom_yaml_models.yaml
-      includedModels:
-        - model-*
-        - model-2-*
-      excludedModels:
-        - sample-model-*
+    includedModels:
+      - model-*
+      - model-2-*
+    excludedModels:
+      - sample-model-*
     labels:
       - Dora AI
 
@@ -267,11 +267,11 @@ catalogs:
     enabled: false
     properties:
       yamlCatalogPath: sample_source_models.yaml
-      includedModels:
-        - model-*
-        - model-2-*
-      excludedModels:
-        - sample-model-*
+    includedModels:
+      - model-*
+      - model-2-*
+    excludedModels:
+      - sample-model-*
     labels:
       - Bella AI validated
       - Dora AI
@@ -283,11 +283,11 @@ catalogs:
     properties:
       apiKey: hugging-face-source-secret
       allowedOrganization: org
-      includedModels:
-        - model-*
-        - model-2-*
-      excludedModels:
-        - sample-model-*
+    includedModels:
+      - model-*
+      - model-2-*
+    excludedModels:
+      - sample-model-*
     labels:
       - Bella AI validated
 `)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR fixes the YAML structure for `includedModels` and `excludedModels` fields in catalog source configs. These fields were incorrectly being nested under the `properties` sub-object, but they should be top-level fields on the catalog entry.

The `properties` sub-object is reserved for source-type-specific configuration:
- For `yaml` type sources: `yamlCatalogPath`
- For `hf` (HuggingFace) type sources: `apiKey`, `allowedOrganization`

In contrast, `includedModels` and `excludedModels` are generic fields that apply to all source types and should be at the same level as `id`, `name`, `type`, `enabled`, and `labels`.

### Before (incorrect)
```yaml
catalogs:
  - id: my-source
    name: My Source
    type: hf
    properties:
      apiKey: my-secret
      includedModels:  # Wrong - nested under properties
        - model-*
      excludedModels:  # Wrong - nested under properties
        - test-*
```

### After (correct)
```yaml
catalogs:
  - id: my-source
    name: My Source
    type: hf
    properties:
      apiKey: my-secret
    includedModels:  # Correct - top-level field
      - model-*
    excludedModels:  # Correct - top-level field
      - test-*
```

### Changes

- **`helpers.go`**: Updated 5 functions:
  - `ParseCatalogYaml`: Now reads `includedModels`/`excludedModels` from top-level
  - `FindCatalogSourceById`: Now reads `includedModels`/`excludedModels` from top-level
  - `ConvertSourceConfigToYamlEntry`: Now writes these fields at the top level
  - `UpdateCatalogSourceInYAML`: Now updates these fields at the top level
  - `BuildOverrideEntryForDefaultSource`: Now sets these fields at the top level

- **`base_testenv.go`**: Updated mock YAML data to use the correct structure

### Test plan

- [x] All 55 BFF repository tests pass
- [ ] Verify catalog source creation with includedModels/excludedModels works correctly
- [ ] Verify catalog source update with includedModels/excludedModels works correctly
- [ ] Verify existing catalog sources with the correct YAML format are parsed properly


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
