### PR TITLE
test: add artifact filtering tests for type and query validation

### DIFF
--- a/catalog/clients/python/src/model_catalog/_client.py
+++ b/catalog/clients/python/src/model_catalog/_client.py
@@ -87,11 +87,11 @@ def _handle_api_errors(func: Callable[..., T]) -> Callable[..., T]:
     def wrapper(*args: Any, **kwargs: Any) -> T:
         try:
             return func(*args, **kwargs)
-        except (ImportError, ValueError, NotImplementedError, TypeError, AttributeError):
+        except (ImportError, NotImplementedError, TypeError, AttributeError):
             # Programming errors - re-raise unchanged
             raise
         except Exception as e:
-            # Runtime errors (network, API) - convert to CatalogError hierarchy
+            # Runtime errors (network, API, validation) - convert to CatalogError hierarchy
             _convert_exception(e)  # Always raises
             raise  # Unreachable, but satisfies mypy
 
@@ -145,17 +145,30 @@ def _convert_exception(e: Exception) -> None:
         msg = f"Unexpected error: {e}"
         raise CatalogError(msg, cause=e) from e
 
+    # Handle Pydantic validation errors (from OpenAPI client parameter validation)
+    try:
+        from pydantic import ValidationError as PydanticValidationError
+
+        if isinstance(e, PydanticValidationError):
+            msg = f"Validation error: {e}"
+            raise CatalogValidationError(msg, cause=e) from e
+    except ImportError:
+        pass
+
     # Handle API exceptions
     if isinstance(e, NotFoundException):
-        msg = f"Resource not found: {e.reason or e.body}"
+        # Include both reason and body for complete error details
+        msg = f"Resource not found: {e.body if e.body else e.reason}"
         raise CatalogNotFoundError(msg, status_code=e.status, cause=e) from e
 
     if isinstance(e, (BadRequestException, UnprocessableEntityException)):
-        msg = f"Validation error: {e.reason or e.body}"
+        # Include both reason and body for complete error details
+        msg = f"Validation error: {e.body if e.body else e.reason}"
         raise CatalogValidationError(msg, status_code=e.status, cause=e) from e
 
     if isinstance(e, ApiException):
-        msg = f"API error ({e.status}): {e.reason or e.body}"
+        # Include both reason and body for complete error details
+        msg = f"API error ({e.status}): {e.body if e.body else e.reason}"
         raise CatalogAPIError(msg, status_code=e.status, cause=e) from e
 
     # Handle network/connection errors using proper isinstance checks
@@ -353,6 +366,7 @@ class CatalogAPIClient:
         self,
         source_id: str,
         model_name: str,
+        artifact_type: str | list[str] | None = None,
         filter_query: str | None = None,
         page_size: int | None = None,
         next_page_token: str | None = None,
@@ -362,6 +376,9 @@ class CatalogAPIClient:
         Args:
             source_id: The source ID containing the model.
             model_name: The model name.
+            artifact_type: Optional artifact type(s) to filter by.
+                Accepts "model-artifact", "metrics-artifact", or a list of these values.
+                Can be a single string or list of strings.
             filter_query: Optional filter query.
             page_size: Optional page size.
             next_page_token: Optional pagination token.
@@ -369,10 +386,19 @@ class CatalogAPIClient:
         Returns:
             Dict with artifacts response.
         """
+        # Convert artifact_type to list format expected by OpenAPI client
+        artifact_type_list = None
+        if artifact_type is not None:
+            if isinstance(artifact_type, str):
+                artifact_type_list = [artifact_type]
+            else:
+                artifact_type_list = artifact_type
+
         page_size_str = str(page_size) if page_size is not None else None
         response = self.catalog_api.get_all_model_artifacts(
             source_id=_encode_path_param(source_id),
             model_name=_encode_path_param(model_name),
+            artifact_type=artifact_type_list,
             filter_query=filter_query,
             page_size=page_size_str,
             next_page_token=next_page_token,


### PR DESCRIPTION
Add test coverage for artifact filtering functionality:
- Add basic tests for artifact type, scenarios with real data left in downstream
- Add negative tests and removed from downstream
- Downstream change https://github.com/opendatahub-io/opendatahub-tests/pull/1079

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
