### PR TITLE
chore(catalog): sort models by NAME by default

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -94,6 +94,8 @@ paths:
             - NAME
             - ACCURACY
 
+            Defaults to `NAME`.
+
             The `ACCURACY` sort will sort by the `overall_average` property in any linked metrics artifact.
 
             In addition, models can be sorted by properties. For example:

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -68,6 +68,8 @@ paths:
             - NAME
             - ACCURACY
 
+            Defaults to `NAME`.
+
             The `ACCURACY` sort will sort by the `overall_average` property in any linked metrics artifact.
 
             In addition, models can be sorted by properties. For example:

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -226,6 +226,10 @@ func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, sourceID
 		return Response(http.StatusBadRequest, err), err
 	}
 
+	if orderBy == "" {
+		orderBy = model.ORDERBYFIELD_NAME
+	}
+
 	listModelsParams := catalog.ListModelsParams{
 		Query:         q,
 		FilterQuery:   filterQuery,

--- a/catalog/pkg/openapi/api_model_catalog_service.go
+++ b/catalog/pkg/openapi/api_model_catalog_service.go
@@ -250,7 +250,7 @@ func (r ApiFindModelsRequest) PageSize(pageSize string) ApiFindModelsRequest {
 	return r
 }
 
-// Specifies the order by criteria for listing entities.  Supported values are: - CREATE_TIME - LAST_UPDATE_TIME - ID - NAME - ACCURACY  The &#x60;ACCURACY&#x60; sort will sort by the &#x60;overall_average&#x60; property in any linked metrics artifact.  In addition, models can be sorted by properties. For example: - &#x60;provider.string_value&#x60; sorts by provider name - &#x60;artifacts.ifeval.double_value&#x60; sorts by the min/max value a property called ifeval across all associated artifacts
+// Specifies the order by criteria for listing entities.  Supported values are: - CREATE_TIME - LAST_UPDATE_TIME - ID - NAME - ACCURACY  Defaults to &#x60;NAME&#x60;.  The &#x60;ACCURACY&#x60; sort will sort by the &#x60;overall_average&#x60; property in any linked metrics artifact.  In addition, models can be sorted by properties. For example: - &#x60;provider.string_value&#x60; sorts by provider name - &#x60;artifacts.ifeval.double_value&#x60; sorts by the min/max value a property called ifeval across all associated artifacts
 func (r ApiFindModelsRequest) OrderBy(orderBy OrderByField) ApiFindModelsRequest {
 	r.orderBy = &orderBy
 	return r


### PR DESCRIPTION
## Description

By default, sort the response from /api/model_catalog/v1alpha1/models by NAME.

## How Has This Been Tested?
Local dev cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
