### PR TITLE
Fix silent drops

### DIFF
--- a/catalog/internal/catalog/modelcatalog/service/catalog_model.go
+++ b/catalog/internal/catalog/modelcatalog/service/catalog_model.go
@@ -106,6 +106,21 @@ func getSourceIDFromContextProperties(propertiesCtx []schema.ContextProperty) st
 	return ""
 }
 
+// escapeLike escapes SQL LIKE metacharacters (%, _, \) in s so it can be used safely as a literal in a LIKE pattern.
+func escapeLike(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		switch c {
+		case '\\', '%', '_':
+			b.WriteRune('\\')
+			b.WriteRune(c)
+		default:
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
 // ApplyStandardPagination overrides the base implementation to use catalog-specific allowed columns
 func (r *CatalogModelRepositoryImpl) ApplyStandardPagination(query *gorm.DB, listOptions *models.CatalogModelListOptions, entities any) *gorm.DB {
 	pageSize := listOptions.GetPageSize()
@@ -297,7 +312,11 @@ func applyCatalogModelListFilters(query *gorm.DB, listOptions *models.CatalogMod
 	if listOptions.Name != nil {
 		query = query.Where(fmt.Sprintf("%s.name LIKE ?", contextTable), listOptions.Name)
 	} else if listOptions.ExternalID != nil {
-		query = query.Where(fmt.Sprintf("%s.external_id = ?", contextTable), listOptions.ExternalID)
+		extID := *listOptions.ExternalID
+		// Match both exact and namespaced (sourceId:externalId) so existing integrations
+		// that filter by external_id without source prefix still return all matching models.
+		namespacedPattern := "%:" + escapeLike(extID)
+		query = query.Where(fmt.Sprintf("(%s.external_id = ? OR %s.external_id LIKE ?)", contextTable, contextTable), extID, namespacedPattern)
 	}
 
 	if listOptions.Query != nil && *listOptions.Query != "" {

--- a/catalog/internal/catalog/modelcatalog/service/catalog_model_test.go
+++ b/catalog/internal/catalog/modelcatalog/service/catalog_model_test.go
@@ -270,6 +270,90 @@ func TestCatalogModelRepository(t *testing.T) {
 		assert.Equal(t, sharedExternalID, *retrieved2.GetAttributes().ExternalID)
 	})
 
+	t.Run("TestListByExternalIDReturnsModelsFromAllSources", func(t *testing.T) {
+		// When external_id is namespaced in DB (sourceId:externalId), listing by raw external_id
+		// should return all models that match across any source (backward compatibility).
+		sharedExtID := "shared-ext-list-test"
+		model1 := &models.CatalogModelImpl{
+			Attributes: &models.CatalogModelAttributes{
+				Name:       apiutils.Of("list-ext-model-a"),
+				ExternalID: apiutils.Of(sharedExtID),
+			},
+			Properties: &[]dbmodels.Properties{
+				{Name: "source_id", StringValue: apiutils.Of("src-list-1")},
+			},
+		}
+		model2 := &models.CatalogModelImpl{
+			Attributes: &models.CatalogModelAttributes{
+				Name:       apiutils.Of("list-ext-model-b"),
+				ExternalID: apiutils.Of(sharedExtID),
+			},
+			Properties: &[]dbmodels.Properties{
+				{Name: "source_id", StringValue: apiutils.Of("src-list-2")},
+			},
+		}
+		_, err := repo.Save(model1)
+		require.NoError(t, err)
+		_, err = repo.Save(model2)
+		require.NoError(t, err)
+
+		listOptions := models.CatalogModelListOptions{
+			ExternalID: &sharedExtID,
+		}
+		result, err := repo.List(listOptions)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Items, 2, "filtering by raw external_id should return all models from all sources")
+		extIDs := make([]string, len(result.Items))
+		for i, m := range result.Items {
+			require.NotNil(t, m.GetAttributes().ExternalID)
+			extIDs[i] = *m.GetAttributes().ExternalID
+		}
+		assert.ElementsMatch(t, extIDs, []string{sharedExtID, sharedExtID})
+	})
+
+	t.Run("TestFilterQueryExternalIDReturnsModelsFromAllSources", func(t *testing.T) {
+		// filterQuery externalId = "value" should match both exact and namespaced stored values.
+		sharedExtID := "filterquery-ext-shared"
+		model1 := &models.CatalogModelImpl{
+			Attributes: &models.CatalogModelAttributes{
+				Name:       apiutils.Of("fq-ext-model-a"),
+				ExternalID: apiutils.Of(sharedExtID),
+			},
+			Properties: &[]dbmodels.Properties{
+				{Name: "source_id", StringValue: apiutils.Of("src-fq-1")},
+			},
+		}
+		model2 := &models.CatalogModelImpl{
+			Attributes: &models.CatalogModelAttributes{
+				Name:       apiutils.Of("fq-ext-model-b"),
+				ExternalID: apiutils.Of(sharedExtID),
+			},
+			Properties: &[]dbmodels.Properties{
+				{Name: "source_id", StringValue: apiutils.Of("src-fq-2")},
+			},
+		}
+		_, err := repo.Save(model1)
+		require.NoError(t, err)
+		_, err = repo.Save(model2)
+		require.NoError(t, err)
+
+		filterQuery := `externalId = "` + sharedExtID + `"`
+		listOptions := models.CatalogModelListOptions{
+			Pagination: dbmodels.Pagination{
+				FilterQuery: &filterQuery,
+			},
+		}
+		result, err := repo.List(listOptions)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Items, 2, "filterQuery externalId = value should return all models from all sources")
+		for _, m := range result.Items {
+			require.NotNil(t, m.GetAttributes().ExternalID)
+			assert.Equal(t, sharedExtID, *m.GetAttributes().ExternalID)
+		}
+	})
+
 	t.Run("TestUpdateWithID", func(t *testing.T) {
 		// First create a model
 		catalogModel := &models.CatalogModelImpl{

--- a/catalog/internal/db/filter/entity_mappings.go
+++ b/catalog/internal/db/filter/entity_mappings.go
@@ -86,6 +86,35 @@ func (c *catalogEntityMappings) IsChildEntity(entityType filter.RestEntityType) 
 	return false
 }
 
+// GetEqualityExpansion implements filter.EqualityExpander so externalId = "x" matches both
+// exact and namespaced (sourceId:x) stored values, returning all models regardless of source.
+func (c *catalogEntityMappings) GetEqualityExpansion(restEntityType filter.RestEntityType, propertyName string, value any) (likeArg any, useExpansion bool) {
+	if restEntityType != filter.RestEntityType(catalogmodels.RestEntityCatalogModel) || propertyName != "externalId" {
+		return nil, false
+	}
+	strVal, ok := value.(string)
+	if !ok || strVal == "" {
+		return nil, false
+	}
+	// Match any source prefix: sourceId:externalId
+	return "%:" + escapeLike(strVal), true
+}
+
+// escapeLike escapes SQL LIKE metacharacters (%, _, \) for safe use as a literal in a LIKE pattern.
+func escapeLike(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch r {
+		case '\\', '%', '_':
+			b.WriteRune('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
 // catalogModelProperties defines the allowed properties for CatalogModel entities
 var catalogModelProperties = map[string]filter.PropertyDefinition{
 	// Common Context properties

--- a/internal/db/filter/query_builder.go
+++ b/internal/db/filter/query_builder.go
@@ -31,6 +31,13 @@ type EntityMappingFunctions interface {
 	IsChildEntity(entityType RestEntityType) bool
 }
 
+// EqualityExpander is an optional interface that EntityMappingFunctions may implement
+// to expand equality conditions (e.g. match both exact and namespaced stored values).
+// If likeArg is returned with useExpansion true, the condition becomes (column = ? OR column LIKE ?).
+type EqualityExpander interface {
+	GetEqualityExpansion(restEntityType RestEntityType, propertyName string, value any) (likeArg any, useExpansion bool)
+}
+
 // QueryBuilder builds GORM queries from filter expressions
 // It handles special cases like prefixed names for child entities (e.g., ModelVersion, ExperimentRun)
 // where names are stored as "parentId:actualName" in the database
@@ -496,6 +503,16 @@ func (qb *QueryBuilder) buildEntityTablePropertyCondition(db *gorm.DB, propRef *
 	// Convert state string values to integers based on entity type
 	value = qb.ConvertStateValue(propRef.Name, value)
 
+	// Optional: expand equality to match both exact and namespaced stored values (e.g. catalog externalId)
+	if operator == "=" && qb.restEntityType != "" {
+		if expander, ok := qb.mappingFuncs.(EqualityExpander); ok {
+			if likeArg, use := expander.GetEqualityExpansion(qb.restEntityType, propRef.Name, value); use {
+				condition := fmt.Sprintf("(%s = ? OR %s LIKE ?)", column, column)
+				return db.Where(condition, value, likeArg)
+			}
+		}
+	}
+
 	// Handle prefixed names for child entities
 	if qb.restEntityType != "" && propRef.Name == "name" && qb.mappingFuncs.IsChildEntity(qb.restEntityType) {
 		if strValue, ok := value.(string); ok {
@@ -532,6 +549,15 @@ func (qb *QueryBuilder) buildEntityTablePropertyConditionString(propRef *Propert
 
 	// Convert state string values to integers based on entity type
 	value = qb.ConvertStateValue(propRef.Name, value)
+
+	// Optional: expand equality to match both exact and namespaced stored values (e.g. catalog externalId)
+	if operator == "=" && qb.restEntityType != "" {
+		if expander, ok := qb.mappingFuncs.(EqualityExpander); ok {
+			if likeArg, use := expander.GetEqualityExpansion(qb.restEntityType, propRef.Name, value); use {
+				return conditionResult{condition: fmt.Sprintf("(%s = ? OR %s LIKE ?)", column, column), args: []any{value, likeArg}}
+			}
+		}
+	}
 
 	// Handle prefixed names for child entities
 	if qb.restEntityType != "" && propRef.Name == "name" && qb.mappingFuncs.IsChildEntity(qb.restEntityType) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR stores expernal ids for model catalog models in namespaced format (sourceId:modelName) so that duplicate models can be added across DIFFERENT sources. 

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
