### PR TITLE
Fix the registry address being used for job

### DIFF
--- a/clients/ui/bff/internal/repositories/model_transfer_jobs.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs.go
@@ -544,8 +544,11 @@ func (m *ModelRegistryRepository) DeleteModelTransferJob(ctx context.Context, cl
 	return &result, nil
 }
 
+// getModelRegistryAddress returns the registry address for use in transfer job env.
+// It uses federated/external address when available (e.g. Route URL from Service annotation)
+// so the job pod can reach the registry via the ingress path when NetworkPolicy restricts direct ClusterIP access.
 func (m *ModelRegistryRepository) getModelRegistryAddress(ctx context.Context, client k8s.KubernetesClientInterface, namespace, modelRegistryID string) (string, error) {
-	modelRegistry, err := m.GetModelRegistry(ctx, client, namespace, modelRegistryID)
+	modelRegistry, err := m.GetModelRegistryWithMode(ctx, client, namespace, modelRegistryID, true)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", ErrModelRegistryNotFound


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to fix the getModelRegistryAddress to returns the registry address. The old logic was working upstream but in midstream we are hitting timeout error 
`aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host 172.30.190.49:8443 ssl:default [Connect call failed ('172.30.190.49', 8443)]`

## How Has This Been Tested?
Try to create a job with this fix  - we will not hit this error
but in midstream we still have SSLCertVerificationError though - while testing locally midstream set the `MODEL_SYNC_REGISTRY_IS_SECURE=false` as workaround and the job should complete.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
