### PR TITLE
Add a way to pass user token to CatalogAPIClient

### DIFF
--- a/catalog/clients/python/src/model_catalog/_client.py
+++ b/catalog/clients/python/src/model_catalog/_client.py
@@ -181,13 +181,14 @@ class CatalogAPIClient:
     # Maximum allowed timeout (5 minutes)
     MAX_TIMEOUT = 300
 
-    def __init__(self, base_url: str, timeout: int = 10, verify_ssl: bool = True):
+    def __init__(self, base_url: str, timeout: int = 10, verify_ssl: bool = True, access_token: str = None):
         """Initialize API client.
 
         Args:
             base_url: Base URL of the catalog service (e.g., http://localhost:8081)
             timeout: Request timeout in seconds (must be positive, max 300)
             verify_ssl: Whether to verify SSL certificates (default True)
+            access_token: Access token for authentication (default None)
 
         Raises:
             ValueError: If base_url is empty or invalid, or timeout is not positive.
@@ -210,9 +211,10 @@ class CatalogAPIClient:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.verify_ssl = verify_ssl
+        self.access_token = access_token
 
         # Configure the generated client
-        config = Configuration(host=self.base_url)
+        config = Configuration(host=self.base_url, access_token=self.access_token)
         config.verify_ssl = verify_ssl
         self.api_client = ApiClient(configuration=config)
         self._configure_timeout(config, timeout)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
