### PR TITLE
Fix 500 error when no artifacts match the filters in hardware configuration table

### DIFF
--- a/catalog/internal/db/models/performance_artifact_service.go
+++ b/catalog/internal/db/models/performance_artifact_service.go
@@ -250,7 +250,13 @@ func (s *PerformanceArtifactService) generateRecommendations(artifacts []Catalog
 }
 
 // validateCustomProperties ensures at least one artifact contains each custom property
+// When there are no artifacts, validation passes (empty result is valid)
 func (s *PerformanceArtifactService) validateCustomProperties(artifacts []CatalogMetricsArtifact, rpsProperty, latencyProperty, hardwareCountProperty, hardwareTypeProperty string) error {
+	// If there are no artifacts, validation passes - empty result is valid
+	if len(artifacts) == 0 {
+		return nil
+	}
+
 	propertyExists := map[string]bool{
 		rpsProperty:           false,
 		latencyProperty:       false,

--- a/catalog/internal/db/models/performance_artifact_service_test.go
+++ b/catalog/internal/db/models/performance_artifact_service_test.go
@@ -208,6 +208,10 @@ func TestPerformanceArtifactService_Recommendataions(t *testing.T) {
 func TestPropertyValidation(t *testing.T) {
 	service := NewPerformanceArtifactService(nil)
 
+	// Test case: empty artifacts should pass validation (not an error condition)
+	err := service.validateCustomProperties([]CatalogMetricsArtifact{}, "rps", "latency", "hw_count", "hw_type")
+	require.NoError(t, err, "Empty artifacts should not cause validation error")
+
 	// Test case: property exists in some artifacts
 	id1 := int32(1)
 	id2 := int32(2)
@@ -238,7 +242,7 @@ func TestPropertyValidation(t *testing.T) {
 	artifacts[1].SetID(id2)
 
 	// Should not error when property exists in at least one artifact
-	err := service.validateCustomProperties(artifacts, "custom_rps", "custom_latency", "custom_hw_count", "custom_hw_type")
+	err = service.validateCustomProperties(artifacts, "custom_rps", "custom_latency", "custom_hw_count", "custom_hw_type")
 	require.NoError(t, err)
 
 	// Test case: property doesn't exist in any artifact


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We were seeing a 500 error when we none of the artifacts in the hardware configuration table matched the filters 
<img width="1040" height="273" alt="Screenshot 2026-01-13 at 8 35 05 PM" src="https://github.com/user-attachments/assets/41c54997-9738-4af4-bcb4-fda83a81e690" />
This is an attempt to fix it - used Cursor for this solution

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
