### PR TITLE
fix: Readability of Code and better accessibility

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/SourceDetailsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/SourceDetailsSection.tsx
@@ -55,6 +55,11 @@ const SourceDetailsSection: React.FC<SourceDetailsSectionProps> = ({
     />
   );
 
+  const sourceTypeLabel =
+    formData.sourceType === CatalogSourceType.HUGGING_FACE
+      ? SOURCE_TYPE_LABELS.HUGGING_FACE
+      : SOURCE_TYPE_LABELS.YAML;
+
   return (
     <FormSection>
       <FormGroup label={FORM_LABELS.NAME} isRequired fieldId="source-name">
@@ -82,10 +87,12 @@ const SourceDetailsSection: React.FC<SourceDetailsSectionProps> = ({
         aria-labelledby="source-type-label"
       >
         {isEditMode ? (
-          <span>
-            {formData.sourceType === CatalogSourceType.HUGGING_FACE
-              ? SOURCE_TYPE_LABELS.HUGGING_FACE
-              : SOURCE_TYPE_LABELS.YAML}
+          <span
+            id="source-type-readonly"
+            data-testid="source-type-readonly"
+            className="pf-v6-u-display-block pf-v6-u-mt-sm"
+          >
+            {sourceTypeLabel}
           </span>
         ) : (
           <Flex spaceItems={{ default: 'spaceItemsMd' }}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- it reduces nesting and makes the JSX cleaner to read.
- id="source-type-readonly" — better accessibility, consistent with how source-name has an id
- data-testid="source-type-readonly" — makes the read-only value directly targetable in tests (previously untestable without traversing the DOM)
- className="pf-v6-u-display-block pf-v6-u-mt-sm" — adds a top margin and block display so the read-only text aligns visually with how the radio buttons are laid out below it in non-edit mode

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
1. Adding a catalog source.
2. Clicking the "Manage source" button on the catalog sources table.
3. Verified the **Source type** field is fully visible with correct label in the modal.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
