### PR TITLE
Remove email field from async copy job form

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -2938,9 +2938,6 @@ components:
         password:
           type: string
           description: OCI registry password (request only, never returned)
-        email:
-          type: string
-          description: OCI registry email (request only, never returned)
         secretName:
           type: string
           description: Name of created K8s secret (response only)

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -814,10 +814,9 @@ func createModelTransferJob(k8sClient kubernetes.Interface, ctx context.Context,
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		StringData: map[string]string{
-			".dockerconfigjson": `{"auths":{"quay.io":{"auth":"bW9jazptb2Nr","email":"test@example.com"}}}`,
+			".dockerconfigjson": `{"auths":{"quay.io":{"auth":"bW9jazptb2Nr"}}}`,
 			"username":          "",
 			"password":          "",
-			"email":             "",
 			"registry":          "",
 		},
 	}

--- a/clients/ui/bff/internal/models/model_transfer_job.go
+++ b/clients/ui/bff/internal/models/model_transfer_job.go
@@ -53,7 +53,6 @@ type ModelTransferJobDestination struct {
 	Type     ModelTransferJobDestinationType `json:"type"`
 	Username string                          `json:"username,omitempty"`
 	Password string                          `json:"password,omitempty"`
-	Email    string                          `json:"email,omitempty"`
 	URI      string                          `json:"uri,omitempty"`
 	Registry string                          `json:"registry,omitempty"`
 }

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs.go
@@ -887,8 +887,8 @@ func buildDestinationSecret(generateNamePrefix, namespace string, payload models
 		registry, _ = extractRegistryFromURI(payload.Destination.URI)
 	}
 
-	dockerConfig := fmt.Sprintf(`{"auths":{"%s":{"auth":"%s","email":"%s"}}}`,
-		registry, auth, payload.Destination.Email)
+	dockerConfig := fmt.Sprintf(`{"auths":{"%s":{"auth":"%s"}}}`,
+		registry, auth)
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/RegistrationDestinationLocationFields.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/RegistrationDestinationLocationFields.tsx
@@ -19,7 +19,6 @@ const RegistrationDestinationLocationFields = <D extends RegistrationCommonFormD
     destinationOciUsername,
     destinationOciPassword,
     destinationOciUri,
-    destinationOciEmail,
   } = formData;
 
   // OCI fields
@@ -66,16 +65,6 @@ const RegistrationDestinationLocationFields = <D extends RegistrationCommonFormD
     />
   );
 
-  const ociEmailInput = (
-    <TextInput
-      type="email"
-      id="destination-oci-email"
-      name="destination-oci-email"
-      value={destinationOciEmail}
-      onChange={(_e, value) => setData('destinationOciEmail', value)}
-    />
-  );
-
   return (
     <>
       <FormGroup label="Registry" isRequired fieldId="destination-oci-registry">
@@ -86,9 +75,6 @@ const RegistrationDestinationLocationFields = <D extends RegistrationCommonFormD
       </FormGroup>
       <FormGroup label="Username" isRequired fieldId="destination-oci-username">
         <FormFieldset component={ociUsernameInput} field="Username" />
-      </FormGroup>
-      <FormGroup label="Email" fieldId="destination-oci-email">
-        <FormFieldset component={ociEmailInput} field="Email" />
       </FormGroup>
       <FormGroup label="Password" isRequired fieldId="destination-oci-password">
         <FormFieldset component={ociPasswordInput} field="Password" />

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/__tests__/utils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/__tests__/utils.spec.ts
@@ -60,7 +60,7 @@ describe('RegisterModel utils', () => {
       destinationOciUsername: '',
       destinationOciPassword: '',
       destinationOciUri: 'quay.io/org/model:v1',
-      destinationOciEmail: '',
+
       jobName: 'test-job',
       jobResourceName: 'test-job-resource',
       versionCustomProperties: {},

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/useRegisterModelData.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/useRegisterModelData.ts
@@ -25,7 +25,7 @@ export type RegistrationCommonFormData = {
   destinationOciUsername: string;
   destinationOciPassword: string;
   destinationOciUri: string;
-  destinationOciEmail: string;
+
   namespace?: string;
   registrationMode?: RegistrationMode.Register | RegistrationMode.RegisterAndStore;
   jobName: string;
@@ -65,7 +65,7 @@ const registrationCommonFormDataDefaults: RegistrationCommonFormData = {
   destinationOciUsername: '',
   destinationOciPassword: '',
   destinationOciUri: '',
-  destinationOciEmail: '',
+
   namespace: '',
   registrationMode: RegistrationMode.Register,
   jobName: '',

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -263,7 +263,6 @@ export const buildModelTransferJobPayload = (
     registry: formData.destinationOciRegistry || undefined,
     username: formData.destinationOciUsername,
     password: formData.destinationOciPassword,
-    email: formData.destinationOciEmail || undefined,
   };
 
   // RegisterModelFormData has modelName (user-provided for new model).

--- a/clients/ui/frontend/src/app/types.ts
+++ b/clients/ui/frontend/src/app/types.ts
@@ -289,7 +289,6 @@ export type ModelTransferJobOCISource = {
   uri: string;
   username: string;
   password: string;
-  email?: string;
   registry?: string;
 };
 
@@ -316,7 +315,6 @@ export type ModelTransferJobOCIDestination = {
   uri: string;
   username: string;
   password: string;
-  email?: string;
   registry?: string;
 };
 


### PR DESCRIPTION
## Description
Removes the optional "email" field from the OCI destination credentials section of the register-and-store (async copy) form. After team discussion, the consensus is that this field is unnecessary — it maps to the `email` property in Docker's `config.json` auth configuration, but OCI registry auth works fine without it and users are not typically asked for it.

Changes across the full stack:
- **Frontend:** Removed the email form field, `destinationOciEmail` state, email mapping in payload builder, and `email` from OCI source/destination types
- **BFF (Go):** Removed `Email` field from `ModelTransferJobDestination` struct and omitted email from the `.dockerconfigjson` auth entry
- **API spec:** Removed `email` property from the destination object in the OpenAPI spec
- **Tests:** Updated test mocks and test data to remove email references

## How Has This Been Tested?
- Frontend TypeScript compiles cleanly (`tsc --noEmit`)
- All frontend unit tests pass (11/11 in `utils.spec.ts`)
- Go BFF compiles successfully (`go build ./...`)

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.