### PR TITLE
feat: add image signer

### DIFF
--- a/clients/python/src/model_registry/signing/__init__.py
+++ b/clients/python/src/model_registry/signing/__init__.py
@@ -1,0 +1,6 @@
+"""Signing utilities for model registry."""
+
+from model_registry.signing.exceptions import InitializationError, SigningError, VerificationError
+from model_registry.signing.image_signer import CommandRunner, ImageSigner
+
+__all__ = ["CommandRunner", "ImageSigner", "InitializationError", "SigningError", "VerificationError"]

--- a/clients/python/src/model_registry/signing/exceptions.py
+++ b/clients/python/src/model_registry/signing/exceptions.py
@@ -1,0 +1,13 @@
+"""Exceptions for signing operations."""
+
+
+class SigningError(Exception):
+    """Raised when image signing fails."""
+
+
+class VerificationError(Exception):
+    """Raised when image verification fails."""
+
+
+class InitializationError(Exception):
+    """Raised when sigstore initialization fails."""

--- a/clients/python/src/model_registry/signing/image_signer.py
+++ b/clients/python/src/model_registry/signing/image_signer.py
@@ -1,0 +1,225 @@
+"""Cosign signing and verification for container images."""
+
+import os
+import shutil
+import subprocess
+import sys
+from functools import partial
+from pathlib import Path
+
+from model_registry.signing.exceptions import InitializationError, SigningError, VerificationError
+
+
+class CommandRunner:
+    """Command execution wrapper for running CLI tools."""
+
+    def __init__(self, **kwargs):
+        """Initialize CommandRunner with default subprocess.run arguments.
+
+        Args:
+            **kwargs: Additional default keyword arguments to pass to subprocess.run
+        """
+        self._run = partial(subprocess.run, check=True, capture_output=True, text=True, **kwargs)
+
+    def run(self, cmd: list[str]) -> subprocess.CompletedProcess:
+        """Run a CLI command and handle output.
+
+        Args:
+            cmd: Command and arguments as a list
+
+        Returns:
+            CompletedProcess instance
+
+        Raises:
+            subprocess.CalledProcessError: If the command fails
+        """
+        result = self._run(cmd)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        return result
+
+
+class ImageSigner:
+    """Tool for signing and verifying container images."""
+
+    def __init__(
+        self,
+        tuf_url: str | None = None,
+        root: str | None = None,
+        root_checksum: str | None = None,
+        identity_token_path: str | os.PathLike[str] | None = None,
+        fulcio_url: str | None = None,
+        rekor_url: str | None = None,
+        certificate_identity: str | None = None,
+        oidc_issuer: str | None = None,
+    ):
+        """Initialize ImageSigner tool.
+
+        Args:
+            tuf_url: Default TUF mirror URL
+            root: Default root JSON URL
+            root_checksum: Default root JSON checksum
+            identity_token_path: Default path to OIDC identity token file
+            fulcio_url: Default Fulcio server URL
+            rekor_url: Default Rekor server URL
+            certificate_identity: Default certificate identity
+            oidc_issuer: Default OIDC issuer URL
+
+        Raises:
+            FileNotFoundError: If identity_token_path is provided but doesn't exist
+        """
+        self.runner = CommandRunner()
+        self.tuf_url = tuf_url
+        self.root = root
+        self.root_checksum = root_checksum
+
+        # Validate identity token path if provided
+        if identity_token_path is not None and not os.path.exists(identity_token_path):
+            msg = f"Identity token file not found: {identity_token_path}"
+            raise FileNotFoundError(msg)
+        self.identity_token_path = identity_token_path
+
+        self.fulcio_url = fulcio_url
+        self.rekor_url = rekor_url
+        self.certificate_identity = certificate_identity
+        self.oidc_issuer = oidc_issuer
+
+    def _get_sigstore_dir(self) -> Path:
+        """Get the sigstore directory path.
+
+        Returns:
+            Path to the sigstore directory
+        """
+        return Path.home() / ".sigstore"
+
+    def initialize(  # noqa: C901
+        self,
+        tuf_url: str | None = None,
+        root: str | None = None,
+        root_checksum: str | None = None,
+        force: bool = False,
+    ):
+        """Initialize sigstore configuration.
+
+        Args:
+            tuf_url: TUF mirror URL (optional, overrides instance default)
+            root: Root JSON URL (optional, overrides instance default)
+            root_checksum: Root JSON checksum (optional, overrides instance default)
+            force: If True, remove existing sigstore directory; if False, raise error if exists
+
+        Raises:
+            FileExistsError: If sigstore directory exists and force=False
+        """
+        # Check for existing sigstore directory
+        sigstore_dir = self._get_sigstore_dir()
+        if sigstore_dir.exists():
+            if not force:
+                msg = f"Sigstore directory already exists: {sigstore_dir}. Use force=True to overwrite."
+                raise FileExistsError(msg)
+            shutil.rmtree(sigstore_dir)
+
+        # Use method args or fall back to instance attributes
+        if tuf_url is None:
+            tuf_url = self.tuf_url
+        if root is None:
+            root = self.root
+        if root_checksum is None:
+            root_checksum = self.root_checksum
+
+        # Initialize cosign with TUF mirror
+        cmd = ["cosign", "initialize"]
+
+        if tuf_url is not None:
+            cmd.extend(["--mirror", tuf_url])
+
+        if root is not None:
+            cmd.extend(["--root", root])
+
+        if root_checksum is not None:
+            cmd.extend(["--root-checksum", root_checksum])
+
+        try:
+            self.runner.run(cmd)
+        except subprocess.CalledProcessError as e:
+            msg = f"Failed to initialize sigstore: {e}"
+            raise InitializationError(msg) from e
+
+    def sign(  # noqa: C901
+        self,
+        image: str,
+        identity_token_path: str | os.PathLike[str] | None = None,
+        fulcio_url: str | None = None,
+        rekor_url: str | None = None,
+    ):
+        """Sign a container image and upload the signature.
+
+        Args:
+            image: Full image reference including digest (e.g., quay.io/user/image@sha256:...)
+            identity_token_path: Path to OIDC identity token file (optional, overrides instance default)
+            fulcio_url: Fulcio server URL (optional, overrides instance default)
+            rekor_url: Rekor server URL (optional, overrides instance default)
+
+        Raises:
+            FileNotFoundError: If identity_token_path is provided but doesn't exist
+        """
+        # Use method args or fall back to instance attributes
+        if identity_token_path is None:
+            identity_token_path = self.identity_token_path
+        if fulcio_url is None:
+            fulcio_url = self.fulcio_url
+        if rekor_url is None:
+            rekor_url = self.rekor_url
+
+        # Validate identity token path if provided
+        if identity_token_path is not None and not os.path.exists(identity_token_path):
+            msg = f"Identity token file not found: {identity_token_path}"
+            raise FileNotFoundError(msg)
+
+        cmd = ["cosign", "sign", "-y"]
+
+        if identity_token_path is not None:
+            cmd.extend(["--identity-token", os.fspath(identity_token_path)])
+
+        if fulcio_url is not None:
+            cmd.extend(["--fulcio-url", fulcio_url])
+
+        if rekor_url is not None:
+            cmd.extend(["--rekor-url", rekor_url])
+
+        cmd.append(image)
+
+        try:
+            self.runner.run(cmd)
+        except subprocess.CalledProcessError as e:
+            msg = f"Failed to sign image {image}: {e}"
+            raise SigningError(msg) from e
+
+    def verify(self, image: str, certificate_identity: str | None = None, oidc_issuer: str | None = None):
+        """Verify a signed container image.
+
+        Args:
+            image: Full image reference including digest (e.g., quay.io/user/image@sha256:...)
+            certificate_identity: Expected certificate identity (optional, overrides instance default)
+            oidc_issuer: OIDC issuer URL (optional, overrides instance default)
+        """
+        # Use method args or fall back to instance attributes
+        if certificate_identity is None:
+            certificate_identity = self.certificate_identity
+        if oidc_issuer is None:
+            oidc_issuer = self.oidc_issuer
+
+        cmd = ["cosign", "verify"]
+
+        if certificate_identity is not None:
+            cmd.extend(["--certificate-identity", certificate_identity])
+
+        if oidc_issuer is not None:
+            cmd.extend(["--certificate-oidc-issuer", oidc_issuer])
+
+        cmd.append(image)
+
+        try:
+            self.runner.run(cmd)
+        except subprocess.CalledProcessError as e:
+            msg = f"Failed to verify image {image}: {e}"
+            raise VerificationError(msg) from e

--- a/clients/python/tests/test_signing.py
+++ b/clients/python/tests/test_signing.py
@@ -1,0 +1,348 @@
+"""Tests for signing utilities."""
+
+from pathlib import Path
+
+import pytest
+
+from model_registry.signing import ImageSigner, InitializationError, SigningError, VerificationError
+
+
+class TestImageSigner:
+    """Test ImageSigner class."""
+
+    def test_initialize_with_all_args(self, tmp_path, mocker):
+        """Test initialize with all arguments provided."""
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        # Mock sigstore dir to safe temp location
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=tmp_path / ".sigstore")
+
+        signer.initialize(
+            tuf_url="https://tuf.example.com",
+            root="https://tuf.example.com/root.json",
+            root_checksum="abc123"
+        )
+
+        mock_runner.run.assert_called_once()
+        cmd = mock_runner.run.call_args[0][0]
+        assert cmd == [
+            "cosign", "initialize",
+            "--mirror", "https://tuf.example.com",
+            "--root", "https://tuf.example.com/root.json",
+            "--root-checksum", "abc123"
+        ]
+
+    def test_initialize_with_instance_defaults(self, tmp_path, mocker):
+        """Test initialize uses instance defaults when method args not provided."""
+        signer = ImageSigner(
+            tuf_url="https://default-tuf.example.com",
+            root="https://default-tuf.example.com/root.json",
+            root_checksum="def456"
+        )
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        # Mock sigstore dir to safe temp location
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=tmp_path / ".sigstore")
+
+        signer.initialize()
+
+        cmd = mock_runner.run.call_args[0][0]
+        assert "https://default-tuf.example.com" in cmd
+        assert "https://default-tuf.example.com/root.json" in cmd
+        assert "def456" in cmd
+
+    def test_initialize_method_args_override_defaults(self, tmp_path, mocker):
+        """Test method arguments override instance defaults."""
+        signer = ImageSigner(
+            tuf_url="https://default-tuf.example.com",
+            root_checksum="default-checksum"
+        )
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        # Mock sigstore dir to safe temp location
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=tmp_path / ".sigstore")
+
+        signer.initialize(
+            tuf_url="https://override-tuf.example.com",
+            root_checksum="override-checksum"
+        )
+
+        cmd = mock_runner.run.call_args[0][0]
+        assert "https://override-tuf.example.com" in cmd
+        assert "override-checksum" in cmd
+        assert "https://default-tuf.example.com" not in cmd
+        assert "default-checksum" not in cmd
+
+    def test_initialize_raises_if_dir_exists_without_force(self, tmp_path, mocker):
+        """Test initialize raises FileExistsError if directory exists and force=False."""
+        # Create actual sigstore dir in temp location
+        temp_sigstore = tmp_path / ".sigstore"
+        temp_sigstore.mkdir()
+        (temp_sigstore / "config.json").write_text("{}")
+
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        # Mock _get_sigstore_dir to return our temp directory
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=temp_sigstore)
+
+        # Should raise because directory exists and force=False
+        with pytest.raises(FileExistsError, match="Sigstore directory already exists"):
+            signer.initialize()
+
+        # Verify directory was NOT removed
+        assert temp_sigstore.exists()
+
+    def test_initialize_removes_sigstore_dir_with_force(self, tmp_path, mocker):
+        """Test initialize removes existing .sigstore directory when force=True."""
+        # Create actual sigstore dir in temp location
+        temp_sigstore = tmp_path / ".sigstore"
+        temp_sigstore.mkdir()
+        (temp_sigstore / "config.json").write_text("{}")
+
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        # Mock _get_sigstore_dir to return our temp directory
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=temp_sigstore)
+
+        signer.initialize(force=True)
+
+        # Verify it was actually removed
+        assert not temp_sigstore.exists()
+
+    def test_initialize_succeeds_if_dir_not_exists(self, tmp_path, mocker):
+        """Test initialize succeeds when directory doesn't exist."""
+        temp_sigstore = tmp_path / ".sigstore"
+
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        # Mock _get_sigstore_dir to return our temp directory (which doesn't exist)
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=temp_sigstore)
+
+        # Should succeed without force since directory doesn't exist
+        signer.initialize()
+
+        mock_runner.run.assert_called_once()
+
+    def test_sign_with_all_args(self, tmp_path, mocker):
+        """Test sign with all arguments provided."""
+        # Create a temporary token file
+        token_file = tmp_path / "token"
+        token_file.write_text("test-token")
+
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        signer.sign(
+            image="quay.io/example/image@sha256:abc123",
+            identity_token_path=str(token_file),
+            fulcio_url="https://fulcio.example.com",
+            rekor_url="https://rekor.example.com"
+        )
+
+        mock_runner.run.assert_called_once()
+        cmd = mock_runner.run.call_args[0][0]
+        assert cmd == [
+            "cosign", "sign", "-y",
+            "--identity-token", str(token_file),
+            "--fulcio-url", "https://fulcio.example.com",
+            "--rekor-url", "https://rekor.example.com",
+            "quay.io/example/image@sha256:abc123"
+        ]
+
+    def test_sign_with_instance_defaults(self, tmp_path, mocker):
+        """Test sign uses instance defaults when method args not provided."""
+        # Create a temporary token file
+        token_file = tmp_path / "default-token"
+        token_file.write_text("test-token")
+
+        signer = ImageSigner(
+            identity_token_path=str(token_file),
+            fulcio_url="https://default-fulcio.example.com",
+            rekor_url="https://default-rekor.example.com"
+        )
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        signer.sign(image="quay.io/example/image@sha256:abc123")
+
+        cmd = mock_runner.run.call_args[0][0]
+        assert str(token_file) in cmd
+        assert "https://default-fulcio.example.com" in cmd
+        assert "https://default-rekor.example.com" in cmd
+
+    def test_sign_accepts_pathlike(self, tmp_path, mocker):
+        """Test sign accepts PathLike objects."""
+        # Create a temporary token file
+        token_file = tmp_path / "token"
+        token_file.write_text("test-token")
+
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        # Pass Path object instead of string
+        signer.sign(
+            image="quay.io/example/image@sha256:abc123",
+            identity_token_path=Path(token_file),
+            fulcio_url="https://fulcio.example.com",
+        )
+
+        mock_runner.run.assert_called_once()
+        cmd = mock_runner.run.call_args[0][0]
+        # os.fspath should have converted Path to string
+        assert str(token_file) in cmd
+
+    def test_sign_raises_if_token_file_not_found(self, mocker):
+        """Test sign raises FileNotFoundError if token file doesn't exist."""
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        with pytest.raises(FileNotFoundError, match="Identity token file not found"):
+            signer.sign(
+                image="quay.io/example/image@sha256:abc123",
+                identity_token_path="/nonexistent/token/file"  # noqa: S106
+            )
+
+    def test_init_raises_if_token_file_not_found(self):
+        """Test __init__ raises FileNotFoundError if token file doesn't exist."""
+        with pytest.raises(FileNotFoundError, match="Identity token file not found"):
+            ImageSigner(identity_token_path="/nonexistent/token/file")  # noqa: S106
+
+    def test_verify_with_all_args(self, mocker):
+        """Test verify with all arguments provided."""
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        signer.verify(
+            image="quay.io/example/image@sha256:abc123",
+            certificate_identity="https://kubernetes.io/namespaces/test/serviceaccounts/default",
+            oidc_issuer="https://oidc.example.com"
+        )
+
+        mock_runner.run.assert_called_once()
+        cmd = mock_runner.run.call_args[0][0]
+        assert cmd == [
+            "cosign", "verify",
+            "--certificate-identity", "https://kubernetes.io/namespaces/test/serviceaccounts/default",
+            "--certificate-oidc-issuer", "https://oidc.example.com",
+            "quay.io/example/image@sha256:abc123"
+        ]
+
+    def test_verify_with_instance_defaults(self, mocker):
+        """Test verify uses instance defaults when method args not provided."""
+        signer = ImageSigner(
+            certificate_identity="https://kubernetes.io/namespaces/default/serviceaccounts/default",
+            oidc_issuer="https://default-oidc.example.com"
+        )
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        signer.verify(image="quay.io/example/image@sha256:abc123")
+
+        cmd = mock_runner.run.call_args[0][0]
+        assert "https://kubernetes.io/namespaces/default/serviceaccounts/default" in cmd
+        assert "https://default-oidc.example.com" in cmd
+
+    def test_initialize_with_no_args_sends_minimal_command(self, tmp_path, mocker):
+        """Test initialize with no arguments sends minimal command."""
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        # Mock sigstore dir to safe temp location
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=tmp_path / ".sigstore")
+
+        signer.initialize()
+
+        cmd = mock_runner.run.call_args[0][0]
+        assert cmd == ["cosign", "initialize"]
+
+    def test_sign_image_is_last_argument(self, tmp_path, mocker):
+        """Test that image reference is always the last argument for sign."""
+        token_file = tmp_path / "token"
+        token_file.write_text("test-token")
+
+        signer = ImageSigner(identity_token_path=str(token_file))
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        signer.sign(image="quay.io/example/image@sha256:abc123")
+
+        cmd = mock_runner.run.call_args[0][0]
+        assert cmd[-1] == "quay.io/example/image@sha256:abc123"
+
+    def test_verify_image_is_last_argument(self, mocker):
+        """Test that image reference is always the last argument for verify."""
+        signer = ImageSigner(certificate_identity="test-id")
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+
+        signer.verify(image="quay.io/example/image@sha256:abc123")
+
+        cmd = mock_runner.run.call_args[0][0]
+        assert cmd[-1] == "quay.io/example/image@sha256:abc123"
+
+    def test_initialize_raises_initialization_error_on_command_failure(self, tmp_path, mocker):
+        """Test initialize raises InitializationError when cosign command fails."""
+        import subprocess
+
+        signer = ImageSigner()
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=tmp_path / ".sigstore")
+
+        # Mock runner to raise CalledProcessError
+        mock_runner = mocker.MagicMock()
+        mock_runner.run.side_effect = subprocess.CalledProcessError(1, ["cosign", "initialize"])
+        signer.runner = mock_runner
+
+        with pytest.raises(InitializationError, match="Failed to initialize sigstore"):
+            signer.initialize(tuf_url="https://tuf.example.com")
+
+    def test_sign_raises_signing_error_on_command_failure(self, tmp_path, mocker):
+        """Test sign raises SigningError when cosign command fails."""
+        import subprocess
+
+        token_file = tmp_path / "token"
+        token_file.write_text("test-token")
+
+        signer = ImageSigner()
+
+        # Mock runner to raise CalledProcessError
+        mock_runner = mocker.MagicMock()
+        mock_runner.run.side_effect = subprocess.CalledProcessError(1, ["cosign", "sign"])
+        signer.runner = mock_runner
+
+        with pytest.raises(SigningError, match="Failed to sign image"):
+            signer.sign(
+                image="quay.io/example/image@sha256:abc123",
+                identity_token_path=str(token_file)
+            )
+
+    def test_verify_raises_verification_error_on_command_failure(self, mocker):
+        """Test verify raises VerificationError when cosign command fails."""
+        import subprocess
+
+        signer = ImageSigner()
+
+        # Mock runner to raise CalledProcessError
+        mock_runner = mocker.MagicMock()
+        mock_runner.run.side_effect = subprocess.CalledProcessError(1, ["cosign", "verify"])
+        signer.runner = mock_runner
+
+        with pytest.raises(VerificationError, match="Failed to verify image"):
+            signer.verify(
+                image="quay.io/example/image@sha256:abc123",
+                certificate_identity="https://kubernetes.io/namespaces/test/serviceaccounts/default"
+            )


### PR DESCRIPTION
This adds an image signer to sign and verify OCI container images using sigstore.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

We'll add end-to-end tests as a follow-up but for now the tests avoid relying on the cosign binary and mainly test that we pass the correct options/args.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with a private securesign instance, by imported `ImageSigner`, and passing:
```
identity_token
fulcio_url
rekor_url
tuf_url
oidc_issuer
```
Then tested sign and verify with a small test image on an oci registry.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
