### PR TITLE
Hardcoded Max value for RPS filter

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/MaxRpsFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/MaxRpsFilter.tsx
@@ -11,10 +11,7 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 import { ModelCatalogNumberFilterKey } from '~/concepts/modelCatalog/const';
 import { useCatalogNumberFilterState } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
-import {
-  FALLBACK_RPS_RANGE,
-  SliderRange,
-} from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
+import { MAX_RPS_RANGE } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import SliderWithInput from './SliderWithInput';
 
@@ -23,22 +20,10 @@ const filterKey = ModelCatalogNumberFilterKey.MAX_RPS;
 const MaxRpsFilter: React.FC = () => {
   const { value: rpsFilterValue, setValue: setRpsFilterValue } =
     useCatalogNumberFilterState(filterKey);
-  const { filterOptions, getPerformanceFilterDefaultValue } = React.useContext(ModelCatalogContext);
+  const { getPerformanceFilterDefaultValue } = React.useContext(ModelCatalogContext);
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const { minValue, maxValue, isSliderDisabled } = React.useMemo((): SliderRange => {
-    // Always get range from filterOptions (which provides the full range across all artifacts)
-    // Don't use performanceArtifacts since we may not have all of them in memory when paginating
-    const filterValue = filterOptions?.filters?.[ModelCatalogNumberFilterKey.MAX_RPS];
-    if (filterValue && 'range' in filterValue && filterValue.range) {
-      return {
-        minValue: filterValue.range.min ?? FALLBACK_RPS_RANGE.minValue,
-        maxValue: filterValue.range.max ?? FALLBACK_RPS_RANGE.maxValue,
-        isSliderDisabled: false,
-      };
-    }
-    return FALLBACK_RPS_RANGE;
-  }, [filterOptions]);
+  const { minValue, maxValue, isSliderDisabled } = MAX_RPS_RANGE;
 
   const [localValue, setLocalValue] = React.useState<number>(() => rpsFilterValue ?? maxValue);
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
@@ -14,6 +14,14 @@ export type SliderRange = {
   isSliderDisabled: boolean;
 };
 
+export const MAX_RPS_MAX_VALUE = 50;
+
+export const MAX_RPS_RANGE: SliderRange = {
+  minValue: 1,
+  maxValue: MAX_RPS_MAX_VALUE,
+  isSliderDisabled: false,
+};
+
 export const FALLBACK_RPS_RANGE: SliderRange = {
   minValue: 1,
   maxValue: 300,


### PR DESCRIPTION
## Fix Max RPS filter to use hardcoded range (1-50) instead of requests_per_second

## Description
Fixed the "Max RPS" filter to use hardcoded values from 1-50 instead of incorrectly deriving its maximum allowed value from the `requests_per_second` field in `filter_options`. 


**Changes made:**
- Added `MAX_RPS_MAX_VALUE = 50` constant in `performanceMetricsUtils.ts`
- Added `MAX_RPS_RANGE` constant with hardcoded `{ minValue: 1, maxValue: 50 }`
- Updated `MaxRpsFilter.tsx` to use `MAX_RPS_RANGE` instead of reading from `filterOptions`
- Removed dependency on `requests_per_second` field for this filter

## How Has This Been Tested?
<img width="767" height="394" alt="Screenshot 2026-01-16 at 11 41 00 AM" src="https://github.com/user-attachments/assets/83e9abe1-3a4c-47d5-8458-8eff3f06b1e6" />


## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added (existing tests cover filter functionality).
- [x] Included any necessary screenshots or gifs if it was a UI change (UI appearance unchanged, only the range values are different).
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.