### PR TITLE
Catalog: add performance params to models API call to support backend sorting logic

### DIFF
--- a/clients/ui/frontend/src/app/api/modelCatalog/service.ts
+++ b/clients/ui/frontend/src/app/api/modelCatalog/service.ts
@@ -27,6 +27,11 @@ export const getCatalogModelsBySource =
     filterData?: ModelCatalogFilterStates,
     filterOptions?: CatalogFilterOptionsList | null,
     filterQuery?: string,
+    performanceParams?: {
+      targetRPS?: number;
+      latencyProperty?: string;
+      recommendations?: boolean;
+    },
   ): Promise<CatalogModelList> => {
     const computedFilterQuery =
       filterQuery ??
@@ -39,6 +44,13 @@ export const getCatalogModelsBySource =
       ...(searchKeyword && { q: searchKeyword }),
       ...queryParams,
       ...(computedFilterQuery && { filterQuery: computedFilterQuery }),
+      ...(performanceParams?.targetRPS !== undefined && { targetRPS: performanceParams.targetRPS }),
+      ...(performanceParams?.latencyProperty && {
+        latencyProperty: performanceParams.latencyProperty,
+      }),
+      ...(performanceParams?.recommendations !== undefined && {
+        recommendations: performanceParams.recommendations,
+      }),
     };
     return handleRestFailures(restGET(hostPath, '/models', allParams, opts)).then((response) => {
       if (isModArchResponse<CatalogModelList>(response)) {

--- a/clients/ui/frontend/src/app/hooks/modelCatalog/useCatalogModelsBySource.ts
+++ b/clients/ui/frontend/src/app/hooks/modelCatalog/useCatalogModelsBySource.ts
@@ -36,6 +36,11 @@ export const useCatalogModelsBySources = (
   filterQuery?: string,
   sortBy?: string | null,
   sortOrder?: string,
+  performanceParams?: {
+    targetRPS?: number;
+    latencyProperty?: string;
+    recommendations?: boolean;
+  },
 ): ModelList => {
   const { api, apiAvailable } = useModelCatalogAPI();
 
@@ -63,6 +68,7 @@ export const useCatalogModelsBySources = (
         filterData,
         filterOptions,
         filterQuery,
+        performanceParams,
       );
     },
     [
@@ -77,6 +83,7 @@ export const useCatalogModelsBySources = (
       filterQuery,
       sortBy,
       sortOrder,
+      performanceParams,
     ],
   );
 
@@ -116,6 +123,7 @@ export const useCatalogModelsBySources = (
         filterData,
         filterOptions,
         filterQuery,
+        performanceParams,
       );
 
       setAllItems((prev) => [...prev, ...response.items]);
@@ -142,6 +150,7 @@ export const useCatalogModelsBySources = (
     filterQuery,
     sortBy,
     sortOrder,
+    performanceParams,
   ]);
 
   React.useEffect(() => {
@@ -158,6 +167,7 @@ export const useCatalogModelsBySources = (
     filterQuery,
     sortBy,
     sortOrder,
+    performanceParams,
   ]);
 
   const refresh = React.useCallback(() => {

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -175,6 +175,11 @@ export type GetCatalogModelsBySource = (
   filterData?: ModelCatalogFilterStates,
   filterOptions?: CatalogFilterOptionsList | null,
   filterQuery?: string,
+  performanceParams?: {
+    targetRPS?: number;
+    latencyProperty?: string;
+    recommendations?: boolean;
+  },
 ) => Promise<CatalogModelList>;
 
 export type GetListSources = (opts: APIOptions) => Promise<CatalogSourceList>;

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -24,7 +24,11 @@ import {
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import EmptyModelCatalogState from '~/app/pages/modelCatalog/EmptyModelCatalogState';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
-import { BASIC_FILTER_KEYS } from '~/concepts/modelCatalog/const';
+import {
+  BASIC_FILTER_KEYS,
+  ModelCatalogNumberFilterKey,
+  parseLatencyFilterKey,
+} from '~/concepts/modelCatalog/const';
 
 type ModelCatalogPageProps = {
   searchTerm: string;
@@ -68,6 +72,24 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
     [sortBy, performanceViewEnabled, activeLatencyField],
   );
 
+  // Derive performance params to pass to the models API when performance view is enabled
+  const performanceParams = React.useMemo(() => {
+    if (!performanceViewEnabled) {
+      return undefined;
+    }
+
+    const targetRPS = filterData[ModelCatalogNumberFilterKey.MAX_RPS];
+    const latencyProperty = activeLatencyField
+      ? parseLatencyFilterKey(activeLatencyField).propertyKey
+      : undefined;
+
+    return {
+      targetRPS,
+      latencyProperty,
+      recommendations: true,
+    };
+  }, [performanceViewEnabled, filterData, activeLatencyField]);
+
   const { catalogModels, catalogModelsLoaded, catalogModelsLoadError } = useCatalogModelsBySources(
     '',
     selectedSourceLabel === CategoryName.allModels ? undefined : selectedSourceLabel,
@@ -78,6 +100,7 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
     undefined, // filterQuery - will be computed from filterData and filterOptions
     sortParams.orderBy,
     sortParams.sortOrder,
+    performanceParams,
   );
 
   const loaded = catalogModelsLoaded && filterOptionsLoaded;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Pass targetRPS, latencyProperty, and recommendations=true to the catalog models API when performance view is enabled. This enables the backend to compute recommendation data as part of sorting models.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On the model catalog page, turn on the performance view toggle. Open the pod log of the model catalog deployment and verify that these 3 properties are making their way all the way to the backend when requesting /models.

```
2026/01/16 18:14:59 "GET http://model-catalog.apps.ui-green-1.dev.datahub.redhat.com:443/api/model_catalog/v1alpha1/sources/redhat_ai_validated_models/models/RedHatAI%2FMistral-Small-3.1-24B-Instruct-2503-quantized.w8a8/artifacts/performance?filterQuery=use_case.string_value%3D%27chatbot%27+AND+ttft_p90.double_value+%3C%3D+892.6553726196289&latencyProperty=ttft_p90&orderBy=ttft_p90.double_value&pageSize=999&recommendations=true&sortOrder=ASC&targetRPS=1 HTTP/1.1" from 127.0.0.1:43642 - 200 60042B in 174.315113ms
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
