### PR TITLE
feat(catalog): named queries for MCP catalog

### DIFF
--- a/catalog/cmd/catalog.go
+++ b/catalog/cmd/catalog.go
@@ -184,9 +184,12 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 	)
 	ctrl := openapi.NewModelCatalogServiceAPIController(svc)
 
-	// Create MCP provider and service
-	mcpProvider := catalog.NewDBMCPCatalog(services)
-	mcpSvc := openapi.NewMCPCatalogServiceAPIService(mcpProvider)
+	// Create MCP provider and service, wiring named query resolution from loaded sources.
+	mcpSources := loader.MCPSources()
+	mcpProvider := catalog.NewDBMCPCatalog(services, func(name string) (map[string]catalog.FieldFilter, bool) {
+		return mcpSources.GetNamedQuery(name)
+	})
+	mcpSvc := openapi.NewMCPCatalogServiceAPIService(mcpProvider, mcpSources)
 	mcpCtrl := openapi.NewMCPCatalogServiceAPIController(mcpSvc)
 
 	server := &http.Server{

--- a/catalog/internal/catalog/basecatalog/config.go
+++ b/catalog/internal/catalog/basecatalog/config.go
@@ -135,5 +135,13 @@ func (c *SourceConfig) Validate() error {
 		mcpSeen[id] = true
 	}
 
+	if err := ValidateNamedQueries(c.NamedQueries); err != nil {
+		return fmt.Errorf("invalid named queries: %w", err)
+	}
+
+	if err := ValidateFieldNames(c.NamedQueries, MCPServerFilterableFields); err != nil {
+		return fmt.Errorf("invalid named queries: %w", err)
+	}
+
 	return nil
 }

--- a/catalog/internal/catalog/basecatalog/filter_query.go
+++ b/catalog/internal/catalog/basecatalog/filter_query.go
@@ -1,0 +1,77 @@
+package basecatalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FieldFiltersToFilterQuery converts a map of FieldFilter (from a named query) into
+// a filterQuery string that the existing filter.Parse() infrastructure can process.
+// Conditions are joined with AND in sorted field-name order for deterministic output.
+//
+// Supported operators and their output:
+//   - =, !=, >, <, >=, <=, LIKE, ILIKE: `field op 'value'` (strings quoted, numerics/bools unquoted)
+//   - IN: `field IN (val1, val2, ...)`
+//   - NOT IN: expanded as `field != val1 AND field != val2 ...` (parser does not support NOT IN natively)
+func FieldFiltersToFilterQuery(filters map[string]FieldFilter) (string, error) {
+	if len(filters) == 0 {
+		return "", nil
+	}
+
+	// Sort field names for deterministic output.
+	fields := make([]string, 0, len(filters))
+	for f := range filters {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+
+	var parts []string
+	for _, field := range fields {
+		ff := filters[field]
+		op := strings.ToUpper(ff.Operator)
+
+		switch op {
+		case "IN":
+			vals, ok := ff.Value.([]any)
+			if !ok {
+				return "", fmt.Errorf("field %q: IN operator requires array value, got %T", field, ff.Value)
+			}
+			items := make([]string, 0, len(vals))
+			for _, v := range vals {
+				items = append(items, formatValue(v))
+			}
+			parts = append(parts, fmt.Sprintf("%s IN (%s)", field, strings.Join(items, ", ")))
+		case "NOT IN":
+			// The filter parser does not support NOT IN natively, so expand as multiple != conditions.
+			vals, ok := ff.Value.([]any)
+			if !ok {
+				return "", fmt.Errorf("field %q: NOT IN operator requires array value, got %T", field, ff.Value)
+			}
+			for _, v := range vals {
+				parts = append(parts, fmt.Sprintf("%s != %s", field, formatValue(v)))
+			}
+		default:
+			parts = append(parts, fmt.Sprintf("%s %s %s", field, op, formatValue(ff.Value)))
+		}
+	}
+
+	return strings.Join(parts, " AND "), nil
+}
+
+// formatValue formats a single filter value for inclusion in a filterQuery string.
+func formatValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		// Escape single quotes inside string values.
+		escaped := strings.ReplaceAll(val, "'", "\\'")
+		return fmt.Sprintf("'%s'", escaped)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}

--- a/catalog/internal/catalog/basecatalog/filter_query_test.go
+++ b/catalog/internal/catalog/basecatalog/filter_query_test.go
@@ -1,0 +1,154 @@
+package basecatalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldFiltersToFilterQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		filters  map[string]FieldFilter
+		expected string
+	}{
+		{
+			name:     "empty filters",
+			filters:  map[string]FieldFilter{},
+			expected: "",
+		},
+		{
+			name:     "nil filters",
+			filters:  nil,
+			expected: "",
+		},
+		{
+			name: "single equality filter with string value",
+			filters: map[string]FieldFilter{
+				"provider": {Operator: "=", Value: "OpenAI"},
+			},
+			expected: "provider = 'OpenAI'",
+		},
+		{
+			name: "single equality filter with integer value",
+			filters: map[string]FieldFilter{
+				"rating": {Operator: ">=", Value: 4},
+			},
+			expected: "rating >= 4",
+		},
+		{
+			name: "boolean value",
+			filters: map[string]FieldFilter{
+				"verified": {Operator: "=", Value: true},
+			},
+			expected: "verified = true",
+		},
+		{
+			name: "false boolean value",
+			filters: map[string]FieldFilter{
+				"deprecated": {Operator: "=", Value: false},
+			},
+			expected: "deprecated = false",
+		},
+		{
+			name: "IN operator with string values",
+			filters: map[string]FieldFilter{
+				"status": {Operator: "IN", Value: []any{"active", "beta"}},
+			},
+			expected: "status IN ('active', 'beta')",
+		},
+		{
+			name: "IN operator with numeric values",
+			filters: map[string]FieldFilter{
+				"tier": {Operator: "IN", Value: []any{1, 2, 3}},
+			},
+			expected: "tier IN (1, 2, 3)",
+		},
+		{
+			name: "NOT IN operator expands to multiple != conditions",
+			filters: map[string]FieldFilter{
+				"status": {Operator: "NOT IN", Value: []any{"deprecated", "archived"}},
+			},
+			// NOT IN expands to individual != conditions because the filter
+			// parser does not support NOT IN natively.
+			expected: "status != 'deprecated' AND status != 'archived'",
+		},
+		{
+			name: "LIKE operator",
+			filters: map[string]FieldFilter{
+				"name": {Operator: "LIKE", Value: "%assistant%"},
+			},
+			expected: "name LIKE '%assistant%'",
+		},
+		{
+			name: "multiple filters joined with AND in sorted order",
+			filters: map[string]FieldFilter{
+				"provider": {Operator: "=", Value: "OpenAI"},
+				"verified": {Operator: "=", Value: true},
+			},
+			// Fields sorted alphabetically: provider before verified
+			expected: "provider = 'OpenAI' AND verified = true",
+		},
+		{
+			name: "string with single quote is escaped",
+			filters: map[string]FieldFilter{
+				"name": {Operator: "=", Value: "O'Reilly"},
+			},
+			expected: "name = 'O\\'Reilly'",
+		},
+		{
+			name: "ILIKE operator",
+			filters: map[string]FieldFilter{
+				"description": {Operator: "ILIKE", Value: "%search%"},
+			},
+			expected: "description ILIKE '%search%'",
+		},
+		{
+			name: "lowercase operator is normalized to uppercase",
+			filters: map[string]FieldFilter{
+				"status": {Operator: "like", Value: "%active%"},
+			},
+			expected: "status LIKE '%active%'",
+		},
+		{
+			name: "not-equal operator",
+			filters: map[string]FieldFilter{
+				"status": {Operator: "!=", Value: "deprecated"},
+			},
+			expected: "status != 'deprecated'",
+		},
+		{
+			name: "float64 value from YAML number parsing",
+			filters: map[string]FieldFilter{
+				"rating": {Operator: ">=", Value: float64(4.5)},
+			},
+			expected: "rating >= 4.5",
+		},
+	}
+
+	t.Run("error on non-array value for IN operator", func(t *testing.T) {
+		filters := map[string]FieldFilter{
+			"status": {Operator: "IN", Value: "not-an-array"},
+		}
+		_, err := FieldFiltersToFilterQuery(filters)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "IN operator requires array value")
+	})
+
+	t.Run("error on non-array value for NOT IN operator", func(t *testing.T) {
+		filters := map[string]FieldFilter{
+			"status": {Operator: "NOT IN", Value: "not-an-array"},
+		}
+		_, err := FieldFiltersToFilterQuery(filters)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "NOT IN operator requires array value")
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := FieldFiltersToFilterQuery(tt.filters)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/catalog/internal/catalog/basecatalog/validation.go
+++ b/catalog/internal/catalog/basecatalog/validation.go
@@ -19,6 +19,43 @@ var supportedOperators = map[string]bool{
 	"NOT IN": true,
 }
 
+// MCPServerFilterableFields is the set of valid field names that may be used in
+// named query filters targeting MCP servers. Field names not in this set are
+// rejected at config-parse time to catch typos early.
+var MCPServerFilterableFields = map[string]bool{
+	// Common Context properties
+	"id":                       true,
+	"name":                     true,
+	"externalId":               true,
+	"createTimeSinceEpoch":     true,
+	"lastUpdateTimeSinceEpoch": true,
+	// MCPServer-specific properties
+	"source_id":        true,
+	"base_name":        true,
+	"description":      true,
+	"provider":         true,
+	"license":          true,
+	"license_link":     true,
+	"logo":             true,
+	"readme":           true,
+	"version":          true,
+	"tags":             true,
+	"transports":       true,
+	"deploymentMode":   true,
+	"documentationUrl": true,
+	"repositoryUrl":    true,
+	"sourceCode":       true,
+	"publishedDate":    true,
+	"lastUpdated":      true,
+	"verifiedSource":   true,
+	"secureEndpoint":   true,
+	"sast":             true,
+	"readOnlyTools":    true,
+	"endpoints":        true,
+	"artifacts":        true,
+	"runtimeMetadata":  true,
+}
+
 // ValidateNamedQueries validates the structure and content of named queries
 func ValidateNamedQueries(namedQueries map[string]map[string]FieldFilter) error {
 	for queryName, fieldFilters := range namedQueries {
@@ -41,6 +78,20 @@ func ValidateNamedQueries(namedQueries map[string]map[string]FieldFilter) error 
 		}
 	}
 
+	return nil
+}
+
+// ValidateFieldNames checks that every field name used across all named queries
+// is present in allowedFields. This catches typos at config-parse time before
+// they silently produce empty results at runtime.
+func ValidateFieldNames(namedQueries map[string]map[string]FieldFilter, allowedFields map[string]bool) error {
+	for queryName, fieldFilters := range namedQueries {
+		for fieldName := range fieldFilters {
+			if !allowedFields[fieldName] {
+				return fmt.Errorf("unknown field %q in named query %q: not a filterable MCP server field", fieldName, queryName)
+			}
+		}
+	}
 	return nil
 }
 

--- a/catalog/internal/catalog/basecatalog/validation_test.go
+++ b/catalog/internal/catalog/basecatalog/validation_test.go
@@ -17,8 +17,8 @@ func TestValidateNamedQueries(t *testing.T) {
 			name: "valid named queries",
 			namedQueries: map[string]map[string]FieldFilter{
 				"test-query": {
-					"field1": {Operator: "=", Value: "value"},
-					"field2": {Operator: ">", Value: 42},
+					"name":     {Operator: "=", Value: "my-server"},
+					"provider": {Operator: "=", Value: "Anthropic"},
 				},
 			},
 			expectError: false,
@@ -27,7 +27,7 @@ func TestValidateNamedQueries(t *testing.T) {
 			name: "invalid operator",
 			namedQueries: map[string]map[string]FieldFilter{
 				"test-query": {
-					"field1": {Operator: "INVALID", Value: "value"},
+					"name": {Operator: "INVALID", Value: "value"},
 				},
 			},
 			expectError:   true,
@@ -37,7 +37,7 @@ func TestValidateNamedQueries(t *testing.T) {
 			name: "empty operator",
 			namedQueries: map[string]map[string]FieldFilter{
 				"test-query": {
-					"field1": {Operator: "", Value: "value"},
+					"name": {Operator: "", Value: "value"},
 				},
 			},
 			expectError:   true,
@@ -47,7 +47,7 @@ func TestValidateNamedQueries(t *testing.T) {
 			name: "nil value",
 			namedQueries: map[string]map[string]FieldFilter{
 				"test-query": {
-					"field1": {Operator: "=", Value: nil},
+					"name": {Operator: "=", Value: nil},
 				},
 			},
 			expectError:   true,
@@ -77,7 +77,7 @@ func TestLoaderValidationIntegration(t *testing.T) {
 		Catalogs: []ModelSource{},
 		NamedQueries: map[string]map[string]FieldFilter{
 			"valid-query": {
-				"field1": {Operator: "=", Value: "value"},
+				"name": {Operator: "=", Value: "my-server"},
 			},
 		},
 	}
@@ -91,7 +91,7 @@ func TestLoaderValidationIntegration(t *testing.T) {
 		Catalogs: []ModelSource{},
 		NamedQueries: map[string]map[string]FieldFilter{
 			"invalid-query": {
-				"field1": {Operator: "INVALID_OP", Value: "value"},
+				"name": {Operator: "INVALID_OP", Value: "value"},
 			},
 		},
 	}
@@ -100,4 +100,40 @@ func TestLoaderValidationIntegration(t *testing.T) {
 	err = ValidateNamedQueries(invalidConfig.NamedQueries)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported operator 'INVALID_OP'")
+}
+
+func TestValidateFieldNames(t *testing.T) {
+	t.Run("valid MCP server field names pass", func(t *testing.T) {
+		queries := map[string]map[string]FieldFilter{
+			"q1": {
+				"name":           {Operator: "=", Value: "server"},
+				"provider":       {Operator: "=", Value: "OpenAI"},
+				"verifiedSource": {Operator: "=", Value: true},
+			},
+		}
+		err := ValidateFieldNames(queries, MCPServerFilterableFields)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unknown field name returns error", func(t *testing.T) {
+		queries := map[string]map[string]FieldFilter{
+			"q1": {
+				"typoField": {Operator: "=", Value: "x"},
+			},
+		}
+		err := ValidateFieldNames(queries, MCPServerFilterableFields)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown field")
+		assert.Contains(t, err.Error(), "typoField")
+	})
+
+	t.Run("nil queries returns no error", func(t *testing.T) {
+		err := ValidateFieldNames(nil, MCPServerFilterableFields)
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty queries returns no error", func(t *testing.T) {
+		err := ValidateFieldNames(map[string]map[string]FieldFilter{}, MCPServerFilterableFields)
+		assert.NoError(t, err)
+	})
 }

--- a/catalog/internal/catalog/catalog.go
+++ b/catalog/internal/catalog/catalog.go
@@ -8,6 +8,7 @@ import (
 
 type (
 	ModelSource = basecatalog.ModelSource
+	FieldFilter = basecatalog.FieldFilter
 )
 
 type (
@@ -20,9 +21,9 @@ type (
 	ListPerformanceArtifactsParams = modelcatalog.ListPerformanceArtifactsParams
 
 	// MCP catalog types
-	MCPProvider                   = mcpcatalog.MCPCatalogProvider
-	ListMCPServersParams          = mcpcatalog.ListMCPServersParams
-	ListMCPServerToolsParams      = mcpcatalog.ListMCPServerToolsParams
+	MCPProvider              = mcpcatalog.MCPCatalogProvider
+	ListMCPServersParams     = mcpcatalog.ListMCPServersParams
+	ListMCPServerToolsParams = mcpcatalog.ListMCPServerToolsParams
 )
 
 var (

--- a/catalog/internal/catalog/mcpcatalog/db_mcp.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp.go
@@ -4,32 +4,56 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubeflow/model-registry/catalog/internal/converter"
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog/models"
+	"github.com/kubeflow/model-registry/catalog/internal/converter"
 	"github.com/kubeflow/model-registry/catalog/internal/db/service"
 	openapi "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 	"github.com/kubeflow/model-registry/internal/apiutils"
 	"github.com/kubeflow/model-registry/pkg/api"
 )
 
+// NamedQueryResolver resolves a named query name to its field filters.
+// Returns (filters, true) if found, or (nil, false) if unknown.
+type NamedQueryResolver func(name string) (map[string]basecatalog.FieldFilter, bool)
+
 type dbMCPCatalogImpl struct {
 	mcpServerRepo     models.MCPServerRepository
 	mcpServerToolRepo models.MCPServerToolRepository
+	resolveNamedQuery NamedQueryResolver
 }
 
-func NewDBMCPCatalog(services service.Services) MCPCatalogProvider {
+func NewDBMCPCatalog(services service.Services, resolver NamedQueryResolver) MCPCatalogProvider {
 	return &dbMCPCatalogImpl{
 		mcpServerRepo:     services.MCPServerRepository,
 		mcpServerToolRepo: services.MCPServerToolRepository,
+		resolveNamedQuery: resolver,
 	}
 }
 
 func (d *dbMCPCatalogImpl) ListMCPServers(ctx context.Context, params ListMCPServersParams) (openapi.MCPServerList, error) {
+	filterQuery := params.FilterQuery
+
+	// Resolve named query server-side and merge with any user-provided filterQuery.
+	if params.NamedQuery != "" {
+		if d.resolveNamedQuery == nil {
+			return openapi.MCPServerList{}, fmt.Errorf("named query %q is not supported: no resolver configured: %w", params.NamedQuery, api.ErrBadRequest)
+		}
+		filters, found := d.resolveNamedQuery(params.NamedQuery)
+		if !found {
+			return openapi.MCPServerList{}, fmt.Errorf("unknown named query %q: %w", params.NamedQuery, api.ErrBadRequest)
+		}
+		resolved, err := basecatalog.FieldFiltersToFilterQuery(filters)
+		if err != nil {
+			return openapi.MCPServerList{}, fmt.Errorf("named query %q has invalid filter: %w", params.NamedQuery, err)
+		}
+		filterQuery = mergeFilterQueries(filterQuery, resolved)
+	}
+
 	// Build MCPServerListOptions from params
 	listOptions := models.MCPServerListOptions{
 		Query:       &params.Query,
-		FilterQuery: &params.FilterQuery,
-		NamedQuery:  &params.NamedQuery,
+		FilterQuery: &filterQuery,
 	}
 
 	if params.Name != "" {
@@ -81,6 +105,20 @@ func (d *dbMCPCatalogImpl) ListMCPServers(ctx context.Context, params ListMCPSer
 		PageSize:      params.PageSize,
 		NextPageToken: serversList.NextPageToken,
 	}, nil
+}
+
+// mergeFilterQueries combines two filterQuery strings with AND.
+// Empty strings are ignored. If both are non-empty, each is wrapped in parentheses
+// to preserve operator precedence.
+func mergeFilterQueries(a, b string) string {
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return fmt.Sprintf("(%s) AND (%s)", a, b)
+	}
 }
 
 func (d *dbMCPCatalogImpl) GetMCPServer(ctx context.Context, serverID string, includeTools bool) (*openapi.MCPServer, error) {

--- a/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
@@ -1,0 +1,176 @@
+package mcpcatalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog/models"
+	internalmodels "github.com/kubeflow/model-registry/internal/db/models"
+	"github.com/kubeflow/model-registry/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mergeFilterQueries tests ---
+
+func TestMergeFilterQueries(t *testing.T) {
+	t.Run("both empty returns empty string", func(t *testing.T) {
+		result := mergeFilterQueries("", "")
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("only first non-empty returns first", func(t *testing.T) {
+		result := mergeFilterQueries("a = 1", "")
+		assert.Equal(t, "a = 1", result)
+	})
+
+	t.Run("only second non-empty returns second", func(t *testing.T) {
+		result := mergeFilterQueries("", "b = 2")
+		assert.Equal(t, "b = 2", result)
+	})
+
+	t.Run("both non-empty wraps each in parens and joins with AND", func(t *testing.T) {
+		result := mergeFilterQueries("a = 1", "b = 2")
+		assert.Equal(t, "(a = 1) AND (b = 2)", result)
+	})
+}
+
+// --- mock repository ---
+
+// mockMCPServerRepo is a minimal MCPServerRepository for unit testing.
+type mockMCPServerRepo struct {
+	listResult *internalmodels.ListWrapper[models.MCPServer]
+	listErr    error
+	// capturedOptions stores the last MCPServerListOptions passed to List.
+	capturedOptions models.MCPServerListOptions
+}
+
+func (m *mockMCPServerRepo) List(opts models.MCPServerListOptions) (*internalmodels.ListWrapper[models.MCPServer], error) {
+	m.capturedOptions = opts
+	return m.listResult, m.listErr
+}
+
+func (m *mockMCPServerRepo) GetByID(_ int32) (models.MCPServer, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockMCPServerRepo) GetByNameAndVersion(_ string, _ string) (models.MCPServer, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockMCPServerRepo) Save(_ models.MCPServer) (models.MCPServer, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockMCPServerRepo) DeleteBySource(_ string) error { return errors.New("not implemented") }
+func (m *mockMCPServerRepo) DeleteByID(_ int32) error      { return errors.New("not implemented") }
+func (m *mockMCPServerRepo) GetDistinctSourceIDs() ([]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+// mockMCPServerToolRepo is a minimal MCPServerToolRepository that always returns empty.
+type mockMCPServerToolRepo struct{}
+
+func (m *mockMCPServerToolRepo) List(_ models.MCPServerToolListOptions) ([]models.MCPServerTool, error) {
+	return nil, nil
+}
+func (m *mockMCPServerToolRepo) GetByID(_ int32) (models.MCPServerTool, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockMCPServerToolRepo) Save(_ models.MCPServerTool, _ *int32) (models.MCPServerTool, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockMCPServerToolRepo) DeleteByParentID(_ int32) error { return errors.New("not implemented") }
+func (m *mockMCPServerToolRepo) DeleteByID(_ int32) error       { return errors.New("not implemented") }
+
+// --- ListMCPServers named query tests ---
+
+func newTestCatalog(repo *mockMCPServerRepo, resolver NamedQueryResolver) *dbMCPCatalogImpl {
+	return &dbMCPCatalogImpl{
+		mcpServerRepo:     repo,
+		mcpServerToolRepo: &mockMCPServerToolRepo{},
+		resolveNamedQuery: resolver,
+	}
+}
+
+func emptyList() *internalmodels.ListWrapper[models.MCPServer] {
+	return &internalmodels.ListWrapper[models.MCPServer]{Items: []models.MCPServer{}}
+}
+
+func TestListMCPServers_NoNamedQuery(t *testing.T) {
+	repo := &mockMCPServerRepo{listResult: emptyList()}
+	cat := newTestCatalog(repo, nil)
+
+	_, err := cat.ListMCPServers(context.Background(), ListMCPServersParams{
+		FilterQuery: "provider = 'OpenAI'",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "provider = 'OpenAI'", *repo.capturedOptions.FilterQuery)
+}
+
+func TestListMCPServers_NamedQueryResolved(t *testing.T) {
+	repo := &mockMCPServerRepo{listResult: emptyList()}
+	resolver := func(name string) (map[string]basecatalog.FieldFilter, bool) {
+		if name == "verified_only" {
+			return map[string]basecatalog.FieldFilter{
+				"verified": {Operator: "=", Value: true},
+			}, true
+		}
+		return nil, false
+	}
+	cat := newTestCatalog(repo, resolver)
+
+	_, err := cat.ListMCPServers(context.Background(), ListMCPServersParams{
+		NamedQuery: "verified_only",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "verified = true", *repo.capturedOptions.FilterQuery)
+}
+
+func TestListMCPServers_NamedQueryMergedWithFilterQuery(t *testing.T) {
+	repo := &mockMCPServerRepo{listResult: emptyList()}
+	resolver := func(name string) (map[string]basecatalog.FieldFilter, bool) {
+		if name == "active" {
+			return map[string]basecatalog.FieldFilter{
+				"status": {Operator: "=", Value: "active"},
+			}, true
+		}
+		return nil, false
+	}
+	cat := newTestCatalog(repo, resolver)
+
+	_, err := cat.ListMCPServers(context.Background(), ListMCPServersParams{
+		NamedQuery:  "active",
+		FilterQuery: "provider = 'OpenAI'",
+	})
+	require.NoError(t, err)
+	// user filterQuery comes first, named query resolved second, both wrapped in parens
+	assert.Equal(t, "(provider = 'OpenAI') AND (status = 'active')", *repo.capturedOptions.FilterQuery)
+}
+
+func TestListMCPServers_NoResolverReturnsError(t *testing.T) {
+	repo := &mockMCPServerRepo{listResult: emptyList()}
+	cat := newTestCatalog(repo, nil)
+
+	_, err := cat.ListMCPServers(context.Background(), ListMCPServersParams{
+		NamedQuery: "any_query",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, api.ErrBadRequest))
+}
+
+func TestListMCPServers_UnknownNamedQueryReturnsError(t *testing.T) {
+	repo := &mockMCPServerRepo{listResult: emptyList()}
+	resolver := func(_ string) (map[string]basecatalog.FieldFilter, bool) {
+		return nil, false
+	}
+	cat := newTestCatalog(repo, resolver)
+
+	_, err := cat.ListMCPServers(context.Background(), ListMCPServersParams{
+		NamedQuery: "nonexistent",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, api.ErrBadRequest))
+}

--- a/catalog/internal/catalog/mcpcatalog/loader.go
+++ b/catalog/internal/catalog/mcpcatalog/loader.go
@@ -161,6 +161,9 @@ func (ml *MCPLoader) updateSources(path string, config *basecatalog.SourceConfig
 		glog.Infof("loaded MCP source %s of type %s", source.ID, source.Type)
 	}
 
+	if config.NamedQueries != nil {
+		return ml.Sources.MergeWithNamedQueries(path, sources, config.NamedQueries)
+	}
 	return ml.Sources.Merge(path, sources)
 }
 

--- a/catalog/internal/catalog/mcpcatalog/loader_test.go
+++ b/catalog/internal/catalog/mcpcatalog/loader_test.go
@@ -706,3 +706,64 @@ func TestMCPLoaderSavesErrorSourceStatus(t *testing.T) {
 	assert.True(t, foundStatus, "status property should be set to 'error'")
 	assert.True(t, foundError, "error property should be set")
 }
+
+func TestMCPLoader_NamedQueriesFromConfig(t *testing.T) {
+	_, services, cleanup := setupMCPLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+
+	// A sources file that includes named queries
+	sourcesFile := filepath.Join(tmpDir, "sources.yaml")
+	err := os.WriteFile(sourcesFile, []byte(`mcp_catalogs: []
+namedQueries:
+  production_ready:
+    verifiedSource:
+      operator: "="
+      value: true
+    version:
+      operator: ">="
+      value: "2"
+`), 0644)
+	require.NoError(t, err)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewMCPLoaderWithState(services, baseLoader)
+
+	err = loader.ParseAllConfigs()
+	require.NoError(t, err)
+
+	queries := loader.Sources.GetNamedQueries()
+	require.Len(t, queries, 1, "should have one named query")
+
+	pq, ok := queries["production_ready"]
+	require.True(t, ok, "production_ready named query should exist")
+	assert.Equal(t, "=", pq["verifiedSource"].Operator)
+	assert.Equal(t, true, pq["verifiedSource"].Value)
+	assert.Equal(t, ">=", pq["version"].Operator)
+	assert.Equal(t, "2", pq["version"].Value)
+}
+
+func TestMCPLoader_InvalidNamedQueriesRejected(t *testing.T) {
+	_, services, cleanup := setupMCPLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+
+	sourcesFile := filepath.Join(tmpDir, "sources.yaml")
+	err := os.WriteFile(sourcesFile, []byte(`mcp_catalogs: []
+namedQueries:
+  bad_query:
+    name:
+      operator: "INVALID_OP"
+      value: "something"
+`), 0644)
+	require.NoError(t, err)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewMCPLoaderWithState(services, baseLoader)
+
+	err = loader.ParseAllConfigs()
+	require.Error(t, err, "invalid named query operator should be rejected")
+	assert.Contains(t, err.Error(), "INVALID_OP")
+}

--- a/catalog/internal/catalog/mcpcatalog/models/mcp_server.go
+++ b/catalog/internal/catalog/mcpcatalog/models/mcp_server.go
@@ -13,7 +13,6 @@ type MCPServerListOptions struct {
 	SourceIDs   *[]string
 	Query       *string
 	FilterQuery *string
-	NamedQuery  *string
 }
 
 // GetRestEntityType implements the FilterApplier interface.

--- a/catalog/internal/catalog/mcpcatalog/sources.go
+++ b/catalog/internal/catalog/mcpcatalog/sources.go
@@ -1,6 +1,7 @@
 package mcpcatalog
 
 import (
+	"maps"
 	"sync"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
@@ -16,8 +17,9 @@ type mcpOriginEntry struct {
 // MCPSourceCollection manages MCP catalog sources from multiple origins with priority-based merging.
 // Later entries in the slice take precedence over earlier ones.
 type MCPSourceCollection struct {
-	mu      sync.RWMutex
-	entries []mcpOriginEntry
+	mu           sync.RWMutex
+	entries      []mcpOriginEntry
+	namedQueries map[string]map[string]basecatalog.FieldFilter
 }
 
 // NewMCPSourceCollection creates a new MCPSourceCollection with the given origin order.
@@ -30,7 +32,8 @@ func NewMCPSourceCollection(originOrder ...string) *MCPSourceCollection {
 		entries[i] = mcpOriginEntry{origin: origin, sources: nil}
 	}
 	return &MCPSourceCollection{
-		entries: entries,
+		entries:      entries,
+		namedQueries: make(map[string]map[string]basecatalog.FieldFilter),
 	}
 }
 
@@ -46,6 +49,76 @@ func (msc *MCPSourceCollection) Merge(origin string, sources map[string]basecata
 	msc.mu.Lock()
 	defer msc.mu.Unlock()
 
+	return msc.mergeSourcesInternal(origin, sources)
+}
+
+// MergeWithNamedQueries adds sources and named queries from one origin.
+// Later origins override earlier ones at the field level within a query.
+func (msc *MCPSourceCollection) MergeWithNamedQueries(origin string, sources map[string]basecatalog.MCPSource, namedQueries map[string]map[string]basecatalog.FieldFilter) error {
+	msc.mu.Lock()
+	defer msc.mu.Unlock()
+
+	if err := msc.mergeSourcesInternal(origin, sources); err != nil {
+		return err
+	}
+
+	// Merge named queries (later origins override earlier ones at field level)
+	for queryName, fieldFilters := range namedQueries {
+		if msc.namedQueries[queryName] == nil {
+			msc.namedQueries[queryName] = make(map[string]basecatalog.FieldFilter)
+		}
+		maps.Copy(msc.namedQueries[queryName], fieldFilters)
+	}
+
+	return nil
+}
+
+// GetNamedQuery returns a copy of a single named query by name.
+// Returns (filters, true) if found, or (nil, false) if unknown.
+// Slice values within each FieldFilter are cloned to prevent callers from
+// accidentally mutating internal state.
+func (msc *MCPSourceCollection) GetNamedQuery(name string) (map[string]basecatalog.FieldFilter, bool) {
+	msc.mu.RLock()
+	defer msc.mu.RUnlock()
+
+	fieldFilters, ok := msc.namedQueries[name]
+	if !ok {
+		return nil, false
+	}
+	result := make(map[string]basecatalog.FieldFilter, len(fieldFilters))
+	for field, ff := range fieldFilters {
+		result[field] = deepCopyFieldFilter(ff)
+	}
+	return result, true
+}
+
+// deepCopyFieldFilter returns a copy of ff where slice values are cloned.
+func deepCopyFieldFilter(ff basecatalog.FieldFilter) basecatalog.FieldFilter {
+	if vals, ok := ff.Value.([]any); ok {
+		cp := make([]any, len(vals))
+		copy(cp, vals)
+		ff.Value = cp
+	}
+	return ff
+}
+
+// GetNamedQueries returns a deep copy of all merged named queries.
+func (msc *MCPSourceCollection) GetNamedQueries() map[string]map[string]basecatalog.FieldFilter {
+	msc.mu.RLock()
+	defer msc.mu.RUnlock()
+
+	result := make(map[string]map[string]basecatalog.FieldFilter, len(msc.namedQueries))
+	for queryName, fieldFilters := range msc.namedQueries {
+		result[queryName] = make(map[string]basecatalog.FieldFilter, len(fieldFilters))
+		for field, ff := range fieldFilters {
+			result[queryName][field] = deepCopyFieldFilter(ff)
+		}
+	}
+	return result
+}
+
+// mergeSourcesInternal performs the source merge. Must be called with lock held.
+func (msc *MCPSourceCollection) mergeSourcesInternal(origin string, sources map[string]basecatalog.MCPSource) error {
 	// Find existing entry for this origin
 	for i := range msc.entries {
 		if msc.entries[i].origin == origin {

--- a/catalog/internal/catalog/mcpcatalog/sources_test.go
+++ b/catalog/internal/catalog/mcpcatalog/sources_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
 	"github.com/kubeflow/model-registry/internal/apiutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMCPSourceCollection_MergeOverride(t *testing.T) {
@@ -700,4 +702,170 @@ func TestMCPSourceCollection_MergeOverride_DynamicOrigin(t *testing.T) {
 	if source.Name != "Extra Override" {
 		t.Errorf("dynamically added origin should override earlier origins, got Name = %s, want 'Extra Override'", source.Name)
 	}
+}
+
+func TestMCPSourceCollection_MergeWithNamedQueries(t *testing.T) {
+	t.Run("stores and retrieves named queries", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Name: "Source 1", Type: "yaml"},
+		}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"production_ready": {
+				"verified": {Operator: "=", Value: true},
+			},
+		}
+
+		err := coll.MergeWithNamedQueries("origin1", sources, queries)
+		require.NoError(t, err)
+
+		result := coll.GetNamedQueries()
+		require.Len(t, result, 1)
+		assert.Equal(t, "=", result["production_ready"]["verified"].Operator)
+		assert.Equal(t, true, result["production_ready"]["verified"].Value)
+	})
+
+	t.Run("later origin overrides field-level within a query", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{}
+
+		queriesA := map[string]map[string]basecatalog.FieldFilter{
+			"quality": {
+				"rating":   {Operator: ">=", Value: 3},
+				"verified": {Operator: "=", Value: false},
+			},
+		}
+		queriesB := map[string]map[string]basecatalog.FieldFilter{
+			"quality": {
+				"verified": {Operator: "=", Value: true}, // overrides origin A
+			},
+		}
+
+		require.NoError(t, coll.MergeWithNamedQueries("originA", sources, queriesA))
+		require.NoError(t, coll.MergeWithNamedQueries("originB", sources, queriesB))
+
+		result := coll.GetNamedQueries()
+		// "rating" from A is still present
+		assert.Equal(t, ">=", result["quality"]["rating"].Operator)
+		assert.Equal(t, 3, result["quality"]["rating"].Value)
+		// "verified" from B overrides A
+		assert.Equal(t, true, result["quality"]["verified"].Value)
+	})
+
+	t.Run("multiple distinct queries accumulated across origins", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{}
+
+		require.NoError(t, coll.MergeWithNamedQueries("originA", sources, map[string]map[string]basecatalog.FieldFilter{
+			"queryA": {"field": {Operator: "=", Value: "a"}},
+		}))
+		require.NoError(t, coll.MergeWithNamedQueries("originB", sources, map[string]map[string]basecatalog.FieldFilter{
+			"queryB": {"field": {Operator: "=", Value: "b"}},
+		}))
+
+		result := coll.GetNamedQueries()
+		assert.Len(t, result, 2)
+		assert.Contains(t, result, "queryA")
+		assert.Contains(t, result, "queryB")
+	})
+
+	t.Run("sources are still merged correctly alongside named queries", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Name: "Source 1", Type: "yaml"},
+		}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"test_query": {"field": {Operator: "=", Value: "val"}},
+		}
+
+		err := coll.MergeWithNamedQueries("origin1", sources, queries)
+		require.NoError(t, err)
+
+		all := coll.AllSources()
+		assert.Contains(t, all, "src1")
+	})
+}
+
+func TestMCPSourceCollection_GetNamedQueries_DeepCopy(t *testing.T) {
+	coll := NewMCPSourceCollection()
+	queries := map[string]map[string]basecatalog.FieldFilter{
+		"my_query": {"field": {Operator: "=", Value: "original"}},
+	}
+	require.NoError(t, coll.MergeWithNamedQueries("origin", map[string]basecatalog.MCPSource{}, queries))
+
+	// Mutate the returned map
+	result := coll.GetNamedQueries()
+	result["my_query"]["field"] = basecatalog.FieldFilter{Operator: "!=", Value: "mutated"}
+	delete(result, "my_query")
+
+	// Internal state must be unchanged
+	result2 := coll.GetNamedQueries()
+	require.Len(t, result2, 1)
+	assert.Equal(t, "=", result2["my_query"]["field"].Operator)
+	assert.Equal(t, "original", result2["my_query"]["field"].Value)
+}
+
+func TestMCPSourceCollection_GetNamedQuery(t *testing.T) {
+	coll := NewMCPSourceCollection()
+	queries := map[string]map[string]basecatalog.FieldFilter{
+		"verified_only": {"verified": {Operator: "=", Value: true}},
+	}
+	require.NoError(t, coll.MergeWithNamedQueries("origin", map[string]basecatalog.MCPSource{}, queries))
+
+	t.Run("returns filters for known query", func(t *testing.T) {
+		filters, ok := coll.GetNamedQuery("verified_only")
+		assert.True(t, ok)
+		require.Len(t, filters, 1)
+		assert.Equal(t, "=", filters["verified"].Operator)
+	})
+
+	t.Run("returns false for unknown query", func(t *testing.T) {
+		filters, ok := coll.GetNamedQuery("nonexistent")
+		assert.False(t, ok)
+		assert.Nil(t, filters)
+	})
+
+	t.Run("returned map is a copy and does not affect internal state", func(t *testing.T) {
+		filters, ok := coll.GetNamedQuery("verified_only")
+		require.True(t, ok)
+		filters["verified"] = basecatalog.FieldFilter{Operator: "!=", Value: false}
+
+		filters2, ok2 := coll.GetNamedQuery("verified_only")
+		require.True(t, ok2)
+		assert.Equal(t, "=", filters2["verified"].Operator)
+	})
+}
+
+func TestMCPSourceCollection_GetNamedQuery_SliceDeepCopy(t *testing.T) {
+	coll := NewMCPSourceCollection()
+	queries := map[string]map[string]basecatalog.FieldFilter{
+		"in_query": {"status": {Operator: "IN", Value: []any{"active", "beta"}}},
+	}
+	require.NoError(t, coll.MergeWithNamedQueries("origin", map[string]basecatalog.MCPSource{}, queries))
+
+	// Mutate the slice returned by GetNamedQuery
+	filters, ok := coll.GetNamedQuery("in_query")
+	require.True(t, ok)
+	sliceVal := filters["status"].Value.([]any)
+	sliceVal[0] = "mutated"
+
+	// Internal state must be unchanged
+	filters2, ok2 := coll.GetNamedQuery("in_query")
+	require.True(t, ok2)
+	assert.Equal(t, "active", filters2["status"].Value.([]any)[0])
+}
+
+func TestMCPSourceCollection_Merge_WithoutNamedQueries(t *testing.T) {
+	// Verify the regular Merge path still works after refactoring.
+	coll := NewMCPSourceCollection()
+	sources := map[string]basecatalog.MCPSource{
+		"src1": {ID: "src1", Name: "Source 1", Type: "yaml"},
+	}
+
+	err := coll.Merge("origin1", sources)
+	require.NoError(t, err)
+
+	all := coll.AllSources()
+	assert.Contains(t, all, "src1")
+	assert.Empty(t, coll.GetNamedQueries())
 }

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog"
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog"
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 	"github.com/kubeflow/model-registry/pkg/api"
 )
@@ -14,14 +15,16 @@ import (
 // MCPCatalogServiceAPIService is a service that implements the logic for the MCPCatalogServiceAPIServicer
 type MCPCatalogServiceAPIService struct {
 	mcpProvider catalog.MCPProvider
+	mcpSources  *mcpcatalog.MCPSourceCollection
 }
 
 var _ MCPCatalogServiceAPIServicer = &MCPCatalogServiceAPIService{}
 
 // NewMCPCatalogServiceAPIService creates a default api service
-func NewMCPCatalogServiceAPIService(mcpProvider catalog.MCPProvider) MCPCatalogServiceAPIServicer {
+func NewMCPCatalogServiceAPIService(mcpProvider catalog.MCPProvider, mcpSources *mcpcatalog.MCPSourceCollection) MCPCatalogServiceAPIServicer {
 	return &MCPCatalogServiceAPIService{
 		mcpProvider: mcpProvider,
+		mcpSources:  mcpSources,
 	}
 }
 
@@ -61,7 +64,24 @@ func (m *MCPCatalogServiceAPIService) FindMCPServers(ctx context.Context, name s
 
 // FindMCPServersFilterOptions - Lists fields, values, and named queries that can be used in `filterQuery` on the list MCP servers endpoint.
 func (m *MCPCatalogServiceAPIService) FindMCPServersFilterOptions(ctx context.Context) (ImplResponse, error) {
-	return ErrorResponse(http.StatusNotImplemented, errors.New("FindMCPServersFilterOptions not implemented")), nil
+	if m.mcpSources == nil {
+		return Response(http.StatusOK, model.FilterOptionsList{}), nil
+	}
+
+	srcQueries := m.mcpSources.GetNamedQueries()
+	converted := make(map[string]map[string]model.FieldFilter, len(srcQueries))
+	for queryName, fieldFilters := range srcQueries {
+		inner := make(map[string]model.FieldFilter, len(fieldFilters))
+		for field, ff := range fieldFilters {
+			inner[field] = model.FieldFilter{
+				Operator: ff.Operator,
+				Value:    ff.Value,
+			}
+		}
+		converted[queryName] = inner
+	}
+
+	return Response(http.StatusOK, model.FilterOptionsList{NamedQueries: &converted}), nil
 }
 
 // GetMCPServer - Get an `MCPServer`.

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog"
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog"
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 	"github.com/kubeflow/model-registry/pkg/api"
 	"github.com/stretchr/testify/assert"
@@ -24,6 +26,9 @@ type mockMCPProvider struct {
 	shouldErrorOnGetServer   bool
 	shouldErrorOnListTools   bool
 	shouldErrorOnGetTool     bool
+	// namedQueryErr simulates an error returned by the provider for a specific named query.
+	// This is used to verify the service correctly propagates provider errors.
+	namedQueryErr map[string]error
 }
 
 func newMockMCPProvider() *mockMCPProvider {
@@ -52,6 +57,12 @@ func (m *mockMCPProvider) addTool(serverID string, toolName string, tool *model.
 func (m *mockMCPProvider) ListMCPServers(ctx context.Context, params catalog.ListMCPServersParams) (model.MCPServerList, error) {
 	if m.shouldErrorOnListServers {
 		return model.MCPServerList{}, fmt.Errorf("mock error in ListMCPServers")
+	}
+
+	if params.NamedQuery != "" {
+		if err, ok := m.namedQueryErr[params.NamedQuery]; ok {
+			return model.MCPServerList{}, err
+		}
 	}
 
 	var items []model.MCPServer
@@ -316,6 +327,57 @@ func TestFindMCPServers(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 			expectError:    true,
 		},
+		{
+			name: "Unknown named query returns bad request",
+			mockSetup: func(provider *mockMCPProvider) {
+				provider.namedQueryErr = map[string]error{
+					"unknown_query": fmt.Errorf("unknown named query %q: %w", "unknown_query", api.ErrBadRequest),
+				}
+			},
+			namedQuery:     "unknown_query",
+			pageSize:       "10",
+			expectedStatus: http.StatusBadRequest,
+			expectError:    true,
+		},
+		{
+			name: "Known named query is forwarded to provider",
+			mockSetup: func(provider *mockMCPProvider) {
+				provider.addServer("1", openAIServer)
+				// production_ready is a known query — no error entry means success
+				provider.namedQueryErr = map[string]error{}
+			},
+			namedQuery:     "production_ready",
+			pageSize:       "10",
+			expectedStatus: http.StatusOK,
+			expectedServerList: &model.MCPServerList{
+				Items: []model.MCPServer{
+					func() model.MCPServer { s := *openAIServer; s.Id = stringPointer("1"); return s }(),
+				},
+				Size:          1,
+				PageSize:      10,
+				NextPageToken: "",
+			},
+		},
+		{
+			name: "Named query combined with filterQuery both forwarded",
+			mockSetup: func(provider *mockMCPProvider) {
+				provider.addServer("1", openAIServer)
+				provider.addServer("2", githubServer)
+				provider.namedQueryErr = map[string]error{}
+			},
+			namedQuery:     "production_ready",
+			filterQuery:    "provider = 'OpenAI'",
+			pageSize:       "10",
+			expectedStatus: http.StatusOK,
+			expectedServerList: &model.MCPServerList{
+				Items: []model.MCPServer{
+					func() model.MCPServer { s := *openAIServer; s.Id = stringPointer("1"); return s }(),
+				},
+				Size:          1,
+				PageSize:      10,
+				NextPageToken: "",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -323,7 +385,7 @@ func TestFindMCPServers(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider)
+			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
 			result, err := service.FindMCPServers(
@@ -436,7 +498,7 @@ func TestGetMCPServer(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider)
+			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
 			result, err := service.GetMCPServer(ctx, tc.serverID, tc.includeTools)
@@ -559,7 +621,7 @@ func TestFindMCPServerTools(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider)
+			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
 			result, err := service.FindMCPServerTools(
@@ -653,7 +715,7 @@ func TestGetMCPServerTool(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider)
+			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
 			result, err := service.GetMCPServerTool(ctx, tc.serverID, tc.toolName)
@@ -677,14 +739,51 @@ func TestGetMCPServerTool(t *testing.T) {
 }
 
 func TestFindMCPServersFilterOptions(t *testing.T) {
-	mockProvider := newMockMCPProvider()
-	service := NewMCPCatalogServiceAPIService(mockProvider)
 	ctx := context.Background()
 
-	result, err := service.FindMCPServersFilterOptions(ctx)
+	t.Run("nil mcpSources returns empty FilterOptionsList", func(t *testing.T) {
+		service := NewMCPCatalogServiceAPIService(newMockMCPProvider(), nil)
+		result, err := service.FindMCPServersFilterOptions(ctx)
 
-	// Should return 501 Not Implemented as per the implementation
-	assert.Equal(t, http.StatusNotImplemented, result.Code)
-	// The function returns an error, but err should be nil as it's handled in the response
-	assert.NoError(t, err)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, result.Code)
+		body, ok := result.Body.(model.FilterOptionsList)
+		require.True(t, ok)
+		assert.Nil(t, body.NamedQueries)
+	})
+
+	t.Run("named queries from mcpSources are returned", func(t *testing.T) {
+		sources := mcpcatalog.NewMCPSourceCollection()
+		err := sources.MergeWithNamedQueries("test", nil, map[string]map[string]basecatalog.FieldFilter{
+			"production_ready": {
+				"maturity": {Operator: "=", Value: "production"},
+			},
+		})
+		require.NoError(t, err)
+
+		service := NewMCPCatalogServiceAPIService(newMockMCPProvider(), sources)
+		result, err := service.FindMCPServersFilterOptions(ctx)
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, result.Code)
+		body, ok := result.Body.(model.FilterOptionsList)
+		require.True(t, ok)
+		require.NotNil(t, body.NamedQueries)
+		nq := *body.NamedQueries
+		require.Contains(t, nq, "production_ready")
+		assert.Equal(t, model.FieldFilter{Operator: "=", Value: "production"}, nq["production_ready"]["maturity"])
+	})
+
+	t.Run("empty named queries returns empty map", func(t *testing.T) {
+		sources := mcpcatalog.NewMCPSourceCollection()
+		service := NewMCPCatalogServiceAPIService(newMockMCPProvider(), sources)
+		result, err := service.FindMCPServersFilterOptions(ctx)
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, result.Code)
+		body, ok := result.Body.(model.FilterOptionsList)
+		require.True(t, ok)
+		require.NotNil(t, body.NamedQueries)
+		assert.Empty(t, *body.NamedQueries)
+	})
 }

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-community-mcp-servers.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-community-mcp-servers.yaml
@@ -1,0 +1,616 @@
+source: Community and custom
+mcp_servers:
+  - name: prometheus-mcp
+    provider: Prometheus Community
+    license: apache-2.0
+    license_link: https://www.apache.org/licenses/LICENSE-2.0
+    description: >-
+      Query Prometheus metrics and alerts directly from your agent.
+      Provides PromQL query execution, alert retrieval, and metric discovery.
+    readme: |-
+      # Prometheus MCP Server
+
+      **MCP Server Summary:**
+      Access Prometheus metrics and alerting data through the MCP protocol.
+
+      ## Features
+      - Execute PromQL queries
+      - Query range data
+      - Retrieve active alerts
+
+      ## Prerequisites
+      - Prometheus server access
+      - Network connectivity to Prometheus API
+    version: "0.9.2"
+    transports:
+      - http
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    repositoryUrl: https://github.com/prometheus-community/prometheus-mcp
+    sourceCode: prometheus-community/prometheus-mcp
+    publishedDate: "2025-01-10"
+    tools:
+      - name: query
+        description: Execute PromQL queries
+        accessType: read_only
+        parameters:
+          - name: query
+            type: string
+            description: PromQL query expression
+            required: true
+      - name: query_range
+        description: Execute PromQL range queries
+        accessType: read_only
+        parameters:
+          - name: query
+            type: string
+            description: PromQL query expression
+            required: true
+          - name: start
+            type: string
+            description: Start timestamp
+            required: true
+          - name: end
+            type: string
+            description: End timestamp
+            required: true
+      - name: get_alerts
+        description: Retrieve active alerts
+        accessType: read_only
+        parameters: []
+    artifacts:
+      - uri: oci://ghcr.io/prometheus-community/prometheus-mcp:0.9.2
+        createTimeSinceEpoch: "1736510400000"
+        lastUpdateTimeSinceEpoch: "1736510400000"
+    customProperties:
+      # Tags (MetadataStringValue with empty string_value)
+      metrics:
+        metadataType: MetadataStringValue
+        string_value: ""
+      monitoring:
+        metadataType: MetadataStringValue
+        string_value: ""
+      alerting:
+        metadataType: MetadataStringValue
+        string_value: ""
+      # Security indicators (MetadataBoolValue)
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: false
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: true
+    createTimeSinceEpoch: "1736510400000"
+    lastUpdateTimeSinceEpoch: "1736510400000"
+
+  - name: kubernetes-mcp
+    provider: CNCF
+    license: apache-2.0
+    license_link: https://www.apache.org/licenses/LICENSE-2.0
+    description: >-
+      Interact with Kubernetes clusters through natural language.
+      List pods, check deployments, view logs, and manage resources.
+    readme: |-
+      # Kubernetes MCP Server
+
+      **MCP Server Summary:**
+      Comprehensive Kubernetes cluster management through MCP.
+
+      ## Features
+      - Pod management and listing
+      - Deployment operations
+      - Log retrieval
+      - Scaling operations
+
+      ## Prerequisites
+      - kubectl configured with cluster access
+      - Appropriate RBAC permissions
+    version: "1.2.0"
+    transports:
+      - stdio
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    repositoryUrl: https://github.com/cncf/kubernetes-mcp
+    sourceCode: cncf/kubernetes-mcp
+    publishedDate: "2025-01-12"
+    tools:
+      - name: get_pods
+        description: List pods in a namespace
+        accessType: read_only
+        parameters:
+          - name: namespace
+            type: string
+            description: Kubernetes namespace
+            required: true
+      - name: get_deployments
+        description: List deployments
+        accessType: read_only
+        parameters:
+          - name: namespace
+            type: string
+            description: Kubernetes namespace
+            required: true
+      - name: get_logs
+        description: Retrieve pod logs
+        accessType: read_only
+        parameters:
+          - name: namespace
+            type: string
+            description: Kubernetes namespace
+            required: true
+          - name: pod_name
+            type: string
+            description: Name of the pod
+            required: true
+      - name: scale_deployment
+        description: Scale a deployment
+        accessType: read_write
+        parameters:
+          - name: namespace
+            type: string
+            description: Kubernetes namespace
+            required: true
+          - name: deployment_name
+            type: string
+            description: Name of the deployment
+            required: true
+          - name: replicas
+            type: number
+            description: Desired number of replicas
+            required: true
+    artifacts:
+      - uri: oci://ghcr.io/cncf/kubernetes-mcp:1.2.0
+        createTimeSinceEpoch: "1736683200000"
+        lastUpdateTimeSinceEpoch: "1736683200000"
+    customProperties:
+      kubernetes:
+        metadataType: MetadataStringValue
+        string_value: ""
+      containers:
+        metadataType: MetadataStringValue
+        string_value: ""
+      orchestration:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1736683200000"
+    lastUpdateTimeSinceEpoch: "1736683200000"
+
+  - name: openshift-mcp
+    provider: Red Hat
+    license: apache-2.0
+    license_link: https://www.apache.org/licenses/LICENSE-2.0
+    description: >-
+      Red Hat OpenShift integration for container platform management.
+      Deploy applications, manage routes, and monitor cluster health.
+    readme: |-
+      # OpenShift MCP Server
+
+      **MCP Server Summary:**
+      Red Hat OpenShift container platform integration.
+
+      ## Features
+      - Project listing
+      - Route management
+      - Build operations
+
+      ## Prerequisites
+      - OpenShift CLI (oc) configured
+      - Cluster admin or developer access
+    version: "1.0.0"
+    transports:
+      - stdio
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    repositoryUrl: https://github.com/redhat/openshift-mcp
+    sourceCode: redhat/openshift-mcp
+    publishedDate: "2025-01-13"
+    tools:
+      - name: get_projects
+        description: List OpenShift projects
+        accessType: read_only
+        parameters: []
+      - name: get_routes
+        description: List routes in a project
+        accessType: read_only
+        parameters:
+          - name: project
+            type: string
+            description: Project name
+            required: true
+      - name: get_builds
+        description: List builds and their status
+        accessType: read_only
+        parameters:
+          - name: project
+            type: string
+            description: Project name
+            required: true
+      - name: start_build
+        description: Trigger a new build
+        accessType: read_write
+        parameters:
+          - name: project
+            type: string
+            description: Project name
+            required: true
+          - name: build_config
+            type: string
+            description: Build configuration name
+            required: true
+    artifacts:
+      - uri: oci://registry.redhat.io/openshift/openshift-mcp:1.0.0
+        createTimeSinceEpoch: "1736769600000"
+        lastUpdateTimeSinceEpoch: "1736769600000"
+    customProperties:
+      openshift:
+        metadataType: MetadataStringValue
+        string_value: ""
+      containers:
+        metadataType: MetadataStringValue
+        string_value: ""
+      kubernetes:
+        metadataType: MetadataStringValue
+        string_value: ""
+      enterprise:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1736769600000"
+    lastUpdateTimeSinceEpoch: "1736769600000"
+
+  - name: elasticsearch-mcp
+    provider: Elastic
+    license: elastic-2.0
+    license_link: https://www.elastic.co/licensing/elastic-license
+    description: >-
+      Query and analyze data in Elasticsearch clusters.
+      Execute searches, aggregations, and manage indices.
+    readme: |-
+      # Elasticsearch MCP Server
+
+      **MCP Server Summary:**
+      Elasticsearch data query and analysis.
+
+      ## Features
+      - Search queries
+      - Aggregations
+      - Index management
+
+      ## Prerequisites
+      - Elasticsearch cluster access
+      - API credentials (if authentication enabled)
+    version: "0.8.0"
+    transports:
+      - http
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    repositoryUrl: https://github.com/elastic/elasticsearch-mcp
+    sourceCode: elastic/elasticsearch-mcp
+    publishedDate: "2024-12-20"
+    tools:
+      - name: search
+        description: Execute a search query
+        accessType: read_only
+        parameters:
+          - name: index
+            type: string
+            description: Index name or pattern
+            required: true
+      - name: aggregate
+        description: Execute an aggregation query
+        accessType: read_only
+        parameters:
+          - name: index
+            type: string
+            description: Index name or pattern
+            required: true
+      - name: get_indices
+        description: List available indices
+        accessType: read_only
+        parameters: []
+    artifacts:
+      - uri: oci://docker.elastic.co/elasticsearch/elasticsearch-mcp:0.8.0
+        createTimeSinceEpoch: "1734696000000"
+        lastUpdateTimeSinceEpoch: "1734696000000"
+    customProperties:
+      search:
+        metadataType: MetadataStringValue
+        string_value: ""
+      analytics:
+        metadataType: MetadataStringValue
+        string_value: ""
+      logging:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: false
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: false
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: true
+    createTimeSinceEpoch: "1734696000000"
+    lastUpdateTimeSinceEpoch: "1734696000000"
+
+  # Remote MCP Servers - hosted externally, accessed via network endpoints
+  # Note: Remote servers do not have artifacts as they are hosted externally
+  - name: openai-assistants-mcp
+    provider: OpenAI
+    license: mit
+    license_link: https://opensource.org/licenses/MIT
+    description: >-
+      Access OpenAI Assistants API for advanced AI conversations and tool use.
+      This is a remotely hosted MCP server provided by OpenAI's cloud infrastructure.
+    readme: |-
+      # OpenAI Assistants MCP Server
+
+      **MCP Server Summary:**
+      Remotely hosted MCP server for OpenAI Assistants integration.
+
+      ## Features
+      - Create and manage AI assistants
+      - Execute conversations with tool use
+      - Retrieve assistant responses
+
+      ## Note
+      This is a remote MCP server hosted by OpenAI. No local deployment required.
+    deploymentMode: remote
+    endpoints:
+      http: https://api.openai.com/v1/mcp
+      sse: https://api.openai.com/v1/mcp/stream
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    documentationUrl: https://platform.openai.com/docs/assistants
+    repositoryUrl: https://github.com/openai/openai-mcp
+    sourceCode: openai/openai-mcp
+    publishedDate: "2025-01-20"
+    tools:
+      - name: create_assistant
+        description: Create a new AI assistant
+        accessType: read_write
+        parameters:
+          - name: name
+            type: string
+            description: Assistant name
+            required: true
+          - name: instructions
+            type: string
+            description: System instructions for the assistant
+            required: true
+      - name: chat
+        description: Send a message to an assistant
+        accessType: read_write
+        parameters:
+          - name: assistant_id
+            type: string
+            description: ID of the assistant
+            required: true
+          - name: message
+            type: string
+            description: User message
+            required: true
+      - name: list_assistants
+        description: List available assistants
+        accessType: read_only
+        parameters: []
+    customProperties:
+      ai:
+        metadataType: MetadataStringValue
+        string_value: ""
+      assistants:
+        metadataType: MetadataStringValue
+        string_value: ""
+      cloud:
+        metadataType: MetadataStringValue
+        string_value: ""
+      remote:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1737388800000"
+    lastUpdateTimeSinceEpoch: "1737388800000"
+
+  - name: anthropic-claude-mcp
+    provider: Anthropic
+    license: apache-2.0
+    license_link: https://www.apache.org/licenses/LICENSE-2.0
+    description: >-
+      Access Anthropic's Claude models through a remotely hosted MCP server.
+      Enables tool use, multi-turn conversations, and computer use capabilities.
+    readme: |-
+      # Anthropic Claude MCP Server
+
+      **MCP Server Summary:**
+      Remote MCP server for Claude AI integration.
+
+      ## Features
+      - Multi-turn conversations with Claude
+      - Tool use and function calling
+      - Computer use capabilities (beta)
+
+      ## Note
+      This server is hosted by Anthropic. API key required for access.
+    deploymentMode: remote
+    endpoints:
+      sse: https://api.anthropic.com/v1/mcp/events
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    documentationUrl: https://docs.anthropic.com/mcp
+    repositoryUrl: https://github.com/anthropic/claude-mcp
+    sourceCode: anthropic/claude-mcp
+    publishedDate: "2025-01-18"
+    tools:
+      - name: chat
+        description: Send a message to Claude
+        accessType: read_only
+        parameters:
+          - name: message
+            type: string
+            description: User message
+            required: true
+          - name: model
+            type: string
+            description: Claude model to use (e.g., claude-3-opus)
+            required: false
+      - name: use_tool
+        description: Have Claude use a tool
+        accessType: read_write
+        parameters:
+          - name: tool_name
+            type: string
+            description: Name of the tool
+            required: true
+          - name: parameters
+            type: object
+            description: Tool parameters
+            required: true
+    customProperties:
+      ai:
+        metadataType: MetadataStringValue
+        string_value: ""
+      claude:
+        metadataType: MetadataStringValue
+        string_value: ""
+      anthropic:
+        metadataType: MetadataStringValue
+        string_value: ""
+      remote:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1737216000000"
+    lastUpdateTimeSinceEpoch: "1737216000000"
+
+  - name: google-gemini-mcp
+    provider: Google
+    license: apache-2.0
+    license_link: https://www.apache.org/licenses/LICENSE-2.0
+    description: >-
+      Google Gemini AI integration through a managed remote MCP server.
+      Access multimodal capabilities, code generation, and reasoning.
+    readme: |-
+      # Google Gemini MCP Server
+
+      **MCP Server Summary:**
+      Remote MCP server for Google Gemini AI.
+
+      ## Features
+      - Multimodal input (text, images, video)
+      - Code generation and execution
+      - Advanced reasoning capabilities
+
+      ## Note
+      Hosted on Google Cloud. API key required.
+    deploymentMode: remote
+    endpoints:
+      http: https://generativelanguage.googleapis.com/v1/mcp
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    documentationUrl: https://ai.google.dev/docs
+    repositoryUrl: https://github.com/google/gemini-mcp
+    sourceCode: google/gemini-mcp
+    publishedDate: "2025-01-15"
+    tools:
+      - name: generate
+        description: Generate content with Gemini
+        accessType: read_only
+        parameters:
+          - name: prompt
+            type: string
+            description: Text prompt
+            required: true
+          - name: model
+            type: string
+            description: Model version (gemini-pro, gemini-ultra)
+            required: false
+      - name: analyze_image
+        description: Analyze an image with Gemini Vision
+        accessType: read_only
+        parameters:
+          - name: image_url
+            type: string
+            description: URL of the image to analyze
+            required: true
+          - name: prompt
+            type: string
+            description: Question about the image
+            required: true
+    customProperties:
+      ai:
+        metadataType: MetadataStringValue
+        string_value: ""
+      gemini:
+        metadataType: MetadataStringValue
+        string_value: ""
+      google:
+        metadataType: MetadataStringValue
+        string_value: ""
+      multimodal:
+        metadataType: MetadataStringValue
+        string_value: ""
+      remote:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: true
+    createTimeSinceEpoch: "1736956800000"
+    lastUpdateTimeSinceEpoch: "1736956800000"

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-organization-mcp-servers.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-organization-mcp-servers.yaml
@@ -1,0 +1,474 @@
+source: Organization MCP
+mcp_servers:
+  - name: dynatrace-mcp
+    provider: Dynatrace
+    license: apache-2.0
+    license_link: https://github.com/dynatrace-oss/dynatrace-mcp-server/blob/main/LICENSE
+    description: >-
+      Official Dynatrace-OSS project exposing DQL queries, problem feeds, and vulnerability data.
+      Gives agents real-time service health, letting them recommend rollbacks or capacity fixes inside OpenShift.
+    readme: |-
+      # Dynatrace MCP Server
+
+      **MCP Server Summary:**
+      The Dynatrace MCP Server provides AI agents with access to observability data, enabling intelligent monitoring and analysis.
+
+      ## Features
+      - Execute DQL queries for real-time observability
+      - Access problem feeds and incident information
+      - Retrieve vulnerability data from monitored services
+
+      ## Prerequisites
+      - Dynatrace API token with appropriate permissions
+      - Dynatrace environment URL
+
+      ## Installation
+      ```bash
+      npm install @dynatrace-oss/dynatrace-mcp-server
+      ```
+
+      ## Configuration
+      Set the following environment variables:
+      - `DYNATRACE_API_TOKEN`: Your Dynatrace API token
+      - `DYNATRACE_ENV_URL`: Your Dynatrace environment URL
+    version: "1.0.1"
+    transports:
+      - http
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    documentationUrl: https://docs.dynatrace.com/mcp
+    repositoryUrl: https://github.com/dynatrace-oss/dynatrace-mcp-server
+    sourceCode: dynatrace-oss/dynatrace-mcp-server
+    publishedDate: "2025-01-15"
+    tools:
+      - name: execute_dql
+        description: Execute Dynatrace Query Language (DQL) queries
+        accessType: read_only
+        parameters:
+          - name: query
+            type: string
+            description: DQL query to execute
+            required: true
+          - name: time_range
+            type: string
+            description: Time range for query (e.g., -1h, -24h)
+            required: false
+      - name: get_problems
+        description: Retrieve active problems and incidents
+        accessType: read_only
+        parameters:
+          - name: status
+            type: string
+            description: "Filter by status: OPEN, RESOLVED, or ALL"
+            required: false
+      - name: get_vulnerabilities
+        description: Query security vulnerabilities in monitored services
+        accessType: read_only
+        parameters:
+          - name: severity
+            type: string
+            description: "Minimum severity: CRITICAL, HIGH, MEDIUM, LOW"
+            required: false
+    artifacts:
+      - uri: oci://ghcr.io/dynatrace-oss/dynatrace-mcp-server:1.0.1
+        createTimeSinceEpoch: "1736942400000"
+        lastUpdateTimeSinceEpoch: "1736942400000"
+    customProperties:
+      observability:
+        metadataType: MetadataStringValue
+        string_value: ""
+      monitoring:
+        metadataType: MetadataStringValue
+        string_value: ""
+      apm:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: true
+    createTimeSinceEpoch: "1736942400000"
+    lastUpdateTimeSinceEpoch: "1736942400000"
+
+  - name: github-mcp
+    provider: GitHub
+    license: mit
+    license_link: https://opensource.org/licenses/MIT
+    description: >-
+      Access GitHub repositories, issues, pull requests, and actions.
+      Search code, create issues, and manage workflows.
+    readme: |-
+      # GitHub MCP Server
+
+      **MCP Server Summary:**
+      Full GitHub integration for AI agents.
+
+      ## Features
+      - Code search across repositories
+      - Issue management
+      - Pull request operations
+
+      ## Prerequisites
+      - GitHub Personal Access Token
+      - Appropriate repository permissions
+    version: "2.1.0"
+    transports:
+      - stdio
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    documentationUrl: https://docs.github.com/mcp
+    repositoryUrl: https://github.com/github/github-mcp
+    sourceCode: github/github-mcp
+    publishedDate: "2025-01-14"
+    tools:
+      - name: search_code
+        description: Search for code across repositories
+        accessType: read_only
+        parameters:
+          - name: query
+            type: string
+            description: Search query
+            required: true
+      - name: get_issues
+        description: List issues for a repository
+        accessType: read_only
+        parameters:
+          - name: owner
+            type: string
+            description: Repository owner
+            required: true
+          - name: repo
+            type: string
+            description: Repository name
+            required: true
+      - name: create_issue
+        description: Create a new issue
+        accessType: read_write
+        revoked: true
+        revokedReason: "Security vulnerability CVE-2025-1234 - write operations temporarily disabled pending patch"
+        parameters:
+          - name: owner
+            type: string
+            description: Repository owner
+            required: true
+          - name: repo
+            type: string
+            description: Repository name
+            required: true
+          - name: title
+            type: string
+            description: Issue title
+            required: true
+      - name: get_pull_requests
+        description: List pull requests
+        accessType: read_only
+        parameters:
+          - name: owner
+            type: string
+            description: Repository owner
+            required: true
+          - name: repo
+            type: string
+            description: Repository name
+            required: true
+    artifacts:
+      - uri: oci://ghcr.io/github/github-mcp:2.1.0
+        createTimeSinceEpoch: "1736856000000"
+        lastUpdateTimeSinceEpoch: "1736856000000"
+    customProperties:
+      git:
+        metadataType: MetadataStringValue
+        string_value: ""
+      version-control:
+        metadataType: MetadataStringValue
+        string_value: ""
+      ci-cd:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1736856000000"
+    lastUpdateTimeSinceEpoch: "1736856000000"
+
+  - name: slack-mcp
+    provider: Slack Technologies
+    license: mit
+    license_link: https://opensource.org/licenses/MIT
+    description: >-
+      Send messages, manage channels, and integrate with Slack workspaces.
+      Perfect for automated notifications and team communication.
+    readme: |-
+      # Slack MCP Server
+
+      **MCP Server Summary:**
+      Slack workspace integration for AI agents.
+
+      ## Features
+      - Send messages to channels
+      - List channels
+      - Retrieve message history
+
+      ## Prerequisites
+      - Slack Bot Token
+      - Appropriate workspace permissions
+    version: "1.5.0"
+    transports:
+      - sse
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    repositoryUrl: https://github.com/slack/slack-mcp
+    sourceCode: slack/slack-mcp
+    publishedDate: "2025-01-08"
+    tools:
+      - name: send_message
+        description: Send a message to a channel
+        accessType: read_write
+        revoked: true
+        revokedReason: "Rate limiting issues detected - tool temporarily disabled while investigating"
+        parameters:
+          - name: channel
+            type: string
+            description: Channel ID or name
+            required: true
+          - name: text
+            type: string
+            description: Message text
+            required: true
+      - name: list_channels
+        description: List available channels
+        accessType: read_only
+        parameters: []
+      - name: get_channel_history
+        description: Get message history for a channel
+        accessType: read_only
+        parameters:
+          - name: channel
+            type: string
+            description: Channel ID
+            required: true
+    artifacts:
+      - uri: oci://ghcr.io/slack/slack-mcp:1.5.0
+        createTimeSinceEpoch: "1736337600000"
+        lastUpdateTimeSinceEpoch: "1736337600000"
+    customProperties:
+      messaging:
+        metadataType: MetadataStringValue
+        string_value: ""
+      collaboration:
+        metadataType: MetadataStringValue
+        string_value: ""
+      notifications:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: false
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1736337600000"
+    lastUpdateTimeSinceEpoch: "1736337600000"
+
+  - name: jira-mcp
+    provider: Atlassian
+    license: apache-2.0
+    license_link: https://www.apache.org/licenses/LICENSE-2.0
+    description: >-
+      Manage Jira issues, projects, and workflows.
+      Create, update, and query issues using natural language.
+    readme: |-
+      # Jira MCP Server
+
+      **MCP Server Summary:**
+      Jira project management integration.
+
+      ## Features
+      - JQL search
+      - Issue creation and updates
+      - Workflow management
+
+      ## Prerequisites
+      - Jira API token
+      - Site URL configuration
+    version: "1.3.2"
+    transports:
+      - http
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    documentationUrl: https://developer.atlassian.com/mcp
+    repositoryUrl: https://github.com/atlassian/jira-mcp
+    sourceCode: atlassian/jira-mcp
+    publishedDate: "2025-01-11"
+    tools:
+      - name: search_issues
+        description: Search issues using JQL
+        accessType: read_only
+        parameters:
+          - name: jql
+            type: string
+            description: JQL query
+            required: true
+      - name: get_issue
+        description: Get issue details
+        accessType: read_only
+        parameters:
+          - name: issue_key
+            type: string
+            description: Issue key (e.g., PROJ-123)
+            required: true
+      - name: create_issue
+        description: Create a new issue
+        accessType: read_write
+        parameters:
+          - name: project
+            type: string
+            description: Project key
+            required: true
+          - name: summary
+            type: string
+            description: Issue summary
+            required: true
+          - name: issue_type
+            type: string
+            description: Issue type
+            required: true
+      - name: update_issue
+        description: Update an existing issue
+        accessType: read_write
+        parameters:
+          - name: issue_key
+            type: string
+            description: Issue key
+            required: true
+    artifacts:
+      - uri: oci://ghcr.io/atlassian/jira-mcp:1.3.2
+        createTimeSinceEpoch: "1736596800000"
+        lastUpdateTimeSinceEpoch: "1736596800000"
+    customProperties:
+      project-management:
+        metadataType: MetadataStringValue
+        string_value: ""
+      issue-tracking:
+        metadataType: MetadataStringValue
+        string_value: ""
+      agile:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1736596800000"
+    lastUpdateTimeSinceEpoch: "1736596800000"
+
+  - name: aws-mcp
+    provider: Amazon Web Services
+    license: apache-2.0
+    license_link: https://www.apache.org/licenses/LICENSE-2.0
+    description: >-
+      Interact with Amazon Web Services resources.
+      Manage EC2 instances, S3 buckets, Lambda functions, and more.
+    readme: |-
+      # AWS MCP Server
+
+      **MCP Server Summary:**
+      Amazon Web Services resource management.
+
+      ## Features
+      - EC2 instance management
+      - S3 bucket operations
+      - Lambda invocation
+      - CloudWatch monitoring
+
+      ## Prerequisites
+      - AWS credentials configured
+      - Appropriate IAM permissions
+    version: "2.0.1"
+    transports:
+      - http
+    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
+    documentationUrl: https://docs.aws.amazon.com/mcp
+    repositoryUrl: https://github.com/aws/aws-mcp
+    sourceCode: aws/aws-mcp
+    publishedDate: "2025-01-09"
+    tools:
+      - name: list_ec2_instances
+        description: List EC2 instances
+        accessType: read_only
+        parameters:
+          - name: region
+            type: string
+            description: AWS region
+            required: true
+      - name: list_s3_buckets
+        description: List S3 buckets
+        accessType: read_only
+        parameters: []
+      - name: invoke_lambda
+        description: Invoke a Lambda function
+        accessType: read_write
+        parameters:
+          - name: function_name
+            type: string
+            description: Lambda function name or ARN
+            required: true
+      - name: describe_cloudwatch_alarms
+        description: List CloudWatch alarms
+        accessType: read_only
+        parameters: []
+    artifacts:
+      - uri: oci://public.ecr.aws/aws/aws-mcp:2.0.1
+        createTimeSinceEpoch: "1736424000000"
+        lastUpdateTimeSinceEpoch: "1736424000000"
+    customProperties:
+      cloud:
+        metadataType: MetadataStringValue
+        string_value: ""
+      aws:
+        metadataType: MetadataStringValue
+        string_value: ""
+      infrastructure:
+        metadataType: MetadataStringValue
+        string_value: ""
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1736424000000"
+    lastUpdateTimeSinceEpoch: "1736424000000"

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-sources.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-sources.yaml
@@ -37,3 +37,36 @@ mcp_catalogs:
     enabled: true
     properties:
       yamlCatalogPath: dev-community-mcp-servers.yaml
+
+# namedQueries define reusable server-side filter presets that clients can
+# reference by name via the `namedQuery` API parameter. Multiple config files
+# can contribute queries; later files override individual fields within a query
+# of the same name.
+namedQueries:
+  # read_only_servers: servers whose tools only perform read operations.
+  # Useful for environments where write-capable tools require additional approval.
+  read_only_servers:
+    readOnlyTools:
+      operator: "="
+      value: true
+
+  # fully_audited: servers that have a verified source, a secure endpoint,
+  # and have passed static analysis security testing (SAST). These are the
+  # highest-trust servers in the catalog.
+  fully_audited:
+    verifiedSource:
+      operator: "="
+      value: true
+    secureEndpoint:
+      operator: "="
+      value: true
+    sast:
+      operator: "="
+      value: true
+
+  # remote_servers: servers hosted externally and accessed via a network
+  # endpoint rather than deployed locally.
+  remote_servers:
+    deploymentMode:
+      operator: "="
+      value: "remote"


### PR DESCRIPTION
## Description

Adds support for accepting and running `namedQueries`. The `namedQuery` parameter to the `/api/mcp_catalog/v1alpha1/mcp_servers` endpoint applies the filters from the sources config.

Also returns `namedQueries` from MCP `filter_options` endpoint.

## How Has This Been Tested?
This PR adds `namedQueries` to the demo catalog files which are loaded by default in tilt. The queries are returned from filter options:

```
curl -s "http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers/filter_options" | jq '.namedQueries'
```

Any of those queries can be provided to `/api/mcp_catalog/v1alpha1/mcp_servers`, for example:

```
$ curl -s "http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers?namedQuery=read_only_servers" | jq '.items[].name'
"prometheus-mcp"
"elasticsearch-mcp"
"dynatrace-mcp"
"google-gemini-mcp"
```

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
