### PR TITLE
Update the newly added catalog tests to ensure they run/skip against live clusters

### DIFF
--- a/catalog/clients/python/tests/test_artifacts.py
+++ b/catalog/clients/python/tests/test_artifacts.py
@@ -119,9 +119,11 @@ class TestArtifacts:
                 assert acc is not None, "Accuracy value is None"
                 assert acc > 0.9, f"Expected accuracy > 0.9, got {acc}"
 
-    def test_filter_artifacts_with_and_logic(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], 
-                                             suppress_ssl_warnings: None) -> None:
+    def test_filter_artifacts_with_and_logic(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str],
+                                             kind_cluster: bool) -> None:
         """Test filtering artifacts with AND logic combining multiple conditions."""
+        if not kind_cluster:
+            pytest.skip("This test would be skipped on non-kind cluster")
         source_id, model_name = model_with_artifacts
 
         # Test combining filters with AND
@@ -150,8 +152,10 @@ class TestArtifacts:
             assert acc is not None and acc > 0.5, f"Expected accuracy > 0.5, got {acc}"
 
     def test_filter_artifacts_with_or_logic(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str],
-                                           suppress_ssl_warnings: None) -> None:
+                                           kind_cluster: bool) -> None:
         """Test filtering artifacts with OR logic combining multiple conditions."""
+        if not kind_cluster:
+            pytest.skip("This test would be skipped on non-kind cluster")
         source_id, model_name = model_with_artifacts
 
         # Test combining filters with OR using existing frameworks in test data
@@ -327,7 +331,8 @@ class TestArtifacts:
         ],
     )
     def test_filter_artifacts_by_artifact_type(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], artifact_type: str | list[str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None,
+            artifact_type: str | list[str]
     ) -> None:
         """Test filtering artifacts by single or multiple artifact types."""
         source_id, model_name = model_with_artifacts
@@ -397,6 +402,7 @@ class TestNegativeArtifacts:
         api_client: CatalogAPIClient,
         model_with_artifacts: tuple[str, str],
         invalid_filter_query: str,
+        suppress_ssl_warnings: None,
     ) -> None:
         """Test that search artifacts by invalid filter query raises a validation error."""
         source_id, model_name = model_with_artifacts

--- a/catalog/clients/python/tests/test_ordering.py
+++ b/catalog/clients/python/tests/test_ordering.py
@@ -154,6 +154,7 @@ class TestFieldOrdering:
         order_by: str,
         sort_order: str,
         api_client: CatalogAPIClient,
+        suppress_ssl_warnings: None,
     ):
         """Test models endpoint sorts correctly by field and order.
 
@@ -292,6 +293,7 @@ class TestAccuracyOrdering:
         sort_order: str,
         filter_query: str,
         api_client: CatalogAPIClient,
+        suppress_ssl_warnings: None,
     ):
         """Test accuracy sorting works correctly with filter applied.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Part of shift left initiative to run upstream tests against live clusters.
## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
