### PR TITLE
fix(proxy): replace panic with graceful error handling in getRepo

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -201,21 +201,78 @@ func newModelRegistryService(ds datastore.Connector) (api.ModelRegistryApi, erro
 		return nil, err
 	}
 
+	artifactRepo, err := getRepo[models.ArtifactRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	modelArtifactRepo, err := getRepo[models.ModelArtifactRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	docArtifactRepo, err := getRepo[models.DocArtifactRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	registeredModelRepo, err := getRepo[models.RegisteredModelRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	modelVersionRepo, err := getRepo[models.ModelVersionRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	servingEnvRepo, err := getRepo[models.ServingEnvironmentRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	inferenceServiceRepo, err := getRepo[models.InferenceServiceRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	serveModelRepo, err := getRepo[models.ServeModelRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	experimentRepo, err := getRepo[models.ExperimentRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	experimentRunRepo, err := getRepo[models.ExperimentRunRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	dataSetRepo, err := getRepo[models.DataSetRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	metricRepo, err := getRepo[models.MetricRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	parameterRepo, err := getRepo[models.ParameterRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+	metricHistoryRepo, err := getRepo[models.MetricHistoryRepository](repoSet)
+	if err != nil {
+		return nil, err
+	}
+
 	modelRegistryService := core.NewModelRegistryService(
-		getRepo[models.ArtifactRepository](repoSet),
-		getRepo[models.ModelArtifactRepository](repoSet),
-		getRepo[models.DocArtifactRepository](repoSet),
-		getRepo[models.RegisteredModelRepository](repoSet),
-		getRepo[models.ModelVersionRepository](repoSet),
-		getRepo[models.ServingEnvironmentRepository](repoSet),
-		getRepo[models.InferenceServiceRepository](repoSet),
-		getRepo[models.ServeModelRepository](repoSet),
-		getRepo[models.ExperimentRepository](repoSet),
-		getRepo[models.ExperimentRunRepository](repoSet),
-		getRepo[models.DataSetRepository](repoSet),
-		getRepo[models.MetricRepository](repoSet),
-		getRepo[models.ParameterRepository](repoSet),
-		getRepo[models.MetricHistoryRepository](repoSet),
+		artifactRepo,
+		modelArtifactRepo,
+		docArtifactRepo,
+		registeredModelRepo,
+		modelVersionRepo,
+		servingEnvRepo,
+		inferenceServiceRepo,
+		serveModelRepo,
+		experimentRepo,
+		experimentRunRepo,
+		dataSetRepo,
+		metricRepo,
+		parameterRepo,
+		metricHistoryRepo,
 		repoSet.TypeMap(),
 	)
 
@@ -224,13 +281,14 @@ func newModelRegistryService(ds datastore.Connector) (api.ModelRegistryApi, erro
 	return modelRegistryService, nil
 }
 
-func getRepo[T any](repoSet datastore.RepoSet) T {
+func getRepo[T any](repoSet datastore.RepoSet) (T, error) {
 	repo, err := repoSet.Repository(reflect.TypeFor[T]())
 	if err != nil {
-		panic(fmt.Sprintf("unable to get repository: %v", err))
+		var zero T
+		return zero, fmt.Errorf("unable to get repository: %w", err)
 	}
 
-	return repo.(T)
+	return repo.(T), nil
 }
 
 func init() {


### PR DESCRIPTION
This PR addresses a reliability issue in cmd/proxy.go where `getRepo` would `panic` if it failed to retrieve a repository from the `repoSet`. Panicking on expected configuration or connection errors can cause the entire proxy server process to crash abruptly in production, leaving little room for graceful degradation or clear logging of the root cause up the initialization chain.

## Changes Made

### 1. Refactored `getRepo` signature
- Before: `func getRepo[T any](repoSet datastore.RepoSet) T`
- After:  `func getRepo[T any](repoSet datastore.RepoSet) (T, error)`

### 2. Error handling instead of panic
- Before:
```go
  panic(fmt.Sprintf("unable to get repository: %v", err))
```
- After:
```go
  var zero T
  return zero, fmt.Errorf("unable to get repository: %w", err)
```

### 3. Return value updated
- Before: `return repo.(T)`
- After:  `return repo.(T), nil`

### 4. Refactored `newModelRegistryService` — eager repo resolution with error checks
Previously, all 14 `getRepo` calls were passed inline as arguments directly into `core.NewModelRegistryService(...)`, meaning any failure would panic
mid-call with no recovery path:
```go
  // Before — all 14 repos resolved inline, panic on any failure
  modelRegistryService := core.NewModelRegistryService(
      getRepo[models.ArtifactRepository](repoSet),
      getRepo[models.ModelArtifactRepository](repoSet),
      getRepo[models.DocArtifactRepository](repoSet),
      getRepo[models.RegisteredModelRepository](repoSet),
      getRepo[models.ModelVersionRepository](repoSet),
      getRepo[models.ServingEnvironmentRepository](repoSet),
      getRepo[models.InferenceServiceRepository](repoSet),
      getRepo[models.ServeModelRepository](repoSet),
      getRepo[models.ExperimentRepository](repoSet),
      getRepo[models.ExperimentRunRepository](repoSet),
      getRepo[models.DataSetRepository](repoSet),
      getRepo[models.MetricRepository](repoSet),
      getRepo[models.ParameterRepository](repoSet),
      getRepo[models.MetricHistoryRepository](repoSet),
      repoSet.TypeMap(),
  )
```

Now each repository is resolved individually with an immediate error check. `core.NewModelRegistryService` is only called once all 14 repos are confirmed
healthy:
```go
  // After — each repo resolved and checked before proceeding
  dataSetRepo, err := getRepo[models.DataSetRepository](repoSet)
  if err != nil {
      return nil, err
  }
  metricRepo, err := getRepo[models.MetricRepository](repoSet)
  if err != nil {
      return nil, err
  }
  parameterRepo, err := getRepo[models.ParameterRepository](repoSet)
  if err != nil {
      return nil, err
  }
  metricHistoryRepo, err := getRepo[models.MetricHistoryRepository](repoSet)
  if err != nil {
      return nil, err
  }
  // ... (same pattern for all 14 repos)

  modelRegistryService := core.NewModelRegistryService(
      artifactRepo,
      modelArtifactRepo,
      docArtifactRepo,
      registeredModelRepo,
      modelVersionRepo,
      servingEnvRepo,
      inferenceServiceRepo,
      serveModelRepo,
      experimentRepo,
      experimentRunRepo,
      dataSetRepo,
      metricRepo,
      parameterRepo,
      metricHistoryRepo,
      repoSet.TypeMap(),
  )
```

## Why This Matters
- Any datastore connection or configuration problem now surfaces as a clean, returnable error instead of a process-killing panic.
- Errors are wrapped with `%w`, making them inspectable via `errors.Is` / `errors.As` up the call stack.
- The service is only constructed when all dependencies are confirmed available, preventing partial initialization states.