### PR TITLE
feat(signing): add instance-level log filtering for signing components

### DIFF
--- a/clients/python/src/model_registry/signing/__init__.py
+++ b/clients/python/src/model_registry/signing/__init__.py
@@ -1,5 +1,7 @@
 """Signing utilities for model registry."""
 
+import logging
+
 from model_registry.signing.config import SigningConfig
 from model_registry.signing.exceptions import (
     BaseSigningError,
@@ -27,3 +29,20 @@ __all__ = [
     "decode_jwt_payload",
     "extract_client_id",
 ]
+
+# Shared parent logger for all signing components, independent of root logger.
+# propagate=False prevents messages from leaking to the root logger (no double-printing).
+logger = logging.getLogger(__name__)
+logger.propagate = False
+if not logger.handlers:  # guard against duplicate handlers on re-import
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(
+        logging.Formatter(
+            fmt="%(asctime)s.%(msecs)03d - %(name)s:%(levelname)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    )
+    logger.addHandler(_handler)
+    # Set to DEBUG so the parent logger never gates messages.
+    # Actual filtering is done per-instance by InstanceLevelAdapter.
+    logger.setLevel(logging.DEBUG)

--- a/clients/python/src/model_registry/signing/_logging.py
+++ b/clients/python/src/model_registry/signing/_logging.py
@@ -1,0 +1,34 @@
+"""Logging utilities for signing components."""
+
+import logging
+
+
+class LogConfig:
+    """Configuration for instance-level logging."""
+
+    def __init__(self, instance_name: str, level: int | None = None):
+        self.instance_name: str = instance_name
+        self.level: int = level if level is not None else logging.WARNING
+
+
+class InstanceLevelAdapter(logging.LoggerAdapter):
+    """Checks instance log level before logging.
+
+    Uses a LogConfig dataclass for instance-level filtering,
+    while keeping extra as a standard dict for LoggerAdapter compatibility.
+    """
+
+    def __init__(self, logger: logging.Logger, log_config: LogConfig):
+        super().__init__(logger, {"instance_name": log_config.instance_name})
+        self.log_config = log_config
+
+    def log(self, level, msg, *args, **kwargs):
+        if level >= self.log_config.level:
+            super().log(level, msg, *args, **kwargs)
+
+    def process(self, msg, kwargs):
+        return f"[{self.log_config.instance_name}] {msg}", kwargs
+
+    def set_log_level(self, level: int) -> None:
+        """Set the log level for this instance."""
+        self.log_config.level = level

--- a/clients/python/src/model_registry/signing/image_signer.py
+++ b/clients/python/src/model_registry/signing/image_signer.py
@@ -2,38 +2,44 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
-import sys
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from typing_extensions import Self
 
+from model_registry.signing._logging import InstanceLevelAdapter, LogConfig
 from model_registry.signing.exceptions import InitializationError, SigningError, VerificationError
 
 if TYPE_CHECKING:
     from .config import SigningConfig
 
+logger = logging.getLogger(__name__)
+
 
 class CommandRunner:
     """Command execution wrapper for running CLI tools."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, logger_adapter: logging.LoggerAdapter, **kwargs):
         """Initialize CommandRunner with default subprocess.run arguments.
 
         Args:
+            logger_adapter: Logger adapter for logging command output
             **kwargs: Additional default keyword arguments to pass to subprocess.run
         """
         self._run = partial(subprocess.run, check=True, capture_output=True, text=True, **kwargs)
+        self._logger: logging.LoggerAdapter = logger_adapter
 
-    def run(self, cmd: list[str]) -> subprocess.CompletedProcess:
-        """Run a CLI command and handle output.
+    def run(self, cmd: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+        """Run a CLI command and log output.
 
         Args:
             cmd: Command and arguments as a list
+            env: Environment variables for the subprocess. Defaults to os.environ.copy().
 
         Returns:
             CompletedProcess instance
@@ -41,11 +47,21 @@ class CommandRunner:
         Raises:
             subprocess.CalledProcessError: If the command fails
         """
-        # Explicitly pass current environment to ensure DOCKER_CONFIG and other vars are inherited
-        result = self._run(cmd, env=os.environ.copy())
-        if result.stderr:
-            print(result.stderr, file=sys.stderr)
-        return result
+        try:
+            if env is None:
+                env = os.environ.copy()
+            result = self._run(cmd, env=env)
+            if result.stdout:
+                self._logger.debug(result.stdout.strip())
+            if result.stderr:
+                self._logger.debug(result.stderr.strip())
+            return result
+        except subprocess.CalledProcessError as e:
+            if e.stdout:
+                self._logger.error(e.stdout.strip())
+            if e.stderr:
+                self._logger.error(e.stderr.strip())
+            raise
 
 
 class ImageSigner:
@@ -62,6 +78,7 @@ class ImageSigner:
         certificate_identity: str | None = None,
         oidc_issuer: str | None = None,
         client_id: str | None = None,
+        log_level: int | None = None,
     ):
         """Initialize ImageSigner tool.
 
@@ -75,11 +92,16 @@ class ImageSigner:
             certificate_identity: Default certificate identity
             oidc_issuer: Default OIDC issuer URL
             client_id: Default OIDC client ID
+            log_level: Log level for this instance (e.g. logging.DEBUG)
 
         Raises:
             FileNotFoundError: If identity_token_path is provided but doesn't exist
         """
-        self.runner = CommandRunner()
+        self.logger = InstanceLevelAdapter(
+            logger,
+            LogConfig(instance_name=type(self).__name__, level=log_level),
+        )
+        self.runner = CommandRunner(logger_adapter=self.logger)
         self.tuf_url = tuf_url
         self.root = root
         self.root_checksum = root_checksum
@@ -175,9 +197,11 @@ class ImageSigner:
             cmd.extend(["--root-checksum", root_checksum])
 
         try:
+            self.logger.debug("Initializing sigstore configuration")
             self.runner.run(cmd)
+            self.logger.debug("Sigstore configuration initialized")
         except subprocess.CalledProcessError as e:
-            msg = f"Failed to initialize sigstore: {e}"
+            msg = f"Failed to initialize sigstore (exit code {e.returncode})"
             raise InitializationError(msg) from e
 
     def sign(  # noqa: C901
@@ -217,13 +241,14 @@ class ImageSigner:
 
         self._ensure_initialized()
 
+        self.logger.info(f"Signing image: {image}")
         cmd = ["cosign", "sign", "-y"]
+        env = os.environ.copy()
 
         if identity_token_path is not None:
-            # Read token content from file (cosign doesn't actually accept file paths despite docs)
             with open(identity_token_path) as f:
                 token_content = f.read().strip()
-            cmd.extend(["--identity-token", token_content])
+            env["COSIGN_IDENTITY_TOKEN"] = token_content
 
         if fulcio_url is not None:
             cmd.extend(["--fulcio-url", fulcio_url])
@@ -238,9 +263,10 @@ class ImageSigner:
         cmd.append(image)
 
         try:
-            self.runner.run(cmd)
+            self.runner.run(cmd, env=env)
+            self.logger.info(f"Signed image successfully: {image}")
         except subprocess.CalledProcessError as e:
-            msg = f"Failed to sign image {image}: {e}"
+            msg = f"Failed to sign image {image} (exit code {e.returncode})"
             raise SigningError(msg) from e
 
     def verify(self, image: str, certificate_identity: str | None = None, oidc_issuer: str | None = None):
@@ -259,6 +285,7 @@ class ImageSigner:
 
         self._ensure_initialized()
 
+        self.logger.info(f"Verifying image: {image}")
         cmd = ["cosign", "verify"]
 
         if certificate_identity is not None:
@@ -271,6 +298,7 @@ class ImageSigner:
 
         try:
             self.runner.run(cmd)
+            self.logger.info(f"Verified image successfully: {image}")
         except subprocess.CalledProcessError as e:
-            msg = f"Failed to verify image {image}: {e}"
+            msg = f"Failed to verify image {image} (exit code {e.returncode})"
             raise VerificationError(msg) from e

--- a/clients/python/src/model_registry/signing/model_signer.py
+++ b/clients/python/src/model_registry/signing/model_signer.py
@@ -12,6 +12,7 @@ from model_signing import signing, verifying
 from typing_extensions import Self
 
 from model_registry.signing import sign_sigstore
+from model_registry.signing._logging import InstanceLevelAdapter, LogConfig
 
 from .exceptions import InitializationError, SigningError, VerificationError
 from .token import decode_jwt_payload, extract_client_id
@@ -21,7 +22,6 @@ if TYPE_CHECKING:
     from .config import SigningConfig
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 PathLike: TypeAlias = str | os.PathLike[str]
 
@@ -47,6 +47,7 @@ class ModelSigner:
         cache_dir: PathLike | None = None,
         signature_filename: str | None = None,
         ignore_paths: Iterable[PathLike] | None = None,
+        log_level: int | None = None,
     ):
         """Initialize ModelSigner with optional default parameters.
 
@@ -64,7 +65,12 @@ class ModelSigner:
                 Each TUF URL gets URL-encoded subdirectory for isolation
             signature_filename: Default filename for signatures (default: model.sig)
             ignore_paths: Default paths to ignore during signing (optional)
+            log_level: Log level for this instance (e.g. logging.DEBUG)
         """
+        self.logger = InstanceLevelAdapter(
+            logger,
+            LogConfig(instance_name=type(self).__name__, level=log_level),
+        )
         self.tuf_url = tuf_url
         self.root_url = root_url
         self.root_checksum = root_checksum
@@ -77,7 +83,7 @@ class ModelSigner:
         self.signature_filename = signature_filename if signature_filename is not None else "model.sig"
         self.ignore_paths = ignore_paths
         # Create trust initializer
-        self.trust_manager = TrustManager(cache_dir)
+        self.trust_manager = TrustManager(cache_dir, logger_adapter=self.logger)
 
     @classmethod
     def from_config(cls, config: SigningConfig) -> Self:
@@ -121,7 +127,7 @@ class ModelSigner:
         """
         trust_config_path = self.get_trust_config_path()
         if not trust_config_path.exists():
-            logger.info("Trust configuration not initialized. Auto-initializing...")
+            self.logger.debug("Trust configuration not initialized. Auto-initializing...")
             self.initialize(
                 fulcio_url=self.fulcio_url,
                 rekor_url=self.rekor_url,
@@ -257,14 +263,14 @@ class ModelSigner:
             raise SigningError(msg)
 
         try:
-            logger.info(f"Signing model: {model_path}")
-
             # Ensure trust configuration is initialized
             self._ensure_trust_initialized()
 
             # Load trust config path
-            logger.info("Initializing signing context...")
+            self.logger.debug("Initializing signing context...")
             trust_config_path = self.get_trust_config_path()
+
+            self.logger.info(f"Signing model: {model_path}")
 
             # Read and parse identity token
             token_str = token_path.read_text().strip()
@@ -299,7 +305,7 @@ class ModelSigner:
 
             config.sign(model_path, signature_path)
 
-            logger.info(f"Signed successfully: {signature_path}")
+            self.logger.info(f"Signed model successfully: {signature_path}")
             return signature_path
 
         except (FileNotFoundError, SigningError, ValueError):
@@ -357,7 +363,7 @@ class ModelSigner:
             raise VerificationError(msg)
 
         try:
-            logger.info(f"Verifying model: {model_path}")
+            self.logger.info(f"Verifying model: {model_path}")
 
             # Ensure trust configuration is initialized
             self._ensure_trust_initialized()
@@ -365,8 +371,8 @@ class ModelSigner:
             # Load trust config path
             trust_config_path = self.get_trust_config_path()
 
-            logger.info(f"Expected identity: {certificate_identity}")
-            logger.info(f"Expected issuer: {oidc_issuer}")
+            self.logger.debug(f"Expected identity: {certificate_identity}")
+            self.logger.debug(f"Expected issuer: {oidc_issuer}")
 
             # Verify using model_signing.verifying API
             verifying.Config().use_sigstore_verifier(
@@ -375,13 +381,13 @@ class ModelSigner:
                 trust_config=trust_config_path,
             ).verify(model_path, signature_path)
 
-            logger.info("Successfully verified model signature")
+            self.logger.info(f"Verified model successfully: {model_path}")
 
         except FileNotFoundError:
             raise
         except ValueError as e:
             # verifying.Config().verify() raises ValueError on verification failure
-            logger.error(f"Verification failed: {e}")
+            self.logger.error(f"Verification failed: {e}")
             msg = f"Verification failed: {e}"
             raise VerificationError(msg) from e
         except VerificationError:

--- a/clients/python/src/model_registry/signing/signer.py
+++ b/clients/python/src/model_registry/signing/signer.py
@@ -1,12 +1,16 @@
 """Unified signer interface for models and container images."""
 
+import logging
 import os
 from collections.abc import Iterable
 from pathlib import Path
 
+from model_registry.signing._logging import InstanceLevelAdapter, LogConfig
 from model_registry.signing.config import SigningConfig
 from model_registry.signing.image_signer import ImageSigner
 from model_registry.signing.model_signer import ModelSigner
+
+logger = logging.getLogger(__name__)
 
 PathLike = str | os.PathLike[str]
 
@@ -32,6 +36,7 @@ class Signer:
         cache_dir: PathLike | None = None,
         signature_filename: str = "model.sig",
         ignore_paths: Iterable[PathLike] | None = None,
+        log_level: int | None = None,
     ):
         """Initialize Signer with configuration.
 
@@ -52,7 +57,13 @@ class Signer:
             cache_dir: Cache directory
             signature_filename: Default signature filename (default: model.sig)
             ignore_paths: Default paths to ignore during signing
+            log_level: Log level for all signing components (e.g. logging.DEBUG)
         """
+        self.logger = InstanceLevelAdapter(
+            logger,
+            LogConfig(instance_name=type(self).__name__, level=log_level),
+        )
+
         self.config = SigningConfig.create(
             tuf_url=tuf_url,
             root_url=root_url,
@@ -70,6 +81,19 @@ class Signer:
         )
         self.model_signer: ModelSigner = ModelSigner.from_config(self.config)
         self.image_signer: ImageSigner = ImageSigner.from_config(self.config)
+
+        if log_level is not None:
+            self.set_log_level(log_level)
+
+    def set_log_level(self, level: int) -> None:
+        """Set the log level for this signer instance and its child signers.
+
+        Args:
+            level: Log level (e.g. logging.DEBUG, logging.INFO, logging.WARNING)
+        """
+        self.logger.set_log_level(level)
+        self.model_signer.logger.set_log_level(level)
+        self.image_signer.logger.set_log_level(level)
 
     def initialize(
         self,
@@ -96,6 +120,7 @@ class Signer:
             oidc_issuer: OIDC issuer (uses config default if not provided)
             force: If True, overwrite existing configuration
         """
+        self.logger.info("Initializing trust configuration")
         # Initialize model signer trust
         self.model_signer.initialize(
             tuf_url=tuf_url,

--- a/clients/python/src/model_registry/signing/trust_manager.py
+++ b/clients/python/src/model_registry/signing/trust_manager.py
@@ -16,7 +16,6 @@ from sigstore._internal.tuf import TrustUpdater
 from .exceptions import InitializationError
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class TrustManager:
@@ -26,13 +25,20 @@ class TrustManager:
     with support for explicit bootstrap (like cosign initialize).
     """
 
-    def __init__(self, cache_dir: str | os.PathLike[str] | None = None):
+    def __init__(
+        self,
+        cache_dir: str | os.PathLike[str] | None = None,
+        *,
+        logger_adapter: logging.LoggerAdapter,
+    ):
         """Initialize TrustManager.
 
         Args:
             cache_dir: Base cache directory (default: platformdirs user_data_dir)
                 Each TUF URL gets URL-encoded subdirectory for isolation
+            logger_adapter: Logger adapter for filtered logging
         """
+        self._logger: logging.LoggerAdapter = logger_adapter
         if cache_dir:
             self.base_cache_dir = Path(cache_dir)
         else:
@@ -113,11 +119,11 @@ class TrustManager:
         try:
             updater = TrustUpdater(url=tuf_url, offline=False)
             trusted_root_path = updater.get_trusted_root_path()
-            logger.info(f"Downloaded (TrustUpdater): {Path(trusted_root_path).name}")
+            self._logger.debug(f"Downloaded (TrustUpdater): {Path(trusted_root_path).name}")
             with open(trusted_root_path) as f:
                 return json.load(f)
         except Exception:
-            logger.info("Direct TrustUpdater failed, trying with bootstrap...")
+            self._logger.debug("Direct TrustUpdater failed, trying with bootstrap...")
             return None
 
     def _load_cached_root(self, cache_path: Path, checksum: str | None) -> bytes | None:
@@ -130,21 +136,21 @@ class TrustManager:
             if checksum:
                 cached_checksum = hashlib.sha256(cached_data).hexdigest()
                 if cached_checksum.lower() == checksum.lower():
-                    logger.info("Using cached root.json (checksum verified)")
+                    self._logger.debug("Using cached root.json (checksum verified)")
                     return cached_data
-                logger.info("Cached root.json checksum mismatch, re-downloading...")
+                self._logger.debug("Cached root.json checksum mismatch, re-downloading...")
                 return None
-            logger.info("Using cached root.json")
+            self._logger.debug("Using cached root.json")
             return cached_data
         except Exception as e:
-            logger.info(f"Could not use cached root.json: {e}, re-downloading...")
+            self._logger.debug(f"Could not use cached root.json: {e}, re-downloading...")
             return None
 
     def _download_root_json(self, urls: list[str]) -> bytes:
         """Download root.json from list of URLs."""
         for url in urls:
             try:
-                logger.info(f"Downloading from: {url}")
+                self._logger.debug(f"Downloading from: {url}")
                 with urllib.request.urlopen(url) as response:  # noqa: S310
                     return response.read()
             except urllib.error.HTTPError:
@@ -159,9 +165,9 @@ class TrustManager:
             if computed_checksum.lower() != expected_checksum.lower():
                 msg = f"Root.json checksum mismatch!\n  Expected: {expected_checksum}\n  Got:      {computed_checksum}"
                 raise InitializationError(msg)
-            logger.info(f"Checksum verified: {computed_checksum}")
+            self._logger.debug(f"Checksum verified: {computed_checksum}")
         else:
-            logger.info("No checksum provided (skipping validation)")
+            self._logger.debug("No checksum provided (skipping validation)")
 
     def _bootstrap_trust_updater(self, tuf_url: str, root_data: bytes) -> dict:
         """Bootstrap TrustUpdater with root.json and return trusted_root."""
@@ -171,7 +177,7 @@ class TrustManager:
 
             updater = TrustUpdater(url=tuf_url, offline=False, bootstrap_root=bootstrap_root)
             trusted_root_path = updater.get_trusted_root_path()
-            logger.info(f"Initialized TUF client: {Path(trusted_root_path).name}")
+            self._logger.debug(f"Initialized TUF client: {Path(trusted_root_path).name}")
 
             with open(trusted_root_path) as f:
                 return json.load(f)
@@ -200,14 +206,14 @@ class TrustManager:
         try:
             # Try direct TrustUpdater first (auto-detect mode only)
             if not root_url:
-                logger.info(f"Downloading trusted root from TUF: {tuf_url}")
+                self._logger.debug(f"Downloading trusted root from TUF: {tuf_url}")
                 result = self._try_direct_trust_updater(tuf_url)
                 if result:
                     return result
 
             # Prepare URLs to try
             if root_url:
-                logger.info(f"Downloading root.json from explicit URL: {root_url}")
+                self._logger.debug(f"Downloading root.json from explicit URL: {root_url}")
                 root_urls = [root_url]
             else:
                 tuf_url_clean = tuf_url.rstrip("/")
@@ -224,12 +230,12 @@ class TrustManager:
             if not root_data:
                 root_data = self._download_root_json(root_urls)
                 self._validate_checksum(root_data, root_checksum)
-                logger.info(f"Downloaded root.json ({len(root_data)} bytes)")
+                self._logger.debug(f"Downloaded root.json ({len(root_data)} bytes)")
 
                 # Cache for future use
                 root_cache_path.parent.mkdir(parents=True, exist_ok=True)
                 root_cache_path.write_bytes(root_data)
-                logger.info(f"Cached to: {root_cache_path}")
+                self._logger.debug(f"Cached to: {root_cache_path}")
 
             # Bootstrap TrustUpdater with root.json
             return self._bootstrap_trust_updater(tuf_url, root_data)
@@ -242,7 +248,7 @@ class TrustManager:
 
     def _transform_and_fix_trust_root(self, trusted_root: dict) -> dict:
         """Apply transformations to trusted root."""
-        logger.info("Transforming checkpointKeyId to logId...")
+        self._logger.debug("Transforming checkpointKeyId to logId...")
         return self._transform_checkpoint_to_logid(trusted_root)
 
     @staticmethod
@@ -341,8 +347,8 @@ class TrustManager:
         # Cache trusted root
         trusted_root = trust_config.get("trustedRoot", {})
         trust_root_path.write_text(json.dumps(trusted_root, indent=2))
-        logger.info(f"Cached trusted root to: {trust_root_path}")
+        self._logger.debug(f"Cached trusted root to: {trust_root_path}")
 
         # Cache complete trust config
         trust_config_path.write_text(json.dumps(trust_config, indent=2))
-        logger.info(f"Cached trust config to: {trust_config_path}")
+        self._logger.debug(f"Cached trust config to: {trust_config_path}")

--- a/clients/python/src/model_registry/types/artifacts.py
+++ b/clients/python/src/model_registry/types/artifacts.py
@@ -12,6 +12,7 @@ Todo:
 
 from __future__ import annotations  # noqa: I001
 
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, TypeVar
@@ -270,6 +271,9 @@ class ModelArtifact(Artifact):
             if source.custom_properties
             else None,
         )
+
+
+warnings.filterwarnings("ignore", message='Field name "schema" in "DataSet" shadows an attribute')
 
 
 class DataSet(Artifact):

--- a/clients/python/tests/test_signing.py
+++ b/clients/python/tests/test_signing.py
@@ -1,7 +1,9 @@
 """Tests for signing utilities."""
 
+import logging
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -14,6 +16,7 @@ from model_registry.signing import (
     SigningError,
     VerificationError,
 )
+from model_registry.signing._logging import InstanceLevelAdapter, LogConfig
 
 TUF_URL = "https://tuf.example.com"
 ROOT_URL = f"{TUF_URL}/root.json"
@@ -175,11 +178,12 @@ class TestImageSigner:
         cmd = mock_runner.run.call_args[0][0]
         assert cmd == [
             "cosign", "sign", "-y",
-            "--identity-token", "test-token",
             "--fulcio-url", FULCIO_URL,
             "--rekor-url", REKOR_URL,
             "quay.io/example/image@sha256:abc123"
         ]
+        env = mock_runner.run.call_args[1]["env"]
+        assert env["COSIGN_IDENTITY_TOKEN"] == "test-token"  # noqa: S105
 
     def test_sign_with_instance_defaults(self, tmp_path, mocker):
         """Test sign uses instance defaults when method args not provided."""
@@ -198,7 +202,8 @@ class TestImageSigner:
         signer.sign(image="quay.io/example/image@sha256:abc123")
 
         cmd = mock_runner.run.call_args[0][0]
-        assert cmd.count("test-token") == 1
+        env = mock_runner.run.call_args[1]["env"]
+        assert env["COSIGN_IDENTITY_TOKEN"] == "test-token"  # noqa: S105
         assert cmd.count("https://default-fulcio.example.com") == 1
         assert cmd.count("https://default-rekor.example.com") == 1
 
@@ -225,9 +230,9 @@ class TestImageSigner:
         )
 
         mock_runner.run.assert_called_once()
-        cmd = mock_runner.run.call_args[0][0]
-        # File content should be read and passed
-        assert cmd.count("test-token") == 1
+        # Token should be passed via env var, not CLI arg
+        env = mock_runner.run.call_args[1]["env"]
+        assert env["COSIGN_IDENTITY_TOKEN"] == "test-token"  # noqa: S105
 
     def test_sign_raises_if_token_file_not_found(self, mocker):
         """Test sign raises FileNotFoundError if token file doesn't exist."""
@@ -961,3 +966,39 @@ class TestTokenUtils:
         # Missing parts
         result = k8s_sub_to_certificate_identity("system:serviceaccount:namespace")
         assert result == "system:serviceaccount:namespace"
+
+
+class TestLogging:
+    """Test signing logging configuration."""
+
+    def test_adapter_filters_below_instance_level(self):
+        """Adapter suppresses messages below instance_level."""
+        mock_logger = MagicMock()
+        adapter = InstanceLevelAdapter(mock_logger, LogConfig(
+            instance_name="Test",
+            level=logging.WARNING,
+        ))
+
+        adapter.info("should be suppressed")
+        mock_logger.log.assert_not_called()
+
+        adapter.warning("should pass")
+        assert mock_logger.log.called
+
+    def test_signing_logger_does_not_propagate(self):
+        """Signing logger is independent of root logger."""
+        signing_logger = logging.getLogger("model_registry.signing")
+        assert signing_logger.propagate is False
+
+    def test_set_log_level_adjusts_instance(self):
+        """Signer.set_log_level adjusts the instance log level."""
+        signer = Signer(log_level=logging.INFO)
+        assert signer.logger.log_config.level == logging.INFO
+
+        signer.set_log_level(logging.DEBUG)
+        assert signer.logger.log_config.level == logging.DEBUG
+
+    def test_signer_accepts_log_level(self):
+        """Signer constructor accepts log_level parameter."""
+        signer = Signer(log_level=logging.DEBUG)
+        assert signer.logger.log_config.level == logging.DEBUG


### PR DESCRIPTION
This adds instance-level log filtering via InstanceLevelAdapter and LogConfig, allowing per-signer log level control without modifying global logger state. The default log level is WARNING (silent) unless explicitly set.

The identity token is also passed to cosign via COSIGN_IDENTITY_TOKEN env var instead of --identity-token CLI arg, preventing token exposure in a process list or exception message.

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This is mainly around cleaning up logging and some minor improvements to signing.

**logging**

It can be helpful and convenient to adjust the log level of individual signer instances with `Signer(..., log_level=logging.DEBUG)`. Best practice is to avoid having dynamically created loggers (i.e. one per class-instance) as they are not garbage collected. But `LoggerAdapter` can help to apply logic in a context-specific way (i.e. we can have a custom subclass of `LoggerAdapter` where instances are passed the same global logger instance, but also some context-specific config). See https://docs.python.org/3/howto/logging-cookbook.html#adding-contextual-information-to-your-logging-output

> While it might be tempting to create [Logger](https://docs.python.org/3/library/logging.html#logging.Logger) instances on a per-connection basis, this is not a good idea because these instances are not garbage collected. While this is not a problem in practice, when the number of [Logger](https://docs.python.org/3/library/logging.html#logging.Logger) instances is dependent on the level of granularity you want to use in logging an application, it could be hard to manage if the number of [Logger](https://docs.python.org/3/library/logging.html#logging.Logger) instances becomes effectively unbounded.

**identity-token**

We should avoid passing the actual identity token value as a cli arg when calling `cosign sign` via `subprocess.run`. cli args are easier to see by tools that can view running processes on a system, and an exception on a `subprocess.run` call will show the args passed. An improvement is to use an env var instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally and in a kubernetes cluster with jupyter notebook:

**setup**

<img width="3293" height="493" alt="image" src="https://github.com/user-attachments/assets/b5f1dba4-487d-4b3a-a6ce-024296077c19" />


`logging.WARNING` (default)
<img width="3296" height="942" alt="image" src="https://github.com/user-attachments/assets/2aa4ceb8-beaa-4358-9807-171c1b4a2ac7" />


`logging.INFO`
<img width="3294" height="1119" alt="image" src="https://github.com/user-attachments/assets/d9d0cf51-dab8-4a14-b943-2131426d10ed" />


`logging.DEBUG`
<img width="3295" height="1742" alt="image" src="https://github.com/user-attachments/assets/6b3185f9-b140-4afe-94c7-44aa2ded6a42" />

Multiple instances with different log levels:
<img width="3295" height="1206" alt="image" src="https://github.com/user-attachments/assets/6bd254b7-f8ae-46a5-be53-c1586b758ff4" />

Note that the two signer instances use the **same** `Logger` instance (`s.logger.logger`) and the log level is handled by filtering that the logger adapter does (`s.logger` is different for each instance)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
