### PR TITLE
feat: auto-initialize image signer

### DIFF
--- a/clients/python/src/model_registry/signing/image_signer.py
+++ b/clients/python/src/model_registry/signing/image_signer.py
@@ -119,6 +119,15 @@ class ImageSigner:
         """
         return Path.home() / ".sigstore"
 
+    def _ensure_initialized(self):
+        """Ensure sigstore configuration is initialized.
+
+        Auto-initializes sigstore config if not already present using instance defaults.
+        """
+        sigstore_dir = self._get_sigstore_dir()
+        if not sigstore_dir.exists():
+            self.initialize()
+
     def initialize(  # noqa: C901
         self,
         tuf_url: str | None = None,
@@ -206,6 +215,8 @@ class ImageSigner:
             msg = f"Identity token file not found: {identity_token_path}"
             raise FileNotFoundError(msg)
 
+        self._ensure_initialized()
+
         cmd = ["cosign", "sign", "-y"]
 
         if identity_token_path is not None:
@@ -245,6 +256,8 @@ class ImageSigner:
             certificate_identity = self.certificate_identity
         if oidc_issuer is None:
             oidc_issuer = self.oidc_issuer
+
+        self._ensure_initialized()
 
         cmd = ["cosign", "verify"]
 

--- a/clients/python/tests/test_signing.py
+++ b/clients/python/tests/test_signing.py
@@ -159,6 +159,11 @@ class TestImageSigner:
         mock_runner = mocker.MagicMock()
         signer.runner = mock_runner
 
+        # Mock _get_sigstore_dir to return existing directory so initialization is skipped
+        sigstore_dir = tmp_path / ".sigstore"
+        sigstore_dir.mkdir()
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=sigstore_dir)
+
         signer.sign(
             image="quay.io/example/image@sha256:abc123",
             identity_token_path=str(token_file),
@@ -207,6 +212,11 @@ class TestImageSigner:
         mock_runner = mocker.MagicMock()
         signer.runner = mock_runner
 
+        # Mock _get_sigstore_dir to return existing directory so initialization is skipped
+        sigstore_dir = tmp_path / ".sigstore"
+        sigstore_dir.mkdir()
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=sigstore_dir)
+
         # Pass Path object instead of string
         signer.sign(
             image="quay.io/example/image@sha256:abc123",
@@ -236,11 +246,16 @@ class TestImageSigner:
         with pytest.raises(FileNotFoundError, match="Identity token file not found"):
             ImageSigner(identity_token_path="/nonexistent/token/file")  # noqa: S106
 
-    def test_verify_with_all_args(self, mocker):
+    def test_verify_with_all_args(self, tmp_path, mocker):
         """Test verify with all arguments provided."""
         signer = ImageSigner()
         mock_runner = mocker.MagicMock()
         signer.runner = mock_runner
+
+        # Mock _get_sigstore_dir to return existing directory so initialization is skipped
+        sigstore_dir = tmp_path / ".sigstore"
+        sigstore_dir.mkdir()
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=sigstore_dir)
 
         signer.verify(
             image="quay.io/example/image@sha256:abc123",
@@ -331,6 +346,11 @@ class TestImageSigner:
 
         signer = ImageSigner()
 
+        # Mock _get_sigstore_dir to return existing directory so initialization is skipped
+        sigstore_dir = tmp_path / ".sigstore"
+        sigstore_dir.mkdir()
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=sigstore_dir)
+
         # Mock runner to raise CalledProcessError
         mock_runner = mocker.MagicMock()
         mock_runner.run.side_effect = subprocess.CalledProcessError(1, ["cosign", "sign"])
@@ -342,9 +362,14 @@ class TestImageSigner:
                 identity_token_path=str(token_file)
             )
 
-    def test_verify_raises_verification_error_on_command_failure(self, mocker):
+    def test_verify_raises_verification_error_on_command_failure(self, tmp_path, mocker):
         """Test verify raises VerificationError when cosign command fails."""
         signer = ImageSigner()
+
+        # Mock _get_sigstore_dir to return existing directory so initialization is skipped
+        sigstore_dir = tmp_path / ".sigstore"
+        sigstore_dir.mkdir()
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=sigstore_dir)
 
         # Mock runner to raise CalledProcessError
         mock_runner = mocker.MagicMock()


### PR DESCRIPTION
This automatically initializes the image signer when the sign or verify method is called.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In a kubernetes cluster:
Ensured sigstore config was not present:
```
rm -rf ~/.sigstore
```
Called signer:
```
signer = Signer()
signer.sign_image(image_ref)
```
Same for verify.

Before this change the sign or verify methods would raise an exception if we didn't first explicitly:
```
signer.initialize()
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
