### PR TITLE
fix(catalog): return the correct original tool name

### DIFF
--- a/catalog/internal/converter/mcp_converter.go
+++ b/catalog/internal/converter/mcp_converter.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -297,8 +298,15 @@ func ConvertDbMCPToolToOpenapi(dbTool models.MCPServerTool) *openapi.MCPTool {
 		accessType = "read_only" // default fallback to prevent API contract violation
 	}
 
+	// Strip internal qualified prefix (serverName@version:) from tool name before returning to API.
+	// The DB stores tools as "server@version:toolName" for uniqueness, but the API should return just "toolName".
+	toolName := *attr.Name
+	if idx := strings.LastIndex(toolName, ":"); idx != -1 {
+		toolName = toolName[idx+1:]
+	}
+
 	// Create OpenAPI tool with required fields
-	openapiTool := openapi.NewMCPTool(*attr.Name, accessType)
+	openapiTool := openapi.NewMCPTool(toolName, accessType)
 
 	// Set ID if available
 	if id := dbTool.GetID(); id != nil {

--- a/catalog/internal/converter/mcp_converter_test.go
+++ b/catalog/internal/converter/mcp_converter_test.go
@@ -1,0 +1,54 @@
+package converter_test
+
+import (
+	"testing"
+
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog/models"
+	"github.com/kubeflow/model-registry/catalog/internal/converter"
+	"github.com/kubeflow/model-registry/internal/apiutils"
+	dbmodels "github.com/kubeflow/model-registry/internal/db/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertDbMCPToolToOpenapi_StripsQualifiedPrefix(t *testing.T) {
+	tests := []struct {
+		name         string
+		storedName   string
+		expectedName string
+	}{
+		{
+			name:         "strips server@version prefix",
+			storedName:   "weather-api@1.0.0:get_current_weather",
+			expectedName: "get_current_weather",
+		},
+		{
+			name:         "strips server-only prefix (no version)",
+			storedName:   "myserver:my_tool",
+			expectedName: "my_tool",
+		},
+		{
+			name:         "no prefix passes through unchanged",
+			storedName:   "plain_tool_name",
+			expectedName: "plain_tool_name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			accessType := "read_only"
+			tool := &models.MCPServerToolImpl{
+				Attributes: &models.MCPServerToolAttributes{
+					Name: apiutils.Of(tc.storedName),
+				},
+				Properties: &[]dbmodels.Properties{
+					{Name: "accessType", StringValue: apiutils.Of(accessType)},
+				},
+			}
+
+			result := converter.ConvertDbMCPToolToOpenapi(tool)
+			require.NotNil(t, result)
+			assert.Equal(t, tc.expectedName, result.Name)
+		})
+	}
+}


### PR DESCRIPTION
## Description

The MCP catalog prefixes the server name and version to tool names to make them unique. This strips the prefix off so that we present the original name in the API response.

## How Has This Been Tested?
Locally on a kind cluster and unit tests.

For example:
```
$ curl -s "http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers/780/tools" | jq '.items[].name'
"list_ec2_instances"
"list_s3_buckets"
"invoke_lambda"
"describe_cloudwatch_alarms"
```

Those names were previously prefixed with `aws-mcp@2.0.1:`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
