### PR TITLE
feat(catalog): filter_options endpoint for MCP catalog

### DIFF
--- a/catalog/cmd/catalog.go
+++ b/catalog/cmd/catalog.go
@@ -186,10 +186,10 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 
 	// Create MCP provider and service, wiring named query resolution from loaded sources.
 	mcpSources := loader.MCPSources()
-	mcpProvider := catalog.NewDBMCPCatalog(services, func(name string) (map[string]catalog.FieldFilter, bool) {
+	mcpProvider := catalog.NewDBMCPCatalog(services, mcpSources, func(name string) (map[string]catalog.FieldFilter, bool) {
 		return mcpSources.GetNamedQuery(name)
 	})
-	mcpSvc := openapi.NewMCPCatalogServiceAPIService(mcpProvider, mcpSources)
+	mcpSvc := openapi.NewMCPCatalogServiceAPIService(mcpProvider)
 	mcpCtrl := openapi.NewMCPCatalogServiceAPIController(mcpSvc)
 
 	server := &http.Server{

--- a/catalog/internal/catalog/basecatalog/filter_options.go
+++ b/catalog/internal/catalog/basecatalog/filter_options.go
@@ -1,0 +1,122 @@
+package basecatalog
+
+import (
+	"sort"
+
+	sharedmodels "github.com/kubeflow/model-registry/catalog/internal/db/models"
+	apimodels "github.com/kubeflow/model-registry/catalog/pkg/openapi"
+	"github.com/kubeflow/model-registry/internal/apiutils"
+)
+
+// DbPropToAPIOption converts a database PropertyOption to an API FilterOption.
+// Returns nil if the property has no values (empty set or nil range).
+func DbPropToAPIOption(prop sharedmodels.PropertyOption) *apimodels.FilterOption {
+	var option apimodels.FilterOption
+
+	switch prop.ValueField() {
+	case sharedmodels.StringValueField:
+		if len(prop.StringValue) == 0 {
+			return nil
+		}
+		option.Type = "string"
+		sort.Strings(prop.StringValue)
+		option.Values = AnySlice(prop.StringValue)
+
+	case sharedmodels.ArrayValueField:
+		if len(prop.ArrayValue) == 0 {
+			return nil
+		}
+		option.Type = "string"
+		sort.Strings(prop.ArrayValue)
+		option.Values = AnySlice(prop.ArrayValue)
+
+	case sharedmodels.IntValueField:
+		if prop.MinIntValue == nil || prop.MaxIntValue == nil {
+			return nil
+		}
+
+		option.Type = "number"
+		option.Range = &apimodels.FilterOptionRange{
+			Min: apiutils.Of(float64(*prop.MinIntValue)),
+			Max: apiutils.Of(float64(*prop.MaxIntValue)),
+		}
+
+	case sharedmodels.DoubleValueField:
+		if prop.MinDoubleValue == nil || prop.MaxDoubleValue == nil {
+			return nil
+		}
+
+		option.Type = "number"
+		option.Range = &apimodels.FilterOptionRange{
+			Min: prop.MinDoubleValue,
+			Max: prop.MaxDoubleValue,
+		}
+	}
+
+	return &option
+}
+
+// AnySlice converts a typed slice to []any.
+func AnySlice[T any](s []T) []any {
+	as := make([]any, len(s))
+	for i, v := range s {
+		as[i] = v
+	}
+	return as
+}
+
+// ConvertNamedQueries converts internal named queries to the API representation,
+// resolving "min"/"max" sentinel values against the provided filter options.
+// Returns nil if queries is empty.
+func ConvertNamedQueries(
+	queries map[string]map[string]FieldFilter,
+	options map[string]apimodels.FilterOption,
+) *map[string]map[string]apimodels.FieldFilter {
+	if len(queries) == 0 {
+		return nil
+	}
+
+	apiNamedQueries := make(map[string]map[string]apimodels.FieldFilter, len(queries))
+	for queryName, fieldFilters := range queries {
+		apiFieldFilters := make(map[string]apimodels.FieldFilter, len(fieldFilters))
+		for fieldName, filter := range fieldFilters {
+			apiFieldFilters[fieldName] = apimodels.FieldFilter{
+				Operator: filter.Operator,
+				Value:    filter.Value,
+			}
+		}
+		ApplyMinMax(apiFieldFilters, options)
+		apiNamedQueries[queryName] = apiFieldFilters
+	}
+
+	return &apiNamedQueries
+}
+
+// ApplyMinMax resolves "min"/"max" sentinel string values in a named query
+// to the actual min/max from the corresponding filter options.
+func ApplyMinMax(query map[string]apimodels.FieldFilter, options map[string]apimodels.FilterOption) {
+	for key, filter := range query {
+		value, ok := filter.Value.(string)
+		if !ok || (value != "min" && value != "max") {
+			continue
+		}
+
+		option, ok := options[key]
+		if !ok || option.Range == nil {
+			continue
+		}
+
+		switch value {
+		case "min":
+			if option.Range.Min != nil {
+				filter.Value = *option.Range.Min
+			}
+		case "max":
+			if option.Range.Max != nil {
+				filter.Value = *option.Range.Max
+			}
+		}
+
+		query[key] = filter
+	}
+}

--- a/catalog/internal/catalog/mcpcatalog/api.go
+++ b/catalog/internal/catalog/mcpcatalog/api.go
@@ -43,4 +43,7 @@ type MCPCatalogProvider interface {
 	// GetMCPServerTool returns a specific tool by server ID and tool name.
 	// If nothing is found it returns nil, without an error.
 	GetMCPServerTool(ctx context.Context, serverID string, toolName string) (*openapi.MCPTool, error)
+
+	// GetFilterOptions returns filterable fields and named queries for the MCP servers endpoint.
+	GetFilterOptions(ctx context.Context) (*openapi.FilterOptionsList, error)
 }

--- a/catalog/internal/catalog/mcpcatalog/db_mcp.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog/models"
 	"github.com/kubeflow/model-registry/catalog/internal/converter"
+	sharedmodels "github.com/kubeflow/model-registry/catalog/internal/db/models"
 	"github.com/kubeflow/model-registry/catalog/internal/db/service"
 	openapi "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 	"github.com/kubeflow/model-registry/internal/apiutils"
@@ -18,17 +19,54 @@ import (
 type NamedQueryResolver func(name string) (map[string]basecatalog.FieldFilter, bool)
 
 type dbMCPCatalogImpl struct {
-	mcpServerRepo     models.MCPServerRepository
-	mcpServerToolRepo models.MCPServerToolRepository
-	resolveNamedQuery NamedQueryResolver
+	mcpServerRepo             models.MCPServerRepository
+	mcpServerToolRepo         models.MCPServerToolRepository
+	resolveNamedQuery         NamedQueryResolver
+	propertyOptionsRepository sharedmodels.PropertyOptionsRepository
+	mcpSources                *MCPSourceCollection
 }
 
-func NewDBMCPCatalog(services service.Services, resolver NamedQueryResolver) MCPCatalogProvider {
+func NewDBMCPCatalog(services service.Services, mcpSources *MCPSourceCollection, resolver NamedQueryResolver) MCPCatalogProvider {
 	return &dbMCPCatalogImpl{
-		mcpServerRepo:     services.MCPServerRepository,
-		mcpServerToolRepo: services.MCPServerToolRepository,
-		resolveNamedQuery: resolver,
+		mcpServerRepo:             services.MCPServerRepository,
+		mcpServerToolRepo:         services.MCPServerToolRepository,
+		resolveNamedQuery:         resolver,
+		propertyOptionsRepository: services.PropertyOptionsRepository,
+		mcpSources:                mcpSources,
 	}
+}
+
+func (d *dbMCPCatalogImpl) GetFilterOptions(ctx context.Context) (*openapi.FilterOptionsList, error) {
+	mcpServerTypeID := d.mcpServerRepo.GetTypeID()
+
+	contextProperties, err := d.propertyOptionsRepository.List(sharedmodels.ContextPropertyOptionType, mcpServerTypeID)
+	if err != nil {
+		return nil, err
+	}
+
+	options := make(map[string]openapi.FilterOption, len(contextProperties))
+
+	for _, prop := range contextProperties {
+		switch prop.Name {
+		case "artifacts", "base_name", "documentationUrl", "logo", "repositoryUrl", "sourceCode", "source_id", "tools", "version":
+			continue
+		}
+
+		option := basecatalog.DbPropToAPIOption(prop)
+		if option != nil {
+			options[prop.FullName("")] = *option
+		}
+	}
+
+	var namedQueriesPtr *map[string]map[string]openapi.FieldFilter
+	if d.mcpSources != nil {
+		namedQueriesPtr = basecatalog.ConvertNamedQueries(d.mcpSources.GetNamedQueries(), options)
+	}
+
+	return &openapi.FilterOptionsList{
+		Filters:      &options,
+		NamedQueries: namedQueriesPtr,
+	}, nil
 }
 
 func (d *dbMCPCatalogImpl) ListMCPServers(ctx context.Context, params ListMCPServersParams) (openapi.MCPServerList, error) {

--- a/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
@@ -7,11 +7,30 @@ import (
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog/models"
+	sharedmodels "github.com/kubeflow/model-registry/catalog/internal/db/models"
 	internalmodels "github.com/kubeflow/model-registry/internal/db/models"
 	"github.com/kubeflow/model-registry/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// mockPropertyOptionsRepo is a minimal PropertyOptionsRepository for unit testing.
+type mockPropertyOptionsRepo struct {
+	contextProps  []sharedmodels.PropertyOption
+	artifactProps []sharedmodels.PropertyOption
+	listErr       error
+}
+
+func (m *mockPropertyOptionsRepo) Refresh(_ sharedmodels.PropertyOptionType) error { return nil }
+func (m *mockPropertyOptionsRepo) List(t sharedmodels.PropertyOptionType, _ int32) ([]sharedmodels.PropertyOption, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	if t == sharedmodels.ContextPropertyOptionType {
+		return m.contextProps, nil
+	}
+	return m.artifactProps, nil
+}
 
 // --- mergeFilterQueries tests ---
 
@@ -69,6 +88,7 @@ func (m *mockMCPServerRepo) DeleteByID(_ int32) error      { return errors.New("
 func (m *mockMCPServerRepo) GetDistinctSourceIDs() ([]string, error) {
 	return nil, errors.New("not implemented")
 }
+func (m *mockMCPServerRepo) GetTypeID() int32 { return 0 }
 
 // mockMCPServerToolRepo is a minimal MCPServerToolRepository that always returns empty.
 type mockMCPServerToolRepo struct{}
@@ -173,4 +193,84 @@ func TestListMCPServers_UnknownNamedQueryReturnsError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, api.ErrBadRequest))
+}
+
+// --- GetFilterOptions tests ---
+
+func newTestCatalogWithFilterOptions(repo *mockMCPServerRepo, propRepo *mockPropertyOptionsRepo, sources *MCPSourceCollection) *dbMCPCatalogImpl {
+	return &dbMCPCatalogImpl{
+		mcpServerRepo:             repo,
+		mcpServerToolRepo:         &mockMCPServerToolRepo{},
+		propertyOptionsRepository: propRepo,
+		mcpSources:                sources,
+	}
+}
+
+func TestGetFilterOptions_EmptyDB(t *testing.T) {
+	repo := &mockMCPServerRepo{}
+	propRepo := &mockPropertyOptionsRepo{}
+	cat := newTestCatalogWithFilterOptions(repo, propRepo, nil)
+
+	result, err := cat.GetFilterOptions(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotNil(t, result.Filters)
+	assert.Empty(t, *result.Filters)
+	assert.Nil(t, result.NamedQueries)
+}
+
+func TestGetFilterOptions_FiltersFromDB(t *testing.T) {
+	providerValues := []string{"OpenAI", "GitHub"}
+	repo := &mockMCPServerRepo{}
+	propRepo := &mockPropertyOptionsRepo{
+		contextProps: []sharedmodels.PropertyOption{
+			{Name: "provider", StringValue: providerValues},
+			{Name: "source_id", StringValue: []string{"src1"}}, // should be skipped
+			{Name: "logo", StringValue: []string{"logo.png"}},  // should be skipped
+		},
+	}
+	cat := newTestCatalogWithFilterOptions(repo, propRepo, nil)
+
+	result, err := cat.GetFilterOptions(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Filters)
+	filters := *result.Filters
+	assert.Contains(t, filters, "provider")
+	assert.NotContains(t, filters, "source_id")
+	assert.NotContains(t, filters, "logo")
+}
+
+func TestGetFilterOptions_NamedQueriesFromSources(t *testing.T) {
+	sources := NewMCPSourceCollection()
+	err := sources.MergeWithNamedQueries("test", nil, map[string]map[string]basecatalog.FieldFilter{
+		"verified_only": {
+			"verifiedSource": {Operator: "=", Value: true},
+		},
+	})
+	require.NoError(t, err)
+
+	repo := &mockMCPServerRepo{}
+	propRepo := &mockPropertyOptionsRepo{}
+	cat := newTestCatalogWithFilterOptions(repo, propRepo, sources)
+
+	result, err := cat.GetFilterOptions(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.NamedQueries)
+	nq := *result.NamedQueries
+	require.Contains(t, nq, "verified_only")
+	assert.Equal(t, true, nq["verified_only"]["verifiedSource"].Value)
+}
+
+func TestGetFilterOptions_PropertyOptionsError(t *testing.T) {
+	repo := &mockMCPServerRepo{}
+	propRepo := &mockPropertyOptionsRepo{listErr: errors.New("db error")}
+	cat := newTestCatalogWithFilterOptions(repo, propRepo, nil)
+
+	_, err := cat.GetFilterOptions(context.Background())
+	require.Error(t, err)
 }

--- a/catalog/internal/catalog/mcpcatalog/models/mcp_server.go
+++ b/catalog/internal/catalog/mcpcatalog/models/mcp_server.go
@@ -53,4 +53,5 @@ type MCPServerRepository interface {
 	DeleteBySource(sourceID string) error
 	DeleteByID(id int32) error
 	GetDistinctSourceIDs() ([]string, error)
+	GetTypeID() int32
 }

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server.go
@@ -302,6 +302,11 @@ func (r *MCPServerRepositoryImpl) DeleteByID(id int32) error {
 	return nil
 }
 
+// GetTypeID returns the MLMD type ID for the kf.MCPServer context type.
+func (r *MCPServerRepositoryImpl) GetTypeID() int32 {
+	return r.GetConfig().TypeID
+}
+
 // GetDistinctSourceIDs retrieves all unique source_id values from MCP servers.
 func (r *MCPServerRepositoryImpl) GetDistinctSourceIDs() ([]string, error) {
 	config := r.GetConfig()

--- a/catalog/internal/catalog/modelcatalog/db_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/modelcatalog/models"
 	sharedmodels "github.com/kubeflow/model-registry/catalog/internal/db/models"
 	"github.com/kubeflow/model-registry/catalog/internal/db/service"
@@ -34,8 +35,8 @@ func NewDBCatalog(services service.Services, sources *SourceCollection) APIProvi
 		catalogArtifactRepository: services.CatalogArtifactRepository,
 		catalogModelRepository:    services.CatalogModelRepository,
 		propertyOptionsRepository: services.PropertyOptionsRepository,
-		performanceService: NewPerformanceArtifactService(services.CatalogArtifactRepository, services.CatalogModelRepository),
-		sources:            sources,
+		performanceService:        NewPerformanceArtifactService(services.CatalogArtifactRepository, services.CatalogModelRepository),
+		sources:                   sources,
 	}
 }
 
@@ -206,7 +207,7 @@ func (d *dbCatalogImpl) GetFilterOptions(ctx context.Context) (*apimodels.Filter
 			continue
 		}
 
-		option := dbPropToAPIOption(prop)
+		option := basecatalog.DbPropToAPIOption(prop)
 		if option != nil {
 			options[prop.FullName("")] = *option
 		}
@@ -218,7 +219,7 @@ func (d *dbCatalogImpl) GetFilterOptions(ctx context.Context) (*apimodels.Filter
 		case "metricsType", "model_id":
 			continue
 		}
-		option := dbPropToAPIOption(prop)
+		option := basecatalog.DbPropToAPIOption(prop)
 		if option != nil {
 			options[prop.FullName("artifacts")] = *option
 		}
@@ -227,62 +228,13 @@ func (d *dbCatalogImpl) GetFilterOptions(ctx context.Context) (*apimodels.Filter
 	// Get named queries from sources configuration
 	var namedQueriesPtr *map[string]map[string]apimodels.FieldFilter
 	if d.sources != nil {
-		namedQueriesMap := d.sources.GetNamedQueries()
-
-		// Convert internal FieldFilter to API FieldFilter
-		apiNamedQueries := make(map[string]map[string]apimodels.FieldFilter, len(namedQueriesMap))
-		for queryName, fieldFilters := range namedQueriesMap {
-			apiFieldFilters := make(map[string]apimodels.FieldFilter, len(fieldFilters))
-			for fieldName, filter := range fieldFilters {
-				apiFieldFilters[fieldName] = apimodels.FieldFilter{
-					Operator: filter.Operator,
-					Value:    filter.Value,
-				}
-			}
-			d.applyMinMax(apiFieldFilters, options)
-			apiNamedQueries[queryName] = apiFieldFilters
-		}
-
-		if len(apiNamedQueries) > 0 {
-			namedQueriesPtr = &apiNamedQueries
-		}
+		namedQueriesPtr = basecatalog.ConvertNamedQueries(d.sources.GetNamedQueries(), options)
 	}
 
 	return &apimodels.FilterOptionsList{
 		Filters:      &options,
 		NamedQueries: namedQueriesPtr,
 	}, nil
-}
-
-func (d *dbCatalogImpl) applyMinMax(query map[string]apimodels.FieldFilter, options map[string]apimodels.FilterOption) {
-	// Find queries where the value is min or max and replace it with the
-	// actual min or max from the filter options.
-	for key, filter := range query {
-		// Find string values that are either min or max
-		value, ok := filter.Value.(string)
-		if !ok || (value != "min" && value != "max") {
-			continue
-		}
-
-		option, ok := options[key]
-		if !ok || option.Range == nil {
-			// Skip fields without a corresponding option or options without a range.
-			continue
-		}
-
-		switch value {
-		case "min":
-			if option.Range.Min != nil {
-				filter.Value = *option.Range.Min
-			}
-		case "max":
-			if option.Range.Max != nil {
-				filter.Value = *option.Range.Max
-			}
-		}
-
-		query[key] = filter
-	}
 }
 
 func (d *dbCatalogImpl) GetPerformanceArtifacts(ctx context.Context, modelName string, sourceID string, params ListPerformanceArtifactsParams) (apimodels.CatalogArtifactList, error) {
@@ -344,60 +296,6 @@ func (d *dbCatalogImpl) GetPerformanceArtifacts(ctx context.Context, modelName s
 	artifactList.Size = int32(len(artifactList.Items))
 
 	return *artifactList, nil
-}
-
-func dbPropToAPIOption(prop sharedmodels.PropertyOption) *apimodels.FilterOption {
-	var option apimodels.FilterOption
-
-	switch prop.ValueField() {
-	case sharedmodels.StringValueField:
-		if len(prop.StringValue) == 0 {
-			return nil
-		}
-		option.Type = "string"
-		sort.Strings(prop.StringValue)
-		option.Values = anySlice(prop.StringValue)
-
-	case sharedmodels.ArrayValueField:
-		if len(prop.ArrayValue) == 0 {
-			return nil
-		}
-		option.Type = "string"
-		sort.Strings(prop.ArrayValue)
-		option.Values = anySlice(prop.ArrayValue)
-
-	case sharedmodels.IntValueField:
-		if prop.MinIntValue == nil || prop.MaxIntValue == nil {
-			return nil
-		}
-
-		option.Type = "number"
-		option.Range = &apimodels.FilterOptionRange{
-			Min: apiutils.Of(float64(*prop.MinIntValue)),
-			Max: apiutils.Of(float64(*prop.MaxIntValue)),
-		}
-
-	case sharedmodels.DoubleValueField:
-		if prop.MinDoubleValue == nil || prop.MaxDoubleValue == nil {
-			return nil
-		}
-
-		option.Type = "number"
-		option.Range = &apimodels.FilterOptionRange{
-			Min: prop.MinDoubleValue,
-			Max: prop.MaxDoubleValue,
-		}
-	}
-
-	return &option
-}
-
-func anySlice[T any](s []T) []any {
-	as := make([]any, len(s))
-	for i, v := range s {
-		as[i] = v
-	}
-	return as
 }
 
 func mapDBModelToAPIModel(m models.CatalogModel) apimodels.CatalogModel {

--- a/catalog/internal/catalog/modelcatalog/db_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog_test.go
@@ -1918,11 +1918,8 @@ func TestApplyMinMax(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a catalog instance to access the applyMinMax method
-			catalog := &dbCatalogImpl{}
-
-			// Apply the method
-			catalog.applyMinMax(tt.inputQuery, tt.inputOptions)
+			// Apply the shared helper
+			basecatalog.ApplyMinMax(tt.inputQuery, tt.inputOptions)
 
 			// Verify the query was modified correctly
 			assert.Equal(t, tt.expectedQuery, tt.inputQuery, tt.description)

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog"
-	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog"
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 	"github.com/kubeflow/model-registry/pkg/api"
 )
@@ -15,16 +14,14 @@ import (
 // MCPCatalogServiceAPIService is a service that implements the logic for the MCPCatalogServiceAPIServicer
 type MCPCatalogServiceAPIService struct {
 	mcpProvider catalog.MCPProvider
-	mcpSources  *mcpcatalog.MCPSourceCollection
 }
 
 var _ MCPCatalogServiceAPIServicer = &MCPCatalogServiceAPIService{}
 
 // NewMCPCatalogServiceAPIService creates a default api service
-func NewMCPCatalogServiceAPIService(mcpProvider catalog.MCPProvider, mcpSources *mcpcatalog.MCPSourceCollection) MCPCatalogServiceAPIServicer {
+func NewMCPCatalogServiceAPIService(mcpProvider catalog.MCPProvider) MCPCatalogServiceAPIServicer {
 	return &MCPCatalogServiceAPIService{
 		mcpProvider: mcpProvider,
-		mcpSources:  mcpSources,
 	}
 }
 
@@ -64,24 +61,11 @@ func (m *MCPCatalogServiceAPIService) FindMCPServers(ctx context.Context, name s
 
 // FindMCPServersFilterOptions - Lists fields, values, and named queries that can be used in `filterQuery` on the list MCP servers endpoint.
 func (m *MCPCatalogServiceAPIService) FindMCPServersFilterOptions(ctx context.Context) (ImplResponse, error) {
-	if m.mcpSources == nil {
-		return Response(http.StatusOK, model.FilterOptionsList{}), nil
+	filterOptions, err := m.mcpProvider.GetFilterOptions(ctx)
+	if err != nil {
+		return ErrorResponse(http.StatusInternalServerError, err), err
 	}
-
-	srcQueries := m.mcpSources.GetNamedQueries()
-	converted := make(map[string]map[string]model.FieldFilter, len(srcQueries))
-	for queryName, fieldFilters := range srcQueries {
-		inner := make(map[string]model.FieldFilter, len(fieldFilters))
-		for field, ff := range fieldFilters {
-			inner[field] = model.FieldFilter{
-				Operator: ff.Operator,
-				Value:    ff.Value,
-			}
-		}
-		converted[queryName] = inner
-	}
-
-	return Response(http.StatusOK, model.FilterOptionsList{NamedQueries: &converted}), nil
+	return Response(http.StatusOK, *filterOptions), nil
 }
 
 // GetMCPServer - Get an `MCPServer`.

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog"
-	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
-	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog"
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
 	"github.com/kubeflow/model-registry/pkg/api"
 	"github.com/stretchr/testify/assert"
@@ -22,13 +20,16 @@ type mockMCPProvider struct {
 	servers map[string]*model.MCPServer
 	tools   map[string]map[string]*model.MCPTool // server_id -> tool_name -> tool
 	// error simulation
-	shouldErrorOnListServers bool
-	shouldErrorOnGetServer   bool
-	shouldErrorOnListTools   bool
-	shouldErrorOnGetTool     bool
+	shouldErrorOnListServers      bool
+	shouldErrorOnGetServer        bool
+	shouldErrorOnListTools        bool
+	shouldErrorOnGetTool          bool
+	shouldErrorOnGetFilterOptions bool
 	// namedQueryErr simulates an error returned by the provider for a specific named query.
 	// This is used to verify the service correctly propagates provider errors.
 	namedQueryErr map[string]error
+	// filterOptions is returned by GetFilterOptions.
+	filterOptions *model.FilterOptionsList
 }
 
 func newMockMCPProvider() *mockMCPProvider {
@@ -156,6 +157,16 @@ func (m *mockMCPProvider) ListMCPServerTools(ctx context.Context, serverID strin
 		PageSize:      params.PageSize,
 		NextPageToken: "",
 	}, nil
+}
+
+func (m *mockMCPProvider) GetFilterOptions(ctx context.Context) (*model.FilterOptionsList, error) {
+	if m.shouldErrorOnGetFilterOptions {
+		return nil, fmt.Errorf("mock error in GetFilterOptions")
+	}
+	if m.filterOptions != nil {
+		return m.filterOptions, nil
+	}
+	return &model.FilterOptionsList{}, nil
 }
 
 func (m *mockMCPProvider) GetMCPServerTool(ctx context.Context, serverID string, toolName string) (*model.MCPTool, error) {
@@ -385,7 +396,7 @@ func TestFindMCPServers(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
+			service := NewMCPCatalogServiceAPIService(mockProvider)
 			ctx := context.Background()
 
 			result, err := service.FindMCPServers(
@@ -498,7 +509,7 @@ func TestGetMCPServer(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
+			service := NewMCPCatalogServiceAPIService(mockProvider)
 			ctx := context.Background()
 
 			result, err := service.GetMCPServer(ctx, tc.serverID, tc.includeTools)
@@ -621,7 +632,7 @@ func TestFindMCPServerTools(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
+			service := NewMCPCatalogServiceAPIService(mockProvider)
 			ctx := context.Background()
 
 			result, err := service.FindMCPServerTools(
@@ -715,7 +726,7 @@ func TestGetMCPServerTool(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
+			service := NewMCPCatalogServiceAPIService(mockProvider)
 			ctx := context.Background()
 
 			result, err := service.GetMCPServerTool(ctx, tc.serverID, tc.toolName)
@@ -741,8 +752,9 @@ func TestGetMCPServerTool(t *testing.T) {
 func TestFindMCPServersFilterOptions(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("nil mcpSources returns empty FilterOptionsList", func(t *testing.T) {
-		service := NewMCPCatalogServiceAPIService(newMockMCPProvider(), nil)
+	t.Run("provider returns empty FilterOptionsList", func(t *testing.T) {
+		provider := newMockMCPProvider()
+		service := NewMCPCatalogServiceAPIService(provider)
 		result, err := service.FindMCPServersFilterOptions(ctx)
 
 		assert.NoError(t, err)
@@ -750,18 +762,25 @@ func TestFindMCPServersFilterOptions(t *testing.T) {
 		body, ok := result.Body.(model.FilterOptionsList)
 		require.True(t, ok)
 		assert.Nil(t, body.NamedQueries)
+		assert.Nil(t, body.Filters)
 	})
 
-	t.Run("named queries from mcpSources are returned", func(t *testing.T) {
-		sources := mcpcatalog.NewMCPSourceCollection()
-		err := sources.MergeWithNamedQueries("test", nil, map[string]map[string]basecatalog.FieldFilter{
+	t.Run("provider returns named queries and filters", func(t *testing.T) {
+		namedQueries := map[string]map[string]model.FieldFilter{
 			"production_ready": {
 				"maturity": {Operator: "=", Value: "production"},
 			},
-		})
-		require.NoError(t, err)
+		}
+		filters := map[string]model.FilterOption{
+			"provider": {Type: "string", Values: []any{"OpenAI", "GitHub"}},
+		}
+		provider := newMockMCPProvider()
+		provider.filterOptions = &model.FilterOptionsList{
+			NamedQueries: &namedQueries,
+			Filters:      &filters,
+		}
 
-		service := NewMCPCatalogServiceAPIService(newMockMCPProvider(), sources)
+		service := NewMCPCatalogServiceAPIService(provider)
 		result, err := service.FindMCPServersFilterOptions(ctx)
 
 		assert.NoError(t, err)
@@ -772,18 +791,18 @@ func TestFindMCPServersFilterOptions(t *testing.T) {
 		nq := *body.NamedQueries
 		require.Contains(t, nq, "production_ready")
 		assert.Equal(t, model.FieldFilter{Operator: "=", Value: "production"}, nq["production_ready"]["maturity"])
+		require.NotNil(t, body.Filters)
+		assert.Contains(t, *body.Filters, "provider")
 	})
 
-	t.Run("empty named queries returns empty map", func(t *testing.T) {
-		sources := mcpcatalog.NewMCPSourceCollection()
-		service := NewMCPCatalogServiceAPIService(newMockMCPProvider(), sources)
+	t.Run("provider error returns internal server error", func(t *testing.T) {
+		provider := newMockMCPProvider()
+		provider.shouldErrorOnGetFilterOptions = true
+
+		service := NewMCPCatalogServiceAPIService(provider)
 		result, err := service.FindMCPServersFilterOptions(ctx)
 
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, result.Code)
-		body, ok := result.Body.(model.FilterOptionsList)
-		require.True(t, ok)
-		require.NotNil(t, body.NamedQueries)
-		assert.Empty(t, *body.NamedQueries)
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusInternalServerError, result.Code)
 	})
 }


### PR DESCRIPTION
## Description

Adds `filters` to the `/api/mcp_catalog/v1alpha1/mcp_servers/filter_options` endpoint.

Builds on #2301.

## How Has This Been Tested?

Tested it locally:

```
curl -s 'http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers/filter_options' | jq .
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
