### PR TITLE
UX fixes for catalog performance filters

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -285,6 +285,14 @@ class ModelCatalog {
     return this;
   }
 
+  closeFilterChip(filterKey: string, value: string) {
+    cy.get(`[data-testid="${filterKey}-filter-chip-${value}"]`)
+      .closest('.pf-v6-c-label')
+      .find('button')
+      .click();
+    return this;
+  }
+
   // Model card content helpers for toggle-based display
   findValidatedModelBenchmarksCount() {
     return cy.findAllByTestId('validated-model-benchmarks');
@@ -333,7 +341,9 @@ class ModelCatalog {
   }
 
   findEmptyStateResetFiltersButton() {
-    return this.findModelCatalogEmptyState().findByRole('button', { name: /Reset filters/i });
+    return this.findModelCatalogEmptyState().findByRole('button', {
+      name: /Reset all (defaults|filters)/i,
+    });
   }
 
   clickApplyFilter() {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -499,7 +499,7 @@ describe('Performance Empty State', () => {
       modelCatalog.findFilterCheckbox('Task', 'audio-to-text').click();
 
       modelCatalog.findPerformanceEmptyState().should('not.exist');
-      modelCatalog.findModelCatalogEmptyState().should('contain.text', 'No result found');
+      modelCatalog.findModelCatalogEmptyState().should('contain.text', 'No results found');
 
       modelCatalog.findEmptyStateResetFiltersButton().click();
       modelCatalog.findPerformanceEmptyState().should('be.visible');
@@ -533,7 +533,7 @@ describe('Performance Empty State', () => {
     modelCatalog.findModelCatalogCards().should('not.exist');
   });
 
-  it('should show "No result found" when toggle is ON and user applies filter that returns 0 results', () => {
+  it('should show "No results found" when toggle is ON and user applies filter that returns 0 results', () => {
     initIntercepts({
       sources: [mockCatalogSource({ labels: ['Provider one'] })],
       hasValidatedModels: true,
@@ -546,10 +546,10 @@ describe('Performance Empty State', () => {
     modelCatalog.findFilterShowMoreButton('Task').click();
     modelCatalog.findFilterCheckbox('Task', 'audio-to-text').click();
     modelCatalog.findPerformanceEmptyState().should('not.exist');
-    modelCatalog.findModelCatalogEmptyState().should('contain.text', 'No result found');
+    modelCatalog.findModelCatalogEmptyState().should('contain.text', 'No results found');
     modelCatalog.findAllModelsToggle().click();
     modelCatalog.findPerformanceEmptyState().should('not.exist');
-    modelCatalog.findModelCatalogEmptyState().should('contain.text', 'No result found');
+    modelCatalog.findModelCatalogEmptyState().should('contain.text', 'No results found');
   });
 });
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersAlert.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersAlert.cy.ts
@@ -157,6 +157,48 @@ describe('Model Catalog Performance Filters Alert', () => {
 
       modelCatalog.findPerformanceFiltersUpdatedAlert().should('not.exist');
     });
+
+    it('should hide alert when Reset all defaults is clicked on catalog page', () => {
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findLoadingState().should('not.exist');
+
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.clickPerformanceInsightsTab();
+
+      modelCatalog.findWorkloadTypeFilter().click();
+      modelCatalog.selectWorkloadType('code_fixing');
+
+      cy.go('back');
+      cy.go('back');
+      modelCatalog.findLoadingState().should('not.exist');
+
+      modelCatalog.findPerformanceFiltersUpdatedAlert().should('be.visible');
+
+      cy.findByRole('button', { name: 'Reset all defaults' }).click();
+
+      modelCatalog.findPerformanceFiltersUpdatedAlert().should('not.exist');
+    });
+
+    it('should hide alert when a performance filter chip is removed on catalog page', () => {
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findLoadingState().should('not.exist');
+
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.clickPerformanceInsightsTab();
+
+      modelCatalog.findWorkloadTypeFilter().click();
+      modelCatalog.selectWorkloadType('code_fixing');
+
+      cy.go('back');
+      cy.go('back');
+      modelCatalog.findLoadingState().should('not.exist');
+
+      modelCatalog.findPerformanceFiltersUpdatedAlert().should('be.visible');
+
+      modelCatalog.closeFilterChip('artifacts.use_case.string_value', 'code_fixing');
+
+      modelCatalog.findPerformanceFiltersUpdatedAlert().should('not.exist');
+    });
   });
 
   describe('Multiple Filter Changes', () => {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
@@ -269,7 +269,7 @@ describe('Model Catalog Performance Filters API Behavior', () => {
       changeWorkloadTypeFilter();
 
       // Click Clear all filters button in the toolbar (PatternFly's native button)
-      cy.findByRole('button', { name: 'Reset all filters' }).click();
+      cy.findByRole('button', { name: 'Reset all defaults' }).click();
 
       // Verify filters are reset to defaults - workload type should NOT show Code Fixing
       cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.workloadType)
@@ -288,7 +288,7 @@ describe('Model Catalog Performance Filters API Behavior', () => {
       modelCatalog.clickApplyFilter();
 
       // Click 'Reset all defaults (PatternFly's native button)
-      cy.findByRole('button', { name: 'Reset all filters' }).click();
+      cy.findByRole('button', { name: 'Reset all defaults' }).click();
 
       // Latency filter should be reset to default (TTFT, not E2E)
       cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.latency)

--- a/clients/ui/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
+++ b/clients/ui/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
@@ -186,7 +186,11 @@ export const ModelCatalogContextProvider: React.FC<ModelCatalogContextProviderPr
     if (defaultQuery) {
       applyNamedQueryDefaults(defaultQuery);
     }
-  }, [filterOptions?.namedQueries, applyNamedQueryDefaults, baseSetFilterData]);
+
+    if (!isOnDetailsPage) {
+      setPerformanceFiltersChangedOnDetailsPage(false);
+    }
+  }, [filterOptions?.namedQueries, applyNamedQueryDefaults, baseSetFilterData, isOnDetailsPage]);
 
   /**
    * Clears basic filters (Task, Provider, License, Language, Tensor Type) to empty.
@@ -263,8 +267,12 @@ export const ModelCatalogContextProvider: React.FC<ModelCatalogContextProviderPr
         const { value } = getSingleFilterDefault(filterOptions, filterKey);
         applyFilterValue(baseSetFilterData, filterKey, value);
       }
+
+      if (!isOnDetailsPage) {
+        setPerformanceFiltersChangedOnDetailsPage(false);
+      }
     },
-    [filterOptions, baseSetFilterData],
+    [filterOptions, baseSetFilterData, isOnDetailsPage],
   );
 
   /**

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
@@ -99,7 +99,7 @@ const HardwareConfigurationFilterToolbar: React.FC<HardwareConfigurationFilterTo
   return (
     <Toolbar
       {...(onResetAllFilters && hasVisibleChips
-        ? { clearAllFilters: onResetAllFilters, clearFiltersButtonText: 'Reset all filters' }
+        ? { clearAllFilters: onResetAllFilters, clearFiltersButtonText: 'Reset all defaults' }
         : {})}
     >
       <ToolbarContent rowWrap={{ default: 'wrap' }}>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -24,6 +24,14 @@ This prevents word wrapping into 3 lines (e.g., keeps "TTFT Latency" together in
 */
 const NBSP = '\u00A0';
 
+const TPS_INFO = {
+  popover:
+    'Throughput measured in tokens per second (tok/s). Higher values indicate faster token generation.',
+  popoverProps: {
+    position: 'left' as const,
+  },
+};
+
 export const hardwareConfigColumns: HardwareConfigColumn[] = [
   {
     field: PerformancePropertyKey.HARDWARE_CONFIGURATION,
@@ -46,7 +54,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
         getStringValue(b.customProperties, PerformancePropertyKey.HARDWARE_CONFIGURATION),
       ),
     isStickyColumn: true,
-    stickyMinWidth: '162px',
+    stickyMinWidth: '200px',
     stickyLeftOffset: '0',
     modifier: 'wrap',
   },
@@ -59,7 +67,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
     ): number => getWorkloadType(a).localeCompare(getWorkloadType(b)),
     isStickyColumn: true,
     stickyMinWidth: '132px',
-    stickyLeftOffset: '162px',
+    stickyLeftOffset: '200px',
     modifier: 'wrap',
     hasRightBorder: true,
   },
@@ -255,6 +263,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
   {
     field: 'tps_mean',
     label: `TPS${NBSP}Mean`,
+    info: TPS_INFO,
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -267,6 +276,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
   {
     field: 'tps_p90',
     label: `TPS${NBSP}P90`,
+    info: TPS_INFO,
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -278,6 +288,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
   {
     field: 'tps_p95',
     label: `TPS${NBSP}P95`,
+    info: TPS_INFO,
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -289,6 +300,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
   {
     field: 'tps_p99',
     label: `TPS${NBSP}P99`,
+    info: TPS_INFO,
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
@@ -3,6 +3,7 @@ import { Td, Tr } from '@patternfly/react-table';
 import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import {
   formatLatency,
+  formatTps,
   formatTokenValue,
   getWorkloadType,
 } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
@@ -52,15 +53,16 @@ const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps
       case 'e2e_p90':
       case 'e2e_p95':
       case 'e2e_p99':
-      case 'tps_mean':
-      case 'tps_p90':
-      case 'tps_p95':
-      case 'tps_p99':
       case 'itl_mean':
       case 'itl_p90':
       case 'itl_p95':
       case 'itl_p99':
         return formatLatency(getDoubleValue(customProperties, field));
+      case 'tps_mean':
+      case 'tps_p90':
+      case 'tps_p95':
+      case 'tps_p99':
+        return formatTps(getDoubleValue(customProperties, field));
       case 'mean_input_tokens':
       case 'mean_output_tokens':
         return formatTokenValue(getDoubleValue(customProperties, field));

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/MaxRpsFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/MaxRpsFilter.tsx
@@ -74,7 +74,7 @@ const MaxRpsFilter: React.FC = () => {
       direction={{ default: 'column' }}
       spaceItems={{ default: 'spaceItemsSm' }}
       flexWrap={{ default: 'wrap' }}
-      style={{ width: '500px', padding: '16px' }}
+      style={{ minWidth: '400px', padding: '16px' }}
     >
       <FlexItem>Max requests per second (RPS)</FlexItem>
       <FlexItem>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -256,10 +256,16 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
     return (
       <EmptyModelCatalogState
         testid="empty-model-catalog-state"
-        title="No result found"
+        title="No results found"
         headerIcon={SearchIcon}
         description="Adjust your filters and try again."
-        primaryAction={<Button onClick={handleFilterReset}>Reset filters</Button>}
+        primaryAction={
+          <Button variant="link" onClick={handleFilterReset}>
+            {performanceViewEnabled && hasPerformanceFiltersChanged
+              ? 'Reset all defaults'
+              : 'Reset all filters'}
+          </Button>
+        }
       />
     );
   }

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
@@ -43,6 +43,8 @@ type CalculateSliderRangeOptions = {
 
 export const formatLatency = (value: number): string => `${value.toFixed(2)} ms`;
 
+export const formatTps = (value: number): string => `${value.toFixed(2)} tok/s`;
+
 export const formatTokenValue = (value: number): string => value.toFixed(0);
 
 export const getWorkloadType = (artifact: CatalogPerformanceMetricsArtifact): string => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Max RPS filter dropdown doesn't overflow in hw configuration table
<img width="349" height="226" alt="Screenshot 2026-03-06 at 2 01 25 PM" src="https://github.com/user-attachments/assets/1a94ecaf-637a-4b51-83a6-4dc90ceed67b" />

- "Reset all filters" was misnamed - it's now changed to "Reset all defaults" including the button content in empty state and chips when the performance filters are changed  - if you change basic filters the button is a link and has content "Reset all filters" - text changed to "No results found" instead of "No result found" for consistency
- Also changed in hw configuration table 
<img width="1025" height="613" alt="Screenshot 2026-03-06 at 4 57 51 PM" src="https://github.com/user-attachments/assets/3a7cb1b5-9c97-4609-b958-d7bfcc371ecf" />
<img width="1020" height="279" alt="Screenshot 2026-03-06 at 5 13 53 PM" src="https://github.com/user-attachments/assets/bab0e764-611c-4bc7-b74b-8ad47c41028b" />
<img width="1054" height="473" alt="Screenshot 2026-03-06 at 5 06 39 PM" src="https://github.com/user-attachments/assets/3ec1813c-2df4-4e9b-b8ca-3df56b3f5968" />


- TPS columns unit changed to to tok/s and all columns have a popover 
<img width="316" height="207" alt="Screenshot 2026-03-06 at 4 53 02 PM" src="https://github.com/user-attachments/assets/e2bed247-3218-45f3-b011-7023d319cbd9" />

- The popover button in hw configuration table isn't partially hidden when you scroll to the far right

https://github.com/user-attachments/assets/d81ebe29-790c-4dad-8653-a53452e6a317

- The alert now disappears when the results list gets further updated, e.g. user applied new filters/reset filters on catalog view. Alert doesn't stay when filters change in catalog landing page. (Tested by cypress)

Cypress tests added and edited accordingly. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Check for the scenarios mentioned above in the description in catalog details page

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.