### PR TITLE
py(tests): refactor assertions to avoid codeql flagging

### DIFF
--- a/clients/python/tests/test_signing.py
+++ b/clients/python/tests/test_signing.py
@@ -66,9 +66,9 @@ class TestImageSigner:
         signer.initialize()
 
         cmd = mock_runner.run.call_args[0][0]
-        assert "https://default-tuf.example.com" in cmd
-        assert "https://default-tuf.example.com/root.json" in cmd
-        assert "def456" in cmd
+        assert cmd.count("https://default-tuf.example.com") == 1
+        assert cmd.count("https://default-tuf.example.com/root.json") == 1
+        assert cmd.count("def456") == 1
 
     def test_initialize_method_args_override_defaults(self, tmp_path, mocker):
         """Test method arguments override instance defaults."""
@@ -88,10 +88,10 @@ class TestImageSigner:
         )
 
         cmd = mock_runner.run.call_args[0][0]
-        assert "https://override-tuf.example.com" in cmd
-        assert "override-checksum" in cmd
-        assert "https://default-tuf.example.com" not in cmd
-        assert "default-checksum" not in cmd
+        assert cmd.count("https://override-tuf.example.com") == 1
+        assert cmd.count("override-checksum") == 1
+        assert cmd.count("https://default-tuf.example.com") == 0
+        assert cmd.count("default-checksum") == 0
 
     def test_initialize_raises_if_dir_exists_without_force(self, tmp_path, mocker):
         """Test initialize raises FileExistsError if directory exists and force=False."""
@@ -193,9 +193,9 @@ class TestImageSigner:
         signer.sign(image="quay.io/example/image@sha256:abc123")
 
         cmd = mock_runner.run.call_args[0][0]
-        assert "test-token" in cmd
-        assert "https://default-fulcio.example.com" in cmd
-        assert "https://default-rekor.example.com" in cmd
+        assert cmd.count("test-token") == 1
+        assert cmd.count("https://default-fulcio.example.com") == 1
+        assert cmd.count("https://default-rekor.example.com") == 1
 
     def test_sign_accepts_pathlike(self, tmp_path, mocker):
         """Test sign accepts PathLike objects."""
@@ -217,7 +217,7 @@ class TestImageSigner:
         mock_runner.run.assert_called_once()
         cmd = mock_runner.run.call_args[0][0]
         # File content should be read and passed
-        assert "test-token" in cmd
+        assert cmd.count("test-token") == 1
 
     def test_sign_raises_if_token_file_not_found(self, mocker):
         """Test sign raises FileNotFoundError if token file doesn't exist."""
@@ -269,8 +269,8 @@ class TestImageSigner:
         signer.verify(image="quay.io/example/image@sha256:abc123")
 
         cmd = mock_runner.run.call_args[0][0]
-        assert "https://kubernetes.io/namespaces/default/serviceaccounts/default" in cmd
-        assert "https://default-oidc.example.com" in cmd
+        assert cmd.count("https://kubernetes.io/namespaces/default/serviceaccounts/default") == 1
+        assert cmd.count("https://default-oidc.example.com") == 1
 
     def test_initialize_with_no_args_sends_minimal_command(self, tmp_path, mocker):
         """Test initialize with no arguments sends minimal command."""
@@ -373,7 +373,7 @@ class TestModelSigner:
         # Should return path within cache_dir
         assert result.parent.parent == tmp_path
         assert result.name == "trust_config.json"
-        assert "https%3A%2F%2Ftuf.example.com" in str(result)
+        assert str(result).count("https%3A%2F%2Ftuf.example.com") == 1
 
     def test_get_trust_config_path_without_tuf_url_raises_error(self):
         """Test get_trust_config_path raises SigningError when tuf_url not set."""


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
avoid: `py/incomplete-url-substring-sanitization`
see also: https://github.com/github/codeql/blob/fedb9464aff82db8e415b26211efa75d806dc9f4/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql

## How Has This Been Tested?
```
poetry run pytest tests/test_signing.py
```

<img width="2671" height="1183" alt="image" src="https://github.com/user-attachments/assets/f4c67bf3-6d4e-41f7-bbf1-52598635b351" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
