### PR TITLE
refactor: tilt catalog resources in a different label

### DIFF
--- a/devenv/Makefile
+++ b/devenv/Makefile
@@ -27,7 +27,15 @@ TILT_VERSION := 0.33.22
 .PHONY: $(POETRY)
 poetry: $(POETRY) ## Download poetry locally if necessary.
 $(POETRY): $(LOCALBIN)
-	test -s $(LOCALBIN)/poetry || curl -sSL https://install.python-poetry.org | POETRY_HOME=$(shell pwd) python3 -
+	@if ! test -s $(LOCALBIN)/poetry; then \
+		python3 -m venv $(shell pwd)/venv; \
+		PYTHON_LIBDIR=$$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR') or '')"); \
+		if [ -n "$$PYTHON_LIBDIR" ]; then \
+			find "$$PYTHON_LIBDIR" -maxdepth 1 -name 'libpython*.so*' -exec ln -sf {} $(shell pwd)/venv/lib/ \; 2>/dev/null || true; \
+		fi; \
+		$(shell pwd)/venv/bin/pip install --quiet poetry; \
+		ln -sf $(shell pwd)/venv/bin/poetry $(LOCALBIN)/poetry; \
+	fi
 
 .PHONY: tilt
 .PHONY: $(TILT)

--- a/devenv/configs/tiltfiles/catalog.tiltfile
+++ b/devenv/configs/tiltfiles/catalog.tiltfile
@@ -1,11 +1,16 @@
 # Use the "local" overlay path if it exists, if not fall-back to "demo".
-localOverlayPath = "../../../manifests/kustomize/options/catalog/overlays/local"
-if os.path.exists(localOverlayPath):
-    manifests = kustomize(localOverlayPath)
-else:
-    manifests = kustomize("../../../manifests/kustomize/options/catalog/overlays/demo")
+catalogBasePath = "../../../manifests/kustomize/options/catalog/base"
+catalogOverlayPath = "../../../manifests/kustomize/options/catalog/overlays/local"
+if not os.path.exists(catalogOverlayPath):
+    catalogOverlayPath = "../../../manifests/kustomize/options/catalog/overlays/demo"
+
+manifests = kustomize(catalogOverlayPath)
 
 objects = decode_yaml_stream(manifests)
+
+config_objects = []
+pvc_objects = []
+workload_objects = []
 
 for o in objects:
     # Deploy catalog resources in kubeflow namespace to match where UI is looking for them
@@ -23,15 +28,58 @@ for o in objects:
         o["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
         o["spec"]["template"]["spec"]["containers"][0]["args"].insert(0, "catalog")
 
-overridden_manifests = encode_yaml_stream(objects)
+    if o["kind"] in ["ConfigMap", "Secret"]:
+        config_objects.append(o)
+    elif o["kind"] == "PersistentVolumeClaim":
+        pvc_objects.append(o)
+    else:
+        workload_objects.append(o)
 
-k8s_yaml(overridden_manifests, allow_duplicates=True)
+k8s_yaml(encode_yaml_stream(config_objects), allow_duplicates=True)
+k8s_yaml(encode_yaml_stream(pvc_objects), allow_duplicates=True)
+k8s_yaml(encode_yaml_stream(workload_objects), allow_duplicates=True)
+
+k8s_resource(
+    new_name="catalog-pvc",
+    objects=[
+        "model-catalog-postgres:persistentvolumeclaim",
+    ],
+    labels="catalog",
+    resource_deps=["kubeflow-namespace"],
+    trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
+k8s_resource(
+    new_name="catalog-config",
+    objects=[
+        "model-catalog-demo-perf-data:configmap",
+        "model-catalog-sources:configmap",
+        "model-catalog-hf-api-key:secret",
+        "model-catalog-postgres:secret",
+    ],
+    labels="catalog",
+    resource_deps=["kubeflow-namespace"],
+)
+
+local_resource(
+    "catalog-config-sync",
+    "kustomize build %s | yq 'select(.kind == \"ConfigMap\" or .kind == \"Secret\")' | sed 's/namespace: default/namespace: kubeflow/' | kubectl apply -n kubeflow -f -" % catalogOverlayPath,
+    deps=[
+        catalogBasePath + "/sources.yaml",
+        catalogBasePath + "/hf-api-key.env",
+        catalogBasePath + "/postgres.env",
+        catalogOverlayPath,
+    ],
+    labels="catalog",
+    resource_deps=["kubeflow-namespace", "catalog-config"],
+    trigger_mode=TRIGGER_MODE_AUTO,
+)
 
 k8s_resource(
     workload="model-catalog-server",
     new_name="catalog",
-    labels="backend",
-    resource_deps=["kubeflow-namespace"],
+    labels="catalog",
+    resource_deps=["kubeflow-namespace", "catalog-config", "catalog-pvc"],
     port_forwards="8082:8080",
     trigger_mode=TRIGGER_MODE_AUTO
 )
@@ -39,8 +87,8 @@ k8s_resource(
 k8s_resource(
     workload="model-catalog-postgres",
     new_name="catalog-db",
-    labels="backend",
-    resource_deps=["kubeflow-namespace"],
+    labels="catalog",
+    resource_deps=["kubeflow-namespace", "catalog-pvc", "catalog-config"],
     port_forwards="5432:5432",
     trigger_mode=TRIGGER_MODE_AUTO
 )

--- a/devenv/configs/tiltfiles/frontend.tiltfile
+++ b/devenv/configs/tiltfiles/frontend.tiltfile
@@ -60,6 +60,7 @@ k8s_resource(
        "model-registry-ui-namespaces-reader-binding:clusterrolebinding",
        "model-registry-ui-services-reader-binding:clusterrolebinding",
        "service-access-cluster-binding:clusterrolebinding",
+       "auth-proxy-config:configmap",
     ],
     labels="requirements",
     resource_deps=["kubeflow-namespace", "ui-rbac-reqs"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- fix a problem with poetry when using tools like asdf/mise
- split model registry and catalog in different labels
- create a new resource "catalog-config-sync" that recreate catalog secrets/cms when detects changes to local related files
- fix a problem where resources where not deployed because of a missing req on kubeflow namespace

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

on local tilt env

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
