### PR TITLE
OWNERS: add fege as Reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,5 +12,6 @@ emeritus_approvers:
 reviewers:
   - Al-Pragliola
   - andreyvelich
+  - fege
   - jonburdo
   - pboyd


### PR DESCRIPTION
I'm happy to sponsor @fege into Reviewer role, following the current [Kubeflow community process](https://github.com/kubeflow/website/blob/fb5cfa5e82dcd2357436e9b09b4ec82b75427fb0/content/en/docs/about/membership.md?plain=1#L87)

- [x] ✅ Demonstrated consistent contributions for at least 3 months
requirement is met, Federico got [accepted as Member July 27](https://github.com/kubeflow/internal-acls/pull/804#event-18504602921), today is Jan 23, so 6 months 2 weeks
- [x] ✅ Primary reviewer for at least 5 PRs to the codebase
Federico contributed significantly for example with the first-hand contribution of Fuzz testing (as author) and in reviews of the following PRs demonstrating substantial ownership of the codebase impacted by testing:
  1. https://github.com/kubeflow/model-registry/pull/2066#discussion_r2668346924
  2. https://github.com/kubeflow/model-registry/pull/1499#discussion_r2303724390
  3. https://github.com/kubeflow/model-registry/pull/1435#discussion_r2262448614
  4. https://github.com/kubeflow/model-registry/pull/1318#discussion_r2259297602
  5. https://github.com/kubeflow/model-registry/pull/1244#issuecomment-3007751044
  (and others...)
- [x] ✅ Reviewed or merged at least 15 substantial PRs to the codebase
[this query](https://github.com/kubeflow/model-registry/pulls?q=is%3Apr+involves%3Afege) returns 26 contributions of different magnitude
- [x] ✅ Knowledgeable about the codebase
the inclusion of `schemathesis` first-hand by Federico helped us check-off tasks required during the Kubeflow CNCF graduation package submission, and considering as well the above links shows that Federico play a vital role in the testing for our codebase too
- [x] ✅ Active engagement with the commmunity by answering user questions in GitHub issues and Slack
Federico contributed to answering KF release liaison [enquiries](https://github.com/kubeflow/model-registry/issues/719#issuecomment-3034588555) from July of 2025 for tasks pertaining to the OpenSSF badge, in addition to what is visible above
- [x] ✅ Sponsored by a subproject approver
  - [ ] With no objections from other approvers
  - [x] ✅ Done through PR to update the OWNERS file
- [x] ✅  May either self-nominate or be nominated by an approver in this subproject
this PR itself

I'm going to keep this PR open for any comments, but I expect mostly will be congratulatory messages 😏 🎉