### PR TITLE
UI: Remove duplicate search label text in filter boxes

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -136,8 +136,7 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
                 <ToolbarGroup variant="filter-group" gap={{ default: 'gapMd' }} alignItems="center">
                   <ToolbarItem>
                     <ThemeAwareSearchInput
-                      dara-testid="search-input"
-                      fieldLabel="Filter by name, description and provider"
+                      data-testid="search-input"
                       aria-label="Search with submit button"
                       className="toolbar-fieldset-wrapper"
                       placeholder="Filter by name, description and provider"

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelTransferJobs/ModelTransferJobsListView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelTransferJobs/ModelTransferJobsListView.tsx
@@ -107,7 +107,6 @@ const ModelTransferJobsListView: React.FC<ModelTransferJobsListViewProps> = ({
           [ModelTransferJobsFilterOptions.jobName]: ({ onChange, ...props }) => (
             <ThemeAwareSearchInput
               {...props}
-              fieldLabel="Filter by job name"
               placeholder="Filter by job name"
               className="toolbar-fieldset-wrapper"
               style={{ minWidth: '270px' }}
@@ -117,7 +116,6 @@ const ModelTransferJobsListView: React.FC<ModelTransferJobsListViewProps> = ({
           [ModelTransferJobsFilterOptions.modelName]: ({ onChange, ...props }) => (
             <ThemeAwareSearchInput
               {...props}
-              fieldLabel="Filter by model name"
               placeholder="Filter by model name"
               className="toolbar-fieldset-wrapper"
               style={{ minWidth: '270px' }}
@@ -127,7 +125,6 @@ const ModelTransferJobsListView: React.FC<ModelTransferJobsListViewProps> = ({
           [ModelTransferJobsFilterOptions.versionName]: ({ onChange, ...props }) => (
             <ThemeAwareSearchInput
               {...props}
-              fieldLabel="Filter by version name"
               placeholder="Filter by version name"
               className="toolbar-fieldset-wrapper"
               style={{ minWidth: '270px' }}
@@ -137,7 +134,6 @@ const ModelTransferJobsListView: React.FC<ModelTransferJobsListViewProps> = ({
           [ModelTransferJobsFilterOptions.namespace]: ({ onChange, ...props }) => (
             <ThemeAwareSearchInput
               {...props}
-              fieldLabel="Filter by namespace"
               placeholder="Filter by namespace"
               className="toolbar-fieldset-wrapper"
               style={{ minWidth: '270px' }}
@@ -147,7 +143,6 @@ const ModelTransferJobsListView: React.FC<ModelTransferJobsListViewProps> = ({
           [ModelTransferJobsFilterOptions.author]: ({ onChange, ...props }) => (
             <ThemeAwareSearchInput
               {...props}
-              fieldLabel="Filter by author"
               placeholder="Filter by author"
               className="toolbar-fieldset-wrapper"
               style={{ minWidth: '270px' }}
@@ -157,7 +152,6 @@ const ModelTransferJobsListView: React.FC<ModelTransferJobsListViewProps> = ({
           [ModelTransferJobsFilterOptions.status]: ({ onChange, ...props }) => (
             <ThemeAwareSearchInput
               {...props}
-              fieldLabel="Filter by status"
               placeholder="Filter by status"
               className="toolbar-fieldset-wrapper"
               style={{ minWidth: '270px' }}

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
@@ -152,7 +152,6 @@ const ModelVersionListView: React.FC<ModelVersionListViewProps> = ({
                       [ModelRegistryVersionsFilterOptions.keyword]: ({ onChange, ...props }) => (
                         <ThemeAwareSearchInput
                           {...props}
-                          fieldLabel="Filter by name, description or label"
                           placeholder="Filter by name, description or label"
                           className="toolbar-fieldset-wrapper"
                           style={{ minWidth: '270px' }}
@@ -162,7 +161,6 @@ const ModelVersionListView: React.FC<ModelVersionListViewProps> = ({
                       [ModelRegistryVersionsFilterOptions.author]: ({ onChange, ...props }) => (
                         <ThemeAwareSearchInput
                           {...props}
-                          fieldLabel="Filter by author"
                           placeholder="Filter by author"
                           className="toolbar-fieldset-wrapper"
                           style={{ minWidth: '270px' }}

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchiveListView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchiveListView.tsx
@@ -70,7 +70,6 @@ const ModelVersionsArchiveListView: React.FC<ModelVersionsArchiveListViewProps> 
                     [ModelRegistryVersionsFilterOptions.keyword]: ({ onChange, ...props }) => (
                       <ThemeAwareSearchInput
                         {...props}
-                        fieldLabel="Filter by name, description or label"
                         placeholder="Filter by name, description or label"
                         className="toolbar-fieldset-wrapper"
                         style={{ minWidth: '270px' }}
@@ -80,7 +79,6 @@ const ModelVersionsArchiveListView: React.FC<ModelVersionsArchiveListViewProps> 
                     [ModelRegistryVersionsFilterOptions.author]: ({ onChange, ...props }) => (
                       <ThemeAwareSearchInput
                         {...props}
-                        fieldLabel="Filter by author"
                         placeholder="Filter by author"
                         className="toolbar-fieldset-wrapper"
                         style={{ minWidth: '270px' }}

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
@@ -94,7 +94,6 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
           [ModelRegistryFilterOptions.keyword]: ({ onChange, ...props }) => (
             <ThemeAwareSearchInput
               {...props}
-              fieldLabel="Filter by name, description or label"
               placeholder="Filter by name, description or label"
               className="toolbar-fieldset-wrapper"
               style={{ minWidth: '270px' }}
@@ -104,7 +103,6 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
           [ModelRegistryFilterOptions.owner]: ({ onChange, ...props }) => (
             <ThemeAwareSearchInput
               {...props}
-              fieldLabel="Filter by owner"
               placeholder="Filter by owner"
               className="toolbar-fieldset-wrapper"
               style={{ minWidth: '270px' }}

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisteredModelsArchive/RegisteredModelsArchiveListView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisteredModelsArchive/RegisteredModelsArchiveListView.tsx
@@ -78,7 +78,6 @@ const RegisteredModelsArchiveListView: React.FC<RegisteredModelsArchiveListViewP
                     [ModelRegistryFilterOptions.keyword]: ({ onChange, ...props }) => (
                       <ThemeAwareSearchInput
                         {...props}
-                        fieldLabel="Filter by name, description or label"
                         placeholder="Filter by name, description or label"
                         className="toolbar-fieldset-wrapper"
                         style={{ minWidth: '270px' }}
@@ -88,7 +87,6 @@ const RegisteredModelsArchiveListView: React.FC<RegisteredModelsArchiveListViewP
                     [ModelRegistryFilterOptions.owner]: ({ onChange, ...props }) => (
                       <ThemeAwareSearchInput
                         {...props}
-                        fieldLabel="Filter by owner"
                         placeholder="Filter by owner"
                         className="toolbar-fieldset-wrapper"
                         style={{ minWidth: '270px' }}

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ThemeAwareSearchInput.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ThemeAwareSearchInput.tsx
@@ -6,7 +6,6 @@ import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormField
 type ThemeAwareSearchInputProps = Omit<SearchInputProps, 'onChange' | 'onClear'> & {
   onChange: (value: string) => void; // Simplified onChange signature
   onClear?: () => void; // Simplified optional onClear signature
-  fieldLabel?: string; // Additional prop for MUI FormFieldset label
   'data-testid'?: string;
   onClick?: () => void;
 };
@@ -15,7 +14,6 @@ const ThemeAwareSearchInput: React.FC<ThemeAwareSearchInputProps> = ({
   value,
   onChange,
   onClear,
-  fieldLabel,
   placeholder,
   isDisabled,
   className,
@@ -32,7 +30,6 @@ const ThemeAwareSearchInput: React.FC<ThemeAwareSearchInputProps> = ({
     return (
       <FormFieldset
         className={className}
-        field={fieldLabel}
         component={
           <TextInput
             value={value}


### PR DESCRIPTION
## Summary
This PR removes duplicated helper text shown in search/filter inputs where the same text appeared both:
- in the field border/legend, and
- as placeholder text.
- Fixes #2245 

To keep the UI cleaner, we now keep only the placeholder text.

## Changes
- Removed `fieldLabel` from `ThemeAwareSearchInput` usages in:
  - model catalog search
  - model registry list filters
  - model versions list/archive filters
  - registered models archive filters
  - model transfer jobs filters

## Result
Search boxes no longer show duplicated label text on the border and inside the input.

## Testing
- Verified code changes are scoped to frontend search/filter components.
- Type-check command could not be executed in this environment (`tsc` not available).
