### PR TITLE
feat: add sourcelabel to mcpservers endpoint

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -30,6 +30,18 @@ paths:
             type: string
           in: query
           required: false
+        - name: sourceLabel
+          description: |-
+            Filter MCP servers by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then MCP servers from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
         - $ref: "#/components/parameters/mcpServerFilterQuery"
         - $ref: "#/components/parameters/namedQuery"
         - $ref: "#/components/parameters/includeTools"

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -225,6 +225,18 @@ paths:
             type: string
           in: query
           required: false
+        - name: sourceLabel
+          description: |-
+            Filter MCP servers by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then MCP servers from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
         - $ref: "#/components/parameters/mcpServerFilterQuery"
         - $ref: "#/components/parameters/namedQuery"
         - $ref: "#/components/parameters/includeTools"

--- a/catalog/internal/server/openapi/api.go
+++ b/catalog/internal/server/openapi/api.go
@@ -48,7 +48,7 @@ type ModelCatalogServiceAPIRouter interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type MCPCatalogServiceAPIServicer interface {
-	FindMCPServers(context.Context, string, string, string, string, bool, int32, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
+	FindMCPServers(context.Context, string, string, []string, string, string, bool, int32, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
 	FindMCPServersFilterOptions(context.Context) (ImplResponse, error)
 	GetMCPServer(context.Context, string, bool) (ImplResponse, error)
 	FindMCPServerTools(context.Context, string, string, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)

--- a/catalog/internal/server/openapi/api_mcp_catalog_service.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service.go
@@ -142,6 +142,10 @@ func (c *MCPCatalogServiceAPIController) FindMCPServers(w http.ResponseWriter, r
 		qParam = param
 	} else {
 	}
+	var sourceLabelParam []string
+	if query.Has("sourceLabel") {
+		sourceLabelParam = strings.Split(query.Get("sourceLabel"), ",")
+	}
 	var filterQueryParam string
 	if query.Has("filterQuery") {
 		param := query.Get("filterQuery")
@@ -217,7 +221,7 @@ func (c *MCPCatalogServiceAPIController) FindMCPServers(w http.ResponseWriter, r
 		nextPageTokenParam = param
 	} else {
 	}
-	result, err := c.service.FindMCPServers(r.Context(), nameParam, qParam, filterQueryParam, namedQueryParam, includeToolsParam, toolLimitParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
+	result, err := c.service.FindMCPServers(r.Context(), nameParam, qParam, sourceLabelParam, filterQueryParam, namedQueryParam, includeToolsParam, toolLimitParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/catalog/pkg/openapi/api_mcp_catalog_service.go
+++ b/catalog/pkg/openapi/api_mcp_catalog_service.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 )
 
@@ -211,6 +212,7 @@ type ApiFindMCPServersRequest struct {
 	ApiService    *MCPCatalogServiceAPIService
 	name          *string
 	q             *string
+	sourceLabel   *[]string
 	filterQuery   *string
 	namedQuery    *string
 	includeTools  *bool
@@ -230,6 +232,12 @@ func (r ApiFindMCPServersRequest) Name(name string) ApiFindMCPServersRequest {
 // Free-form keyword search across name, description, and provider.
 func (r ApiFindMCPServersRequest) Q(q string) ApiFindMCPServersRequest {
 	r.q = &q
+	return r
+}
+
+// Filter MCP servers by the label associated with the source. Multiple values can be separated by commas. If one of the values is the string &#x60;null&#x60;, then MCP servers from every source without a label will be returned.
+func (r ApiFindMCPServersRequest) SourceLabel(sourceLabel []string) ApiFindMCPServersRequest {
+	r.sourceLabel = &sourceLabel
 	return r
 }
 
@@ -325,6 +333,17 @@ func (a *MCPCatalogServiceAPIService) FindMCPServersExecute(r ApiFindMCPServersR
 	}
 	if r.q != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "q", r.q, "form", "")
+	}
+	if r.sourceLabel != nil {
+		t := *r.sourceLabel
+		if reflect.TypeOf(t).Kind() == reflect.Slice {
+			s := reflect.ValueOf(t)
+			for i := 0; i < s.Len(); i++ {
+				parameterAddToHeaderOrQuery(localVarQueryParams, "sourceLabel", s.Index(i).Interface(), "form", "multi")
+			}
+		} else {
+			parameterAddToHeaderOrQuery(localVarQueryParams, "sourceLabel", t, "form", "multi")
+		}
 	}
 	if r.filterQuery != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "filterQuery", r.filterQuery, "form", "")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

depends on #2268 

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- Adds a sourceLabel query parameter to GET /api/mcp_catalog/v1alpha1/mcp_servers, mirroring the existing parameter on the GET /models endpoint.
- Allows filtering MCP servers by the label associated with their catalog source, with support for multiple comma-separated values and the special null value to match sources without a label.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.