### PR TITLE
fix(tsconfig): include ES2022.Object lib to support Object.hasOwn

### DIFF
--- a/clients/ui/frontend/tsconfig.json
+++ b/clients/ui/frontend/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": [
       "es2021",
       "dom",
+      "ES2022.Object",
       "ES2023.Array"
     ],
     "sourceMap": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The Module Federation DTS plugin fails to generate type declarations because `Object.hasOwn()` (used in `ModelCatalogStringFilter.tsx`) is an ES2022 API, but the `tsconfig.json` `lib` only includes `es2021`.

This adds "ES2022.Object" to the `lib` array, following the existing pattern of cherry-picking specific ES features (like ES2023.Array already present).

Error in midstream screenshot(before):
<img width="1310" height="352" alt="Screenshot 2026-03-17 at 3 18 55 PM" src="https://github.com/user-attachments/assets/469f7358-c125-4b70-85dd-e6dbf783ae36" />

After:
<img width="1310" height="158" alt="Screenshot 2026-03-17 at 3 27 28 PM" src="https://github.com/user-attachments/assets/4126b55a-ee8c-4f35-bd3a-c41582282c73" />


### Why this only surfaces in federated mode
The bundler transpiles TypeScript without type-checking, so mock/standalone mode works fine. The Module Federation DTS plugin explicitly runs `tsc` to generate `.d.ts` files for remote type consumption — that's the only code path that triggers the error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested midstream by checking the terminal


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
