### PR TITLE
add partially avail source status

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -875,10 +875,12 @@ components:
       description: |-
         Operational status of a catalog source.
         - `available`: The source is functioning correctly and models can be retrieved
+        - `partially-available`: The source loaded some models successfully but encountered errors with others
         - `error`: The source is experiencing issues and cannot provide models
         - `disabled`: The source has been intentionally disabled
       enum:
         - available
+        - partially-available
         - error
         - disabled
       type: string

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -713,10 +713,12 @@ components:
       description: |-
         Operational status of a catalog source.
         - `available`: The source is functioning correctly and models can be retrieved
+        - `partially-available`: The source loaded some models successfully but encountered errors with others
         - `error`: The source is experiencing issues and cannot provide models
         - `disabled`: The source has been intentionally disabled
       enum:
         - available
+        - partially-available
         - error
         - disabled
       type: string

--- a/catalog/clients/python/src/catalog_openapi/models/catalog_source_status.py
+++ b/catalog/clients/python/src/catalog_openapi/models/catalog_source_status.py
@@ -19,13 +19,14 @@ from typing_extensions import Self
 
 
 class CatalogSourceStatus(str, Enum):
-    """Operational status of a catalog source. - `available`: The source is functioning correctly and models can be retrieved - `error`: The source is experiencing issues and cannot provide models - `disabled`: The source has been intentionally disabled
+    """Operational status of a catalog source. - `available`: The source is functioning correctly and models can be retrieved - `partially-available`: The source loaded some models successfully but encountered errors with others - `error`: The source is experiencing issues and cannot provide models - `disabled`: The source has been intentionally disabled
     """
 
     """
     allowed enum values
     """
     AVAILABLE = "available"
+    PARTIALLY_MINUS_AVAILABLE = "partially-available"
     ERROR = "error"
     DISABLED = "disabled"
 

--- a/catalog/clients/python/tests/test_sources.py
+++ b/catalog/clients/python/tests/test_sources.py
@@ -145,7 +145,7 @@ class TestSourceStatus:
             assert status is not None or enabled is not None
 
             if status:
-                valid_statuses = {"available", "disabled", "error", "loading", "pending"}
+                valid_statuses = {"available", "partially-available", "disabled", "error", "loading", "pending"}
                 assert status in valid_statuses, f"Unexpected status: {status}"
 
     def test_enabled_and_status_consistency(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):

--- a/catalog/internal/catalog/hf_catalog.go
+++ b/catalog/internal/catalog/hf_catalog.go
@@ -549,7 +549,7 @@ func (p *hfModelProvider) getModelsFromHF(ctx context.Context) ([]ModelProviderR
 	}
 
 	if len(failedModels) > 0 {
-		return records, fmt.Errorf("Failed to fetch some models, ensure models exist and are accessible with given credentials. Failed models: %v", failedModels)
+		return records, &PartiallyAvailableError{FailedModels: failedModels}
 	}
 
 	return records, nil

--- a/catalog/internal/db/service/catalog_source_test.go
+++ b/catalog/internal/db/service/catalog_source_test.go
@@ -265,6 +265,7 @@ func TestCatalogSourceRepository(t *testing.T) {
 			hasError bool
 		}{
 			{"status-available", "available", "", false},
+			{"status-partially-available", "partially-available", "some models failed to load", true},
 			{"status-error", "error", "connection timeout", true},
 			{"status-disabled", "disabled", "", false},
 		}

--- a/catalog/pkg/openapi/model_catalog_source_status.go
+++ b/catalog/pkg/openapi/model_catalog_source_status.go
@@ -15,19 +15,21 @@ import (
 	"fmt"
 )
 
-// CatalogSourceStatus Operational status of a catalog source. - `available`: The source is functioning correctly and models can be retrieved - `error`: The source is experiencing issues and cannot provide models - `disabled`: The source has been intentionally disabled
+// CatalogSourceStatus Operational status of a catalog source. - `available`: The source is functioning correctly and models can be retrieved - `partially-available`: The source loaded some models successfully but encountered errors with others - `error`: The source is experiencing issues and cannot provide models - `disabled`: The source has been intentionally disabled
 type CatalogSourceStatus string
 
 // List of CatalogSourceStatus
 const (
-	CATALOGSOURCESTATUS_AVAILABLE CatalogSourceStatus = "available"
-	CATALOGSOURCESTATUS_ERROR     CatalogSourceStatus = "error"
-	CATALOGSOURCESTATUS_DISABLED  CatalogSourceStatus = "disabled"
+	CATALOGSOURCESTATUS_AVAILABLE           CatalogSourceStatus = "available"
+	CATALOGSOURCESTATUS_PARTIALLY_AVAILABLE CatalogSourceStatus = "partially-available"
+	CATALOGSOURCESTATUS_ERROR               CatalogSourceStatus = "error"
+	CATALOGSOURCESTATUS_DISABLED            CatalogSourceStatus = "disabled"
 )
 
 // All allowed values of CatalogSourceStatus enum
 var AllowedCatalogSourceStatusEnumValues = []CatalogSourceStatus{
 	"available",
+	"partially-available",
 	"error",
 	"disabled",
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds a new source status to the model catalog called "partially-available". This status is used to represent sources (specifically HF type for now) that are able to load some models but not all models. The status is replacing the previously used "error" status to better represent the state of the source. A follow up PR will be created that ensures these sources are present in the dashboard so that any successfully pulled models are not hidden.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

Tested locally with Kind/ Tilt
<img width="685" height="443" alt="Screenshot 2026-02-13 at 9 24 05 AM" src="https://github.com/user-attachments/assets/b0638167-97e9-4e12-8f96-24648b144acf" />
