### PR TITLE
feat: add model signer

### DIFF
--- a/clients/python/noxfile.py
+++ b/clients/python/noxfile.py
@@ -53,7 +53,7 @@ def mypy(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(
-        ".",
+        ".[signing]",
         "requests",
         "pytest",
         "pytest-asyncio",
@@ -73,7 +73,7 @@ def tests(session: Session) -> None:
 def e2e_tests(session: Session) -> None:
     """Run the test suite."""
     packages = [
-        ".",
+        ".[signing]",
         "ray",
         "requests",
         "pytest",

--- a/clients/python/poetry.lock
+++ b/clients/python/poetry.lock
@@ -274,6 +274,19 @@ doc = ["doc8", "sphinx (>=7.0.0)", "sphinx-autobuild", "sphinx-autodoc-typehints
 test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytz (==2021.1)", "simplejson (==3.*)"]
 
 [[package]]
+name = "asn1crypto"
+version = "1.5.1"
+description = "Fast ASN.1 parser and serializer with definitions for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67"},
+    {file = "asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c"},
+]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
@@ -357,6 +370,129 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "blake3"
+version = "1.0.8"
+description = "Python bindings for the Rust blake3 crate"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "blake3-1.0.8-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:8956bb9aec47b6c37ccce935a943588f1f5e6e2e85d43bb7cb76a574238f8a9b"},
+    {file = "blake3-1.0.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7adbbee5dd0c302218eb8acdfd82b7006930eb5798f56f79f9cca89f6f192662"},
+    {file = "blake3-1.0.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:859cd57bac097a2cd63cb36d64c2f6f16c9edece5590f929e70157478e46dc9e"},
+    {file = "blake3-1.0.8-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9e1d70bf76c02846d0868a3d413eb6c430b76a315e12f1b2e59b5cf56c1f62a3"},
+    {file = "blake3-1.0.8-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3fe26f145fcb82931d1820b55c0279f72f8f8e49450dd9d74efbfd409b28423"},
+    {file = "blake3-1.0.8-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:97c076d58ee37eb5b2d8d91bb9db59c5a008fd59c71845dc57fe438aeeabaf10"},
+    {file = "blake3-1.0.8-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78731ce7fca46f776ae45fb5271a2a76c4a92c9687dd4337e84b2ae9a174b28f"},
+    {file = "blake3-1.0.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c65e373c8b47174b969ee61a89ee56922f722972eb650192845c8546df8d9db9"},
+    {file = "blake3-1.0.8-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:db54946792d2b8c6fa4be73e6e334519f13c1b52e7ff346b3e2ec8ad3eb59401"},
+    {file = "blake3-1.0.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:67d9c42c42eb1c7aedcf901591c743266009fcf48babf6d6f8450f567cb94a84"},
+    {file = "blake3-1.0.8-cp310-cp310-win32.whl", hash = "sha256:444215a1e5201f8fa4e5c7352e938a7070cd33d66aeb1dd9b1103a64b6920f9e"},
+    {file = "blake3-1.0.8-cp310-cp310-win_amd64.whl", hash = "sha256:725c52c4d393c7bd1a10682df322d480734002a1389b320366c660568708846b"},
+    {file = "blake3-1.0.8-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:9a8946cb6b1d2b2096daaaa89856f39887bce2b78503fa31b78173e3a86fa281"},
+    {file = "blake3-1.0.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:adccc3a139207e02bb7d7bb0715fe0b87069685aad5f3afff820b2f829467904"},
+    {file = "blake3-1.0.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fcfe81b3ae3fb5d2e88be0d3259603ff95f0d5ed69f655c28fdaef31e49a470"},
+    {file = "blake3-1.0.8-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:58ce8d45a5bb5326482de72ea1969a378634236186a970fef63058a5b7b8b435"},
+    {file = "blake3-1.0.8-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83605dbf43f581d8b7175b7f3bfe5388bad5a7c6ac175c9c11d669da31133f4b"},
+    {file = "blake3-1.0.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b5573b052777142b2cecc453d022c3f21aa4aba75011258410bb98f41c1a727"},
+    {file = "blake3-1.0.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe1b02ab49bfd969ef50b9f17482a2011c77536654af21807ba5c2674e0bb2a0"},
+    {file = "blake3-1.0.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7780666dc6be809b49442d6d5ce06fdbe33024a87560b58471103ec17644682"},
+    {file = "blake3-1.0.8-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:af394b50c6aa0b1b957a99453d1ee440ef67cd2d1b5669c731647dc723de8a3a"},
+    {file = "blake3-1.0.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c63ece266a43014cf29e772a82857cd8e90315ae3ed53e3c5204851596edd5f2"},
+    {file = "blake3-1.0.8-cp311-cp311-win32.whl", hash = "sha256:44c2815d4616fad7e2d757d121c0a11780f70ffc817547b3059b5c7e224031a7"},
+    {file = "blake3-1.0.8-cp311-cp311-win_amd64.whl", hash = "sha256:8f2ef8527a7a8afd99b16997d015851ccc0fe2a409082cebb980af2554e5c74c"},
+    {file = "blake3-1.0.8-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:d8da4233984d51471bd4e4366feda1d90d781e712e0a504ea54b1f2b3577557b"},
+    {file = "blake3-1.0.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1257be19f2d381c868a34cc822fc7f12f817ddc49681b6d1a2790bfbda1a9865"},
+    {file = "blake3-1.0.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:269f255b110840e52b6ce9db02217e39660ebad3e34ddd5bca8b8d378a77e4e1"},
+    {file = "blake3-1.0.8-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:66ca28a673025c40db3eba21a9cac52f559f83637efa675b3f6bd8683f0415f3"},
+    {file = "blake3-1.0.8-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bcb04966537777af56c1f399b35525aa70a1225816e121ff95071c33c0f7abca"},
+    {file = "blake3-1.0.8-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5b5da177d62cc4b7edf0cea08fe4dec960c9ac27f916131efa890a01f747b93"},
+    {file = "blake3-1.0.8-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:38209b10482c97e151681ea3e91cc7141f56adbbf4820a7d701a923124b41e6a"},
+    {file = "blake3-1.0.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:504d1399b7fb91dfe5c25722d2807990493185faa1917456455480c36867adb5"},
+    {file = "blake3-1.0.8-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c84af132aa09abeadf9a0118c8fb26f4528f3f42c10ef8be0fcf31c478774ec4"},
+    {file = "blake3-1.0.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a25db3d36b55f5ed6a86470155cc749fc9c5b91c949b8d14f48658f9d960d9ec"},
+    {file = "blake3-1.0.8-cp312-cp312-win32.whl", hash = "sha256:e0fee93d5adcd44378b008c147e84f181f23715307a64f7b3db432394bbfce8b"},
+    {file = "blake3-1.0.8-cp312-cp312-win_amd64.whl", hash = "sha256:6a6eafc29e4f478d365a87d2f25782a521870c8514bb43734ac85ae9be71caf7"},
+    {file = "blake3-1.0.8-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:46dc20976bd6c235959ef0246ec73420d1063c3da2839a9c87ca395cf1fd7943"},
+    {file = "blake3-1.0.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d17eb6382634b3a5bc0c0e0454d5265b0becaeeadb6801ed25150b39a999d0cc"},
+    {file = "blake3-1.0.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19fc6f2b7edab8acff6895fc6e38c19bd79f4c089e21153020c75dfc7397d52d"},
+    {file = "blake3-1.0.8-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4f54cff7f15d91dc78a63a2dd02a3dccdc932946f271e2adb4130e0b4cf608ba"},
+    {file = "blake3-1.0.8-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7e12a777f6b798eb8d06f875d6e108e3008bd658d274d8c676dcf98e0f10537"},
+    {file = "blake3-1.0.8-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ddfc59b0176fb31168f08d5dd536e69b1f4f13b5a0f4b0c3be1003efd47f9308"},
+    {file = "blake3-1.0.8-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a2336d5b2a801a7256da21150348f41610a6c21dae885a3acb1ebbd7333d88d8"},
+    {file = "blake3-1.0.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4072196547484c95a5a09adbb952e9bb501949f03f9e2a85e7249ef85faaba8"},
+    {file = "blake3-1.0.8-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:0eab3318ec02f8e16fe549244791ace2ada2c259332f0c77ab22cf94dfff7130"},
+    {file = "blake3-1.0.8-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a33b9a1fb6d1d559a8e0d04b041e99419a6bb771311c774f6ff57ed7119c70ed"},
+    {file = "blake3-1.0.8-cp313-cp313-win32.whl", hash = "sha256:e171b169cb7ea618e362a4dddb7a4d4c173bbc08b9ba41ea3086dd1265530d4f"},
+    {file = "blake3-1.0.8-cp313-cp313-win_amd64.whl", hash = "sha256:3168c457255b5d2a2fc356ba696996fcaff5d38284f968210d54376312107662"},
+    {file = "blake3-1.0.8-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4d672c24dc15ec617d212a338a4ca14b449829b6072d09c96c63b6e6b621aed"},
+    {file = "blake3-1.0.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:1af0e5a29aa56d4fba904452ae784740997440afd477a15e583c38338e641f41"},
+    {file = "blake3-1.0.8-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef153c5860d5bf1cc71aece69b28097d2a392913eb323d6b52555c875d0439fc"},
+    {file = "blake3-1.0.8-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e8ae3689f0c7bfa6ce6ae45cab110e4c3442125c4c23b28f1f097856de26e4d1"},
+    {file = "blake3-1.0.8-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3fb83532f7456ddeb68dae1b36e1f7c52f9cb72852ac01159bbcb1a12b0f8be0"},
+    {file = "blake3-1.0.8-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ae7754c7d96e92a70a52e07c732d594cf9924d780f49fffd3a1e9235e0f5ba7"},
+    {file = "blake3-1.0.8-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4bacaae75e98dee3b7da6c5ee3b81ee21a3352dd2477d6f1d1dbfd38cdbf158a"},
+    {file = "blake3-1.0.8-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9456c829601d72852d8ba0af8dae0610f7def1d59f5942efde1e2ef93e8a8b57"},
+    {file = "blake3-1.0.8-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:497ef8096ec4ac1ffba9a66152cee3992337cebf8ea434331d8fd9ce5423d227"},
+    {file = "blake3-1.0.8-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:511133bab85ff60ed143424ce484d08c60894ff7323f685d7a6095f43f0c85c3"},
+    {file = "blake3-1.0.8-cp313-cp313t-win32.whl", hash = "sha256:9c9fbdacfdeb68f7ca53bb5a7a5a593ec996eaf21155ad5b08d35e6f97e60877"},
+    {file = "blake3-1.0.8-cp313-cp313t-win_amd64.whl", hash = "sha256:3cec94ed5676821cf371e9c9d25a41b4f3ebdb5724719b31b2749653b7cc1dfa"},
+    {file = "blake3-1.0.8-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:2c33dac2c6112bc23f961a7ca305c7e34702c8177040eb98d0389d13a347b9e1"},
+    {file = "blake3-1.0.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c445eff665d21c3b3b44f864f849a2225b1164c08654beb23224a02f087b7ff1"},
+    {file = "blake3-1.0.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a47939f04b89c5c6ff1e51e883e5efab1ea1bf01a02f4d208d216dddd63d0dd8"},
+    {file = "blake3-1.0.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:73e0b4fa25f6e3078526a592fb38fca85ef204fd02eced6731e1cdd9396552d4"},
+    {file = "blake3-1.0.8-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b0543c57eb9d6dac9d4bced63e9f7f7b546886ac04cec8da3c3d9c8f30cbbb7"},
+    {file = "blake3-1.0.8-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed972ebd553c0c25363459e9fc71a38c045d8419e365b59acd8cd791eff13981"},
+    {file = "blake3-1.0.8-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3bafdec95dfffa3f6571e529644744e280337df15ddd9728f224ba70c5779b23"},
+    {file = "blake3-1.0.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d78f06f3fb838b34c330e2987090376145cbe5944d8608a0c4779c779618f7b"},
+    {file = "blake3-1.0.8-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:dd03ff08d1b6e4fdda1cd03826f971ae8966ef6f683a8c68aa27fb21904b5aa9"},
+    {file = "blake3-1.0.8-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:4e02a3c499e35bf51fc15b2738aca1a76410804c877bcd914752cac4f71f052a"},
+    {file = "blake3-1.0.8-cp314-cp314-win32.whl", hash = "sha256:a585357d5d8774aad9ffc12435de457f9e35cde55e0dc8bc43ab590a6929e59f"},
+    {file = "blake3-1.0.8-cp314-cp314-win_amd64.whl", hash = "sha256:9ab5998e2abd9754819753bc2f1cf3edf82d95402bff46aeef45ed392a5468bf"},
+    {file = "blake3-1.0.8-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e2df12f295f95a804338bd300e8fad4a6f54fd49bd4d9c5893855a230b5188a8"},
+    {file = "blake3-1.0.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:63379be58438878eeb76ebe4f0efbeaabf42b79f2cff23b6126b7991588ced67"},
+    {file = "blake3-1.0.8-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88d527c247f9609dc1d45a08fd243e39f0d5300d54c57e048de24d4fa9240ebb"},
+    {file = "blake3-1.0.8-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506a47897a11ebe8f3cdeb52f1365d6a2f83959e98ccb0c830f8f73277d4d358"},
+    {file = "blake3-1.0.8-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5122a61b3b004bbbd979bdf83a3aaab432da3e2a842d7ddf1c273f2503b4884"},
+    {file = "blake3-1.0.8-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0171e85d56dec1219abdae5f49a0ed12cb3f86a454c29160a64fd8a8166bba37"},
+    {file = "blake3-1.0.8-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:003f61e8c41dd9931edddf1cc6a1bb680fb2ac0ad15493ef4a1df9adc59ce9df"},
+    {file = "blake3-1.0.8-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2c3151955efb09ba58cd3e1263521e15e9e3866a40d6bd3556d86fc968e8f95"},
+    {file = "blake3-1.0.8-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:5eb25bca3cee2e0dd746a214784fb36be6a43640c01c55b6b4e26196e72d076c"},
+    {file = "blake3-1.0.8-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ab4e1dea4fa857944944db78e8f20d99ee2e16b2dea5a14f514fb0607753ac83"},
+    {file = "blake3-1.0.8-cp314-cp314t-win32.whl", hash = "sha256:67f1bc11bf59464ef092488c707b13dd4e872db36e25c453dfb6e0c7498df9f1"},
+    {file = "blake3-1.0.8-cp314-cp314t-win_amd64.whl", hash = "sha256:421b99cdf1ff2d1bf703bc56c454f4b286fce68454dd8711abbcb5a0df90c19a"},
+    {file = "blake3-1.0.8-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:af18817da1eb5bd65d068fb9c18235edc328a45b09025346fa65fe52b1b0c9b6"},
+    {file = "blake3-1.0.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:add39ffa9e5074264f12ab409cdf059bc967817644b455e3fad46139001cc108"},
+    {file = "blake3-1.0.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b201961c6dcc7123e69fff6019298d9e4394c7e585a300e999664bca8070d83c"},
+    {file = "blake3-1.0.8-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a5b9196a4768e5475475bdf2010dc76b2792f95805731a645196d180a7e12570"},
+    {file = "blake3-1.0.8-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:04b95bcd6c1b61480923adc571ffab377618d170f528f6cf4f6a6fff94e3c309"},
+    {file = "blake3-1.0.8-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ca8bc7e816370118262da11783e1fdf8992f250789ae08e8182fb7c26e14ded0"},
+    {file = "blake3-1.0.8-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2bacf9757e93ac376c612dc0d45931a591ea0caf5583ab93d99dd32a2905ec43"},
+    {file = "blake3-1.0.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23e181318f5a62e4e6ce7be0875b4f65543abe47fe48cc4f4e9ab8f2bf9e01c5"},
+    {file = "blake3-1.0.8-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:83347ef28d774e84442c71fc5aa8817498753d47831a533536ead1a7ccd44a41"},
+    {file = "blake3-1.0.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c9ab5ef61aaa6df2f769548a071fddcacbb0f56102a9c48f40878b10ae1a2657"},
+    {file = "blake3-1.0.8-cp38-cp38-win32.whl", hash = "sha256:efb1ab89fa47b5acb36f1530c4eb83ae20aaec9ac17808ff014b2650fbc3c7ba"},
+    {file = "blake3-1.0.8-cp38-cp38-win_amd64.whl", hash = "sha256:fe61d52da1d102aabb0e315d3fc613c11c103376aa0a8510aeee159939612f76"},
+    {file = "blake3-1.0.8-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:119829e13eca177f5626c43f753acc4813eb8ae414c2d70ef7571078177163c7"},
+    {file = "blake3-1.0.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:411f61cb817eb25547b91944301ccfa624ccdc69d70822866d8ad0b0e9e3ca64"},
+    {file = "blake3-1.0.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94b2d4922c75174083988b8b0d2c78e72be7376ac59ab19c3e5d17a7c9c1cc0f"},
+    {file = "blake3-1.0.8-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53304b6df3f8d826850c1d977d9a69edbf3e48476b95f7cb6175ec650856a3c5"},
+    {file = "blake3-1.0.8-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:98915260c378d4c45088f1e227b053834ed95aeca89336184f192489ad0dd5d4"},
+    {file = "blake3-1.0.8-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc9fc4a0a1a13991b23a589fb6fbb8290bd94a72c130e69e27c9769612516424"},
+    {file = "blake3-1.0.8-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0c492630d384fc4400e9860b16e09e0dbe79e960e95b237b9a1ea3f95ea3125d"},
+    {file = "blake3-1.0.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2682ba10fb3b36fe8a6823be50910f1145a8a5158bc555145fadcc4afb984c3"},
+    {file = "blake3-1.0.8-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e6cb2316949c614e64f6b7796b9eca28b1b57406d27debc99398a746e9b426c7"},
+    {file = "blake3-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b37f63c5952b32b5064096141b394ed17569d318637a06a2cae9bfedd852f0ef"},
+    {file = "blake3-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f13c25c215c284adca0c07cffae1518cafcac3900f1d45fff51c7e6ab98efec1"},
+    {file = "blake3-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:c5bfe1a1ada3ed2c715f692ce1a3b221d7f6b4d5e6001d24774ef07de013192c"},
+    {file = "blake3-1.0.8.tar.gz", hash = "sha256:513cc7f0f5a7c035812604c2c852a0c1468311345573de647e310aca4ab165ba"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_full_version < \"3.12.0\""}
+
+[[package]]
 name = "boto3"
 version = "1.42.39"
 description = "The AWS SDK for Python"
@@ -409,7 +545,104 @@ files = [
     {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
     {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
 ]
-markers = {main = "extra == \"hf\""}
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\" and extra == \"signing\""
+files = [
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "charset-normalizer"
@@ -417,7 +650,7 @@ version = "3.3.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7.0"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
     {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
@@ -522,7 +755,7 @@ files = [
     {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
     {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
-markers = {main = "extra == \"hf\" or extra == \"olot\""}
+markers = {main = "extra == \"hf\" or extra == \"olot\" or extra == \"signing\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -538,7 +771,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "(extra == \"hf\" or extra == \"olot\") and platform_system == \"Windows\""}
+markers = {main = "(extra == \"hf\" or extra == \"olot\" or extra == \"signing\") and platform_system == \"Windows\""}
 
 [[package]]
 name = "coverage"
@@ -649,6 +882,102 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "cryptography"
+version = "46.0.4"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = true
+python-versions = "!=3.9.0,!=3.9.1,>=3.8"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47bcd19517e6389132f76e2d5303ded6cf3f78903da2158a671be8de024f4cd0"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:01df4f50f314fbe7009f54046e908d1754f19d0c6d3070df1e6268c5a4af09fa"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5aa3e463596b0087b3da0dbe2b2487e9fc261d25da85754e30e3b40637d61f81"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0a9ad24359fee86f131836a9ac3bffc9329e956624a2d379b613f8f8abaf5255"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:dc1272e25ef673efe72f2096e92ae39dea1a1a450dd44918b15351f72c5a168e"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:de0f5f4ec8711ebc555f54735d4c673fc34b65c44283895f1a08c2b49d2fd99c"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:eeeb2e33d8dbcccc34d64651f00a98cb41b2dc69cef866771a5717e6734dfa32"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3d425eacbc9aceafd2cb429e42f4e5d5633c6f873f5e567077043ef1b9bbf616"},
+    {file = "cryptography-46.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91627ebf691d1ea3976a031b61fb7bac1ccd745afa03602275dda443e11c8de0"},
+    {file = "cryptography-46.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2d08bc22efd73e8854b0b7caff402d735b354862f1145d7be3b9c0f740fef6a0"},
+    {file = "cryptography-46.0.4-cp311-abi3-win32.whl", hash = "sha256:82a62483daf20b8134f6e92898da70d04d0ef9a75829d732ea1018678185f4f5"},
+    {file = "cryptography-46.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:6225d3ebe26a55dbc8ead5ad1265c0403552a63336499564675b29eb3184c09b"},
+    {file = "cryptography-46.0.4-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:485e2b65d25ec0d901bca7bcae0f53b00133bf3173916d8e421f6fddde103908"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:078e5f06bd2fa5aea5a324f2a09f914b1484f1d0c2a4d6a8a28c74e72f65f2da"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dce1e4f068f03008da7fa51cc7abc6ddc5e5de3e3d1550334eaf8393982a5829"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2067461c80271f422ee7bdbe79b9b4be54a5162e90345f86a23445a0cf3fd8a2"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:c92010b58a51196a5f41c3795190203ac52edfd5dc3ff99149b4659eba9d2085"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:829c2b12bbc5428ab02d6b7f7e9bbfd53e33efd6672d21341f2177470171ad8b"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:62217ba44bf81b30abaeda1488686a04a702a261e26f87db51ff61d9d3510abd"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:9c2da296c8d3415b93e6053f5a728649a87a48ce084a9aaf51d6e46c87c7f2d2"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9b34d8ba84454641a6bf4d6762d15847ecbd85c1316c0a7984e6e4e9f748ec2e"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:df4a817fa7138dd0c96c8c8c20f04b8aaa1fac3bbf610913dcad8ea82e1bfd3f"},
+    {file = "cryptography-46.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b1de0ebf7587f28f9190b9cb526e901bf448c9e6a99655d2b07fff60e8212a82"},
+    {file = "cryptography-46.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9b4d17bc7bd7cdd98e3af40b441feaea4c68225e2eb2341026c84511ad246c0c"},
+    {file = "cryptography-46.0.4-cp314-cp314t-win32.whl", hash = "sha256:c411f16275b0dea722d76544a61d6421e2cc829ad76eec79280dbdc9ddf50061"},
+    {file = "cryptography-46.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:728fedc529efc1439eb6107b677f7f7558adab4553ef8669f0d02d42d7b959a7"},
+    {file = "cryptography-46.0.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a9556ba711f7c23f77b151d5798f3ac44a13455cc68db7697a1096e6d0563cab"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bf75b0259e87fa70bddc0b8b4078b76e7fd512fd9afae6c1193bcf440a4dbef"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c268a3490df22270955966ba236d6bc4a8f9b6e4ffddb78aac535f1a5ea471d"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:812815182f6a0c1d49a37893a303b44eaac827d7f0d582cecfc81b6427f22973"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:a90e43e3ef65e6dcf969dfe3bb40cbf5aef0d523dff95bfa24256be172a845f4"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a05177ff6296644ef2876fce50518dffb5bcdf903c85250974fc8bc85d54c0af"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:daa392191f626d50f1b136c9b4cf08af69ca8279d110ea24f5c2700054d2e263"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e07ea39c5b048e085f15923511d8121e4a9dc45cee4e3b970ca4f0d338f23095"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d5a45ddc256f492ce42a4e35879c5e5528c09cd9ad12420828c972951d8e016b"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:6bb5157bf6a350e5b28aee23beb2d84ae6f5be390b2f8ee7ea179cda077e1019"},
+    {file = "cryptography-46.0.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd5aba870a2c40f87a3af043e0dee7d9eb02d4aff88a797b48f2b43eff8c3ab4"},
+    {file = "cryptography-46.0.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:93d8291da8d71024379ab2cb0b5c57915300155ad42e07f76bea6ad838d7e59b"},
+    {file = "cryptography-46.0.4-cp38-abi3-win32.whl", hash = "sha256:0563655cb3c6d05fb2afe693340bc050c30f9f34e15763361cf08e94749401fc"},
+    {file = "cryptography-46.0.4-cp38-abi3-win_amd64.whl", hash = "sha256:fa0900b9ef9c49728887d1576fd8d9e7e3ea872fa9b25ef9b64888adc434e976"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:766330cce7416c92b5e90c3bb71b1b79521760cdcfc3a6a1a182d4c9fab23d2b"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c236a44acfb610e70f6b3e1c3ca20ff24459659231ef2f8c48e879e2d32b73da"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:8a15fb869670efa8f83cbffbc8753c1abf236883225aed74cd179b720ac9ec80"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:fdc3daab53b212472f1524d070735b2f0c214239df131903bae1d598016fa822"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:44cc0675b27cadb71bdbb96099cca1fa051cd11d2ade09e5cd3a2edb929ed947"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be8c01a7d5a55f9a47d1888162b76c8f49d62b234d88f0ff91a9fbebe32ffbc3"},
+    {file = "cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
+typing-extensions = {version = ">=4.13.2", markers = "python_full_version < \"3.11.0\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.4)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+description = "DNS toolkit"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
+    {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
+]
+
+[package.extras]
+dev = ["black (>=25.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.17.0)", "mypy (>=1.17)", "pylint (>=3)", "pytest (>=8.4)", "pytest-cov (>=6.2.0)", "quart-trio (>=0.12.0)", "sphinx (>=8.2.0)", "sphinx-rtd-theme (>=3.0.0)", "twine (>=6.1.0)", "wheel (>=0.45.0)"]
+dnssec = ["cryptography (>=45)"]
+doh = ["h2 (>=4.2.0)", "httpcore (>=1.0.0)", "httpx (>=0.28.0)"]
+doq = ["aioquic (>=1.2.0)"]
+idna = ["idna (>=3.10)"]
+trio = ["trio (>=0.30)"]
+wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
+
+[[package]]
 name = "docutils"
 version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
@@ -659,6 +988,23 @@ files = [
     {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
     {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
 ]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+description = "A robust email address syntax and deliverability validation library."
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"},
+    {file = "email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426"},
+]
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+idna = ">=2.0.0"
 
 [[package]]
 name = "exceptiongroup"
@@ -1097,6 +1443,27 @@ hypothesis = ">=6.84.3"
 jsonschema = ">=4.18.0"
 
 [[package]]
+name = "id"
+version = "1.6.1"
+description = "A tool for generating OIDC identities"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca"},
+    {file = "id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069"},
+]
+
+[package.dependencies]
+urllib3 = ">=2,<3"
+
+[package.extras]
+dev = ["build", "bump (>=1.3.2)", "id[lint,test]"]
+lint = ["bandit", "interrogate", "mypy", "ruff (<0.14.15)"]
+test = ["coverage[toml]", "pretend", "pytest", "pytest-cov"]
+
+[[package]]
 name = "idna"
 version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -1119,6 +1486,44 @@ files = [
     {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
     {file = "imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"},
 ]
+
+[[package]]
+name = "importlib-resources"
+version = "5.13.0"
+description = "Read resources from Python packages"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"signing\" and python_version == \"3.10\""
+files = [
+    {file = "importlib_resources-5.13.0-py3-none-any.whl", hash = "sha256:9f7bd0c97b79972a6cce36a366356d16d5e13b09679c11a58f1014bfdf8e64b2"},
+    {file = "importlib_resources-5.13.0.tar.gz", hash = "sha256:82d5c6cca930697dbbd86c93333bb2c2e72861d4789a11c2662b933e5ad2b528"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7) ; platform_python_implementation != \"PyPy\"", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1) ; platform_python_implementation != \"PyPy\"", "pytest-ruff"]
+
+[[package]]
+name = "in-toto-attestation"
+version = "0.9.3"
+description = "Python bindings for the in-toto Attestation Framework"
+optional = true
+python-versions = "~=3.7"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "in_toto_attestation-0.9.3-py3-none-any.whl", hash = "sha256:1f44d3f3bded1ed551e260c5e9f834ee05de03f1d2f360bada5a172c11d748ff"},
+    {file = "in_toto_attestation-0.9.3.tar.gz", hash = "sha256:cc0cf97417d94953b9fee6e9d415a11c59b4d47cee4f13746ffe935b28e3e8c4"},
+]
+
+[package.dependencies]
+protobuf = "*"
+
+[package.extras]
+dev = ["build", "in-toto-attestation[lint,test]"]
+lint = ["mypy", "ruff", "types-protobuf"]
+test = ["coverage[toml]", "pytest", "pytest-cov"]
 
 [[package]]
 name = "iniconfig"
@@ -1364,11 +1769,12 @@ version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
     {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
 ]
+markers = {main = "extra == \"signing\""}
 
 [package.dependencies]
 mdurl = ">=0.1,<1.0"
@@ -1479,11 +1885,12 @@ version = "0.1.2"
 description = "Markdown URL utilities"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
+markers = {main = "extra == \"signing\""}
 
 [[package]]
 name = "msgpack"
@@ -1819,6 +2226,24 @@ files = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.5.1"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31"},
+    {file = "platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda"},
+]
+
+[package.extras]
+docs = ["furo (>=2025.9.25)", "proselint (>=0.14)", "sphinx (>=8.2.3)", "sphinx-autodoc-typehints (>=3.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.4.2)", "pytest-cov (>=7)", "pytest-mock (>=3.15.1)"]
+type = ["mypy (>=1.18.2)"]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
@@ -1948,7 +2373,7 @@ version = "6.33.5"
 description = ""
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b"},
     {file = "protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c"},
@@ -1960,6 +2385,33 @@ files = [
     {file = "protobuf-6.33.5-cp39-cp39-win_amd64.whl", hash = "sha256:8f04fa32763dcdb4973d537d6b54e615cc61108c7cb38fe59310c3192d29510a"},
     {file = "protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02"},
     {file = "protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c"},
+]
+markers = {main = "extra == \"signing\""}
+
+[[package]]
+name = "pyasn1"
+version = "0.6.2"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf"},
+    {file = "pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"},
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\" and extra == \"signing\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
 
 [[package]]
@@ -1976,6 +2428,7 @@ files = [
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
+email-validator = {version = ">=2.0.0", optional = true, markers = "extra == \"email\""}
 pydantic-core = "2.41.5"
 typing-extensions = ">=4.14.1"
 typing-inspection = ">=0.4.2"
@@ -2124,15 +2577,56 @@ version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
     {file = "pygments-2.17.2.tar.gz", hash = "sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"},
 ]
+markers = {main = "extra == \"signing\""}
 
 [package.extras]
 plugins = ["importlib-metadata ; python_version < \"3.8\""]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+description = "JSON Web Token implementation in Python"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469"},
+    {file = "pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623"},
+]
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
+
+[[package]]
+name = "pyopenssl"
+version = "25.3.0"
+description = "Python wrapper module around the OpenSSL library"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6"},
+    {file = "pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329"},
+]
+
+[package.dependencies]
+cryptography = ">=45.0.7,<47"
+typing-extensions = {version = ">=4.9", markers = "python_version < \"3.13\" and python_version >= \"3.8\""}
+
+[package.extras]
+docs = ["sphinx (!=5.2.0,!=5.2.0.post0,!=7.2.5)", "sphinx_rtd_theme"]
+test = ["pretend", "pytest (>=3.0.1)", "pytest-rerunfailures"]
 
 [[package]]
 name = "pyrate-limiter"
@@ -2463,7 +2957,7 @@ version = "2.32.5"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
@@ -2478,6 +2972,38 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "rfc3161-client"
+version = "1.0.5"
+description = ""
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "rfc3161_client-1.0.5-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8a54fdb2f9e64481272b89137a7b71403cf1d30f5505c2e0c15a47a1cc100264"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d9ed8e597d0ee7387da1945e1583c4516b26f133770b3956e079606e2d90b69c"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61c04b4953453e5c26a1949c20adac415b65cd062dab0960574d6c36240222d2"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31b6ee79f15b93d90952efd0395bb3f5ebf07941469c5c6eb32f9b64312cda6e"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c53a6711bab0c3f77dc9cf1e2fd750da475ff7abbc40ffe0333d8c518a8a9c8"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09c47582ecea2ca4a3debf8a1eda775cc3d5ae1379da40272cc065d32e639a7a"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d31d30e354d2349ae8483ce811ef61498a3780daf8622c0b79d8cd44d271b46b"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:ae440461a310ae097417afe536d9d22fd71c95fbc9d21db3561b2707bed0aff0"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:8fb34470e867a29cc15dc4987ea14f19d3bd25c863e132b6f75dca583e2cc67e"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3106f3361a5a36789f43d2700e5678c847a9d3460a23f455f4c20cd39314c557"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-win32.whl", hash = "sha256:078e4bbf0770ddc472e2ca96cf1e23efd0c313e6682b4c2c9765e1fdf09f55a3"},
+    {file = "rfc3161_client-1.0.5-cp39-abi3-win_amd64.whl", hash = "sha256:e904430e27e75a5a379fc4aac09bd60ba5f4b48054f0481b2fb417297e404047"},
+    {file = "rfc3161_client-1.0.5.tar.gz", hash = "sha256:f1a2e32e2a053455cee1ff9b325b88dbc7c66c8882dde60962add92f572df5c5"},
+]
+
+[package.dependencies]
+cryptography = ">=43,<47"
+
+[package.extras]
+dev = ["maturin (>=1.7,<2.0)", "rfc3161-client[doc,lint,test]"]
+lint = ["interrogate", "mypy", "ruff (>=0.7,<0.14)", "types-requests"]
+test = ["coverage[toml]", "pretend", "pytest", "pytest-cov"]
 
 [[package]]
 name = "rfc3339-validator"
@@ -2507,16 +3033,63 @@ files = [
 ]
 
 [[package]]
+name = "rfc8785"
+version = "0.1.4"
+description = "A pure-Python implementation of RFC 8785 (JSON Canonicalization Scheme)"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48"},
+    {file = "rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da"},
+]
+
+[package.extras]
+dev = ["build", "rfc8785[doc,lint,test]"]
+doc = ["pdoc"]
+lint = ["interrogate", "mypy (>=1.0)", "ruff (>=0.3,<1.0)"]
+test = ["coverage", "pytest", "pytest-cov"]
+
+[[package]]
+name = "rh-model-signing"
+version = "0.0.3"
+description = "A tool for signing and verifying ML models (Red Hat Tech Preview)"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "rh_model_signing-0.0.3-py3-none-any.whl", hash = "sha256:50a4827483187e9b31e9e409a50830b08ba62caa3b13041fc534f83e8822f434"},
+    {file = "rh_model_signing-0.0.3.tar.gz", hash = "sha256:244327f6a6857ff8ed2fd19bab7d511d727a90dfad720467392daa1123a75545"},
+]
+
+[package.dependencies]
+asn1crypto = "*"
+blake3 = "*"
+click = "*"
+cryptography = "*"
+in-toto-attestation = "*"
+sigstore = ">=4.0"
+sigstore-models = ">=0.0.5"
+typing-extensions = "*"
+
+[package.extras]
+otel = ["opentelemetry-api", "opentelemetry-distro", "opentelemetry-exporter-otlp", "opentelemetry-instrumentation", "opentelemetry-instrumentation-urllib3", "opentelemetry-sdk"]
+pkcs11 = ["pykcs11"]
+
+[[package]]
 name = "rich"
 version = "14.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.8.0"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0"},
     {file = "rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"},
 ]
+markers = {main = "extra == \"signing\""}
 
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
@@ -2770,6 +3343,29 @@ docs = ["mkdocs-material", "mkdocstrings[python]"]
 tests = ["aiohttp (>=3.9.1,<4.0)", "coverage (>=6)", "fastapi (>=0.86.0)", "flask (>=2.1.1,<3.0)", "hypothesis-openapi (>=0.2,<1) ; python_version >= \"3.10\"", "pydantic (>=1.10.2)", "pytest-asyncio (>=1.0,<2.0)", "pytest-httpserver (>=1.0,<2.0)", "pytest-mock (>=3.7.0,<4.0)", "pytest-trio (>=0.8,<1.0)", "pytest-xdist (>=3,<4.0)", "strawberry-graphql[fastapi] (>=0.109.0)", "syrupy (>=4,<6.0)", "tomli-w (>=1.2.0)", "trustme (>=0.9.0,<1.0)"]
 
 [[package]]
+name = "securesystemslib"
+version = "1.3.1"
+description = "A library that provides cryptographic and general-purpose routines for Secure Systems Lab projects at NYU"
+optional = true
+python-versions = "~=3.8"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "securesystemslib-1.3.1-py3-none-any.whl", hash = "sha256:2e5414bbdde33155a91805b295cbedc4ae3f12b48dccc63e1089093537f43c81"},
+    {file = "securesystemslib-1.3.1.tar.gz", hash = "sha256:ca915f4b88209bb5450ac05426b859d74b7cd1421cafcf73b8dd3418a0b17486"},
+]
+
+[package.extras]
+awskms = ["boto3", "botocore", "cryptography (>=40.0.0)"]
+azurekms = ["azure-identity", "azure-keyvault-keys", "cryptography (>=40.0.0)"]
+crypto = ["cryptography (>=40.0.0)"]
+gcpkms = ["cryptography (>=40.0.0)", "google-cloud-kms"]
+hsm = ["asn1crypto", "cryptography (>=40.0.0)", "pykcs11"]
+pyspx = ["pyspx (>=0.5.0)"]
+sigstore = ["sigstore (>=3.0,<4.0)"]
+vault = ["cryptography (>=40.0.0)", "hvac"]
+
+[[package]]
 name = "setuptools"
 version = "80.10.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -2803,6 +3399,81 @@ files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
 ]
+
+[[package]]
+name = "sigstore"
+version = "4.2.0"
+description = "A tool for signing Python package distributions"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "sigstore-4.2.0-py3-none-any.whl", hash = "sha256:ed2e0f50aae85148a8aa4fc0f57c298927fce430ad1f988f38611ce90c85829f"},
+    {file = "sigstore-4.2.0.tar.gz", hash = "sha256:bdbb49a42fd5f0ea6765919adb42ccee7254c482330764d0842eec4e11ad78d7"},
+]
+
+[package.dependencies]
+cryptography = ">=42,<47"
+id = ">=1.1.0"
+importlib_resources = {version = ">=5.7,<6.0", markers = "python_version < \"3.11\""}
+platformdirs = ">=4.2,<5.0"
+pyasn1 = ">=0.6,<1.0"
+pydantic = ">=2,<3"
+pyjwt = ">=2.1"
+pyOpenSSL = ">=23.0.0"
+requests = "*"
+rfc3161-client = ">=1.0.3,<1.1.0"
+rfc8785 = ">=0.1.2,<0.2.0"
+rich = ">=13,<15"
+sigstore-models = "0.0.6"
+sigstore-rekor-types = "0.0.18"
+tuf = ">=6.0,<7.0"
+
+[package.extras]
+dev = ["build", "bump (>=1.3.2)", "sigstore[doc,lint,test]"]
+doc = ["mkdocs-material[imaging]", "mkdocstrings-python"]
+lint = ["bandit", "mypy (>=1.1,<2.0)", "ruff (<0.14.15)", "types-pyOpenSSL", "types-requests"]
+test = ["coverage[toml]", "pretend", "pytest", "pytest-cov"]
+
+[[package]]
+name = "sigstore-models"
+version = "0.0.6"
+description = "Pydantic based models for Sigstore's protobuf specifications"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "sigstore_models-0.0.6-py3-none-any.whl", hash = "sha256:5201a68f4d7d0f8bec1e2f4378eb646b084c52609a4e31db8c385095fff68b2e"},
+    {file = "sigstore_models-0.0.6.tar.gz", hash = "sha256:c766c09470c2a7e8a4a333c893f07e2001c56a3ff1757b1a246119f53169a849"},
+]
+
+[package.dependencies]
+pydantic = ">=2.12"
+typing-extensions = ">=4.14.1"
+
+[[package]]
+name = "sigstore-rekor-types"
+version = "0.0.18"
+description = "Python models for Rekor's API types"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "sigstore_rekor_types-0.0.18-py3-none-any.whl", hash = "sha256:b62bf38c5b1a62bc0d7fe0ee51a0709e49311d137c7880c329882a8f4b2d1d78"},
+    {file = "sigstore_rekor_types-0.0.18.tar.gz", hash = "sha256:19aef25433218ebf9975a1e8b523cc84aaf3cd395ad39a30523b083ea7917ec5"},
+]
+
+[package.dependencies]
+pydantic = {version = ">=2,<3", extras = ["email"]}
+
+[package.extras]
+codegen = ["datamodel-code-generator (>=0.25.2)", "sigstore-rekor-types[lint]"]
+dev = ["build", "sigstore-rekor-types[codegen,doc,lint]"]
+doc = ["pdoc (>=14.2,<16.0)"]
+lint = ["mypy (>=1.0)", "ruff (<0.7.5)"]
 
 [[package]]
 name = "six"
@@ -3165,6 +3836,23 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "tuf"
+version = "6.0.0"
+description = "A secure updater framework for Python"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"signing\""
+files = [
+    {file = "tuf-6.0.0-py3-none-any.whl", hash = "sha256:458f663a233d95cc76dde0e1a3d01796516a05ce2781fefafebe037f7729601a"},
+    {file = "tuf-6.0.0.tar.gz", hash = "sha256:9eed0f7888c5fff45dc62164ff243a05d47fb8a3208035eb268974287e0aee8d"},
+]
+
+[package.dependencies]
+securesystemslib = ">=1.0,<2.0"
+urllib3 = ">=1.21.1,<3"
+
+[[package]]
 name = "typer-slim"
 version = "0.20.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -3264,7 +3952,6 @@ files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
-markers = {main = "extra == \"boto3\""}
 
 [package.extras]
 brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
@@ -3657,8 +4344,9 @@ propcache = ">=0.2.0"
 boto3 = ["boto3"]
 hf = ["huggingface-hub"]
 olot = ["olot"]
+signing = ["platformdirs", "rh-model-signing"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, < 4.0"
-content-hash = "904550f7879582371f3690abfac0050b1211185d4d445ae9f2e3dcef7e1f2ba5"
+content-hash = "3f2eb0bc33d61151af5127fab9d0f7f164640b41b6083fec31da460d442d402f"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -27,11 +27,14 @@ nest-asyncio = "^1.6.0"
 huggingface-hub = { version = ">=0.20.1,<1.4.0", optional = true }
 olot = { version = "^0.1.6", optional = true }
 boto3 = { version = "^1.37.34", optional = true }
+rh-model-signing = { version = "0.0.3", optional = true }
+platformdirs = { version = "^4.0.0", optional = true }
 
 [tool.poetry.extras]
 hf = ["huggingface-hub"]
 boto3 = ["boto3"]
 olot = ["olot"]
+signing = ["rh-model-signing", "platformdirs"]
 
 [tool.poetry.group.docs]
 optional = true

--- a/clients/python/src/model_registry/signing/__init__.py
+++ b/clients/python/src/model_registry/signing/__init__.py
@@ -1,6 +1,25 @@
 """Signing utilities for model registry."""
 
-from model_registry.signing.exceptions import InitializationError, SigningError, VerificationError
+from model_registry.signing.exceptions import (
+    BaseSigningError,
+    InitializationError,
+    SigningError,
+    VerificationError,
+)
 from model_registry.signing.image_signer import CommandRunner, ImageSigner
+from model_registry.signing.model_signer import ModelSigner
+from model_registry.signing.token import decode_jwt_payload, extract_client_id
+from model_registry.signing.trust_manager import TrustManager
 
-__all__ = ["CommandRunner", "ImageSigner", "InitializationError", "SigningError", "VerificationError"]
+__all__ = [
+    "CommandRunner",
+    "ImageSigner",
+    "ModelSigner",
+    "TrustManager",
+    "BaseSigningError",
+    "InitializationError",
+    "SigningError",
+    "VerificationError",
+    "decode_jwt_payload",
+    "extract_client_id",
+]

--- a/clients/python/src/model_registry/signing/exceptions.py
+++ b/clients/python/src/model_registry/signing/exceptions.py
@@ -1,13 +1,17 @@
 """Exceptions for signing operations."""
 
 
-class SigningError(Exception):
-    """Raised when image signing fails."""
+class BaseSigningError(Exception):
+    """Base exception for signing operations."""
 
 
-class VerificationError(Exception):
-    """Raised when image verification fails."""
+class SigningError(BaseSigningError):
+    """Raised when signing fails."""
 
 
-class InitializationError(Exception):
-    """Raised when sigstore initialization fails."""
+class VerificationError(BaseSigningError):
+    """Raised when verification fails."""
+
+
+class InitializationError(BaseSigningError):
+    """Raised when initialization fails."""

--- a/clients/python/src/model_registry/signing/model_signer.py
+++ b/clients/python/src/model_registry/signing/model_signer.py
@@ -1,0 +1,368 @@
+"""ModelSigner for signing and verifying ML models with Sigstore."""
+
+import logging
+import os
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TypeAlias
+
+from model_signing import signing, verifying
+
+from model_registry.signing import sign_sigstore
+
+from .exceptions import InitializationError, SigningError, VerificationError
+from .token import decode_jwt_payload, extract_client_id
+from .trust_manager import TrustManager
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+PathLike: TypeAlias = str | os.PathLike[str]
+
+
+class ModelSigner:
+    """Tool for signing and verifying models.
+
+    This uses OpenSSF Model Signing (OMS) to produce a single model.sig file for a
+    directory containing a collection of files.
+    """
+
+    def __init__(
+        self,
+        tuf_url: str | None = None,
+        root_url: str | None = None,
+        root_checksum: str | None = None,
+        identity_token_path: PathLike | None = None,
+        fulcio_url: str | None = None,
+        rekor_url: str | None = None,
+        tsa_url: str | None = None,
+        certificate_identity: str | None = None,
+        oidc_issuer: str | None = None,
+        cache_dir: PathLike | None = None,
+        signature_filename: str = "model.sig",
+        ignore_paths: Iterable[PathLike] | None = None,
+    ):
+        """Initialize ModelSigner with optional default parameters.
+
+        Args:
+            tuf_url: Default TUF server URL
+            root_url: URL to TUF root.json for bootstrap (optional)
+            root_checksum: SHA256 checksum of root.json for validation (optional)
+            identity_token_path: Default path to identity token file
+            fulcio_url: Default Fulcio (CA) server URL
+            rekor_url: Default Rekor (transparency log) server URL
+            tsa_url: Default TSA (timestamp authority) server URL
+            certificate_identity: Default certificate identity for verification
+            oidc_issuer: Default OIDC issuer URL
+            cache_dir: Base cache directory (default: platformdirs user_data_dir)
+                Each TUF URL gets URL-encoded subdirectory for isolation
+            signature_filename: Default filename for signatures (default: model.sig)
+            ignore_paths: Default paths to ignore during signing (optional)
+        """
+        self.tuf_url = tuf_url
+        self.root_url = root_url
+        self.root_checksum = root_checksum
+        self.identity_token_path = identity_token_path
+        self.fulcio_url = fulcio_url
+        self.rekor_url = rekor_url
+        self.tsa_url = tsa_url
+        self.certificate_identity = certificate_identity
+        self.oidc_issuer = oidc_issuer
+        self.signature_filename = signature_filename
+        self.ignore_paths = ignore_paths
+
+        # Create trust initializer
+        self.trust_manager = TrustManager(cache_dir)
+
+    def get_trust_config_path(self) -> Path:
+        """Get the path to the cached trust configuration file.
+
+        Returns:
+            Path to trust_config.json
+
+        Raises:
+            SigningError: If tuf_url is not configured
+        """
+        if not self.tuf_url:
+            msg = "tuf_url is not configured. Provide it during instantiation."
+            raise SigningError(msg)
+        return self.trust_manager.get_trust_config_path(self.tuf_url)
+
+    def _ensure_trust_initialized(self):
+        """Ensure trust configuration is initialized.
+
+        Auto-initializes trust config if not already present using instance defaults.
+
+        Raises:
+            SigningError: If tuf_url is not configured
+        """
+        trust_config_path = self.get_trust_config_path()
+        if not trust_config_path.exists():
+            logger.info("Trust configuration not initialized. Auto-initializing...")
+            self.initialize(
+                fulcio_url=self.fulcio_url,
+                rekor_url=self.rekor_url,
+                tsa_url=self.tsa_url,
+                oidc_issuer=self.oidc_issuer,
+                force=True,
+            )
+
+    def initialize(  # noqa: C901
+        self,
+        tuf_url: str | None = None,
+        root_url: str | None = None,
+        root_checksum: str | None = None,
+        fulcio_url: str | None = None,
+        rekor_url: str | None = None,
+        tsa_url: str | None = None,
+        oidc_issuer: str | None = None,
+        force: bool = False,
+    ):
+        """Download and cache trust configuration from TUF.
+
+        Args:
+            tuf_url: TUF URL (uses instance default if not provided)
+            root_url: URL to TUF root.json for bootstrap (uses instance default if not provided)
+            root_checksum: SHA256 checksum of root.json (uses instance default if not provided)
+            fulcio_url: Fulcio URL (optional - extracted from TUF if available, otherwise required)
+            rekor_url: Rekor URL (optional - extracted from TUF if available, otherwise required)
+            tsa_url: TSA URL (optional - extracted from TUF if available, otherwise required)
+            oidc_issuer: OIDC issuer (uses instance default if not provided)
+            force: If True, overwrite existing cached config
+
+        Raises:
+            InitializationError: If initialization fails
+            FileExistsError: If trust config exists and force=False
+
+        Note:
+            Service URLs (fulcio_url, rekor_url, tsa_url) will be extracted from
+            TUF trusted_root metadata if available. You can override them with
+            explicit parameters for custom deployments or environments.
+        """
+        # Use method args or fall back to instance defaults
+        if tuf_url is None:
+            tuf_url = self.tuf_url
+        if root_url is None:
+            root_url = self.root_url
+        if root_checksum is None:
+            root_checksum = self.root_checksum
+        if fulcio_url is None:
+            fulcio_url = self.fulcio_url
+        if rekor_url is None:
+            rekor_url = self.rekor_url
+        if tsa_url is None:
+            tsa_url = self.tsa_url
+        if oidc_issuer is None:
+            oidc_issuer = self.oidc_issuer
+
+        if not tuf_url:
+            msg = "tuf_url is required"
+            raise InitializationError(msg)
+
+        # Delegate to TrustManager
+        self.trust_manager.initialize(
+            tuf_url=tuf_url,
+            root_url=root_url,
+            root_checksum=root_checksum,
+            fulcio_url=fulcio_url,
+            rekor_url=rekor_url,
+            tsa_url=tsa_url,
+            oidc_issuer=oidc_issuer,
+            force=force,
+        )
+
+    def sign(  # noqa: C901
+        self,
+        model_path: PathLike,
+        signature_path: PathLike | None = None,
+        identity_token_path: PathLike | None = None,
+        fulcio_url: str | None = None,
+        rekor_url: str | None = None,
+        tsa_url: str | None = None,
+        client_id: str | None = None,
+        ignore_paths: Iterable[PathLike] | None = None,
+    ) -> Path:
+        """Sign a model directory.
+
+        Args:
+            model_path: Path to model directory
+            signature_path: Path where signature file should be written (default: model_path/signature_filename)
+            identity_token_path: Path to identity token file (uses instance default if not provided)
+            fulcio_url: Fulcio URL (uses instance default if not provided)
+            rekor_url: Rekor URL (uses instance default if not provided)
+            tsa_url: TSA URL (uses instance default if not provided)
+            client_id: OIDC client ID (extracted from token if not provided)
+            ignore_paths: Paths to ignore during signing (uses instance default if not provided)
+
+        Returns:
+            Path to the signature file
+
+        Raises:
+            SigningError: If signing fails or required parameters missing
+            FileNotFoundError: If model_path or identity_token_path doesn't exist
+            ValueError: If token format is invalid
+        """
+        model_path = Path(model_path)
+        if not model_path.exists():
+            msg = f"Model path not found: {model_path}. Expected directory containing model files."
+            raise FileNotFoundError(msg)
+        if not model_path.is_dir():
+            msg = f"Model path must be a directory, got file: {model_path}"
+            raise FileNotFoundError(msg)
+
+        # Use method args or fall back to instance defaults
+        if identity_token_path is None:
+            identity_token_path = self.identity_token_path
+        if fulcio_url is None:
+            fulcio_url = self.fulcio_url
+        if rekor_url is None:
+            rekor_url = self.rekor_url
+        if tsa_url is None:
+            tsa_url = self.tsa_url
+        if ignore_paths is None:
+            ignore_paths = self.ignore_paths
+
+        # Validate identity_token_path is provided
+        if identity_token_path is None:
+            msg = "Identity token path is required for signing. Provide via parameter or during instantiation."
+            raise SigningError(msg)
+
+        # Validate identity token file exists
+        token_path = Path(identity_token_path)
+        if not token_path.exists():
+            msg = f"Identity token file not found: {token_path}. Expected JWT token file."
+            raise SigningError(msg)
+
+        try:
+            logger.info(f"Signing model: {model_path}")
+
+            # Ensure trust configuration is initialized
+            self._ensure_trust_initialized()
+
+            # Load trust config path
+            logger.info("Initializing signing context...")
+            trust_config_path = self.get_trust_config_path()
+
+            # Read and parse identity token
+            token_str = token_path.read_text().strip()
+
+            # Extract client_id from token if not provided
+            if client_id is None:
+                claims = decode_jwt_payload(token_str)
+                client_id = extract_client_id(claims)
+
+            # Create signer with trust configuration
+            signer = sign_sigstore.Signer(
+                identity_token=token_str,
+                oidc_issuer=self.oidc_issuer,
+                client_id=client_id,
+                trust_config=trust_config_path,
+            )
+
+            # Use provided signature_path or default to model_path/signature_filename
+            signature_path = (
+                model_path / self.signature_filename if signature_path is None else Path(signature_path)
+            ).absolute()
+
+            # Sign using model-signing API
+            config = signing.Config()
+
+            # paths added to _ignored_paths will be used only if they are a
+            # subpath of the model_path dir
+            config._hashing_config._ignored_paths |= {signature_path}
+            if ignore_paths is not None:
+                config._hashing_config._ignored_paths |= {Path(p) for p in ignore_paths}
+            config._signer = signer
+
+            config.sign(model_path, signature_path)
+
+            logger.info(f"Signed successfully: {signature_path}")
+            return signature_path
+
+        except (FileNotFoundError, SigningError, ValueError):
+            raise
+        except Exception as e:
+            msg = f"Signing failed: {e}"
+            raise SigningError(msg) from e
+
+    def verify(  # noqa: C901
+        self,
+        model_path: PathLike,
+        signature_path: PathLike | None = None,
+        certificate_identity: str | None = None,
+        oidc_issuer: str | None = None,
+    ) -> None:
+        """Verify a signed model.
+
+        Verifies the model signature and raises an exception if verification fails.
+
+        Args:
+            model_path: Path to model directory
+            signature_path: Path to signature file (default: model_path/signature_filename)
+            certificate_identity: Expected certificate identity (uses instance default if not provided)
+            oidc_issuer: OIDC issuer (uses instance default if not provided)
+
+        Raises:
+            VerificationError: If verification fails or required parameters missing
+            FileNotFoundError: If model_path or signature doesn't exist
+        """
+        model_path = Path(model_path)
+        if not model_path.exists():
+            msg = f"Model path not found: {model_path}. Expected directory containing signed model."
+            raise FileNotFoundError(msg)
+
+        # Use provided signature_path or default to model_path/signature_filename
+        signature_path = model_path / self.signature_filename if signature_path is None else Path(signature_path)
+
+        if not signature_path.exists():
+            msg = f"Signature not found at {signature_path}. Model may not be signed."
+            raise FileNotFoundError(msg)
+
+        # Use method args or fall back to instance defaults
+        if certificate_identity is None:
+            certificate_identity = self.certificate_identity
+        if oidc_issuer is None:
+            oidc_issuer = self.oidc_issuer
+
+        # Validate required parameters
+        if certificate_identity is None:
+            msg = "certificate_identity is required for verification. Provide via parameter or during instantiation."
+            raise VerificationError(msg)
+
+        if oidc_issuer is None:
+            msg = "oidc_issuer is required for verification. Provide via parameter or during instantiation."
+            raise VerificationError(msg)
+
+        try:
+            logger.info(f"Verifying model: {model_path}")
+
+            # Ensure trust configuration is initialized
+            self._ensure_trust_initialized()
+
+            # Load trust config path
+            trust_config_path = self.get_trust_config_path()
+
+            logger.info(f"Expected identity: {certificate_identity}")
+            logger.info(f"Expected issuer: {oidc_issuer}")
+
+            # Verify using model_signing.verifying API
+            verifying.Config().use_sigstore_verifier(
+                identity=certificate_identity,
+                oidc_issuer=oidc_issuer,
+                trust_config=trust_config_path,
+            ).verify(model_path, signature_path)
+
+            logger.info("Successfully verified model signature")
+
+        except FileNotFoundError:
+            raise
+        except ValueError as e:
+            # verifying.Config().verify() raises ValueError on verification failure
+            logger.error(f"Verification failed: {e}")
+            msg = f"Verification failed: {e}"
+            raise VerificationError(msg) from e
+        except VerificationError:
+            raise
+        except Exception as e:
+            msg = f"Verification failed: {e}"
+            raise VerificationError(msg) from e

--- a/clients/python/src/model_registry/signing/sign_sigstore.py
+++ b/clients/python/src/model_registry/signing/sign_sigstore.py
@@ -1,0 +1,107 @@
+"""Sigstore signer implementation for model signing."""
+# mypy: ignore-errors
+
+import pathlib
+
+from model_signing._signing.sign_sigstore import _DEFAULT_CLIENT_ID, _DEFAULT_CLIENT_SECRET
+from model_signing._signing.sign_sigstore import Signer as BaseSigner
+from sigstore import models as sigstore_models
+from sigstore import oidc as sigstore_oidc
+from sigstore import sign as sigstore_signer
+
+
+class Signer(BaseSigner):
+    """Signing using Sigstore."""
+
+    def __init__(
+        self,
+        *,
+        oidc_issuer: str | None = None,
+        use_ambient_credentials: bool = True,
+        use_staging: bool = False,
+        identity_token: str | None = None,
+        force_oob: bool = False,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        trust_config: pathlib.Path | None = None,
+    ):
+        """Initializes Sigstore signers.
+
+        Needs to set-up a signing context to use the public goods instance and
+        machinery for getting an identity token to use in signing.
+
+        Args:
+            oidc_issuer: An optional OpenID Connect issuer to use instead of the
+              default production one. Only relevant if `use_staging = False`.
+              Default is empty, relying on the Sigstore configuration.
+            use_ambient_credentials: Use ambient credentials (also known as
+              Workload Identity). Default is True. If ambient credentials cannot
+              be used (not available, or option disabled), a flow to get signer
+              identity via OIDC will start.
+            use_staging: Use staging configurations, instead of production. This
+              is supposed to be set to True only when testing. Default is False.
+            force_oob: If True, forces an out-of-band (OOB) OAuth flow. If set,
+              the OAuth authentication will not attempt to open the default web
+              browser. Instead, it will display a URL and code for manual
+              authentication. Default is False, which means the browser will be
+              opened automatically if possible.
+            identity_token: An explicit identity token to use when signing,
+              taking precedence over any ambient credential or OAuth workflow.
+            client_id: An optional client ID to use when performing OIDC-based
+              authentication. This is typically used to identify the
+              application making the request to the OIDC provider. If not
+              provided, the default client ID configured by Sigstore will be
+              used.
+            client_secret: An optional client secret to use along with the
+              client ID when authenticating with the OIDC provider. This is
+              required for confidential clients that need to prove their
+              identity to the OIDC provider. If not provided, it is assumed
+              that the client is public or the provider does not require a
+              secret.
+            trust_config: A path to a custom trust configuration. When
+              provided, the signature verification process will rely on the
+              supplied PKI and trust configurations, instead of the default
+              Sigstore setup. If not specified, the default Sigstore
+              configuration is used.
+        """
+        # Initializes the signing and issuer contexts based on provided
+        # configuration.
+        if use_staging:
+            trust_config = sigstore_models.ClientTrustConfig.staging()
+        elif trust_config:
+            trust_config = sigstore_models.ClientTrustConfig.from_json(trust_config.read_text())
+        else:
+            trust_config = sigstore_models.ClientTrustConfig.production()
+
+        if not oidc_issuer:
+            oidc_issuer = trust_config.signing_config.get_oidc_url()
+
+        self._oidc_issuer = oidc_issuer
+        self._signing_context = sigstore_signer.SigningContext.from_trust_config(trust_config)
+        self._use_ambient_credentials = use_ambient_credentials
+        self._identity_token = identity_token
+        self._force_oob = force_oob
+        self._client_id = client_id or _DEFAULT_CLIENT_ID
+        self._client_secret = client_secret or _DEFAULT_CLIENT_SECRET
+
+    def _get_identity_token(self) -> sigstore_oidc.IdentityToken:
+        """Obtains an identity token to use in signing.
+
+        The precedence matches that of sigstore-python:
+        1) Explicitly supplied identity token
+        2) Ambient credential detected in the environment, if enabled
+        3) Interactive OAuth flow
+        """
+        if self._identity_token:
+            return sigstore_oidc.IdentityToken(self._identity_token, self._client_id)
+        if self._use_ambient_credentials:
+            token = sigstore_oidc.detect_credential(self._client_id)
+            if token:
+                return sigstore_oidc.IdentityToken(token, self._client_id)
+
+        issuer = sigstore_oidc.Issuer(self._oidc_issuer)
+        return issuer.identity_token(
+            force_oob=self._force_oob,
+            client_id=self._client_id,
+            client_secret=self._client_secret,
+        )

--- a/clients/python/src/model_registry/signing/token.py
+++ b/clients/python/src/model_registry/signing/token.py
@@ -1,0 +1,59 @@
+"""Token utility functions for model signing."""
+
+import base64
+import json
+
+
+def decode_jwt_payload(token: str) -> dict:
+    """Decode JWT token payload to dictionary.
+
+    Args:
+        token: JWT token string in format header.payload.signature
+
+    Returns:
+        Dictionary of claims from the token payload
+
+    Raises:
+        ValueError: If token format is invalid or decoding fails
+
+    Note:
+        JWT format per OpenID spec: "A JWT is represented as the concatenation of
+        the Encoded JWT Header, the JWT Second Part, and the JWT Third Part, in that
+        order, with the parts being separated by period ('.') characters."
+        https://openid.net/specs/draft-jones-json-web-token-07.html
+    """
+    try:
+        # Validate JWT has exactly 3 parts (header.payload.signature)
+        parts = token.split(".")
+        if len(parts) != 3:
+            msg = f"Invalid JWT format: expected 3 parts separated by '.', got {len(parts)}"
+            raise ValueError(msg)
+
+        payload = parts[1]
+        # Add proper padding for base64 decoding
+        padding = len(payload) % 4
+        if padding:
+            payload += "=" * (4 - padding)
+        return json.loads(base64.b64decode(payload))
+    except (IndexError, json.JSONDecodeError, Exception) as e:
+        msg = f"Failed to decode JWT token payload: {e}"
+        raise ValueError(msg) from e
+
+
+def extract_client_id(claims: dict) -> str | None:
+    """Extract client_id from decoded JWT claims' aud (audience) field.
+
+    The aud claim can be either a string or an array of strings.
+    If it's an array, returns the first element.
+
+    Args:
+        claims: Decoded JWT claims dictionary
+
+    Returns:
+        Client ID from aud claim, or None if not present or empty
+    """
+    aud = claims.get("aud")
+
+    if isinstance(aud, list):
+        return aud[0] if aud else None
+    return aud

--- a/clients/python/src/model_registry/signing/trust_manager.py
+++ b/clients/python/src/model_registry/signing/trust_manager.py
@@ -1,0 +1,348 @@
+"""TrustManager for TUF trust configuration initialization and caching."""
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib import parse
+
+import platformdirs
+from sigstore._internal.tuf import TrustUpdater
+
+from .exceptions import InitializationError
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class TrustManager:
+    """Manages TUF trust configuration initialization and caching.
+
+    Handles downloading, validating, and caching root.json from TUF servers,
+    with support for explicit bootstrap (like cosign initialize).
+    """
+
+    def __init__(self, cache_dir: str | os.PathLike[str] | None = None):
+        """Initialize TrustManager.
+
+        Args:
+            cache_dir: Base cache directory (default: platformdirs user_data_dir)
+                Each TUF URL gets URL-encoded subdirectory for isolation
+        """
+        if cache_dir:
+            self.base_cache_dir = Path(cache_dir)
+        else:
+            self.base_cache_dir = Path(platformdirs.user_data_dir("model-registry")) / "signing"
+
+    def get_tuf_cache_dir(self, tuf_url: str) -> Path:
+        """Get cache directory for a specific TUF URL with URL-encoded isolation."""
+        repo_base = parse.quote(tuf_url, safe="")
+        return self.base_cache_dir / repo_base
+
+    def get_root_json_path(self, tuf_url: str) -> Path:
+        """Get cached root.json path for bootstrap."""
+        return self.get_tuf_cache_dir(tuf_url) / "root.json"
+
+    def get_trust_root_path(self, tuf_url: str) -> Path:
+        """Get trusted_root.json cache path."""
+        return self.get_tuf_cache_dir(tuf_url) / "root" / "targets" / "trusted_root.json"
+
+    def get_trust_config_path(self, tuf_url: str) -> Path:
+        """Get trust_config.json cache path."""
+        return self.get_tuf_cache_dir(tuf_url) / "trust_config.json"
+
+    def initialize(
+        self,
+        tuf_url: str,
+        root_url: str | None = None,
+        root_checksum: str | None = None,
+        fulcio_url: str | None = None,
+        rekor_url: str | None = None,
+        tsa_url: str | None = None,
+        oidc_issuer: str | None = None,
+        force: bool = False,
+    ) -> dict:
+        """Download and cache trust configuration from TUF.
+
+        Args:
+            tuf_url: TUF repository URL
+            root_url: Explicit root.json URL (like cosign --root)
+            root_checksum: SHA256 checksum to validate root.json
+            fulcio_url: Fulcio CA URL (optional - may be extracted from TUF)
+            rekor_url: Rekor transparency log URL (optional)
+            tsa_url: Timestamp authority URL (optional)
+            oidc_issuer: OIDC issuer URL
+            force: If True, overwrite existing cached config
+
+        Returns:
+            Trust configuration dict ready for signing/verification
+
+        Raises:
+            InitializationError: If initialization fails
+            FileExistsError: If config exists and force=False
+        """
+        config_path = self.get_trust_config_path(tuf_url)
+        if config_path.exists() and not force:
+            msg = f"Trust configuration already exists at {config_path}. Use force=True to overwrite."
+            raise FileExistsError(msg)
+
+        try:
+            # Download trusted root
+            trusted_root = self._download_trusted_root(tuf_url, root_url=root_url, root_checksum=root_checksum)
+
+            # Transform and create config
+            trusted_root = self._transform_and_fix_trust_root(trusted_root)
+            trust_config = self._create_trust_config(trusted_root, fulcio_url, rekor_url, tsa_url, oidc_issuer)
+
+            # Cache results
+            self._cache_trust_config(tuf_url, trust_config)
+            return trust_config
+
+        except Exception as e:
+            if isinstance(e, (InitializationError, FileExistsError)):
+                raise
+            msg = f"Trust initialization failed: {e}"
+            raise InitializationError(msg) from e
+
+    def _try_direct_trust_updater(self, tuf_url: str) -> dict | None:
+        """Try TrustUpdater without bootstrap (auto-detect mode only)."""
+        try:
+            updater = TrustUpdater(url=tuf_url, offline=False)
+            trusted_root_path = updater.get_trusted_root_path()
+            logger.info(f"Downloaded (TrustUpdater): {Path(trusted_root_path).name}")
+            with open(trusted_root_path) as f:
+                return json.load(f)
+        except Exception:
+            logger.info("Direct TrustUpdater failed, trying with bootstrap...")
+            return None
+
+    def _load_cached_root(self, cache_path: Path, checksum: str | None) -> bytes | None:
+        """Load cached root.json and validate checksum if provided."""
+        if not cache_path.exists():
+            return None
+
+        try:
+            cached_data = cache_path.read_bytes()
+            if checksum:
+                cached_checksum = hashlib.sha256(cached_data).hexdigest()
+                if cached_checksum.lower() == checksum.lower():
+                    logger.info("Using cached root.json (checksum verified)")
+                    return cached_data
+                logger.info("Cached root.json checksum mismatch, re-downloading...")
+                return None
+            logger.info("Using cached root.json")
+            return cached_data
+        except Exception as e:
+            logger.info(f"Could not use cached root.json: {e}, re-downloading...")
+            return None
+
+    def _download_root_json(self, urls: list[str]) -> bytes:
+        """Download root.json from list of URLs."""
+        for url in urls:
+            try:
+                logger.info(f"Downloading from: {url}")
+                with urllib.request.urlopen(url) as response:  # noqa: S310
+                    return response.read()
+            except urllib.error.HTTPError:
+                continue
+        msg = f"Could not download root.json from: {urls}"
+        raise InitializationError(msg)
+
+    def _validate_checksum(self, data: bytes, expected_checksum: str | None):
+        """Validate SHA256 checksum if provided."""
+        if expected_checksum:
+            computed_checksum = hashlib.sha256(data).hexdigest()
+            if computed_checksum.lower() != expected_checksum.lower():
+                msg = f"Root.json checksum mismatch!\n  Expected: {expected_checksum}\n  Got:      {computed_checksum}"
+                raise InitializationError(msg)
+            logger.info(f"Checksum verified: {computed_checksum}")
+        else:
+            logger.info("No checksum provided (skipping validation)")
+
+    def _bootstrap_trust_updater(self, tuf_url: str, root_data: bytes) -> dict:
+        """Bootstrap TrustUpdater with root.json and return trusted_root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bootstrap_root = Path(tmpdir) / "root.json"
+            bootstrap_root.write_bytes(root_data)
+
+            updater = TrustUpdater(url=tuf_url, offline=False, bootstrap_root=bootstrap_root)
+            trusted_root_path = updater.get_trusted_root_path()
+            logger.info(f"Initialized TUF client: {Path(trusted_root_path).name}")
+
+            with open(trusted_root_path) as f:
+                return json.load(f)
+
+    def _download_trusted_root(
+        self,
+        tuf_url: str,
+        root_url: str | None = None,
+        root_checksum: str | None = None,
+    ) -> dict:
+        """Download trusted_root.json from TUF server.
+
+        Supports explicit root.json URL (cosign-style) or auto-detection.
+
+        Args:
+            tuf_url: TUF repository URL
+            root_url: Explicit URL to root.json (optional, auto-detect if not provided)
+            root_checksum: SHA256 checksum to validate root.json (optional)
+
+        Returns:
+            Parsed trusted_root.json as dict
+
+        Raises:
+            InitializationError: If download or initialization fails
+        """
+        try:
+            # Try direct TrustUpdater first (auto-detect mode only)
+            if not root_url:
+                logger.info(f"Downloading trusted root from TUF: {tuf_url}")
+                result = self._try_direct_trust_updater(tuf_url)
+                if result:
+                    return result
+
+            # Prepare URLs to try
+            if root_url:
+                logger.info(f"Downloading root.json from explicit URL: {root_url}")
+                root_urls = [root_url]
+            else:
+                tuf_url_clean = tuf_url.rstrip("/")
+                root_urls = [
+                    f"{tuf_url_clean}/root.json",
+                    f"{tuf_url_clean}/1.root.json",
+                ]
+
+            # Try cache first
+            root_cache_path = self.get_root_json_path(tuf_url)
+            root_data = self._load_cached_root(root_cache_path, root_checksum)
+
+            # Download if not cached
+            if not root_data:
+                root_data = self._download_root_json(root_urls)
+                self._validate_checksum(root_data, root_checksum)
+                logger.info(f"Downloaded root.json ({len(root_data)} bytes)")
+
+                # Cache for future use
+                root_cache_path.parent.mkdir(parents=True, exist_ok=True)
+                root_cache_path.write_bytes(root_data)
+                logger.info(f"Cached to: {root_cache_path}")
+
+            # Bootstrap TrustUpdater with root.json
+            return self._bootstrap_trust_updater(tuf_url, root_data)
+
+        except InitializationError:
+            raise
+        except Exception as e:
+            msg = f"Failed to download trusted root: {e}"
+            raise InitializationError(msg) from e
+
+    def _transform_and_fix_trust_root(self, trusted_root: dict) -> dict:
+        """Apply transformations to trusted root."""
+        logger.info("Transforming checkpointKeyId to logId...")
+        return self._transform_checkpoint_to_logid(trusted_root)
+
+    @staticmethod
+    def _transform_checkpoint_to_logid(obj):
+        """Transform checkpointKeyId to logId recursively (TUF v0.1 → v0.2)."""
+        if isinstance(obj, dict):
+            if "checkpointKeyId" in obj:
+                obj["logId"] = obj.pop("checkpointKeyId")
+            for key, value in obj.items():
+                obj[key] = TrustManager._transform_checkpoint_to_logid(value)
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                obj[i] = TrustManager._transform_checkpoint_to_logid(item)
+        return obj
+
+    def _create_trust_config(
+        self,
+        trusted_root: dict,
+        fulcio_url: str | None = None,
+        rekor_url: str | None = None,
+        tsa_url: str | None = None,
+        oidc_issuer: str | None = None,
+    ) -> dict:
+        """Create complete trust configuration from trusted root."""
+        tsa_url_full = None
+        if tsa_url:
+            tsa_url_full = tsa_url.rstrip("/") + "/api/v1/timestamp"
+
+        return {
+            "mediaType": "application/vnd.dev.sigstore.clienttrustconfig.v0.1+json",
+            "trustedRoot": trusted_root,
+            "signingConfig": {
+                "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+                "caUrls": (
+                    [
+                        {
+                            "url": fulcio_url,
+                            "majorApiVersion": 1,
+                            "validFor": {"start": "2020-01-01T00:00:00Z"},
+                            "operator": "",
+                        }
+                    ]
+                    if fulcio_url
+                    else []
+                ),
+                "oidcUrls": (
+                    [
+                        {
+                            "url": oidc_issuer,
+                            "majorApiVersion": 1,
+                            "validFor": {"start": "2020-01-01T00:00:00Z"},
+                            "operator": "",
+                        }
+                    ]
+                    if oidc_issuer
+                    else []
+                ),
+                "rekorTlogUrls": (
+                    [
+                        {
+                            "url": rekor_url,
+                            "majorApiVersion": 1,
+                            "validFor": {"start": "2020-01-01T00:00:00Z"},
+                            "operator": "",
+                        }
+                    ]
+                    if rekor_url
+                    else []
+                ),
+                "tsaUrls": (
+                    [
+                        {
+                            "url": tsa_url_full,
+                            "majorApiVersion": 1,
+                            "validFor": {"start": "2020-01-01T00:00:00Z"},
+                            "operator": "",
+                        }
+                    ]
+                    if tsa_url_full
+                    else []
+                ),
+                "rekorTlogConfig": {"selector": "ANY"},
+                "tsaConfig": {"selector": "ANY"},
+            },
+        }
+
+    def _cache_trust_config(self, tuf_url: str, trust_config: dict):
+        """Cache trust configuration to disk."""
+        trust_root_path = self.get_trust_root_path(tuf_url)
+        trust_config_path = self.get_trust_config_path(tuf_url)
+
+        # Create cache directories
+        trust_root_path.parent.mkdir(parents=True, exist_ok=True)
+        trust_config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Cache trusted root
+        trusted_root = trust_config.get("trustedRoot", {})
+        trust_root_path.write_text(json.dumps(trusted_root, indent=2))
+        logger.info(f"Cached trusted root to: {trust_root_path}")
+
+        # Cache complete trust config
+        trust_config_path.write_text(json.dumps(trust_config, indent=2))
+        logger.info(f"Cached trust config to: {trust_config_path}")

--- a/clients/python/tests/test_token.py
+++ b/clients/python/tests/test_token.py
@@ -1,0 +1,106 @@
+"""Tests for token utility functions."""
+
+import base64
+import json
+
+import pytest
+
+from model_registry.signing.token import decode_jwt_payload, extract_client_id
+
+
+def create_jwt_token(payload_data: dict) -> str:
+    """Helper to create a JWT token for testing."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(payload_data).encode()).decode().rstrip("=")
+    signature = "fake-signature"
+    return f"{header}.{payload}.{signature}"
+
+
+class TestDecodeJwtPayload:
+    """Test decode_jwt_payload function."""
+
+    @pytest.mark.parametrize("payload_data", [
+        {"sub": "test-user", "aud": "test-audience", "iss": "test-issuer"},
+        {"sub": "x"},  # Short payload to test padding
+        {
+            "sub": "system:serviceaccount:test:sa",
+            "aud": ["aud1", "aud2"],
+            "kubernetes.io": {
+                "namespace": "test",
+                "serviceaccount": {"name": "sa", "uid": "123"}
+            }
+        },
+    ])
+    def test_decode_valid_jwt(self, payload_data):
+        """Test decoding valid JWT tokens with various payloads."""
+        token = create_jwt_token(payload_data)
+        result = decode_jwt_payload(token)
+        assert result == payload_data
+
+    @pytest.mark.parametrize(("invalid_token", "error_pattern"), [
+        ("not-a-valid-token", "Failed to decode JWT token payload"),
+        ("header.payload", "Failed to decode JWT token payload"),  # Missing signature
+        ("header..signature", "Failed to decode JWT token payload"),  # Empty payload
+    ])
+    def test_decode_invalid_format_raises_error(self, invalid_token, error_pattern):
+        """Test that invalid token formats raise ValueError."""
+        with pytest.raises(ValueError, match=error_pattern):
+            decode_jwt_payload(invalid_token)
+
+    def test_decode_invalid_base64_raises_error(self):
+        """Test that invalid base64 in payload raises ValueError."""
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+        payload = "!!!invalid-base64!!!"
+        signature = "fake-signature"
+        token = f"{header}.{payload}.{signature}"
+
+        with pytest.raises(ValueError, match="Failed to decode JWT token payload"):
+            decode_jwt_payload(token)
+
+    def test_decode_invalid_json_raises_error(self):
+        """Test that invalid JSON in payload raises ValueError."""
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+        payload = base64.urlsafe_b64encode(b"not-valid-json").decode().rstrip("=")
+        signature = "fake-signature"
+        token = f"{header}.{payload}.{signature}"
+
+        with pytest.raises(ValueError, match="Failed to decode JWT token payload"):
+            decode_jwt_payload(token)
+
+
+class TestExtractClientId:
+    """Test extract_client_id function."""
+
+    @pytest.mark.parametrize(("claims", "expected"), [
+        # String aud
+        ({"aud": "https://example.com/issuer"}, "https://example.com/issuer"),
+        # Array with single element
+        ({"aud": ["https://example.com/issuer"]}, "https://example.com/issuer"),
+        # Array with multiple elements (returns first)
+        ({"aud": ["first", "second", "third"]}, "first"),
+        # Empty array
+        ({"aud": []}, None),
+        # Missing aud
+        ({"sub": "test-user", "iss": "test-issuer"}, None),
+        # None aud
+        ({"aud": None}, None),
+        # Kubernetes token
+        ({
+            "aud": ["https://kubernetes.default.svc"],
+            "iss": "https://kubernetes.default.svc",
+            "kubernetes.io": {"namespace": "default"}
+        }, "https://kubernetes.default.svc"),
+    ])
+    def test_extract_client_id(self, claims, expected):
+        """Test extracting client_id from various claim structures."""
+        result = extract_client_id(claims)
+        assert result == expected
+
+    def test_extract_preserves_claims(self):
+        """Test that extract_client_id doesn't modify the claims dict."""
+        original_claims = {"aud": "test", "sub": "subject"}
+        claims = original_claims.copy()
+
+        extract_client_id(claims)
+
+        assert claims == original_claims


### PR DESCRIPTION
This implements OMS signing to produce a signal .sig file for any repo or collection of files.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
