### PR TITLE
Fix toggling performance filters on and off again does not restore sectioned "all models" view

### DIFF
--- a/clients/ui/frontend/src/app/hooks/modelCatalog/useHasVisibleFiltersApplied.ts
+++ b/clients/ui/frontend/src/app/hooks/modelCatalog/useHasVisibleFiltersApplied.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
+import { hasFiltersApplied } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import { BASIC_FILTER_KEYS } from '~/concepts/modelCatalog/const';
+
+export const useHasVisibleFiltersApplied = (): boolean => {
+  const { filterData, performanceViewEnabled } = React.useContext(ModelCatalogContext);
+
+  return React.useMemo(
+    () =>
+      performanceViewEnabled
+        ? hasFiltersApplied(filterData)
+        : hasFiltersApplied(filterData, BASIC_FILTER_KEYS),
+    [filterData, performanceViewEnabled],
+  );
+};

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
@@ -4,20 +4,16 @@ import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-sha
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
 import ModelCatalogFilters from '~/app/pages/modelCatalog/components/ModelCatalogFilters';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
-import { hasFiltersApplied } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { CategoryName } from '~/app/modelCatalogTypes';
-import { BASIC_FILTER_KEYS } from '~/concepts/modelCatalog/const';
+import { useHasVisibleFiltersApplied } from '~/app/hooks/modelCatalog/useHasVisibleFiltersApplied';
 import ModelCatalogSourceLabelSelectorNavigator from './ModelCatalogSourceLabelSelectorNavigator';
 import ModelCatalogAllModelsView from './ModelCatalogAllModelsView';
 import ModelCatalogGalleryView from './ModelCatalogGalleryView';
 
 const ModelCatalog: React.FC = () => {
   const [searchTerm, setSearchTerm] = React.useState('');
-  const { selectedSourceLabel, filterData, clearAllFilters, performanceViewEnabled } =
-    React.useContext(ModelCatalogContext);
-  const filtersApplied = performanceViewEnabled
-    ? hasFiltersApplied(filterData)
-    : hasFiltersApplied(filterData, BASIC_FILTER_KEYS);
+  const { selectedSourceLabel, clearAllFilters } = React.useContext(ModelCatalogContext);
+  const filtersApplied = useHasVisibleFiltersApplied();
   const isAllModelsView =
     selectedSourceLabel === CategoryName.allModels && !searchTerm && !filtersApplied;
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -13,6 +13,7 @@ import { ChartBarIcon, SearchIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { useCatalogModelsBySources } from '~/app/hooks/modelCatalog/useCatalogModelsBySource';
+import { useHasVisibleFiltersApplied } from '~/app/hooks/modelCatalog/useHasVisibleFiltersApplied';
 import { CatalogModel, CategoryName, SourceLabel } from '~/app/modelCatalogTypes';
 import ModelCatalogCard from '~/app/pages/modelCatalog/components/ModelCatalogCard';
 import {
@@ -52,9 +53,7 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
     performanceViewEnabled,
     sortBy,
   } = React.useContext(ModelCatalogContext);
-  const filtersApplied = performanceViewEnabled
-    ? hasFiltersApplied(filterData)
-    : hasFiltersApplied(filterData, BASIC_FILTER_KEYS);
+  const filtersApplied = useHasVisibleFiltersApplied();
 
   // When performance view is disabled, exclude performance filters from API queries
   // Memoize to prevent infinite re-fetching


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When "Model performance view" toggle is activated and deactivated, the default filters still active, and make the gallery doesn't show the view separated by categories.

![Before the fix](https://github.com/user-attachments/assets/b4e429a6-16f0-4044-b7f1-4a63f3ba114a)
Before the fix

To fix that, some changes in the filter logic was necessary.
![After the fix](https://github.com/user-attachments/assets/9d37ce93-45f4-44fb-b7b1-4470a1cee215)
After the fix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested:
###Steps to Reproduce
Navigate to model catalog, see the separate sections in "all models"
Turn on the performance view, see the cards combine into one section
Turn off the performance view, the cards stay combined in one section

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
