### PR TITLE
Fix server side filtering when the performance toggle is OFF

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
@@ -42,7 +42,6 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
     filterData,
     filterOptions,
     filterOptionsLoaded,
-    performanceViewEnabled,
     setPerformanceFiltersChangedOnDetailsPage,
     setFilterData,
   } = React.useContext(ModelCatalogContext);
@@ -72,20 +71,16 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
   }, [filterOptionsLoaded]);
 
   // Get performance-specific filter params for the /performance_artifacts endpoint
-  // Only apply performance filters when toggle is ON
-  const targetRPS = performanceViewEnabled
-    ? filterData[ModelCatalogNumberFilterKey.MAX_RPS]
-    : undefined;
+  const targetRPS = filterData[ModelCatalogNumberFilterKey.MAX_RPS];
+
   // Get full filter key and convert to short property key for the catalog API
-  const latencyFieldName = performanceViewEnabled
-    ? getActiveLatencyFieldName(filterData)
-    : undefined;
+  const latencyFieldName = getActiveLatencyFieldName(filterData);
+
   const latencyProperty = latencyFieldName
     ? parseLatencyFilterKey(latencyFieldName).propertyKey
     : undefined;
 
   // Fetch performance artifacts from server with filtering/sorting/pagination
-  // When toggle is OFF, don't pass filterData so no perf filters are applied
   const [performanceArtifactsList, performanceArtifactsLoaded, performanceArtifactsError] =
     useCatalogPerformanceArtifacts(
       decodedParams.sourceId || '',
@@ -98,8 +93,8 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
         //      we need to implement proper cursor-based pagination in the performance artifacts table.
         pageSize: '99999',
       },
-      performanceViewEnabled ? filterData : undefined,
-      performanceViewEnabled ? filterOptions : undefined,
+      filterData,
+      filterOptions,
     );
 
   React.useEffect(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
This PR aims to fix the server side filtering when the performance toggle is off.

https://github.com/user-attachments/assets/421ecc10-a55b-44bc-9704-1ea01df01c4f

## How Has This Been Tested?
  - Turn off the performance toggle
  - go to performance insights page
  - make sure the server side filtering is working as expected
  - check the server side filtering with toggle on as well
  - 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
