### PR TITLE
feat: add assetType to labels endpoint

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -170,6 +170,7 @@ paths:
       tags:
         - ModelCatalogService
       parameters:
+        - $ref: "#/components/parameters/assetType"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/labelOrderBy"
         - $ref: "#/components/parameters/sortOrder"
@@ -2071,7 +2072,7 @@ components:
       required: false
     assetType:
       name: assetType
-      description: Filter sources by asset type.
+      description: Filter by asset type.
       schema:
         $ref: "#/components/schemas/CatalogAssetType"
       in: query

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -160,6 +160,7 @@ paths:
       tags:
         - ModelCatalogService
       parameters:
+        - $ref: "#/components/parameters/assetType"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/labelOrderBy"
         - $ref: "#/components/parameters/sortOrder"
@@ -1794,7 +1795,7 @@ components:
       required: false
     assetType:
       name: assetType
-      description: Filter sources by asset type.
+      description: Filter by asset type.
       schema:
         $ref: "#/components/schemas/CatalogAssetType"
       in: query

--- a/catalog/internal/server/openapi/api.go
+++ b/catalog/internal/server/openapi/api.go
@@ -60,7 +60,7 @@ type MCPCatalogServiceAPIServicer interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type ModelCatalogServiceAPIServicer interface {
-	FindLabels(context.Context, string, string, model.SortOrder, string) (ImplResponse, error)
+	FindLabels(context.Context, model.CatalogAssetType, string, string, model.SortOrder, string) (ImplResponse, error)
 	FindModels(context.Context, bool, int32, string, string, string, string, []string, string, []string, string, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
 	FindModelsFilterOptions(context.Context) (ImplResponse, error)
 	FindSources(context.Context, string, model.CatalogAssetType, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)

--- a/catalog/internal/server/openapi/api_model_catalog_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service.go
@@ -165,6 +165,13 @@ func (c *ModelCatalogServiceAPIController) FindLabels(w http.ResponseWriter, r *
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	var assetTypeParam model.CatalogAssetType
+	if query.Has("assetType") {
+		param := model.CatalogAssetType(query.Get("assetType"))
+
+		assetTypeParam = param
+	} else {
+	}
 	var pageSizeParam string
 	if query.Has("pageSize") {
 		param := query.Get("pageSize")
@@ -193,7 +200,7 @@ func (c *ModelCatalogServiceAPIController) FindLabels(w http.ResponseWriter, r *
 		nextPageTokenParam = param
 	} else {
 	}
-	result, err := c.service.FindLabels(r.Context(), pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
+	result, err := c.service.FindLabels(r.Context(), assetTypeParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -138,16 +138,38 @@ func (m *ModelCatalogServiceAPIService) GetAllModelPerformanceArtifacts(ctx cont
 	return Response(http.StatusOK, artifacts), nil
 }
 
-func (m *ModelCatalogServiceAPIService) FindLabels(ctx context.Context, pageSize string, orderBy string, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
+func (m *ModelCatalogServiceAPIService) FindLabels(ctx context.Context, assetType model.CatalogAssetType, pageSize string, orderBy string, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
+	if assetType == "" {
+		assetType = model.CATALOGASSETTYPE_MODELS
+	} else if !assetType.IsValid() {
+		err := fmt.Errorf("invalid value '%s' for assetType: valid values are %v", assetType, model.AllowedCatalogAssetTypeEnumValues)
+		return ErrorResponse(http.StatusBadRequest, err), err
+	}
+
 	labels := m.labels.All()
 	if len(labels) > math.MaxInt32 {
 		err := errors.New("too many registered labels")
 		return ErrorResponse(http.StatusInternalServerError, err), err
 	}
 
+	// Filter labels by assetType
+	filtered := make([]map[string]any, 0, len(labels))
+	for _, label := range labels {
+		labelAssetType := model.CATALOGASSETTYPE_MODELS // default when not specified
+		if at, ok := label["assetType"]; ok {
+			if atStr, ok := at.(string); ok {
+				labelAssetType = model.CatalogAssetType(atStr)
+			}
+		}
+		if labelAssetType != assetType {
+			continue
+		}
+		filtered = append(filtered, label)
+	}
+
 	// Wrap labels to make them sortable
-	sortableLabels := make([]sortableLabel, len(labels))
-	for i, label := range labels {
+	sortableLabels := make([]sortableLabel, len(filtered))
+	for i, label := range filtered {
 		sortableLabels[i] = sortableLabel{
 			data:  label,
 			index: i, // Keep original index for stable sort

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -847,6 +847,7 @@ func TestFindLabels(t *testing.T) {
 	testCases := []struct {
 		name            string
 		labels          []map[string]any
+		assetType       model.CatalogAssetType
 		pageSize        string
 		orderBy         string
 		sortOrder       model.SortOrder
@@ -1034,6 +1035,84 @@ func TestFindLabels(t *testing.T) {
 			expectedItems:   3,
 			expectNextToken: false,
 		},
+		{
+			name: "Default assetType returns model labels",
+			labels: []map[string]any{
+				{"name": "model-label", "assetType": "models"},
+				{"name": "mcp-label", "assetType": "mcp_servers"},
+				{"name": "implicit-model-label"},
+			},
+			assetType:       "",
+			pageSize:        "10",
+			expectedStatus:  http.StatusOK,
+			expectedSize:    2,
+			expectedItems:   2,
+			expectNextToken: false,
+		},
+		{
+			name: "Explicit assetType=models",
+			labels: []map[string]any{
+				{"name": "model-label", "assetType": "models"},
+				{"name": "mcp-label", "assetType": "mcp_servers"},
+				{"name": "implicit-model-label"},
+			},
+			assetType:       model.CATALOGASSETTYPE_MODELS,
+			pageSize:        "10",
+			expectedStatus:  http.StatusOK,
+			expectedSize:    2,
+			expectedItems:   2,
+			expectNextToken: false,
+		},
+		{
+			name: "assetType=mcp_servers",
+			labels: []map[string]any{
+				{"name": "model-label", "assetType": "models"},
+				{"name": "mcp-label-1", "assetType": "mcp_servers"},
+				{"name": "mcp-label-2", "assetType": "mcp_servers"},
+				{"name": "implicit-model-label"},
+			},
+			assetType:       model.CATALOGASSETTYPE_MCP_SERVERS,
+			pageSize:        "10",
+			expectedStatus:  http.StatusOK,
+			expectedSize:    2,
+			expectedItems:   2,
+			expectNextToken: false,
+		},
+		{
+			name: "Invalid assetType returns 400",
+			labels: []map[string]any{
+				{"name": "label1"},
+			},
+			assetType:      model.CatalogAssetType("invalid"),
+			pageSize:       "10",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Null label with assetType filtering",
+			labels: []map[string]any{
+				{"name": nil, "displayName": "Community models"},
+				{"name": "mcp-label", "displayName": "MCP label", "assetType": "mcp_servers"},
+			},
+			assetType:       model.CATALOGASSETTYPE_MCP_SERVERS,
+			pageSize:        "10",
+			expectedStatus:  http.StatusOK,
+			expectedSize:    1,
+			expectedItems:   1,
+			expectNextToken: false,
+		},
+		{
+			name: "Empty result when no labels match assetType",
+			labels: []map[string]any{
+				{"name": "model-label", "assetType": "models"},
+				{"name": "implicit-model-label"},
+			},
+			assetType:       model.CATALOGASSETTYPE_MCP_SERVERS,
+			pageSize:        "10",
+			expectedStatus:  http.StatusOK,
+			expectedSize:    0,
+			expectedItems:   0,
+			expectNextToken: false,
+		},
 	}
 
 	// Run test cases
@@ -1049,6 +1128,7 @@ func TestFindLabels(t *testing.T) {
 			// Call FindLabels
 			resp, err := service.FindLabels(
 				context.Background(),
+				tc.assetType,
 				tc.pageSize,
 				tc.orderBy,
 				tc.sortOrder,

--- a/catalog/pkg/openapi/api_model_catalog_service.go
+++ b/catalog/pkg/openapi/api_model_catalog_service.go
@@ -27,10 +27,17 @@ type ModelCatalogServiceAPIService service
 type ApiFindLabelsRequest struct {
 	ctx           context.Context
 	ApiService    *ModelCatalogServiceAPIService
+	assetType     *CatalogAssetType
 	pageSize      *string
 	orderBy       *string
 	sortOrder     *SortOrder
 	nextPageToken *string
+}
+
+// Filter by asset type.
+func (r ApiFindLabelsRequest) AssetType(assetType CatalogAssetType) ApiFindLabelsRequest {
+	r.assetType = &assetType
+	return r
 }
 
 // Number of entities in each page.
@@ -98,6 +105,13 @@ func (a *ModelCatalogServiceAPIService) FindLabelsExecute(r ApiFindLabelsRequest
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.assetType != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "assetType", r.assetType, "form", "")
+	} else {
+		var defaultValue CatalogAssetType = "models"
+		parameterAddToHeaderOrQuery(localVarQueryParams, "assetType", defaultValue, "form", "")
+		r.assetType = &defaultValue
+	}
 	if r.pageSize != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "pageSize", r.pageSize, "form", "")
 	}
@@ -671,7 +685,7 @@ func (r ApiFindSourcesRequest) Name(name string) ApiFindSourcesRequest {
 	return r
 }
 
-// Filter sources by asset type.
+// Filter by asset type.
 func (r ApiFindSourcesRequest) AssetType(assetType CatalogAssetType) ApiFindSourcesRequest {
 	r.assetType = &assetType
 	return r


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds assetType filtering to the /api/model_catalog/v1alpha1/labels endpoint, consistent with the existing sources endpoint pattern. This enables proper categorization of labels for MCP servers vs models in the catalog UI.

 - Labels without assetType default to models (backward compatible)
 - Invalid assetType values return 400 Bad Request
 - Includes unit tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.