### PR TITLE
fix(bff): include SA groups in namespace registry access SubjectAccessReview

### DIFF
--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -577,9 +577,9 @@ func createNamespaceDefaultSARegistryAccessRBAC(k8sClient kubernetes.Interface, 
 		},
 		Subjects: []rbacv1.Subject{
 			{
-				Kind:      "ServiceAccount",
-				Name:      "default",
-				Namespace: namespace,
+				Kind:     "Group",
+				Name:     "system:serviceaccounts:" + namespace,
+				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -604,9 +604,9 @@ func createCrossNamespaceRegistryAccessBinding(k8sClient kubernetes.Interface, c
 		},
 		Subjects: []rbacv1.Subject{
 			{
-				Kind:      "ServiceAccount",
-				Name:      "default",
-				Namespace: jobNamespace,
+				Kind:     "Group",
+				Name:     "system:serviceaccounts:" + jobNamespace,
+				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/clients/ui/bff/internal/integrations/kubernetes/namespace_registry_access.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/namespace_registry_access.go
@@ -24,6 +24,11 @@ func CanNamespaceAccessRegistry(
 	sar := &authv1.SubjectAccessReview{
 		Spec: authv1.SubjectAccessReviewSpec{
 			User: saSubject,
+			Groups: []string{
+				"system:serviceaccounts",
+				"system:serviceaccounts:" + jobNamespace,
+				"system:authenticated",
+			},
 			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:      "get",
 				Resource:  "services",


### PR DESCRIPTION
## Description

The `CanNamespaceAccessRegistry` function creates a `SubjectAccessReview` (SAR) to check if a namespace's default ServiceAccount can access a model registry service. The SAR only set the `User` field but not `Groups`, which meant group-based RoleBindings (e.g. for `system:serviceaccounts:{namespace}`) were never matched by the RBAC authorizer.

This caused the "register and store" form to always show "namespace does not have access" even after granting access via the settings page, because the settings page creates RoleBindings with Group subjects (`system:serviceaccounts:{namespace}`) rather than direct ServiceAccount subjects.

The fix adds the service account's standard groups (`system:serviceaccounts`, `system:serviceaccounts:{namespace}`, `system:authenticated`) to the SAR spec so the RBAC authorizer evaluates both direct-user and group-based RoleBindings.

Also updates the test RBAC setup to use Group-based RoleBinding subjects (matching what the settings page creates) so the tests properly validate this behavior.

## How Has This Been Tested?

- Verified on a live cluster by creating raw SubjectAccessReviews:
  - Without groups → `allowed: false`
  - With groups → `allowed: true` (matched by the Group-based RoleBinding created by the settings page)
- All 31 existing Kubernetes integration tests pass with the updated test fixtures.
- The test fixtures were updated to use Group subjects instead of direct ServiceAccount subjects, matching the real-world behavior.
- Also created a temporary sync PR to test in ODH: https://github.com/opendatahub-io/odh-dashboard/pull/6742

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)