### PR TITLE
fix: vertical alignment mismatch in Settings table rows

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableRow.tsx
@@ -79,17 +79,17 @@ const CatalogSourceConfigsTableRow: React.FC<CatalogSourceConfigsTableRowProps> 
   return (
     <>
       <Tr>
-        <Td dataLabel="Name">
+        <Td dataLabel="Name" style={{ verticalAlign: 'middle' }}>
           <span data-testid={`source-name-${catalogSourceConfig.id}`}>
             {catalogSourceConfig.name}
           </span>
         </Td>
-        <Td dataLabel="Organization">
+        <Td dataLabel="Organization" style={{ verticalAlign: 'middle' }}>
           <span data-testid={`source-organization-${catalogSourceConfig.id}`}>
             {organizationValue}
           </span>
         </Td>
-        <Td dataLabel="Model visibility">
+        <Td dataLabel="Model visibility" style={{ verticalAlign: 'middle' }}>
           {hasFilters ? (
             <Label
               color={ModelVisibilityBadgeColor.FILTERED}
@@ -107,12 +107,12 @@ const CatalogSourceConfigsTableRow: React.FC<CatalogSourceConfigsTableRowProps> 
             </Label>
           )}
         </Td>
-        <Td dataLabel="Source type">
+        <Td dataLabel="Source type" style={{ verticalAlign: 'middle' }}>
           <span data-testid={`source-type-${catalogSourceConfig.id}`}>
             {CATALOG_SOURCE_TYPE_LABELS[catalogSourceConfig.type]}
           </span>
         </Td>
-        <Td dataLabel="Enable">
+        <Td dataLabel="Enable" style={{ verticalAlign: 'middle' }}>
           <Switch
             data-testid={`enable-toggle-${catalogSourceConfig.id}`}
             id={`enable-toggle-${catalogSourceConfig.id}`}
@@ -122,10 +122,10 @@ const CatalogSourceConfigsTableRow: React.FC<CatalogSourceConfigsTableRowProps> 
             onChange={(_event, checked) => handleEnableToggle(checked)}
           />
         </Td>
-        <Td dataLabel="Validation status">
+        <Td dataLabel="Validation status" style={{ verticalAlign: 'middle' }}>
           <CatalogSourceStatus catalogSourceConfig={catalogSourceConfig} />
         </Td>
-        <Td dataLabel="Actions">
+        <Td dataLabel="Actions" style={{ verticalAlign: 'middle' }}>
           <Button
             variant="link"
             onClick={handleManageSource}
@@ -134,7 +134,7 @@ const CatalogSourceConfigsTableRow: React.FC<CatalogSourceConfigsTableRowProps> 
             Manage source
           </Button>
         </Td>
-        <Td isActionCell>
+        <Td isActionCell style={{ verticalAlign: 'middle' }}>
           {!isDefault && (
             <ActionsColumn
               items={[

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistriesTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistriesTableRow.tsx
@@ -32,7 +32,7 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
 
   return (
     <Tr>
-      <Td dataLabel="Model registry name">
+      <Td dataLabel="Model registry name" style={{ verticalAlign: 'middle' }}>
         <ResourceNameTooltip resource={mr}>
           <strong>
             {mr.metadata.annotations?.['openshift.io/display-name'] || mr.metadata.name}
@@ -42,10 +42,10 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
           <p>{mr.metadata.annotations['openshift.io/description']}</p>
         )}
       </Td>
-      <Td dataLabel="Status">
+      <Td dataLabel="Status" style={{ verticalAlign: 'middle' }}>
         <ModelRegistryTableRowStatus conditions={mr.status?.conditions} />
       </Td>
-      <Td modifier="fitContent">
+      <Td modifier="fitContent" style={{ verticalAlign: 'middle' }}>
         {filteredRoleBindings.length === 0 ? (
           <Tooltip content="You can manage permissions when the model registry becomes available.">
             <Button isAriaDisabled variant="link">
@@ -61,7 +61,7 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
           </Button>
         )}
       </Td>
-      <Td isActionCell>
+      <Td isActionCell style={{ verticalAlign: 'middle' }}>
         <ActionsColumn
           items={[
             {


### PR DESCRIPTION
## Summary
- Fix vertical alignment of table cell content in Model Registry Settings and Model Catalog Sources Settings pages
- All `<Td>` cells now use `verticalAlign: 'middle'` so content is consistently centered within rows

more information
Fix #2415 

Before:
<img width="561" height="506" alt="Screenshot From 2026-03-17 10-09-13" src="https://github.com/user-attachments/assets/53724546-1c0f-4e26-9bc2-6db6884d1e2a" />
<img width="876" height="552" alt="Screenshot From 2026-03-17 09-32-14" src="https://github.com/user-attachments/assets/615d66b7-24a0-4c11-8be0-562482a9d250" />
<img width="2208" height="400" alt="Screenshot From 2026-03-17 09-28-09" src="https://github.com/user-attachments/assets/ed36f6f4-91f6-49c3-9d5c-6489eda37868" />


After:
<img width="2202" height="513" alt="Screenshot From 2026-03-17 10-18-51" src="https://github.com/user-attachments/assets/6017b50e-f6a3-4ee2-b11e-18174ea5585a" />
<img width="2202" height="344" alt="Screenshot From 2026-03-17 10-18-37" src="https://github.com/user-attachments/assets/5faf1392-f63e-44ca-9327-a45d05e97e51" />

