### PR TITLE
feat: add /ok-to-test workflow to approve fork PR runs

### DIFF
--- a/.github/workflows/gh-workflow-approve.yml
+++ b/.github/workflows/gh-workflow-approve.yml
@@ -3,105 +3,69 @@ name: Approve Workflow Runs
 permissions:
   actions: write
   contents: read
-  pull-requests: write
 
 on:
-  issue_comment:
-    types: [created]
   pull_request_target:
     types:
       - labeled
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
   ok-to-test:
-    if: |
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/ok-to-test')) ||
-      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test') || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     continue-on-error: true
 
     steps:
-      - name: Checkout repository
-        if: github.event_name == 'issue_comment'
-        uses: actions/checkout@v6
-
-      - name: Check if commenter is in OWNERS file
-        if: github.event_name == 'issue_comment'
-        id: owners-check
+      - name: Check if author is a Kubeflow GitHub member
+        id: membership-check
         env:
-          COMMENTER: ${{ github.event.comment.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          pip3 install pyyaml -q
-          python3 << 'EOF'
-          import yaml, os
+          echo "::group::PR Information"
+          echo "PR Number: #$PR_NUMBER"
+          echo "PR Author: $PR_AUTHOR"
+          echo "Author Association: $AUTHOR_ASSOCIATION"
+          echo "::endgroup::"
 
-          commenter = os.environ["COMMENTER"].lower()
-          with open("OWNERS", "r") as f:
-              data = yaml.safe_load(f)
-
-          owners = set()
-          for key in ("approvers", "reviewers"):
-              for person in data.get(key, []):
-                  owners.add(person.strip().lower())
-
-          if commenter in owners:
-              print(f"::notice::User '{commenter}' is listed in OWNERS file. Proceeding with approval.")
-              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                  f.write("is_owner=true\n")
-          else:
-              print(f"::warning::User '{commenter}' is not listed in OWNERS file. Skipping approval.")
-              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                  f.write("is_owner=false\n")
-          EOF
-
-      - name: Add ok-to-test label
-        if: github.event_name == 'issue_comment' && steps.owners-check.outputs.is_owner == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit "${{ github.event.issue.number }}" --add-label "ok-to-test" --repo "$GITHUB_REPOSITORY"
+          if [[ "$AUTHOR_ASSOCIATION" == "MEMBER" || "$AUTHOR_ASSOCIATION" == "OWNER" || "$AUTHOR_ASSOCIATION" == "COLLABORATOR" ]]; then
+            echo "::notice::Author '$PR_AUTHOR' is a trusted contributor (association: $AUTHOR_ASSOCIATION). Auto-approving workflow runs."
+            echo "is_member=true" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::Author '$PR_AUTHOR' is not a trusted contributor (association: $AUTHOR_ASSOCIATION). Checking for 'ok-to-test' label."
+            echo "is_member=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Approve Pending Workflow Runs
-        if: |
-          (github.event_name == 'issue_comment' && steps.owners-check.outputs.is_owner == 'true') ||
-          (github.event_name == 'pull_request_target')
+        if: steps.membership-check.outputs.is_member == 'true' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
         uses: actions/github-script@v8
         with:
           retries: 3
           script: |
-            let headSha;
-            if (context.eventName === 'issue_comment') {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.issue.number,
-              });
-              headSha = pr.head.sha;
-            } else {
-              headSha = context.payload.pull_request.head.sha;
-            }
-
             const request = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               event: "pull_request",
               status: "action_required",
-              head_sha: headSha,
+              head_sha: context.payload.pull_request.head.sha,
             }
 
-            core.info(`Getting workflow runs that need approval for commit ${headSha}`)
+            core.info(`Getting workflow runs that need approval for commit ${request.head_sha}`)
             const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, request)
 
             core.info(`Found ${runs.length} workflow runs that need approval`)
             for (const run of runs) {
               core.info(`Approving workflow run ${run.id}`)
-              await github.rest.actions.approveWorkflowRun({
+              const request = {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: run.id,
-              })
+              }
+              await github.rest.actions.approveWorkflowRun(request)
             }


### PR DESCRIPTION
## Description

Add `gh-workflow-approve.yml` workflow to approve pending workflow runs for fork PRs, following the [kubeflow/pipelines](https://github.com/kubeflow/pipelines/blob/master/.github/workflows/gh-workflow-approve.yml) pattern.

When external contributors open PRs from forks, their workflow runs require manual approval. This workflow automates that:
- Auto-approves workflow runs for trusted contributors (org members, owners, collaborators) via `author_association`
- Approves workflow runs when a reviewer adds the `ok-to-test` label (added by Prow when someone comments `/ok-to-test`)
- Re-approves on new commits (`synchronize`) if the `ok-to-test` label is already present

## How Has This Been Tested?

This is a GitHub Actions workflow — it cannot be tested locally. The workflow logic follows the same pattern already running in production in `kubeflow/pipelines`. Testing will occur on the first fork PR after merge by having a reviewer comment `/ok-to-test`.

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).