### PR TITLE
feat: add assetType query param to sources endpoint

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -326,6 +326,7 @@ paths:
         - ModelCatalogService
       parameters:
         - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/assetType"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/orderBy"
         - $ref: "#/components/parameters/sortOrder"
@@ -2054,6 +2055,13 @@ components:
         format: int32
         default: 10
         maximum: 100
+      in: query
+      required: false
+    assetType:
+      name: assetType
+      description: Filter sources by asset type.
+      schema:
+        $ref: "#/components/schemas/CatalogAssetType"
       in: query
       required: false
     artifactType:

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -187,6 +187,7 @@ paths:
         - ModelCatalogService
       parameters:
         - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/assetType"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/orderBy"
         - $ref: "#/components/parameters/sortOrder"
@@ -1777,6 +1778,13 @@ components:
         format: int32
         default: 10
         maximum: 100
+      in: query
+      required: false
+    assetType:
+      name: assetType
+      description: Filter sources by asset type.
+      schema:
+        $ref: "#/components/schemas/CatalogAssetType"
       in: query
       required: false
     artifactType:

--- a/catalog/internal/server/openapi/api.go
+++ b/catalog/internal/server/openapi/api.go
@@ -63,7 +63,7 @@ type ModelCatalogServiceAPIServicer interface {
 	FindLabels(context.Context, string, string, model.SortOrder, string) (ImplResponse, error)
 	FindModels(context.Context, bool, int32, string, string, string, string, []string, string, []string, string, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
 	FindModelsFilterOptions(context.Context) (ImplResponse, error)
-	FindSources(context.Context, string, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
+	FindSources(context.Context, string, model.CatalogAssetType, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
 	PreviewCatalogSource(context.Context, *os.File, string, string, string, *os.File) (ImplResponse, error)
 	GetModel(context.Context, string, string) (ImplResponse, error)
 	GetAllModelArtifacts(context.Context, string, string, []model.ArtifactTypeQueryParam, []model.ArtifactTypeQueryParam, string, string, string, model.SortOrder, string) (ImplResponse, error)

--- a/catalog/internal/server/openapi/api_model_catalog_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service.go
@@ -362,6 +362,13 @@ func (c *ModelCatalogServiceAPIController) FindSources(w http.ResponseWriter, r 
 		nameParam = param
 	} else {
 	}
+	var assetTypeParam model.CatalogAssetType
+	if query.Has("assetType") {
+		param := model.CatalogAssetType(query.Get("assetType"))
+
+		assetTypeParam = param
+	} else {
+	}
 	var pageSizeParam string
 	if query.Has("pageSize") {
 		param := query.Get("pageSize")
@@ -390,7 +397,7 @@ func (c *ModelCatalogServiceAPIController) FindSources(w http.ResponseWriter, r 
 		nextPageTokenParam = param
 	} else {
 	}
-	result, err := c.service.FindSources(r.Context(), nameParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
+	result, err := c.service.FindSources(r.Context(), nameParam, assetTypeParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -371,7 +371,7 @@ func (m *ModelCatalogServiceAPIService) GetModel(ctx context.Context, sourceID, 
 	return Response(http.StatusOK, model), nil
 }
 
-func (m *ModelCatalogServiceAPIService) FindSources(ctx context.Context, name string, strPageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
+func (m *ModelCatalogServiceAPIService) FindSources(ctx context.Context, name string, assetType model.CatalogAssetType, strPageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	sources := m.sources.All()
 	if len(sources) > math.MaxInt32 {
 		err := errors.New("too many registered models")
@@ -396,10 +396,18 @@ func (m *ModelCatalogServiceAPIService) FindSources(ctx context.Context, name st
 
 	items := make([]model.CatalogSource, 0, len(sources))
 
+	if assetType == "" {
+		assetType = model.CATALOGASSETTYPE_MODELS
+	}
+
 	name = strings.ToLower(name)
 
 	for _, v := range sources {
 		if !strings.Contains(strings.ToLower(v.Name), name) {
+			continue
+		}
+
+		if v.HasAssetType() && v.GetAssetType() != assetType {
 			continue
 		}
 

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -754,6 +754,7 @@ func TestFindSources(t *testing.T) {
 			resp, err := service.FindSources(
 				context.Background(),
 				tc.nameFilter,
+				"",
 				tc.pageSize,
 				tc.orderBy,
 				tc.sortOrder,

--- a/catalog/pkg/openapi/api_model_catalog_service.go
+++ b/catalog/pkg/openapi/api_model_catalog_service.go
@@ -658,6 +658,7 @@ type ApiFindSourcesRequest struct {
 	ctx           context.Context
 	ApiService    *ModelCatalogServiceAPIService
 	name          *string
+	assetType     *CatalogAssetType
 	pageSize      *string
 	orderBy       *OrderByField
 	sortOrder     *SortOrder
@@ -667,6 +668,12 @@ type ApiFindSourcesRequest struct {
 // Name of entity to search.
 func (r ApiFindSourcesRequest) Name(name string) ApiFindSourcesRequest {
 	r.name = &name
+	return r
+}
+
+// Filter sources by asset type.
+func (r ApiFindSourcesRequest) AssetType(assetType CatalogAssetType) ApiFindSourcesRequest {
+	r.assetType = &assetType
 	return r
 }
 
@@ -737,6 +744,13 @@ func (a *ModelCatalogServiceAPIService) FindSourcesExecute(r ApiFindSourcesReque
 
 	if r.name != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "name", r.name, "form", "")
+	}
+	if r.assetType != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "assetType", r.assetType, "form", "")
+	} else {
+		var defaultValue CatalogAssetType = "models"
+		parameterAddToHeaderOrQuery(localVarQueryParams, "assetType", defaultValue, "form", "")
+		r.assetType = &defaultValue
 	}
 	if r.pageSize != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageSize", r.pageSize, "form", "")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- Adds an assetType query parameter to GET /api/model_catalog/v1alpha1/sources to allow filtering catalog sources by the type of assets they manage (models or mcp_servers).
- Defaults to models when the parameter is not provided, ensuring backward compatibility — existing callers continue to see only model sources without any changes.
- Callers must explicitly pass ?assetType=mcp_servers to retrieve MCP server sources.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built locally plus unit tests still passing

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
