### PR TITLE
fix: add transfer jobs link to empty registered models state

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
@@ -95,6 +95,10 @@ class ModelRegistry {
     cy.findByTestId('empty-registered-models').should('exist');
   }
 
+  findEmptyStateTransferJobsButton() {
+    return cy.findByTestId('empty-model-registry-transfer-jobs-action');
+  }
+
   findViewDetailsButton() {
     return cy.findByTestId('view-details-button');
   }

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -14,6 +14,7 @@ import {
 import { be } from '~/__tests__/cypress/cypress/utils/should';
 import { MODEL_REGISTRY_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
+import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
 
 type HandlersProps = {
   modelRegistries?: ModelRegistry[];
@@ -200,6 +201,32 @@ describe('Model Registry core', () => {
     //     'To request access to a new or existing model registry, contact your administrator.',
     //   )
     //   .should('exist');
+  });
+
+  it('Empty state shows transfer jobs link when RegistryStorage feature is enabled', () => {
+    initIntercepts({
+      registeredModels: [],
+    });
+
+    window.localStorage.setItem(TempDevFeature.RegistryStorage, 'true');
+    modelRegistry.visit();
+    modelRegistry.navigate();
+    modelRegistry.shouldregisteredModelsEmpty();
+    modelRegistry.findEmptyStateTransferJobsButton().should('exist');
+    modelRegistry.findEmptyStateTransferJobsButton().click();
+    verifyRelativeURL('/model-registry/modelregistry-sample/model-transfer-jobs');
+  });
+
+  it('Empty state hides transfer jobs link when RegistryStorage feature is disabled', () => {
+    initIntercepts({
+      registeredModels: [],
+    });
+
+    window.localStorage.removeItem(TempDevFeature.RegistryStorage);
+    modelRegistry.visit();
+    modelRegistry.navigate();
+    modelRegistry.shouldregisteredModelsEmpty();
+    modelRegistry.findEmptyStateTransferJobsButton().should('not.exist');
   });
 
   describe('Registered model table', () => {

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
-import { ToolbarGroup } from '@patternfly/react-core';
+import { Button, ToolbarGroup } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import { ProjectObjectType, typedEmptyImage } from 'mod-arch-shared';
 import { ModelVersion, RegisteredModel } from '~/app/types';
 import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import {
+  modelTransferJobsUrl,
   registeredModelArchiveUrl,
   registerModelUrl,
 } from '~/app/pages/modelRegistry/screens/routeUtils';
 import EmptyModelRegistryState from '~/app/pages/modelRegistry/screens/components/EmptyModelRegistryState';
 import { filterRegisteredModels } from '~/app/pages/modelRegistry/screens/utils';
 import { filterArchiveModels, filterLiveModels } from '~/app/utils';
+import { useTempDevFeatureAvailable, TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
 import {
   initialModelRegistryFilterData,
   ModelRegistryFilterDataType,
@@ -35,6 +37,7 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
 }) => {
   const navigate = useNavigate();
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
+  const isModelTransferJobsAvailable = useTempDevFeatureAvailable(TempDevFeature.RegistryStorage);
   const [filterData, setFilterData] = React.useState<ModelRegistryFilterDataType>(
     initialModelRegistryFilterData,
   );
@@ -76,6 +79,17 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
         secondaryActionOnClick={() => {
           navigate(registeredModelArchiveUrl(preferredModelRegistry?.name));
         }}
+        customAction={
+          isModelTransferJobsAvailable ? (
+            <Button
+              data-testid="empty-model-registry-transfer-jobs-action"
+              variant="link"
+              onClick={() => navigate(modelTransferJobsUrl(preferredModelRegistry?.name))}
+            >
+              View model transfer jobs
+            </Button>
+          ) : undefined
+        }
       />
     );
   }


### PR DESCRIPTION
## Description

When a failed model transfer job is created and no other models are registered, the user cannot navigate to the model transfer jobs view. The only navigation paths to this view are through the toast notification (which disappears) and the kebab menu in the registered models table toolbar (which is not rendered when the table is empty). This leaves users stranded with no way to access their failed transfer jobs except by manually appending `/model-transfer-jobs` to the URL.

This PR adds a "View model transfer jobs" link button to the empty state of the registered models page, using the existing `customAction` prop on `EmptyModelRegistryState`. 

## How Has This Been Tested?

- **Manual testing**: Ran the application locally in PatternFly mode with mock clients (`MOCK_K8S_CLIENT=true MOCK_MR_CLIENT=true`). Temporarily changed mock data to return no live models to trigger the empty state. Enabled the `tempDevRegistryStorageFeatureAvailable` localStorage flag and confirmed the "View model transfer jobs" link appeared alongside "Register model" and "View archived models". Verified clicking the link navigated to the correct `/model-transfer-jobs` URL. Verified the link does not appear when the feature flag is disabled.
- **Cypress tests added**: Two new test cases covering feature-enabled (link visible + navigation) and feature-disabled (link hidden) scenarios.
- 
<img width="1016" height="841" alt="Screenshot 2026-03-10 at 11 42 08 AM" src="https://github.com/user-attachments/assets/ad5925b5-9e6a-4f21-970a-1ca86d030c1f" />
<img width="997" height="484" alt="Screenshot 2026-03-10 at 11 42 13 AM" src="https://github.com/user-attachments/assets/e3cead66-8411-483a-99f7-280e67e773de" />


## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.