### PR TITLE
Standardize the listing of models with or without the Performance View toggle enabled.

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -5,7 +5,8 @@ import {
   EmptyState,
   EmptyStateVariant,
   Flex,
-  Gallery,
+  Grid,
+  GridItem,
   Spinner,
   Title,
 } from '@patternfly/react-core';
@@ -222,16 +223,17 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
   return (
     <>
       <ScrollViewOnMount shouldScroll scrollToTop />
-      <Gallery hasGutter minWidths={{ default: '300px' }}>
+      <Grid hasGutter>
         {catalogModels.items.map((model: CatalogModel) => (
-          <ModelCatalogCard
-            key={`${model.name}/${model.source_id}`}
-            model={model}
-            source={getSourceFromSourceId(model.source_id || '', catalogSources)}
-            truncate
-          />
+          <GridItem key={`${model.name}/${model.source_id}`} sm={6} md={6} lg={6} xl={6} xl2={3}>
+            <ModelCatalogCard
+              model={model}
+              source={getSourceFromSourceId(model.source_id || '', catalogSources)}
+              truncate
+            />
+          </GridItem>
         ))}
-      </Gallery>
+      </Grid>
       {catalogModels.hasMore && (
         <Bullseye className="pf-v6-u-mt-lg">
           {catalogModels.isLoadingMore ? (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The presentation of model cards is different when the "Model performance view" toggle is active.
I standardized this card listing, now maintaining the same behaviour as when "Model performance view" is deactivated.

Without PF mode
<video src="https://github.com/user-attachments/assets/ec838826-9bb3-4c13-9316-94245eda6690" controls></video>

With PF mode
<video src="https://github.com/user-attachments/assets/6d326d86-ea67-4866-a5b4-a6b3b6dd3a36" controls></video>



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested like in the videos.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
