### PR TITLE
fix(catalog): remove field name validation that crashes model catalog startup

### DIFF
--- a/catalog/internal/catalog/basecatalog/config.go
+++ b/catalog/internal/catalog/basecatalog/config.go
@@ -139,9 +139,5 @@ func (c *SourceConfig) Validate() error {
 		return fmt.Errorf("invalid named queries: %w", err)
 	}
 
-	if err := ValidateFieldNames(c.NamedQueries, MCPServerFilterableFields); err != nil {
-		return fmt.Errorf("invalid named queries: %w", err)
-	}
-
 	return nil
 }

--- a/catalog/internal/catalog/basecatalog/validation.go
+++ b/catalog/internal/catalog/basecatalog/validation.go
@@ -19,43 +19,6 @@ var supportedOperators = map[string]bool{
 	"NOT IN": true,
 }
 
-// MCPServerFilterableFields is the set of valid field names that may be used in
-// named query filters targeting MCP servers. Field names not in this set are
-// rejected at config-parse time to catch typos early.
-var MCPServerFilterableFields = map[string]bool{
-	// Common Context properties
-	"id":                       true,
-	"name":                     true,
-	"externalId":               true,
-	"createTimeSinceEpoch":     true,
-	"lastUpdateTimeSinceEpoch": true,
-	// MCPServer-specific properties
-	"source_id":        true,
-	"base_name":        true,
-	"description":      true,
-	"provider":         true,
-	"license":          true,
-	"license_link":     true,
-	"logo":             true,
-	"readme":           true,
-	"version":          true,
-	"tags":             true,
-	"transports":       true,
-	"deploymentMode":   true,
-	"documentationUrl": true,
-	"repositoryUrl":    true,
-	"sourceCode":       true,
-	"publishedDate":    true,
-	"lastUpdated":      true,
-	"verifiedSource":   true,
-	"secureEndpoint":   true,
-	"sast":             true,
-	"readOnlyTools":    true,
-	"endpoints":        true,
-	"artifacts":        true,
-	"runtimeMetadata":  true,
-}
-
 // ValidateNamedQueries validates the structure and content of named queries
 func ValidateNamedQueries(namedQueries map[string]map[string]FieldFilter) error {
 	for queryName, fieldFilters := range namedQueries {
@@ -78,20 +41,6 @@ func ValidateNamedQueries(namedQueries map[string]map[string]FieldFilter) error 
 		}
 	}
 
-	return nil
-}
-
-// ValidateFieldNames checks that every field name used across all named queries
-// is present in allowedFields. This catches typos at config-parse time before
-// they silently produce empty results at runtime.
-func ValidateFieldNames(namedQueries map[string]map[string]FieldFilter, allowedFields map[string]bool) error {
-	for queryName, fieldFilters := range namedQueries {
-		for fieldName := range fieldFilters {
-			if !allowedFields[fieldName] {
-				return fmt.Errorf("unknown field %q in named query %q: not a filterable MCP server field", fieldName, queryName)
-			}
-		}
-	}
 	return nil
 }
 

--- a/catalog/internal/catalog/basecatalog/validation_test.go
+++ b/catalog/internal/catalog/basecatalog/validation_test.go
@@ -101,39 +101,3 @@ func TestLoaderValidationIntegration(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported operator 'INVALID_OP'")
 }
-
-func TestValidateFieldNames(t *testing.T) {
-	t.Run("valid MCP server field names pass", func(t *testing.T) {
-		queries := map[string]map[string]FieldFilter{
-			"q1": {
-				"name":           {Operator: "=", Value: "server"},
-				"provider":       {Operator: "=", Value: "OpenAI"},
-				"verifiedSource": {Operator: "=", Value: true},
-			},
-		}
-		err := ValidateFieldNames(queries, MCPServerFilterableFields)
-		assert.NoError(t, err)
-	})
-
-	t.Run("unknown field name returns error", func(t *testing.T) {
-		queries := map[string]map[string]FieldFilter{
-			"q1": {
-				"typoField": {Operator: "=", Value: "x"},
-			},
-		}
-		err := ValidateFieldNames(queries, MCPServerFilterableFields)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "unknown field")
-		assert.Contains(t, err.Error(), "typoField")
-	})
-
-	t.Run("nil queries returns no error", func(t *testing.T) {
-		err := ValidateFieldNames(nil, MCPServerFilterableFields)
-		assert.NoError(t, err)
-	})
-
-	t.Run("empty queries returns no error", func(t *testing.T) {
-		err := ValidateFieldNames(map[string]map[string]FieldFilter{}, MCPServerFilterableFields)
-		assert.NoError(t, err)
-	})
-}

--- a/manifests/kustomize/options/catalog/overlays/odh/default-sources.yaml
+++ b/manifests/kustomize/options/catalog/overlays/odh/default-sources.yaml
@@ -23,3 +23,14 @@ labels:
   - name: null
     displayName: Community and custom
     description: A broad collection of third-party, community, and admin-configured models.
+namedQueries:
+  default-performance-filters:
+    "artifacts.use_case.string_value":
+      operator: "="
+      value: chatbot
+    "artifacts.requests_per_second.double_value":
+      operator: "<="
+      value: 1
+    "artifacts.ttft_p90.double_value":
+      operator: "<="
+      value: max


### PR DESCRIPTION
## Description

Named queries validated field names against a fixed allowlist of MCP server fields (`MCPServerFilterableFields`). However the validation failed for model catalog named queries and the pod crash-looped on startup with:

```
invalid named queries: unknown field "artifacts.requests_per_second.double_value" in named query "default-performance-filters": not a filterable MCP server field
```

The field name allowlist adds marginal value, so this removes `ValidateFieldNames` and `MCPServerFilterableFields` entirely. Structural validation (operators, non-empty names, non-nil values) still runs.

## How Has This Been Tested?
On a local development cluster (the odh overlay now reproduces the problem)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
