### PR TITLE
fix(catalog): reject invalid pageSize and nextPageToken with 400

### DIFF
--- a/catalog/internal/catalog/modelcatalog/service/catalog_model.go
+++ b/catalog/internal/catalog/modelcatalog/service/catalog_model.go
@@ -495,11 +495,13 @@ func (r *CatalogModelRepositoryImpl) applyCustomOrdering(query *gorm.DB, listOpt
 	nextPageToken := listOptions.GetNextPageToken()
 	if nextPageToken != "" {
 		// Parse the cursor from the token
-		if cursor, err := scopes.DecodeCursor(nextPageToken); err == nil {
+		cursor, err := scopes.DecodeCursor(nextPageToken)
+		if err != nil {
+			_ = query.AddError(fmt.Errorf("invalid nextPageToken: %w", err))
+		} else {
 			// Apply WHERE clause for cursor-based pagination with ACCURACY
 			query = r.applyCursorPagination(query, cursor, sortColumn, sortOrder)
 		}
-		// If token parsing fails, fall back to no cursor (first page)
 	}
 
 	// Apply pagination limit

--- a/catalog/internal/db/pagination/pagination.go
+++ b/catalog/internal/db/pagination/pagination.go
@@ -51,16 +51,19 @@ func ApplyNameOrdering(query *gorm.DB, tableName string, sortOrder string, nextP
 
 	// Handle cursor-based pagination for NAME
 	if nextPageToken != "" {
-		if cursor, err := scopes.DecodeCursor(nextPageToken); err == nil {
-			// Cursor pagination based on name (string comparison)
-			cmp := ">"
-			if order == "DESC" {
-				cmp = "<"
-			}
-			// Use proper string comparison with name and ID as tie-breaker
-			query = query.Where(fmt.Sprintf("(%s.name %s ? OR (%s.name = ? AND %s.id > ?))", tableName, cmp, tableName, tableName),
-				cursor.Value, cursor.Value, cursor.ID)
+		cursor, err := scopes.DecodeCursor(nextPageToken)
+		if err != nil {
+			_ = query.AddError(fmt.Errorf("invalid nextPageToken: %w", err))
+			return query
 		}
+		// Cursor pagination based on name (string comparison)
+		cmp := ">"
+		if order == "DESC" {
+			cmp = "<"
+		}
+		// Use proper string comparison with name and ID as tie-breaker
+		query = query.Where(fmt.Sprintf("(%s.name %s ? OR (%s.name = ? AND %s.id > ?))", tableName, cmp, tableName, tableName),
+			cursor.Value, cursor.Value, cursor.ID)
 	}
 
 	// Apply pagination limit

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog"
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
@@ -27,14 +26,9 @@ func NewMCPCatalogServiceAPIService(mcpProvider catalog.MCPProvider) MCPCatalogS
 
 // FindMCPServers - List MCP servers.
 func (m *MCPCatalogServiceAPIService) FindMCPServers(ctx context.Context, name string, q string, sourceLabel []string, filterQuery string, namedQuery string, includeTools bool, toolLimit int32, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	pageSizeInt := int32(10)
-
-	if pageSize != "" {
-		parsed, err := strconv.ParseInt(pageSize, 10, 32)
-		if err != nil {
-			return Response(http.StatusBadRequest, err), err
-		}
-		pageSizeInt = int32(parsed)
+	pageSizeInt, err := parsePaginationParams(pageSize, nextPageToken)
+	if err != nil {
+		return ErrorResponse(http.StatusBadRequest, err), err
 	}
 
 	// Convert parameters to internal format
@@ -84,14 +78,9 @@ func (m *MCPCatalogServiceAPIService) GetMCPServer(ctx context.Context, serverID
 
 // FindMCPServerTools - List MCP server tools.
 func (m *MCPCatalogServiceAPIService) FindMCPServerTools(ctx context.Context, serverID string, filterQuery string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	pageSizeInt := int32(10)
-
-	if pageSize != "" {
-		parsed, err := strconv.ParseInt(pageSize, 10, 32)
-		if err != nil {
-			return Response(http.StatusBadRequest, err), err
-		}
-		pageSizeInt = int32(parsed)
+	pageSizeInt, err := parsePaginationParams(pageSize, nextPageToken)
+	if err != nil {
+		return ErrorResponse(http.StatusBadRequest, err), err
 	}
 
 	// Convert parameters to internal format

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -45,15 +45,9 @@ func (m *ModelCatalogServiceAPIService) GetAllModelArtifacts(ctx context.Context
 		modelName = newName
 	}
 
-	var err error
-	pageSizeInt := int32(10)
-
-	if pageSize != "" {
-		parsed, err := strconv.ParseInt(pageSize, 10, 32)
-		if err != nil {
-			return Response(http.StatusBadRequest, err), err
-		}
-		pageSizeInt = int32(parsed)
+	pageSizeInt, err := parsePaginationParams(pageSize, nextPageToken)
+	if err != nil {
+		return ErrorResponse(http.StatusBadRequest, err), err
 	}
 
 	// Handle multiple artifact types
@@ -97,15 +91,9 @@ func (m *ModelCatalogServiceAPIService) GetAllModelPerformanceArtifacts(ctx cont
 		modelName = newName
 	}
 
-	var err error
-	pageSizeInt := int32(10)
-
-	if pageSize != "" {
-		parsed, err := strconv.ParseInt(pageSize, 10, 32)
-		if err != nil {
-			return Response(http.StatusBadRequest, err), err
-		}
-		pageSizeInt = int32(parsed)
+	pageSizeInt, err := parsePaginationParams(pageSize, nextPageToken)
+	if err != nil {
+		return ErrorResponse(http.StatusBadRequest, err), err
 	}
 
 	// Call the provider's GetPerformanceArtifacts method
@@ -230,15 +218,9 @@ func (m *ModelCatalogServiceAPIService) FindLabels(ctx context.Context, assetTyp
 
 func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommended bool, targetRPS int32, latencyProperty string, rpsProperty string, hardwareCountProperty string, hardwareTypeProperty string, sourceIDs []string, q string, sourceLabels []string, filterQuery string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	// Validate pagination parameters
-	var err error
-	pageSizeInt := int32(10)
-
-	if pageSize != "" {
-		parsed, err := strconv.ParseInt(pageSize, 10, 32)
-		if err != nil {
-			return ErrorResponse(http.StatusBadRequest, fmt.Errorf("invalid pagination parameters: %w", err)), err
-		}
-		pageSizeInt = int32(parsed)
+	pageSizeInt, err := parsePaginationParams(pageSize, nextPageToken)
+	if err != nil {
+		return ErrorResponse(http.StatusBadRequest, err), err
 	}
 
 	if len(sourceIDs) == 1 && sourceIDs[0] == "" {

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -339,7 +339,9 @@ func TestFindModels(t *testing.T) {
 			assert.Equal(t, tc.expectedModelList.Size, modelList.Size)
 			assert.Equal(t, tc.expectedModelList.PageSize, modelList.PageSize)
 			if !assert.Equal(t, tc.expectedModelList.NextPageToken, modelList.NextPageToken) && tc.expectedModelList.NextPageToken != "" {
-				assert.Equal(t, decodeStringCursor(tc.expectedModelList.NextPageToken), decodeStringCursor(modelList.NextPageToken))
+				expectedCursor, _ := decodeStringCursor(tc.expectedModelList.NextPageToken)
+				actualCursor, _ := decodeStringCursor(modelList.NextPageToken)
+				assert.Equal(t, expectedCursor, actualCursor)
 			}
 
 			// Deep equality check for items

--- a/catalog/internal/server/openapi/pagination.go
+++ b/catalog/internal/server/openapi/pagination.go
@@ -7,7 +7,30 @@ import (
 	"strings"
 
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
+	"github.com/kubeflow/model-registry/internal/db/scopes"
 )
+
+// parsePaginationParams validates and parses pageSize and nextPageToken for DB-backed endpoints.
+// It returns the page size as int32, or an error if either parameter is invalid.
+func parsePaginationParams(pageSize string, nextPageToken string) (int32, error) {
+	pageSizeInt := int32(10)
+	if pageSize != "" {
+		parsed, err := strconv.ParseInt(pageSize, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("invalid pageSize: %w", err)
+		}
+		if parsed < 1 {
+			return 0, fmt.Errorf("pageSize must be at least 1, got %d", parsed)
+		}
+		pageSizeInt = int32(parsed)
+	}
+	if nextPageToken != "" {
+		if _, err := scopes.DecodeCursor(nextPageToken); err != nil {
+			return 0, fmt.Errorf("invalid nextPageToken: %w", err)
+		}
+	}
+	return pageSizeInt, nil
+}
 
 type paginator[T model.Sortable] struct {
 	PageSize  int32
@@ -42,7 +65,11 @@ func newPaginator[T model.Sortable](pageSize string, orderBy model.OrderByField,
 	}
 
 	if nextPageToken != "" {
-		p.cursor = decodeStringCursor(nextPageToken)
+		cursor, err := decodeStringCursor(nextPageToken)
+		if err != nil {
+			return nil, fmt.Errorf("invalid nextPageToken: %w", err)
+		}
+		p.cursor = cursor
 	}
 
 	return p, nil
@@ -106,18 +133,17 @@ func (c *stringCursor) String() string {
 	return base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", c.Value, c.ID))
 }
 
-func decodeStringCursor(encoded string) *stringCursor {
+func decodeStringCursor(encoded string) (*stringCursor, error) {
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		// Show the first page on a bad token.
-		return nil
+		return nil, fmt.Errorf("invalid token encoding: %w", err)
 	}
 	parts := strings.SplitN(string(decoded), ":", 2)
 	if len(parts) != 2 {
-		return nil
+		return nil, fmt.Errorf("invalid token format")
 	}
 	return &stringCursor{
 		Value: parts[0],
 		ID:    parts[1],
-	}
+	}, nil
 }

--- a/catalog/internal/server/openapi/pagination_test.go
+++ b/catalog/internal/server/openapi/pagination_test.go
@@ -112,17 +112,6 @@ func TestPaginateSources(t *testing.T) {
 			expectedFirstID:    "source5",
 			expectedLastID:     "source9",
 		},
-		{
-			name:               "Invalid token",
-			items:              allSources,
-			pageSize:           "10",
-			orderBy:            "ID",
-			nextPageToken:      "invalid-token",
-			expectedItemsCount: 10,
-			expectedNextToken:  true,
-			expectedFirstID:    "source0",
-			expectedLastID:     "source9",
-		},
 	}
 
 	for _, tc := range testCases {
@@ -147,6 +136,21 @@ func TestPaginateSources(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewPaginator_InvalidToken(t *testing.T) {
+	_, err := newPaginator[model.CatalogSource]("10", "ID", "", "invalid-token")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid nextPageToken")
+	// Verify a valid token does not produce an error
+	allSources := createCatalogSources(25)
+	validToken := (&stringCursor{Value: "source9", ID: "source9"}).String()
+	paginator, err := newPaginator[model.CatalogSource]("10", "ID", "", validToken)
+	assert.NoError(t, err)
+	assert.NotNil(t, paginator)
+	pagedItems, _ := paginator.Paginate(allSources)
+	assert.Equal(t, 10, len(pagedItems))
+	assert.Equal(t, "source10", pagedItems[0].Id)
 }
 
 func TestNewPaginator_InvalidPageSize(t *testing.T) {
@@ -190,6 +194,74 @@ func TestNewPaginator_InvalidPageSize(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, paginator)
+			}
+		})
+	}
+}
+
+func TestParsePaginationParams(t *testing.T) {
+	testCases := []struct {
+		name          string
+		pageSize      string
+		nextPageToken string
+		expectError   bool
+		errContains   string
+		expectedSize  int32
+	}{
+		{
+			name:         "empty values use defaults",
+			pageSize:     "",
+			expectedSize: 10,
+		},
+		{
+			name:         "valid pageSize",
+			pageSize:     "25",
+			expectedSize: 25,
+		},
+		{
+			name:        "negative pageSize returns error",
+			pageSize:    "-5",
+			expectError: true,
+			errContains: "pageSize must be at least 1",
+		},
+		{
+			name:        "zero pageSize returns error",
+			pageSize:    "0",
+			expectError: true,
+			errContains: "pageSize must be at least 1",
+		},
+		{
+			name:        "non-numeric pageSize returns error",
+			pageSize:    "abc",
+			expectError: true,
+			errContains: "invalid pageSize",
+		},
+		{
+			name:          "garbage nextPageToken returns error",
+			pageSize:      "10",
+			nextPageToken: "asdf1234garbage",
+			expectError:   true,
+			errContains:   "invalid nextPageToken",
+		},
+		{
+			name:          "plaintext nextPageToken returns error",
+			pageSize:      "10",
+			nextPageToken: "not-a-real-token",
+			expectError:   true,
+			errContains:   "invalid nextPageToken",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			size, err := parsePaginationParams(tc.pageSize, tc.nextPageToken)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				assert.Equal(t, int32(0), size)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedSize, size)
 			}
 		})
 	}

--- a/internal/db/scopes/paginate.go
+++ b/internal/db/scopes/paginate.go
@@ -88,7 +88,9 @@ func PaginateWithOptions(value any, pagination *models.Pagination, db *gorm.DB, 
 
 		if nextPageToken != "" {
 			decodedCursor, err := DecodeCursor(nextPageToken)
-			if err == nil {
+			if err != nil {
+				_ = db.AddError(fmt.Errorf("invalid nextPageToken: %w", err))
+			} else {
 				db = buildWhereClause(db, decodedCursor, orderBy, sortOrder, tablePrefix)
 			}
 		}


### PR DESCRIPTION
## Description

Reject negative, zero, and non-numeric pageSize values with 400 Bad Request. Reject malformed nextPageToken values the same way, rather than silently falling back to page 1.

## How Has This Been Tested?
On a local kind cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
