### PR TITLE
feat(catalog): validate MCP catalog endpoints

### DIFF
--- a/catalog/internal/catalog/mcpcatalog/providers.go
+++ b/catalog/internal/catalog/mcpcatalog/providers.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 
@@ -123,9 +125,34 @@ type yamlMCPArtifact struct {
 
 // yamlMCPEndpoints represents MCP server endpoints
 type yamlMCPEndpoints struct {
-	HTTP      *string `yaml:"http,omitempty"`
-	SSE       *string `yaml:"sse,omitempty"`
-	WebSocket *string `yaml:"websocket,omitempty"`
+	HTTP      *string `yaml:"http,omitempty" json:"http,omitempty"`
+	SSE       *string `yaml:"sse,omitempty" json:"sse,omitempty"`
+	WebSocket *string `yaml:"websocket,omitempty" json:"websocket,omitempty"`
+}
+
+// validate checks that all non-nil endpoint URLs have valid schemes.
+// HTTP and SSE endpoints must use http/https; WebSocket endpoints also accept ws/wss.
+func (e *yamlMCPEndpoints) validate() error {
+	type endpointField struct {
+		name    string
+		url     *string
+		schemes []string
+	}
+	fields := []endpointField{
+		{"http", e.HTTP, []string{"http", "https"}},
+		{"sse", e.SSE, []string{"http", "https"}},
+		{"websocket", e.WebSocket, []string{"http", "https", "ws", "wss"}},
+	}
+	for _, f := range fields {
+		if f.url == nil {
+			continue
+		}
+		u, err := url.Parse(*f.url)
+		if err != nil || !slices.Contains(f.schemes, u.Scheme) {
+			return fmt.Errorf("%s endpoint %q must be a valid URL with one of the following schemes: %v", f.name, *f.url, f.schemes)
+		}
+	}
+	return nil
 }
 
 // yamlMCPCatalog represents a complete MCP catalog YAML file
@@ -312,8 +339,18 @@ func (ys *yamlMCPServer) ToMCPServerProviderRecord() MCPServerProviderRecord {
 		}
 	}
 
+	// Validate remote servers have at least one endpoint
+	if ys.DeploymentMode != nil && *ys.DeploymentMode == "remote" {
+		if ys.Endpoints == nil || (ys.Endpoints.HTTP == nil && ys.Endpoints.SSE == nil && ys.Endpoints.WebSocket == nil) {
+			return MCPServerProviderRecord{Error: fmt.Errorf("server %q has deploymentMode 'remote' but no endpoints defined", ys.Name)}
+		}
+	}
+
 	// Convert endpoints to JSON
 	if ys.Endpoints != nil {
+		if err := ys.Endpoints.validate(); err != nil {
+			return MCPServerProviderRecord{Error: fmt.Errorf("server %q has invalid endpoints: %w", ys.Name, err)}
+		}
 		if jsonBytes, err := json.Marshal(ys.Endpoints); err == nil {
 			properties = append(properties, mrmodels.NewStringProperty("endpoints", string(jsonBytes), false))
 		}

--- a/catalog/internal/catalog/mcpcatalog/providers_test.go
+++ b/catalog/internal/catalog/mcpcatalog/providers_test.go
@@ -2,6 +2,7 @@ package mcpcatalog
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -260,6 +261,169 @@ func TestYamlMCPProviderInvalidFile(t *testing.T) {
 	require.Len(t, records, 1, "expected one error record for unreadable file")
 	assert.NotNil(t, records[0].Error, "error record should have non-nil Error")
 	assert.Nil(t, records[0].Server, "error record should have nil Server")
+}
+
+func TestYamlMCPEndpointsValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		server      *yamlMCPServer
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "remote server with valid HTTP endpoint passes",
+			server: &yamlMCPServer{
+				Name:           "remote-http",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{HTTP: strPtr("https://api.example.com/mcp")},
+			},
+		},
+		{
+			name: "remote server with valid SSE endpoint passes",
+			server: &yamlMCPServer{
+				Name:           "remote-sse",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{SSE: strPtr("https://api.example.com/mcp/events")},
+			},
+		},
+		{
+			name: "remote server with both endpoints passes",
+			server: &yamlMCPServer{
+				Name:           "remote-both",
+				DeploymentMode: strPtr("remote"),
+				Endpoints: &yamlMCPEndpoints{
+					HTTP: strPtr("https://api.example.com/mcp"),
+					SSE:  strPtr("https://api.example.com/mcp/events"),
+				},
+			},
+		},
+		{
+			name: "remote server with no endpoints is rejected",
+			server: &yamlMCPServer{
+				Name:           "remote-no-endpoints",
+				DeploymentMode: strPtr("remote"),
+			},
+			wantErr:     true,
+			errContains: "no endpoints defined",
+		},
+		{
+			name: "remote server with empty endpoints struct is rejected",
+			server: &yamlMCPServer{
+				Name:           "remote-empty-endpoints",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{},
+			},
+			wantErr:     true,
+			errContains: "no endpoints defined",
+		},
+		{
+			name: "local server without endpoints passes",
+			server: &yamlMCPServer{
+				Name:           "local-no-endpoints",
+				DeploymentMode: strPtr("local"),
+			},
+		},
+		{
+			name: "local server with endpoints passes (hybrid)",
+			server: &yamlMCPServer{
+				Name:           "local-with-endpoints",
+				DeploymentMode: strPtr("local"),
+				Endpoints:      &yamlMCPEndpoints{HTTP: strPtr("https://api.example.com/mcp")},
+			},
+		},
+		{
+			name: "non-HTTP URL in HTTP endpoint is rejected",
+			server: &yamlMCPServer{
+				Name:           "bad-url-scheme",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{HTTP: strPtr("ftp://example.com/mcp")},
+			},
+			wantErr:     true,
+			errContains: "must be a valid URL",
+		},
+		{
+			name: "malformed URL is rejected",
+			server: &yamlMCPServer{
+				Name:           "malformed-url",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{HTTP: strPtr("not-a-url-at-all")},
+			},
+			wantErr:     true,
+			errContains: "must be a valid URL",
+		},
+		{
+			name: "plain http URL is accepted",
+			server: &yamlMCPServer{
+				Name:           "plain-http",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{HTTP: strPtr("http://api.example.com/mcp")},
+			},
+		},
+		{
+			name: "websocket-only remote server passes",
+			server: &yamlMCPServer{
+				Name:           "remote-ws",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{WebSocket: strPtr("wss://api.example.com/ws")},
+			},
+		},
+		{
+			name: "ws scheme accepted for websocket endpoint",
+			server: &yamlMCPServer{
+				Name:           "remote-ws-plain",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{WebSocket: strPtr("ws://api.example.com/ws")},
+			},
+		},
+		{
+			name: "ftp scheme rejected for websocket endpoint",
+			server: &yamlMCPServer{
+				Name:           "bad-ws-scheme",
+				DeploymentMode: strPtr("remote"),
+				Endpoints:      &yamlMCPEndpoints{WebSocket: strPtr("ftp://example.com/ws")},
+			},
+			wantErr:     true,
+			errContains: "must be a valid URL",
+		},
+		{
+			name: "server with no deploymentMode and endpoints passes",
+			server: &yamlMCPServer{
+				Name:      "no-mode-with-endpoints",
+				Endpoints: &yamlMCPEndpoints{HTTP: strPtr("https://api.example.com/mcp")},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record := tc.server.ToMCPServerProviderRecord()
+			if tc.wantErr {
+				assert.NotNil(t, record.Error, "expected an error but got none")
+				if tc.errContains != "" {
+					assert.Contains(t, record.Error.Error(), tc.errContains)
+				}
+			} else {
+				assert.Nil(t, record.Error, "expected no error but got: %v", record.Error)
+				assert.NotNil(t, record.Server)
+			}
+		})
+	}
+}
+
+func TestYamlMCPEndpointsJSONKeys(t *testing.T) {
+	endpoints := &yamlMCPEndpoints{
+		HTTP: strPtr("https://api.example.com/mcp"),
+		SSE:  strPtr("https://api.example.com/mcp/events"),
+	}
+
+	jsonBytes, err := json.Marshal(endpoints)
+	require.NoError(t, err)
+
+	jsonStr := string(jsonBytes)
+	assert.Contains(t, jsonStr, `"http":`, "JSON key should be lowercase 'http'")
+	assert.Contains(t, jsonStr, `"sse":`, "JSON key should be lowercase 'sse'")
+	assert.NotContains(t, jsonStr, `"HTTP":`, "JSON key must not be uppercase 'HTTP'")
+	assert.NotContains(t, jsonStr, `"SSE":`, "JSON key must not be uppercase 'SSE'")
 }
 
 // Helper function


### PR DESCRIPTION
## Description

Adds validation that remote endpoints have at least one endpoint, and that all HTTP-based protocols have a http:// or https:// URL (except for WebSockets which can have ws:// or wss://).

## How Has This Been Tested?
On a local development cluster and with unit tests.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
