### PR TITLE
Fix catalog registration form microcopy when storage toggle is hidden

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/RegistrationCommonFormSections.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/RegistrationCommonFormSections.tsx
@@ -71,6 +71,8 @@ const RegistrationCommonFormSections = <D extends RegistrationCommonFormData>({
     }
   }, [registrationMode, setData, isCatalogOciSource]);
 
+  const isRegistryStorageAvailable = !isCatalogOciSource;
+
   const versionNameInput = (
     <TextInput
       isRequired
@@ -157,16 +159,20 @@ const RegistrationCommonFormSections = <D extends RegistrationCommonFormData>({
         </FormGroup>
       </FormSection>
       <FormSection
-        title="Model location and storage"
+        title={isRegistryStorageAvailable ? 'Model location and storage' : 'Model location'}
         description={
-          <>
-            Choose <strong>Register</strong> to use the model&apos;s original storage location for
-            artifact storage, or <strong>Register and store</strong> to specify a different artifact
-            storage location.
-          </>
+          isRegistryStorageAvailable ? (
+            <>
+              Choose <strong>Register</strong> to use the model&apos;s original storage location for
+              artifact storage, or <strong>Register and store</strong> to specify a different
+              artifact storage location.
+            </>
+          ) : (
+            'Specify the model location by providing either the object storage details or the URI.'
+          )
         }
       >
-        {!isCatalogOciSource && (
+        {isRegistryStorageAvailable && (
           <ToggleGroup
             aria-label="Registration mode"
             className={spacing.mtMd}


### PR DESCRIPTION
## Description
When registering a catalog model with an OCI source URI, the "Register and store" toggle is correctly hidden (since OCI-to-OCI storage transfer doesn't apply). However, the section title still says "Model location and storage" and the description still references the "Register and store" option, which is confusing.

This PR conditionally updates the "Model location and storage" `FormSection` when the storage toggle is hidden:
- **Title**: "Model location" instead of "Model location and storage"
- **Description**: "Specify the model location by providing either the object storage details or the URI." instead of the text referencing "Register" / "Register and store"

Introduces an `isRegistryStorageAvailable` boolean (inverse of `isCatalogOciSource`) for readability.

## How Has This Been Tested?
- Manual testing: verified the form renders correctly for both OCI catalog models (no toggle, updated microcopy) and non-OCI models (toggle present, original microcopy)
- Existing lint passes clean

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)