### PR TITLE
add jonburdo to approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ approvers:
   - Al-Pragliola
   - andreyvelich  # noqa(kubeflow-hub-team)
   - ederign
+  - jonburdo
   - pboyd
   - rareddy
   - tarilabs
@@ -13,5 +14,4 @@ reviewers:
   - Al-Pragliola
   - andreyvelich
   - fege
-  - jonburdo
   - pboyd


### PR DESCRIPTION
I would like to become an Approver in the kubeflow hub working group.

I've met the [requirements](https://www.kubeflow.org/docs/about/membership/#approver) as described below.

- Have met the responsibilities of the Reviewer role (as defined above) of the codebase for at least 3 months

  I have been a Reviewer for 3 months (since Oct 27, 2025):
  https://github.com/kubeflow/model-registry/pull/1796#issuecomment-3450413411

- Primary reviewer for at least 10 substantial PRs to the codebase

  - https://github.com/kubeflow/model-registry/pull/2007
  - https://github.com/kubeflow/model-registry/pull/1963
  - https://github.com/kubeflow/model-registry/pull/1922
  - https://github.com/kubeflow/model-registry/pull/1885
  - https://github.com/kubeflow/model-registry/pull/1879
  - https://github.com/kubeflow/model-registry/pull/1818
  - https://github.com/kubeflow/model-registry/pull/1812
  - https://github.com/kubeflow/model-registry/pull/1788
  - https://github.com/kubeflow/model-registry/pull/1767
  - https://github.com/kubeflow/model-registry/pull/1623
  - https://github.com/kubeflow/model-registry/pull/1553
  - https://github.com/kubeflow/model-registry/pull/1545
  - https://github.com/kubeflow/model-registry/pull/1542
  - https://github.com/kubeflow/model-registry/pull/1455
  - https://github.com/kubeflow/model-registry/pull/1394
  - https://github.com/kubeflow/model-registry/pull/1374
  - https://github.com/kubeflow/model-registry/pull/1326

- Reviewed or merged at least 30 PRs to the codebase
  - [merged PRs that I've reviewed](https://github.com/kubeflow/model-registry/pulls?q=is%3Apr+is%3Amerged+reviewed-by%3Ajonburdo+-author%3Ajonburdo) (50 as of today)
  - [merged PRs that I've authored](https://github.com/kubeflow/model-registry/pulls?q=is%3Apr+is%3Amerged+author%3Ajonburdo+) (23 as of today)

- Nominated by a WG Lead or Chair
  - With no objections from other Leads or Chairs
  - Done through PR to update the relevant OWNERS file

  nominated by @tarilabs

Additional evidence:
- [closed PRs that "involve" me](https://github.com/kubeflow/model-registry/pulls?q=is%3Apr+is%3Aclosed+involves%3Ajonburdo+) (35)
