### PR TITLE
Fix arbitrary changing max value of latency slider in details page

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/LatencyFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/LatencyFilter.tsx
@@ -114,11 +114,8 @@ const LatencyFilter: React.FC = () => {
   }, [currentActiveFilter]);
 
   const { minValue, maxValue, isSliderDisabled } = React.useMemo((): SliderRange => {
-    // Use full filter key for accessing filterOptions
     const filterKey = getLatencyFilterKey(localFilter.metric, localFilter.percentile);
 
-    // Always get range from filterOptions (which provides the full range across all artifacts)
-    // Don't use performanceArtifacts since we may not have all of them in memory when paginating
     const latencyFilter = filterOptions?.filters?.[filterKey];
     if (latencyFilter && 'range' in latencyFilter && latencyFilter.range) {
       return {
@@ -129,6 +126,22 @@ const LatencyFilter: React.FC = () => {
     }
     return FALLBACK_LATENCY_RANGE;
   }, [localFilter.metric, localFilter.percentile, filterOptions]);
+
+  // Reset value to max when metric or percentile changes (range changes)
+  // This ensures the value is always valid for the current range
+  const prevMetricRef = React.useRef(localFilter.metric);
+  const prevPercentileRef = React.useRef(localFilter.percentile);
+
+  React.useEffect(() => {
+    const metricChanged = prevMetricRef.current !== localFilter.metric;
+    const percentileChanged = prevPercentileRef.current !== localFilter.percentile;
+
+    if (metricChanged || percentileChanged) {
+      setLocalFilter((prev) => ({ ...prev, value: maxValue }));
+      prevMetricRef.current = localFilter.metric;
+      prevPercentileRef.current = localFilter.percentile;
+    }
+  }, [localFilter.metric, localFilter.percentile, maxValue]);
 
   const clampedValue = React.useMemo(
     () => Math.min(Math.max(localFilter.value, minValue), maxValue),
@@ -214,7 +227,7 @@ const LatencyFilter: React.FC = () => {
                   ) {
                     const selectedMetric = METRIC_OPTIONS.find((opt) => opt.value === value);
                     if (selectedMetric) {
-                      setLocalFilter({ ...localFilter, metric: selectedMetric.value });
+                      setLocalFilter((prev) => ({ ...prev, metric: selectedMetric.value }));
                     }
                   }
                   setIsMetricOpen(false);
@@ -273,7 +286,10 @@ const LatencyFilter: React.FC = () => {
                           (opt) => opt.value === value,
                         );
                         if (selectedPercentile) {
-                          setLocalFilter({ ...localFilter, percentile: selectedPercentile.value });
+                          setLocalFilter((prev) => ({
+                            ...prev,
+                            percentile: selectedPercentile.value,
+                          }));
                         }
                       }
                       setIsPercentileOpen(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Now the max value is fixed even after applying filters and re-opening the latency dropdown in details page. This change is tested midstream.

https://github.com/user-attachments/assets/6eab408e-6db3-41b7-84dd-e2c941879c19

https://github.com/user-attachments/assets/318fddef-0e21-4553-92a3-b707ef1434a4



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to details page(hardware configuration table) of model catalog of any model - change the slider value of the latency filter and apply filter - re-open the filter and check whether the max value stays the same(shouldn't change to the changed value)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
