### PR TITLE
Improve help text for YAML and HF catalog sources

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ModelVisibilitySection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ModelVisibilitySection.tsx
@@ -16,10 +16,10 @@ import {
   FORM_LABELS,
   PLACEHOLDERS,
   DESCRIPTIONS,
-  FIELD_HELPER_TEXT,
   getFilterInfoWithOrg,
   getAllowedModelsHelp,
   getExcludedModelsHelp,
+  getModelsFieldHelperText,
 } from '~/app/pages/modelCatalogSettings/constants';
 import { CatalogSourceType } from '~/app/modelCatalogTypes';
 
@@ -44,6 +44,7 @@ const ModelVisibilitySection: React.FC<ModelVisibilitySectionProps> = ({
 
   const allowedModelsHelp = getAllowedModelsHelp(organization);
   const excludedModelsHelp = getExcludedModelsHelp(organization);
+  const modelsFieldHelperText = getModelsFieldHelperText(isHuggingFaceMode);
 
   const allowedModelsPlaceholder = isHuggingFaceMode
     ? PLACEHOLDERS.ALLOWED_MODELS_HF
@@ -101,7 +102,7 @@ const ModelVisibilitySection: React.FC<ModelVisibilitySectionProps> = ({
           </FormHelperText>
           <FormHelperText>
             <HelperText>
-              <HelperTextItem>{FIELD_HELPER_TEXT.INCLUDED_MODELS}</HelperTextItem>
+              <HelperTextItem>{modelsFieldHelperText}</HelperTextItem>
             </HelperText>
           </FormHelperText>
         </FormGroup>
@@ -115,7 +116,7 @@ const ModelVisibilitySection: React.FC<ModelVisibilitySectionProps> = ({
           </FormHelperText>
           <FormHelperText>
             <HelperText>
-              <HelperTextItem>{FIELD_HELPER_TEXT.EXCLUDED_MODELS}</HelperTextItem>
+              <HelperTextItem>{modelsFieldHelperText}</HelperTextItem>
             </HelperText>
           </FormHelperText>
         </FormGroup>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.ts
@@ -42,9 +42,9 @@ export const HELP_TEXT = {
 export const PLACEHOLDERS = {
   ORGANIZATION: 'Example: Google',
   ALLOWED_MODELS_HF: 'Enter model names, one per line (e.g., gemma-7b*)',
-  ALLOWED_MODELS_GENERIC: 'Example: Llama*, Llama-3.1-8B-Instruct',
+  ALLOWED_MODELS_GENERIC: 'Example: Google/gemma-7b*, Meta/Llama-3.1-8B-Instruct',
   EXCLUDED_MODELS_HF: 'Enter model names, one per line (e.g., gemma-7b-test*)',
-  EXCLUDED_MODELS_GENERIC: 'Example: Llama*, Llama-3.1-8B-Instruct',
+  EXCLUDED_MODELS_GENERIC: 'Example: Google/gemma-7b-test*, Meta/Llama*',
 } as const;
 
 export const DESCRIPTIONS = {
@@ -72,9 +72,7 @@ export const getExcludedModelsHelp = (organization?: string): string =>
     ? `Enter the names of ${organization} models to exclude from this source. These models will not appear in the model catalog.`
     : 'Enter the names of models to exclude from this source. These models will not appear in the model catalog.';
 
-export const FIELD_HELPER_TEXT = {
-  INCLUDED_MODELS:
-    'Separate model names using commas. To include all models with a specific prefix, enter the prefix followed by an asterisk. Example, Llama*',
-  EXCLUDED_MODELS:
-    'Separate model names using commas. To exclude all models with a specific prefix, enter the prefix followed by an asterisk. Example, Llama*',
-} as const;
+export const getModelsFieldHelperText = (isHuggingFaceSource: boolean): string =>
+  isHuggingFaceSource
+    ? 'Separate model names using commas. Use an asterisk for prefix matching. Example: Llama*'
+    : 'Separate model names using commas, including the organization prefix. Use an asterisk for prefix matching. Example: Google/gemma*';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Improve the help text and placeholders on the fields to be clear that the org prefix is required for YAML sources and not for HF sources.

Cosmetic changes - no tests required
<img width="514" height="545" alt="Screenshot 2026-02-03 at 9 11 43 PM" src="https://github.com/user-attachments/assets/d92daa94-a003-4c0a-a743-ac5a6fff01b1" />
<img width="521" height="467" alt="Screenshot 2026-02-03 at 9 11 51 PM" src="https://github.com/user-attachments/assets/02c7f83f-367a-4807-8f19-48946cfb53c6" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Check included and excluded help text for HF and YAML catalog sources in Model catalog sources admin page

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
