### PR TITLE
Model type classification hf

### DIFF
--- a/catalog/README.md
+++ b/catalog/README.md
@@ -169,7 +169,7 @@ The Hugging Face catalog provider automatically classifies models based on their
 
 **Classification Heuristic:**
 
-The classification logic (`classifyModelTypeFromTasks`) examines the model's task list and:
+The classification logic examines the model's task list and:
 1. Checks if any task matches the **generative tasks** set → classifies as `"generative"`
 2. Checks if any task matches the **predictive tasks** set → classifies as `"predictive"`
 3. If both generative and predictive tasks are present, **generative takes priority**

--- a/catalog/internal/catalog/hf_catalog_test.go
+++ b/catalog/internal/catalog/hf_catalog_test.go
@@ -1491,167 +1491,167 @@ func TestClassifyModelTypeFromTasks(t *testing.T) {
 	tests := []struct {
 		name     string
 		tasks    []string
-		expected string
+		expected ModelType
 	}{
 		{
 			name:     "generative task - text-generation",
 			tasks:    []string{"text-generation"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "generative task - summarization",
 			tasks:    []string{"summarization"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "generative task - translation",
 			tasks:    []string{"translation"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "generative task - text-to-image",
 			tasks:    []string{"text-to-image"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "generative task - text-to-speech",
 			tasks:    []string{"text-to-speech"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "predictive task - text-classification",
 			tasks:    []string{"text-classification"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "predictive task - image-classification",
 			tasks:    []string{"image-classification"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "predictive task - question-answering",
 			tasks:    []string{"question-answering"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "predictive task - object-detection",
 			tasks:    []string{"object-detection"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "predictive task - feature-extraction",
 			tasks:    []string{"feature-extraction"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "multiple generative tasks",
 			tasks:    []string{"text-generation", "summarization"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "multiple predictive tasks",
 			tasks:    []string{"text-classification", "image-classification"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "generative takes priority over predictive",
 			tasks:    []string{"text-generation", "text-classification"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "unknown task",
 			tasks:    []string{"unknown-task"},
-			expected: "unknown",
+			expected: ModelTypeUnknown,
 		},
 		{
 			name:     "empty tasks",
 			tasks:    []string{},
-			expected: "unknown",
+			expected: ModelTypeUnknown,
 		},
 		{
 			name:     "case insensitive - GENERATIVE",
 			tasks:    []string{"TEXT-GENERATION"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "case insensitive - Predictive",
 			tasks:    []string{"Text-Classification"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "task with whitespace",
 			tasks:    []string{"  text-generation  "},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "all generative task types - summarization",
 			tasks:    []string{"summarization"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "all generative task types - translation",
 			tasks:    []string{"translation"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "all generative task types - text-to-image",
 			tasks:    []string{"text-to-image"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "all generative task types - unconditional-image-generation",
 			tasks:    []string{"unconditional-image-generation"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "all generative task types - image-to-image",
 			tasks:    []string{"image-to-image"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "all generative task types - audio-to-audio",
 			tasks:    []string{"audio-to-audio"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 		{
 			name:     "all predictive task types - zero-shot-classification",
 			tasks:    []string{"zero-shot-classification"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "all predictive task types - audio-classification",
 			tasks:    []string{"audio-classification"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "all predictive task types - document-question-answering",
 			tasks:    []string{"document-question-answering"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "all predictive task types - image-segmentation",
 			tasks:    []string{"image-segmentation"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "all predictive task types - keypoint-detection",
 			tasks:    []string{"keypoint-detection"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "all predictive task types - image-feature-extraction",
 			tasks:    []string{"image-feature-extraction"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "all predictive task types - fill-mask",
 			tasks:    []string{"fill-mask"},
-			expected: "predictive",
+			expected: ModelTypePredictive,
 		},
 		{
 			name:     "unknown task with recognized task - should classify based on recognized",
 			tasks:    []string{"unknown-task", "text-generation"},
-			expected: "generative",
+			expected: ModelTypeGenerative,
 		},
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds heuristic-based classifications to Hugging Face models by recognizing tasks & pipeline_tags that correspond to generative or predictive models. This will create a new custom property called "model_type" that has the values "generative", "predictive", or "unknown" for all HF models.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
