### PR TITLE
fix(bff): show pod termination message for already-failed transfer jobs

### DIFF
--- a/clients/ui/bff/internal/repositories/model_transfer_jobs.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs.go
@@ -152,12 +152,12 @@ func (m *ModelRegistryRepository) GetAllModelTransferJobs(ctx context.Context, c
 		for i := range transferJobs {
 			key := transferJobs[i].Namespace + "/" + transferJobs[i].Name
 			if errMsg, ok := podErrorsByJob[key]; ok {
+				if transferJobs[i].ErrorMessage == "" {
+					transferJobs[i].ErrorMessage = errMsg
+				}
 				if transferJobs[i].Status == models.ModelTransferJobStatusRunning ||
 					transferJobs[i].Status == models.ModelTransferJobStatusPending {
 					transferJobs[i].Status = models.ModelTransferJobStatusFailed
-					if transferJobs[i].ErrorMessage == "" {
-						transferJobs[i].ErrorMessage = errMsg
-					}
 				}
 			}
 			if result, ok := podTerminationByJob[key]; ok {

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
@@ -282,6 +282,91 @@ func TestGetAllModelTransferJobs_TerminatedNonZeroExitCodeOverridesStatusAndMess
 	}
 }
 
+func TestGetAllModelTransferJobs_AlreadyFailedJobGetsTerminationMessage(t *testing.T) {
+	repo := NewModelRegistryRepository()
+
+	jobStatus := batchv1.JobStatus{
+		Failed: 1, // K8s Job controller already marked it failed
+	}
+	containerState := corev1.ContainerState{
+		Terminated: &corev1.ContainerStateTerminated{
+			ExitCode: 1,
+			Message:  "terminated due to error",
+			Reason:   "Error",
+		},
+	}
+
+	client := buildSingleJobFixture("job-already-failed", jobStatus, containerState)
+
+	jobModel := mustGetSingleJob(t, repo, client, "kubeflow", "model-registry-id")
+	if jobModel.Status != models.ModelTransferJobStatusFailed {
+		t.Fatalf("expected job status Failed, got %s", jobModel.Status)
+	}
+	expectedPrefix := "Container exited with code 1:"
+	if jobModel.ErrorMessage == "" || jobModel.ErrorMessage[:len(expectedPrefix)] != expectedPrefix {
+		t.Fatalf("expected error message to start with %q, got %q", expectedPrefix, jobModel.ErrorMessage)
+	}
+}
+
+func TestGetAllModelTransferJobs_AlreadyFailedJobPrefersTerminationOverEmptyCondition(t *testing.T) {
+	repo := NewModelRegistryRepository()
+
+	job := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "job-failed-empty-condition",
+			Namespace: "kubeflow",
+		},
+		Status: batchv1.JobStatus{
+			Failed: 1,
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:   batchv1.JobFailed,
+					Status: corev1.ConditionTrue,
+					// Message intentionally empty — common real-world case
+				},
+			},
+		},
+	}
+
+	jobs := &batchv1.JobList{Items: []batchv1.Job{job}}
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "job-failed-empty-condition-pod",
+			Namespace: "kubeflow",
+			Labels:    map[string]string{"job-name": job.Name},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Message:  "specific error from container",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := &fakeKubernetesClient{
+		jobs: jobs,
+		podsByNamespace: map[string]*corev1.PodList{
+			"kubeflow": {Items: []corev1.Pod{pod}},
+		},
+	}
+
+	jobModel := mustGetSingleJob(t, repo, client, "kubeflow", "model-registry-id")
+	if jobModel.Status != models.ModelTransferJobStatusFailed {
+		t.Fatalf("expected job status Failed, got %s", jobModel.Status)
+	}
+	expectedPrefix := "Container exited with code 1:"
+	if jobModel.ErrorMessage == "" || jobModel.ErrorMessage[:len(expectedPrefix)] != expectedPrefix {
+		t.Fatalf("expected error message from pod termination, got %q", jobModel.ErrorMessage)
+	}
+}
+
 func TestGetAllModelTransferJobs_TerminationMessageParsesIDs(t *testing.T) {
 	repo := NewModelRegistryRepository()
 


### PR DESCRIPTION
## Description

When a model transfer job fails and the Kubernetes Job controller has already marked it as `Failed` (via `job.Status.Failed > 0`), the pod termination message was not being used to populate the `errorMessage` field. This caused the UI to show "Failure reason (unknown)" instead of the actual error (e.g. AWS credential failures).

**Root cause:** The error message enrichment from pod container statuses was nested inside a status guard that only applied to `Running` or `Pending` jobs. When the job was already `Failed`, the entire block was skipped — including the `errorMessage` assignment.

**Fix:** Decouple the error message enrichment from the status override. The `errorMessage` is now always populated from the pod termination message when it's empty, regardless of the job's current status. The status override to `Failed` still only applies to `Running`/`Pending` jobs.

## How Has This Been Tested?

Two new unit tests added that **fail without the fix** and **pass with it**:

1. `TestGetAllModelTransferJobs_AlreadyFailedJobGetsTerminationMessage` — job with `Failed: 1` + terminated pod with exit code 1 → verifies `errorMessage` is populated from pod termination
2. `TestGetAllModelTransferJobs_AlreadyFailedJobPrefersTerminationOverEmptyCondition` — job with `Failed: 1` and an empty `JobFailed` condition + terminated pod → verifies pod termination message is used when the job condition message is empty

All existing tests continue to pass.

```
go test ./internal/repositories/ -run TestGetAllModelTransferJobs -v
```

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.