### PR TITLE
[reopening #2148] Add ordering tests for catalog e2e from downstream

### DIFF
--- a/catalog/clients/python/src/catalog_openapi/models/catalog_model.py
+++ b/catalog/clients/python/src/catalog_openapi/models/catalog_model.py
@@ -75,13 +75,11 @@ class CatalogModel(BaseModel):
         * `None` is only added to the output dict for nullable fields that
           were set at model initialization. Other fields with value `None`
           are ignored.
-        * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
+        * OpenAPI `readOnly` fields were excluded:
+        "create_time_since_epoch" and "last_update_time_since_epoch" are now
+        being returned to properly test them in e2e test.
         """
-        excluded_fields: set[str] = set([
-            "create_time_since_epoch",
-            "last_update_time_since_epoch",
-        ])
+        excluded_fields: set[str] = set([])
 
         _dict = self.model_dump(
             by_alias=True,

--- a/catalog/clients/python/tests/sorting_utils.py
+++ b/catalog/clients/python/tests/sorting_utils.py
@@ -1,0 +1,66 @@
+"""Utility functions for sorting tests."""
+
+import pytest
+from typing import Any
+
+
+def get_field_value(item: dict[str, Any], field: str) -> Any:
+    """Extract field value from an item for sorting comparison.
+
+    Args:
+        item: Model/item dictionary from API response
+        field: Field name (ID, CREATE_TIME, LAST_UPDATE_TIME)
+
+    Returns:
+        The field value, converted appropriately for comparison
+
+    Raises:
+        ValueError: If field is invalid or missing from item
+    """
+    field_mapping = {
+        "ID": "id",
+        "CREATE_TIME": "createTimeSinceEpoch",
+        "LAST_UPDATE_TIME": "lastUpdateTimeSinceEpoch",
+    }
+
+    if field not in field_mapping:
+        raise ValueError(f"Invalid field: {field}")
+
+    api_field = field_mapping[field]
+    value = item.get(api_field)
+
+    if value is None:
+        raise ValueError(f"Field {field} ({api_field}) is missing from item: {item}")
+
+    # Convert ID for proper numeric comparison
+    if field == "ID":
+        try:
+            return int(value)
+        except ValueError:
+            return str(value)
+
+    return value
+
+
+def validate_items_sorted_correctly(items: list[dict], field: str, order: str) -> bool:
+    """Verify items are sorted correctly by the specified field.
+
+    Args:
+        items: List of items to validate
+        field: Field name to check sorting on (ID, CREATE_TIME, LAST_UPDATE_TIME)
+        order: Sort order (ASC or DESC)
+
+    Returns:
+        True if items are sorted correctly, False otherwise
+    """
+    if len(items) < 2:
+        pytest.fail("List has fewer than 2 items, double check the data you are passing to this function")
+
+    values = [get_field_value(item, field) for item in items]
+
+    if order == "ASC":
+        return all(values[i] <= values[i + 1] for i in range(len(values) - 1))
+    elif order == "DESC":
+        return all(values[i] >= values[i + 1] for i in range(len(values) - 1))
+    else:
+        raise ValueError(f"Invalid sort order: {order}")

--- a/manifests/kustomize/options/catalog/overlays/e2e/test-catalog.yaml
+++ b/manifests/kustomize/options/catalog/overlays/e2e/test-catalog.yaml
@@ -5,6 +5,10 @@ models:
   # Models with artifacts and accuracy for ordering/filtering tests
   - name: test-model-1
     description: Primary test model with high accuracy
+    createTimeSinceEpoch: "1700000000000"
+    lastUpdateTimeSinceEpoch: "1700100000000"
+    tasks:
+      - text-generation
     customProperties:
       size:
         metadataType: MetadataStringValue
@@ -31,6 +35,10 @@ models:
 
   - name: test-model-2
     description: Secondary test model with medium accuracy
+    createTimeSinceEpoch: "1700200000000"
+    lastUpdateTimeSinceEpoch: "1700300000000"
+    tasks:
+      - text-generation
     customProperties:
       size:
         metadataType: MetadataStringValue
@@ -57,6 +65,10 @@ models:
 
   - name: test-model-3
     description: Third test model with low accuracy
+    createTimeSinceEpoch: "1700400000000"
+    lastUpdateTimeSinceEpoch: "1700250000000"
+    tasks:
+      - text-generation
     artifacts:
       - name: tensorrt-artifact
         uri: s3://bucket/test-model-3.tar.gz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is reopening https://github.com/kubeflow/model-registry/pull/2148

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
