### PR TITLE
feat(catalog): add includedServers/excludedServers filtering to MCP sources

### DIFF
--- a/catalog/internal/catalog/basecatalog/name_filter.go
+++ b/catalog/internal/catalog/basecatalog/name_filter.go
@@ -1,0 +1,151 @@
+package basecatalog
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// NameFilter encapsulates include/exclude pattern matching for names.
+type NameFilter struct {
+	included []*compiledPattern
+	excluded []*compiledPattern
+}
+
+type compiledPattern struct {
+	re *regexp.Regexp
+}
+
+func newCompiledPattern(field string, idx int, raw string) (*compiledPattern, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, fmt.Errorf("%s[%d]: pattern cannot be empty", field, idx)
+	}
+
+	// Convert a simple glob (only supporting '*') into a regexp.
+	var b strings.Builder
+	b.WriteString("(?i)^")
+	for _, r := range value {
+		if r == '*' {
+			b.WriteString(".*")
+			continue
+		}
+		b.WriteString(regexp.QuoteMeta(string(r)))
+	}
+	b.WriteString("$")
+
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return nil, fmt.Errorf("%s[%d]: invalid pattern %q: %w", field, idx, value, err)
+	}
+
+	return &compiledPattern{re: re}, nil
+}
+
+func compilePatterns(field string, patterns []string) ([]*compiledPattern, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	compiled := make([]*compiledPattern, 0, len(patterns))
+	for i, pattern := range patterns {
+		cp, err := newCompiledPattern(field, i, pattern)
+		if err != nil {
+			return nil, err
+		}
+		compiled = append(compiled, cp)
+	}
+	return compiled, nil
+}
+
+// ValidatePatterns validates that the included and excluded patterns
+// are valid (non-empty, compilable, non-conflicting). This is useful for early validation
+// at configuration load time without constructing the full NameFilter.
+func ValidatePatterns(includedField string, included []string, excludedField string, excluded []string) error {
+	// Log conflicts but don't fail validation to avoid pod crash
+	detectConflictingPatterns(includedField, included, excludedField, excluded)
+
+	if _, err := compilePatterns(includedField, included); err != nil {
+		return err
+	}
+
+	if _, err := compilePatterns(excludedField, excluded); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewNameFilter builds a NameFilter from the provided include/exclude pattern lists.
+// It does not perform conflict detection between included and excluded patterns;
+// callers should use ValidatePatterns at config load time to catch conflicts early.
+func NewNameFilter(includedField string, included []string, excludedField string, excluded []string) (*NameFilter, error) {
+	inc, err := compilePatterns(includedField, included)
+	if err != nil {
+		return nil, err
+	}
+
+	exc, err := compilePatterns(excludedField, excluded)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(inc) == 0 && len(exc) == 0 {
+		return nil, nil
+	}
+
+	return &NameFilter{
+		included: inc,
+		excluded: exc,
+	}, nil
+}
+
+func detectConflictingPatterns(includedField string, included []string, excludedField string, excluded []string) {
+	if len(included) == 0 || len(excluded) == 0 {
+		return
+	}
+
+	includedIdx := make(map[string]int, len(included))
+	for i, pattern := range included {
+		value := strings.TrimSpace(pattern)
+		includedIdx[value] = i
+	}
+
+	for _, pattern := range excluded {
+		value := strings.TrimSpace(pattern)
+		if _, exists := includedIdx[value]; exists {
+			glog.Errorf("pattern %q is defined in both %s and %s; the exclude rule will take precedence", value, includedField, excludedField)
+			// Continue processing instead of returning error to avoid pod crash
+		}
+	}
+}
+
+// Allows returns true if the provided name passes the include/exclude rules.
+func (f *NameFilter) Allows(name string) bool {
+	if f == nil {
+		return true
+	}
+
+	if len(f.included) > 0 {
+		matched := false
+		for _, pattern := range f.included {
+			if pattern.re.MatchString(name) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	for _, pattern := range f.excluded {
+		if pattern.re.MatchString(name) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/catalog/internal/catalog/basecatalog/name_filter_test.go
+++ b/catalog/internal/catalog/basecatalog/name_filter_test.go
@@ -1,0 +1,97 @@
+package basecatalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameFilterAllows(t *testing.T) {
+	filter, err := NewNameFilter("included", []string{"Granite/*"}, "excluded", []string{"Granite/beta-*"})
+	require.NoError(t, err)
+
+	assert.True(t, filter.Allows("Granite/3-1-instruct"))
+	assert.False(t, filter.Allows("Granite/beta-release"))
+	assert.False(t, filter.Allows("Other/model"))
+
+	// Test case-insensitive matching
+	assert.True(t, filter.Allows("granite/3-1-instruct"))
+	assert.True(t, filter.Allows("GRANITE/3-1-instruct"))
+	assert.False(t, filter.Allows("granite/beta-release"))
+
+	allowAll, err := NewNameFilter("included", []string{"*"}, "excluded", nil)
+	require.NoError(t, err)
+	assert.True(t, allowAll.Allows("anything/goes"))
+}
+
+func TestNameFilterConflictsAndValidation(t *testing.T) {
+	_, err := NewNameFilter("included", []string{"meta-llama/Llama-3.2-1B"}, "excluded", []string{"meta-llama/Llama-3.2-1B"})
+	require.NoError(t, err)
+
+	_, err = NewNameFilter("included", []string{"Granite/*"}, "excluded", []string{"Granite/*"})
+	require.NoError(t, err)
+
+	_, err = NewNameFilter("included", []string{""}, "excluded", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pattern cannot be empty")
+}
+
+func TestNameFilterWithWildcardInMiddle(t *testing.T) {
+	// Test that wildcards match across the entire name
+	filter, err := NewNameFilter("included", nil, "excluded", []string{"*deprecated*", "*old*"})
+	require.NoError(t, err)
+
+	assert.True(t, filter.Allows("Granite/empty-stable"))
+	assert.False(t, filter.Allows("Mistral/empty-deprecated"))
+	assert.False(t, filter.Allows("DeepSeek/empty-old-v1"))
+	assert.False(t, filter.Allows("Foo/old"))
+	assert.False(t, filter.Allows("Bar/deprecated"))
+
+	// Test that */pattern* requires the pattern immediately after /
+	filter2, err := NewNameFilter("included", nil, "excluded", []string{"*/deprecated", "*/old*"})
+	require.NoError(t, err)
+
+	assert.True(t, filter2.Allows("Mistral/empty-deprecated")) // doesn't match */deprecated (no immediate match after /)
+	assert.False(t, filter2.Allows("Foo/deprecated"))          // matches */deprecated
+	assert.False(t, filter2.Allows("Bar/old-model"))           // matches */old*
+}
+
+func TestValidatePatterns(t *testing.T) {
+	t.Run("no filters", func(t *testing.T) {
+		err := ValidatePatterns("includedModels", nil, "excludedModels", nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid patterns", func(t *testing.T) {
+		err := ValidatePatterns("includedModels", []string{"Granite/*", "Meta/*"}, "excludedModels", []string{"*-beta"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("conflicting patterns", func(t *testing.T) {
+		err := ValidatePatterns("includedModels", []string{"Granite/*"}, "excludedModels", []string{"Granite/*"})
+		require.NoError(t, err)
+	})
+
+	t.Run("conflicting patterns", func(t *testing.T) {
+		err := ValidatePatterns("includedModels", []string{"Granite/model-2"}, "excludedModels", []string{"Granite/model-2"})
+		require.NoError(t, err)
+	})
+
+	t.Run("empty pattern in includedModels", func(t *testing.T) {
+		err := ValidatePatterns("includedModels", []string{"Granite/*", ""}, "excludedModels", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pattern cannot be empty")
+	})
+
+	t.Run("whitespace-only pattern", func(t *testing.T) {
+		err := ValidatePatterns("includedModels", []string{"   "}, "excludedModels", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pattern cannot be empty")
+	})
+
+	t.Run("valid glob patterns", func(t *testing.T) {
+		err := ValidatePatterns("includedModels", []string{"valid/*"}, "excludedModels", nil)
+		assert.NoError(t, err) // Our conversion always produces valid regex
+	})
+}

--- a/catalog/internal/catalog/basecatalog/source_types.go
+++ b/catalog/internal/catalog/basecatalog/source_types.go
@@ -83,13 +83,16 @@ func (s ModelSource) GetId() string {
 
 // MCPSource represents a source of MCP servers
 type MCPSource struct {
-	Name       string                     `json:"name" yaml:"name"`
-	ID         string                     `json:"id" yaml:"id"`
-	Type       string                     `json:"type" yaml:"type"`
-	Enabled    *bool                      `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Properties map[string]any             `json:"properties" yaml:"properties"`
-	Labels     []string                   `json:"labels" yaml:"labels"`
+	Name       string                      `json:"name" yaml:"name"`
+	ID         string                      `json:"id" yaml:"id"`
+	Type       string                      `json:"type" yaml:"type"`
+	Enabled    *bool                       `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Properties map[string]any              `json:"properties" yaml:"properties"`
+	Labels     []string                    `json:"labels" yaml:"labels"`
 	AssetType  *apimodels.CatalogAssetType `json:"assetType,omitempty" yaml:"assetType,omitempty"`
+
+	IncludedServers []string `json:"includedServers,omitempty" yaml:"includedServers,omitempty"`
+	ExcludedServers []string `json:"excludedServers,omitempty" yaml:"excludedServers,omitempty"`
 
 	// Origin is the absolute path of the config file this source was loaded from.
 	// This is set automatically during loading and used for resolving relative paths.

--- a/catalog/internal/catalog/mcpcatalog/loader.go
+++ b/catalog/internal/catalog/mcpcatalog/loader.go
@@ -154,6 +154,10 @@ func (ml *MCPLoader) updateSources(path string, config *basecatalog.SourceConfig
 			return fmt.Errorf("invalid MCP source: duplicate id %s", source.ID)
 		}
 
+		if err := ValidateServerFilters(source.IncludedServers, source.ExcludedServers); err != nil {
+			return fmt.Errorf("invalid MCP source %s: %w", source.ID, err)
+		}
+
 		// Set the origin path so relative paths in properties can be resolved
 		// relative to this config file's directory
 		source.Origin = path
@@ -200,8 +204,16 @@ func (ml *MCPLoader) loadAllServers(ctx context.Context, sources map[string]base
 			continue
 		}
 
+		// Build server name filter from source include/exclude config
+		filter, err := NewServerFilterFromSource(&source)
+		if err != nil {
+			glog.Errorf("Error building server filter for source %s: %v", source.Name, err)
+			basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, source.ID, basecatalog.SourceStatusError, err.Error())
+			continue
+		}
+
 		// Load servers from this provider
-		err = ml.loadServersFromProvider(ctx, source.ID, provider)
+		err = ml.loadServersFromProvider(ctx, source.ID, provider, filter)
 		if err != nil {
 			if errors.Is(err, ErrMCPPartiallyAvailable) {
 				glog.Warningf("Partial error loading servers from source %s: %v", source.Name, err)
@@ -237,7 +249,7 @@ func (ml *MCPLoader) loadAllServers(ctx context.Context, sources map[string]base
 // loadServersFromProvider loads all servers from a single provider.
 // Returns MCPPartiallyAvailableError if some servers loaded successfully but others failed.
 // Returns a regular error if all servers failed to load.
-func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, sourceID string, provider MCPProvider) error {
+func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, sourceID string, provider MCPProvider, filter *ServerFilter) error {
 	recordChan := provider.Servers(ctx)
 
 	validServerNames := mapset.NewSet[string]()
@@ -280,6 +292,19 @@ func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, sourceID strin
 		serverName := ""
 		if record.Server.GetAttributes() != nil && record.Server.GetAttributes().Name != nil {
 			serverName = *record.Server.GetAttributes().Name
+		}
+
+		// Apply include/exclude filter
+		if !filter.Allows(serverName) {
+			if serverName == "" {
+				glog.Warningf("MCP server with no name was dropped by includedServers/excludedServers filter; check includedServers/excludedServers configuration")
+			} else {
+				glog.V(2).Infof("Skipping excluded MCP server: %s", serverName)
+			}
+			continue
+		}
+
+		if serverName != "" {
 			validServerNames.Add(serverName)
 		}
 

--- a/catalog/internal/catalog/mcpcatalog/loader_test.go
+++ b/catalog/internal/catalog/mcpcatalog/loader_test.go
@@ -767,3 +767,208 @@ namedQueries:
 	require.Error(t, err, "invalid named query operator should be rejected")
 	assert.Contains(t, err.Error(), "INVALID_OP")
 }
+
+func TestMCPLoaderExcludedServersNotSaved(t *testing.T) {
+	_, services, cleanup := setupMCPLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+
+	serversFile := filepath.Join(tmpDir, "servers.yaml")
+	err := os.WriteFile(serversFile, []byte(`mcp_servers:
+  - name: "allowed-server"
+    description: "This server should be loaded"
+  - name: "excluded-server"
+    description: "This server should be skipped"
+`), 0644)
+	require.NoError(t, err)
+
+	sourcesFile := filepath.Join(tmpDir, "sources.yaml")
+	err = os.WriteFile(sourcesFile, []byte(`mcp_catalogs:
+  - name: "Filter Test Catalog"
+    id: filter_test_catalog
+    type: yaml
+    enabled: true
+    excludedServers:
+      - "excluded-server"
+    properties:
+      yamlCatalogPath: `+serversFile+`
+`), 0644)
+	require.NoError(t, err)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewMCPLoaderWithState(services, baseLoader)
+	ctx := context.Background()
+
+	err = loader.ParseAllConfigs()
+	require.NoError(t, err)
+
+	baseLoader.SetLeader(true)
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- loader.PerformLeaderOperations(ctx, mapset.NewSet[string]())
+	}()
+
+	select {
+	case err := <-leaderDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for leader operations")
+	}
+
+	baseLoader.WaitForInflightWrites(5 * time.Second)
+
+	// allowed-server should be present
+	server, err := services.MCPServerRepository.GetByNameAndVersion("allowed-server", "")
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+
+	// excluded-server must not be present
+	_, err = services.MCPServerRepository.GetByNameAndVersion("excluded-server", "")
+	assert.Error(t, err, "excluded-server should not be saved to the database")
+}
+
+func TestMCPLoaderIncludedServersOnly(t *testing.T) {
+	_, services, cleanup := setupMCPLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+
+	serversFile := filepath.Join(tmpDir, "servers.yaml")
+	err := os.WriteFile(serversFile, []byte(`mcp_servers:
+  - name: "allowed-server"
+    description: "This server should be loaded"
+  - name: "other-server"
+    description: "This server is not in the include list"
+`), 0644)
+	require.NoError(t, err)
+
+	sourcesFile := filepath.Join(tmpDir, "sources.yaml")
+	err = os.WriteFile(sourcesFile, []byte(`mcp_catalogs:
+  - name: "Include Filter Catalog"
+    id: include_filter_catalog
+    type: yaml
+    enabled: true
+    includedServers:
+      - "allowed-server"
+    properties:
+      yamlCatalogPath: `+serversFile+`
+`), 0644)
+	require.NoError(t, err)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewMCPLoaderWithState(services, baseLoader)
+	ctx := context.Background()
+
+	err = loader.ParseAllConfigs()
+	require.NoError(t, err)
+
+	baseLoader.SetLeader(true)
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- loader.PerformLeaderOperations(ctx, mapset.NewSet[string]())
+	}()
+
+	select {
+	case err := <-leaderDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for leader operations")
+	}
+
+	baseLoader.WaitForInflightWrites(5 * time.Second)
+
+	// allowed-server should be present
+	server, err := services.MCPServerRepository.GetByNameAndVersion("allowed-server", "")
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+
+	// other-server must not be present (not in include list)
+	_, err = services.MCPServerRepository.GetByNameAndVersion("other-server", "")
+	assert.Error(t, err, "other-server should not be saved because it is not in includedServers")
+}
+
+func TestMCPLoaderNoFilterAllowsAll(t *testing.T) {
+	_, services, cleanup := setupMCPLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+
+	serversFile := filepath.Join(tmpDir, "servers.yaml")
+	err := os.WriteFile(serversFile, []byte(`mcp_servers:
+  - name: "server-a"
+    description: "First server"
+  - name: "server-b"
+    description: "Second server"
+`), 0644)
+	require.NoError(t, err)
+
+	sourcesFile := filepath.Join(tmpDir, "sources.yaml")
+	err = os.WriteFile(sourcesFile, []byte(`mcp_catalogs:
+  - name: "No Filter Catalog"
+    id: no_filter_catalog
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: `+serversFile+`
+`), 0644)
+	require.NoError(t, err)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewMCPLoaderWithState(services, baseLoader)
+	ctx := context.Background()
+
+	err = loader.ParseAllConfigs()
+	require.NoError(t, err)
+
+	baseLoader.SetLeader(true)
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- loader.PerformLeaderOperations(ctx, mapset.NewSet[string]())
+	}()
+
+	select {
+	case err := <-leaderDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for leader operations")
+	}
+
+	baseLoader.WaitForInflightWrites(5 * time.Second)
+
+	_, err = services.MCPServerRepository.GetByNameAndVersion("server-a", "")
+	require.NoError(t, err)
+
+	_, err = services.MCPServerRepository.GetByNameAndVersion("server-b", "")
+	require.NoError(t, err)
+}
+
+func TestMCPLoaderInvalidServerFilterRejected(t *testing.T) {
+	_, services, cleanup := setupMCPLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+
+	sourcesFile := filepath.Join(tmpDir, "sources.yaml")
+	err := os.WriteFile(sourcesFile, []byte(`mcp_catalogs:
+  - name: "Bad Filter Catalog"
+    id: bad_filter_catalog
+    type: yaml
+    enabled: true
+    includedServers:
+      - ""
+    properties:
+      someProp: someValue
+`), 0644)
+	require.NoError(t, err)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewMCPLoaderWithState(services, baseLoader)
+
+	err = loader.ParseAllConfigs()
+	require.Error(t, err, "empty includedServers pattern should be rejected at config load time")
+	assert.Contains(t, err.Error(), "includedServers")
+}

--- a/catalog/internal/catalog/mcpcatalog/server_filter.go
+++ b/catalog/internal/catalog/mcpcatalog/server_filter.go
@@ -1,0 +1,36 @@
+package mcpcatalog
+
+import (
+	"fmt"
+
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
+)
+
+// ServerFilter encapsulates include/exclude pattern matching for MCP server names.
+type ServerFilter = basecatalog.NameFilter
+
+// ValidateServerFilters validates that the includedServers and excludedServers patterns
+// are valid (non-empty, compilable, non-conflicting). This is useful for early validation
+// at configuration load time without constructing the full ServerFilter.
+func ValidateServerFilters(included, excluded []string) error {
+	return basecatalog.ValidatePatterns("includedServers", included, "excludedServers", excluded)
+}
+
+// NewServerFilter builds a ServerFilter from the provided include/exclude pattern lists.
+func NewServerFilter(included, excluded []string) (*ServerFilter, error) {
+	return basecatalog.NewNameFilter("includedServers", included, "excludedServers", excluded)
+}
+
+// NewServerFilterFromSource composes a ServerFilter using the source-level configuration.
+func NewServerFilterFromSource(source *basecatalog.MCPSource) (*ServerFilter, error) {
+	if source == nil {
+		return nil, fmt.Errorf("source cannot be nil when building server filters")
+	}
+
+	filter, err := NewServerFilter(source.IncludedServers, source.ExcludedServers)
+	if err != nil {
+		return nil, fmt.Errorf("invalid includedServers/excludedServers configuration for source %s: %w", source.ID, err)
+	}
+
+	return filter, nil
+}

--- a/catalog/internal/catalog/mcpcatalog/server_filter_test.go
+++ b/catalog/internal/catalog/mcpcatalog/server_filter_test.go
@@ -1,0 +1,91 @@
+package mcpcatalog
+
+import (
+	"testing"
+
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServerFilterFromSource_NilSource(t *testing.T) {
+	_, err := NewServerFilterFromSource(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source cannot be nil")
+}
+
+func TestNewServerFilterFromSource_NoFilters(t *testing.T) {
+	source := &basecatalog.MCPSource{ID: "test"}
+	filter, err := NewServerFilterFromSource(source)
+	require.NoError(t, err)
+	assert.Nil(t, filter, "nil filter expected when no patterns are set")
+}
+
+func TestNewServerFilterFromSource_IncludeOnly(t *testing.T) {
+	source := &basecatalog.MCPSource{
+		ID:              "test",
+		IncludedServers: []string{"github*", "slack*"},
+	}
+	filter, err := NewServerFilterFromSource(source)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	assert.True(t, filter.Allows("github-mcp"))
+	assert.True(t, filter.Allows("slack-mcp"))
+	assert.False(t, filter.Allows("jira-mcp"))
+}
+
+func TestNewServerFilterFromSource_ExcludeOnly(t *testing.T) {
+	source := &basecatalog.MCPSource{
+		ID:              "test",
+		ExcludedServers: []string{"internal*"},
+	}
+	filter, err := NewServerFilterFromSource(source)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	assert.True(t, filter.Allows("github-mcp"))
+	assert.False(t, filter.Allows("internal-mcp"))
+	assert.False(t, filter.Allows("internal-tools"))
+}
+
+func TestNewServerFilterFromSource_IncludeAndExclude(t *testing.T) {
+	source := &basecatalog.MCPSource{
+		ID:              "test",
+		IncludedServers: []string{"github*"},
+		ExcludedServers: []string{"github-internal"},
+	}
+	filter, err := NewServerFilterFromSource(source)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+
+	assert.True(t, filter.Allows("github-public"))
+	assert.False(t, filter.Allows("github-internal"))
+	assert.False(t, filter.Allows("slack-mcp"))
+}
+
+func TestNewServerFilterFromSource_InvalidPattern(t *testing.T) {
+	source := &basecatalog.MCPSource{
+		ID:              "test",
+		IncludedServers: []string{""},
+	}
+	_, err := NewServerFilterFromSource(source)
+	require.Error(t, err)
+}
+
+func TestNewServerFilter_NilSafe(t *testing.T) {
+	// A nil *ServerFilter must allow everything (NameFilter.Allows is nil-safe)
+	var filter *ServerFilter
+	assert.True(t, filter.Allows("anything"))
+}
+
+func TestValidateServerFilters_Valid(t *testing.T) {
+	err := ValidateServerFilters([]string{"github*"}, []string{"*internal"})
+	require.NoError(t, err)
+}
+
+func TestValidateServerFilters_EmptyPattern(t *testing.T) {
+	err := ValidateServerFilters([]string{""}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "includedServers")
+}

--- a/catalog/internal/catalog/mcpcatalog/sources.go
+++ b/catalog/internal/catalog/mcpcatalog/sources.go
@@ -159,6 +159,13 @@ func mergeMCPSources(base, override basecatalog.MCPSource) basecatalog.MCPSource
 	result.Origin = common.Origin
 	result.AssetType = common.AssetType
 
+	if override.IncludedServers != nil {
+		result.IncludedServers = override.IncludedServers
+	}
+	if override.ExcludedServers != nil {
+		result.ExcludedServers = override.ExcludedServers
+	}
+
 	return result
 }
 

--- a/catalog/internal/catalog/mcpcatalog/sources_test.go
+++ b/catalog/internal/catalog/mcpcatalog/sources_test.go
@@ -408,8 +408,8 @@ func TestMCPSourceCollection_MergeOverride(t *testing.T) {
 					ID:        "mcp_github",
 					Name:      "GitHub MCP Server",
 					Type:      "sse",
-					Enabled:   apiutils.Of(true),                      // Default applied
-					Labels:    []string{},                             // Default applied
+					Enabled:   apiutils.Of(true),                        // Default applied
+					Labels:    []string{},                               // Default applied
 					AssetType: model.CATALOGASSETTYPE_MCP_SERVERS.Ptr(), // Default applied
 				},
 			},
@@ -875,4 +875,101 @@ func TestMCPSourceCollection_Merge_WithoutNamedQueries(t *testing.T) {
 	all := coll.AllSources()
 	assert.Contains(t, all, "src1")
 	assert.Empty(t, coll.GetNamedQueries())
+}
+
+func TestMergeMCPSources_IncludedExcludedServers(t *testing.T) {
+	tests := []struct {
+		name         string
+		base         basecatalog.MCPSource
+		override     basecatalog.MCPSource
+		wantIncluded []string
+		wantExcluded []string
+	}{
+		{
+			name: "override replaces includedServers",
+			base: basecatalog.MCPSource{
+				ID:              "src",
+				IncludedServers: []string{"github*"},
+			},
+			override: basecatalog.MCPSource{
+				ID:              "src",
+				IncludedServers: []string{"slack*"},
+			},
+			wantIncluded: []string{"slack*"},
+			wantExcluded: nil,
+		},
+		{
+			name: "override replaces excludedServers",
+			base: basecatalog.MCPSource{
+				ID:              "src",
+				ExcludedServers: []string{"internal*"},
+			},
+			override: basecatalog.MCPSource{
+				ID:              "src",
+				ExcludedServers: []string{"private*"},
+			},
+			wantIncluded: nil,
+			wantExcluded: []string{"private*"},
+		},
+		{
+			name: "nil override inherits base includedServers",
+			base: basecatalog.MCPSource{
+				ID:              "src",
+				IncludedServers: []string{"github*"},
+			},
+			override: basecatalog.MCPSource{
+				ID: "src",
+				// IncludedServers nil -> inherit from base
+			},
+			wantIncluded: []string{"github*"},
+			wantExcluded: nil,
+		},
+		{
+			name: "nil override inherits base excludedServers",
+			base: basecatalog.MCPSource{
+				ID:              "src",
+				ExcludedServers: []string{"internal*"},
+			},
+			override: basecatalog.MCPSource{
+				ID: "src",
+				// ExcludedServers nil -> inherit from base
+			},
+			wantIncluded: nil,
+			wantExcluded: []string{"internal*"},
+		},
+		{
+			name: "empty slice override clears includedServers",
+			base: basecatalog.MCPSource{
+				ID:              "src",
+				IncludedServers: []string{"github*"},
+			},
+			override: basecatalog.MCPSource{
+				ID:              "src",
+				IncludedServers: []string{}, // explicitly clear
+			},
+			wantIncluded: []string{},
+			wantExcluded: nil,
+		},
+		{
+			name: "empty slice override clears excludedServers",
+			base: basecatalog.MCPSource{
+				ID:              "src",
+				ExcludedServers: []string{"internal*"},
+			},
+			override: basecatalog.MCPSource{
+				ID:              "src",
+				ExcludedServers: []string{}, // explicitly clear
+			},
+			wantIncluded: nil,
+			wantExcluded: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeMCPSources(tt.base, tt.override)
+			assert.Equal(t, tt.wantIncluded, result.IncludedServers)
+			assert.Equal(t, tt.wantExcluded, result.ExcludedServers)
+		})
+	}
 }

--- a/catalog/internal/catalog/modelcatalog/model_filter.go
+++ b/catalog/internal/catalog/modelcatalog/model_filter.go
@@ -2,160 +2,23 @@ package modelcatalog
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
-	"github.com/golang/glog"
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
 )
 
 // ModelFilter encapsulates include/exclude pattern matching for model names.
-type ModelFilter struct {
-	included []*compiledPattern
-	excluded []*compiledPattern
-}
-
-type compiledPattern struct {
-	raw string
-	re  *regexp.Regexp
-}
-
-func newCompiledPattern(field string, idx int, raw string) (*compiledPattern, error) {
-	value := strings.TrimSpace(raw)
-	if value == "" {
-		return nil, fmt.Errorf("%s[%d]: pattern cannot be empty", field, idx)
-	}
-
-	// Convert a simple glob (only supporting '*') into a regexp.
-	var b strings.Builder
-	b.WriteString("(?i)^")
-	for _, r := range value {
-		if r == '*' {
-			b.WriteString(".*")
-			continue
-		}
-		b.WriteString(regexp.QuoteMeta(string(r)))
-	}
-	b.WriteString("$")
-
-	re, err := regexp.Compile(b.String())
-	if err != nil {
-		return nil, fmt.Errorf("%s[%d]: invalid pattern %q: %w", field, idx, value, err)
-	}
-
-	return &compiledPattern{
-		raw: value,
-		re:  re,
-	}, nil
-}
-
-func compilePatterns(field string, patterns []string) ([]*compiledPattern, error) {
-	if len(patterns) == 0 {
-		return nil, nil
-	}
-
-	compiled := make([]*compiledPattern, 0, len(patterns))
-	for i, pattern := range patterns {
-		cp, err := newCompiledPattern(field, i, pattern)
-		if err != nil {
-			return nil, err
-		}
-		compiled = append(compiled, cp)
-	}
-	return compiled, nil
-}
+type ModelFilter = basecatalog.NameFilter
 
 // ValidateSourceFilters validates that the includedModels and excludedModels patterns
 // are valid (non-empty, compilable, non-conflicting). This is useful for early validation
 // at configuration load time without constructing the full ModelFilter.
 func ValidateSourceFilters(included, excluded []string) error {
-	// Log conflicts but don't fail validation to avoid pod crash
-	detectConflictingPatterns(included, excluded)
-
-	if _, err := compilePatterns("includedModels", included); err != nil {
-		return err
-	}
-
-	if _, err := compilePatterns("excludedModels", excluded); err != nil {
-		return err
-	}
-
-	return nil
+	return basecatalog.ValidatePatterns("includedModels", included, "excludedModels", excluded)
 }
 
 // NewModelFilter builds a ModelFilter from the provided include/exclude pattern lists.
 func NewModelFilter(included, excluded []string) (*ModelFilter, error) {
-	if err := ValidateSourceFilters(included, excluded); err != nil {
-		return nil, err
-	}
-
-	inc, err := compilePatterns("includedModels", included)
-	if err != nil {
-		return nil, err
-	}
-
-	exc, err := compilePatterns("excludedModels", excluded)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(inc) == 0 && len(exc) == 0 {
-		return nil, nil
-	}
-
-	return &ModelFilter{
-		included: inc,
-		excluded: exc,
-	}, nil
-}
-
-func detectConflictingPatterns(included, excluded []string) error {
-	if len(included) == 0 || len(excluded) == 0 {
-		return nil
-	}
-
-	includedIdx := make(map[string]int, len(included))
-	for i, pattern := range included {
-		value := strings.TrimSpace(pattern)
-		includedIdx[value] = i
-	}
-
-	for _, pattern := range excluded {
-		value := strings.TrimSpace(pattern)
-		if _, exists := includedIdx[value]; exists {
-			glog.Errorf("pattern %q is defined in both includedModels and excludedModels, skipping", value)
-			// Continue processing instead of returning error to avoid pod crash
-		}
-	}
-	return nil
-}
-
-// Allows returns true if the provided model name passes the include/exclude rules.
-func (f *ModelFilter) Allows(name string) bool {
-	if f == nil {
-		return true
-	}
-
-	if len(f.included) > 0 {
-		matched := false
-		for _, pattern := range f.included {
-			if pattern.re.MatchString(name) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return false
-		}
-	}
-
-	for _, pattern := range f.excluded {
-		if pattern.re.MatchString(name) {
-			return false
-		}
-	}
-
-	return true
+	return basecatalog.NewNameFilter("includedModels", included, "excludedModels", excluded)
 }
 
 // NewModelFilterFromSource composes a ModelFilter using the source-level configuration and any legacy additions.

--- a/catalog/internal/catalog/modelcatalog/model_filter_test.go
+++ b/catalog/internal/catalog/modelcatalog/model_filter_test.go
@@ -9,36 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestModelFilterAllows(t *testing.T) {
-	filter, err := NewModelFilter([]string{"Granite/*"}, []string{"Granite/beta-*"})
-	require.NoError(t, err)
-
-	assert.True(t, filter.Allows("Granite/3-1-instruct"))
-	assert.False(t, filter.Allows("Granite/beta-release"))
-	assert.False(t, filter.Allows("Other/model"))
-
-	// Test case-insensitive matching
-	assert.True(t, filter.Allows("granite/3-1-instruct"))
-	assert.True(t, filter.Allows("GRANITE/3-1-instruct"))
-	assert.False(t, filter.Allows("granite/beta-release"))
-
-	allowAll, err := NewModelFilter([]string{"*"}, nil)
-	require.NoError(t, err)
-	assert.True(t, allowAll.Allows("anything/goes"))
-}
-
-func TestModelFilterConflictsAndValidation(t *testing.T) {
-	_, err := NewModelFilter([]string{"meta-llama/Llama-3.2-1B"}, []string{"meta-llama/Llama-3.2-1B"})
-	require.NoError(t, err)
-
-	_, err = NewModelFilter([]string{"Granite/*"}, []string{"Granite/*"})
-	require.NoError(t, err)
-
-	_, err = NewModelFilter([]string{""}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "pattern cannot be empty")
-}
-
 func TestNewModelFilterFromSourceMergesLegacy(t *testing.T) {
 	source := &basecatalog.ModelSource{
 		CatalogSource: apimodels.CatalogSource{
@@ -54,63 +24,4 @@ func TestNewModelFilterFromSourceMergesLegacy(t *testing.T) {
 
 	assert.True(t, filter.Allows("Granite/model"))
 	assert.False(t, filter.Allows("Legacy/model"))
-}
-
-func TestModelFilterWithWildcardInMiddle(t *testing.T) {
-	// Test that wildcards match across the entire name
-	filter, err := NewModelFilter(nil, []string{"*deprecated*", "*old*"})
-	require.NoError(t, err)
-
-	assert.True(t, filter.Allows("Granite/empty-stable"))
-	assert.False(t, filter.Allows("Mistral/empty-deprecated"))
-	assert.False(t, filter.Allows("DeepSeek/empty-old-v1"))
-	assert.False(t, filter.Allows("Foo/old"))
-	assert.False(t, filter.Allows("Bar/deprecated"))
-
-	// Test that */pattern* requires the pattern immediately after /
-	filter2, err := NewModelFilter(nil, []string{"*/deprecated", "*/old*"})
-	require.NoError(t, err)
-
-	assert.True(t, filter2.Allows("Mistral/empty-deprecated")) // doesn't match */deprecated (no immediate match after /)
-	assert.False(t, filter2.Allows("Foo/deprecated"))          // matches */deprecated
-	assert.False(t, filter2.Allows("Bar/old-model"))           // matches */old*
-}
-
-func TestValidateSourceFilters(t *testing.T) {
-	t.Run("no filters", func(t *testing.T) {
-		err := ValidateSourceFilters(nil, nil)
-		assert.NoError(t, err)
-	})
-
-	t.Run("valid patterns", func(t *testing.T) {
-		err := ValidateSourceFilters([]string{"Granite/*", "Meta/*"}, []string{"*-beta"})
-		assert.NoError(t, err)
-	})
-
-	t.Run("conflicting patterns", func(t *testing.T) {
-		err := ValidateSourceFilters([]string{"Granite/*"}, []string{"Granite/*"})
-		require.NoError(t, err)
-	})
-
-	t.Run("conflicting patterns", func(t *testing.T) {
-		err := ValidateSourceFilters([]string{"Granite/model-2"}, []string{"Granite/model-2"})
-		require.NoError(t, err)
-	})
-
-	t.Run("empty pattern in includedModels", func(t *testing.T) {
-		err := ValidateSourceFilters([]string{"Granite/*", ""}, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "pattern cannot be empty")
-	})
-
-	t.Run("whitespace-only pattern", func(t *testing.T) {
-		err := ValidateSourceFilters([]string{"   "}, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "pattern cannot be empty")
-	})
-
-	t.Run("valid glob patterns", func(t *testing.T) {
-		err := ValidateSourceFilters([]string{"valid/*"}, nil)
-		assert.NoError(t, err) // Our conversion always produces valid regex
-	})
 }

--- a/catalog/internal/catalog/modelcatalog/names.go
+++ b/catalog/internal/catalog/modelcatalog/names.go
@@ -10,8 +10,8 @@ import (
 // Stored names use the format "sourceId:modelName" for DB uniqueness; this strips the prefix
 // so callers get the name without the source id prepended.
 func DisplayNameFromStoredName(storedName string) string {
-	if idx := strings.Index(storedName, ":"); idx >= 0 {
-		return storedName[idx+1:]
+	if _, after, ok := strings.Cut(storedName, ":"); ok {
+		return after
 	}
 	return storedName
 }


### PR DESCRIPTION
## Description

Filter MCP servers by glob patterns using includedServers and excludedServers on MCP source entries, mirroring the existing includedModels/excludedModels behavior on model sources.

## How Has This Been Tested?
Unit tests and on a local kind cluster

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
