### PR TITLE
fix(catalog): implement sourceLabel filtering for MCP catalog endpoint

### DIFF
--- a/catalog/cmd/catalog.go
+++ b/catalog/cmd/catalog.go
@@ -192,7 +192,7 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 	mcpProvider := catalog.NewDBMCPCatalog(services, mcpSources, func(name string) (map[string]catalog.FieldFilter, bool) {
 		return mcpSources.GetNamedQuery(name)
 	})
-	mcpSvc := openapi.NewMCPCatalogServiceAPIService(mcpProvider)
+	mcpSvc := openapi.NewMCPCatalogServiceAPIService(mcpProvider, mcpSources)
 	mcpCtrl := openapi.NewMCPCatalogServiceAPIController(mcpSvc)
 
 	server := &http.Server{

--- a/catalog/internal/catalog/mcpcatalog/api.go
+++ b/catalog/internal/catalog/mcpcatalog/api.go
@@ -8,6 +8,7 @@ import (
 
 type ListMCPServersParams struct {
 	Name, Query, FilterQuery, NamedQuery string
+	SourceIDs                            []string
 	IncludeTools                         bool
 	ToolLimit                            int32
 	PageSize                             int32

--- a/catalog/internal/catalog/mcpcatalog/db_mcp.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp.go
@@ -99,6 +99,10 @@ func (d *dbMCPCatalogImpl) ListMCPServers(ctx context.Context, params ListMCPSer
 		listOptions.Name = &params.Name
 	}
 
+	if len(params.SourceIDs) > 0 {
+		listOptions.SourceIDs = &params.SourceIDs
+	}
+
 	// Set pagination
 	orderBy := strings.ToUpper(string(params.OrderBy))
 	sortOrder := strings.ToUpper(string(params.SortOrder))

--- a/catalog/internal/catalog/mcpcatalog/sources.go
+++ b/catalog/internal/catalog/mcpcatalog/sources.go
@@ -2,6 +2,8 @@ package mcpcatalog
 
 import (
 	"maps"
+	"slices"
+	"strings"
 	"sync"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
@@ -215,4 +217,47 @@ func (msc *MCPSourceCollection) AllSources() map[string]basecatalog.MCPSource {
 	defer msc.mu.RUnlock()
 
 	return msc.merged()
+}
+
+// ByLabel returns enabled sources that have any of the labels provided. The matching
+// is case insensitive.
+//
+// If a label is "null", every source without a label is returned.
+func (msc *MCPSourceCollection) ByLabel(labels []string) []basecatalog.MCPSource {
+	msc.mu.RLock()
+	defer msc.mu.RUnlock()
+
+	labelMap := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		labelMap[strings.ToLower(label)] = struct{}{}
+	}
+
+	matches := map[string]basecatalog.MCPSource{}
+	sources := msc.merged()
+
+	if _, hasNull := labelMap["null"]; hasNull {
+		for _, source := range sources {
+			if source.Enabled == nil || !*source.Enabled {
+				continue
+			}
+			if len(source.Labels) == 0 {
+				matches[source.ID] = source
+			}
+		}
+	}
+
+OUTER:
+	for _, source := range sources {
+		if source.Enabled == nil || !*source.Enabled {
+			continue
+		}
+		for _, label := range source.Labels {
+			if _, match := labelMap[strings.ToLower(label)]; match {
+				matches[source.ID] = source
+				continue OUTER
+			}
+		}
+	}
+
+	return slices.Collect(maps.Values(matches))
 }

--- a/catalog/internal/catalog/mcpcatalog/sources_test.go
+++ b/catalog/internal/catalog/mcpcatalog/sources_test.go
@@ -862,6 +862,84 @@ func TestMCPSourceCollection_GetNamedQuery_SliceDeepCopy(t *testing.T) {
 	assert.Equal(t, "active", filters2["status"].Value.([]any)[0])
 }
 
+func TestMCPSourceCollection_ByLabel(t *testing.T) {
+	makeCollection := func(sources map[string]basecatalog.MCPSource) *MCPSourceCollection {
+		coll := NewMCPSourceCollection()
+		_ = coll.Merge("test", sources)
+		return coll
+	}
+
+	t.Run("returns source with matching label", func(t *testing.T) {
+		coll := makeCollection(map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Labels: []string{"openai"}, Enabled: apiutils.Of(true)},
+			"src2": {ID: "src2", Labels: []string{"github"}, Enabled: apiutils.Of(true)},
+		})
+
+		result := coll.ByLabel([]string{"openai"})
+		require.Len(t, result, 1)
+		assert.Equal(t, "src1", result[0].ID)
+	})
+
+	t.Run("returns multiple sources matching any label (OR semantics)", func(t *testing.T) {
+		coll := makeCollection(map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Labels: []string{"openai"}, Enabled: apiutils.Of(true)},
+			"src2": {ID: "src2", Labels: []string{"github"}, Enabled: apiutils.Of(true)},
+			"src3": {ID: "src3", Labels: []string{"other"}, Enabled: apiutils.Of(true)},
+		})
+
+		result := coll.ByLabel([]string{"openai", "github"})
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("matching is case insensitive", func(t *testing.T) {
+		coll := makeCollection(map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Labels: []string{"OpenAI"}, Enabled: apiutils.Of(true)},
+		})
+
+		result := coll.ByLabel([]string{"openai"})
+		require.Len(t, result, 1)
+		assert.Equal(t, "src1", result[0].ID)
+	})
+
+	t.Run("skips disabled sources", func(t *testing.T) {
+		coll := makeCollection(map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Labels: []string{"openai"}, Enabled: apiutils.Of(false)},
+		})
+
+		result := coll.ByLabel([]string{"openai"})
+		assert.Empty(t, result)
+	})
+
+	t.Run("null label matches sources with no labels", func(t *testing.T) {
+		coll := makeCollection(map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Labels: []string{}, Enabled: apiutils.Of(true)},
+			"src2": {ID: "src2", Labels: []string{"openai"}, Enabled: apiutils.Of(true)},
+		})
+
+		result := coll.ByLabel([]string{"null"})
+		require.Len(t, result, 1)
+		assert.Equal(t, "src1", result[0].ID)
+	})
+
+	t.Run("non-matching label returns empty slice", func(t *testing.T) {
+		coll := makeCollection(map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Labels: []string{"openai"}, Enabled: apiutils.Of(true)},
+		})
+
+		result := coll.ByLabel([]string{"no-match"})
+		assert.Empty(t, result)
+	})
+
+	t.Run("deduplicates by source ID", func(t *testing.T) {
+		coll := makeCollection(map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Labels: []string{"openai", "ai"}, Enabled: apiutils.Of(true)},
+		})
+
+		result := coll.ByLabel([]string{"openai", "ai"})
+		assert.Len(t, result, 1)
+	})
+}
+
 func TestMCPSourceCollection_Merge_WithoutNamedQueries(t *testing.T) {
 	// Verify the regular Merge path still works after refactoring.
 	coll := NewMCPSourceCollection()

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
@@ -13,14 +13,16 @@ import (
 // MCPCatalogServiceAPIService is a service that implements the logic for the MCPCatalogServiceAPIServicer
 type MCPCatalogServiceAPIService struct {
 	mcpProvider catalog.MCPProvider
+	mcpSources  *catalog.MCPSourceCollection
 }
 
 var _ MCPCatalogServiceAPIServicer = &MCPCatalogServiceAPIService{}
 
 // NewMCPCatalogServiceAPIService creates a default api service
-func NewMCPCatalogServiceAPIService(mcpProvider catalog.MCPProvider) MCPCatalogServiceAPIServicer {
+func NewMCPCatalogServiceAPIService(mcpProvider catalog.MCPProvider, mcpSources *catalog.MCPSourceCollection) MCPCatalogServiceAPIServicer {
 	return &MCPCatalogServiceAPIService{
 		mcpProvider: mcpProvider,
+		mcpSources:  mcpSources,
 	}
 }
 
@@ -31,10 +33,32 @@ func (m *MCPCatalogServiceAPIService) FindMCPServers(ctx context.Context, name s
 		return ErrorResponse(http.StatusBadRequest, err), err
 	}
 
+	// Clean up empty sourceLabel values
+	if len(sourceLabel) == 1 && sourceLabel[0] == "" {
+		sourceLabel = nil
+	}
+
+	// Convert sourceLabels to sourceIDs
+	var sourceIDs []string
+	if len(sourceLabel) > 0 && m.mcpSources != nil {
+		sources := m.mcpSources.ByLabel(sourceLabel)
+		if len(sources) == 0 {
+			return Response(http.StatusOK, model.MCPServerList{
+				Items:    []model.MCPServer{},
+				PageSize: pageSizeInt,
+			}), nil
+		}
+		sourceIDs = make([]string, len(sources))
+		for i, source := range sources {
+			sourceIDs[i] = source.ID
+		}
+	}
+
 	// Convert parameters to internal format
 	params := catalog.ListMCPServersParams{
 		Name:          name,
 		Query:         q,
+		SourceIDs:     sourceIDs,
 		FilterQuery:   filterQuery,
 		NamedQuery:    namedQuery,
 		IncludeTools:  includeTools,

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
@@ -9,7 +9,10 @@ import (
 	"time"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog"
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/basecatalog"
+	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog"
 	model "github.com/kubeflow/model-registry/catalog/pkg/openapi"
+	"github.com/kubeflow/model-registry/internal/apiutils"
 	"github.com/kubeflow/model-registry/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +33,8 @@ type mockMCPProvider struct {
 	namedQueryErr map[string]error
 	// filterOptions is returned by GetFilterOptions.
 	filterOptions *model.FilterOptionsList
+	// capturedParams captures the last params passed to ListMCPServers.
+	capturedParams *catalog.ListMCPServersParams
 }
 
 func newMockMCPProvider() *mockMCPProvider {
@@ -56,6 +61,7 @@ func (m *mockMCPProvider) addTool(serverID string, toolName string, tool *model.
 }
 
 func (m *mockMCPProvider) ListMCPServers(ctx context.Context, params catalog.ListMCPServersParams) (model.MCPServerList, error) {
+	m.capturedParams = &params
 	if m.shouldErrorOnListServers {
 		return model.MCPServerList{}, fmt.Errorf("mock error in ListMCPServers")
 	}
@@ -396,7 +402,7 @@ func TestFindMCPServers(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider)
+			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
 			result, err := service.FindMCPServers(
@@ -509,7 +515,7 @@ func TestGetMCPServer(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider)
+			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
 			result, err := service.GetMCPServer(ctx, tc.serverID, tc.includeTools)
@@ -632,7 +638,7 @@ func TestFindMCPServerTools(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider)
+			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
 			result, err := service.FindMCPServerTools(
@@ -726,7 +732,7 @@ func TestGetMCPServerTool(t *testing.T) {
 			mockProvider := newMockMCPProvider()
 			tc.mockSetup(mockProvider)
 
-			service := NewMCPCatalogServiceAPIService(mockProvider)
+			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
 			result, err := service.GetMCPServerTool(ctx, tc.serverID, tc.toolName)
@@ -754,7 +760,7 @@ func TestFindMCPServersFilterOptions(t *testing.T) {
 
 	t.Run("provider returns empty FilterOptionsList", func(t *testing.T) {
 		provider := newMockMCPProvider()
-		service := NewMCPCatalogServiceAPIService(provider)
+		service := NewMCPCatalogServiceAPIService(provider, nil)
 		result, err := service.FindMCPServersFilterOptions(ctx)
 
 		assert.NoError(t, err)
@@ -780,7 +786,7 @@ func TestFindMCPServersFilterOptions(t *testing.T) {
 			Filters:      &filters,
 		}
 
-		service := NewMCPCatalogServiceAPIService(provider)
+		service := NewMCPCatalogServiceAPIService(provider, nil)
 		result, err := service.FindMCPServersFilterOptions(ctx)
 
 		assert.NoError(t, err)
@@ -799,10 +805,89 @@ func TestFindMCPServersFilterOptions(t *testing.T) {
 		provider := newMockMCPProvider()
 		provider.shouldErrorOnGetFilterOptions = true
 
-		service := NewMCPCatalogServiceAPIService(provider)
+		service := NewMCPCatalogServiceAPIService(provider, nil)
 		result, err := service.FindMCPServersFilterOptions(ctx)
 
 		assert.Error(t, err)
 		assert.Equal(t, http.StatusInternalServerError, result.Code)
+	})
+}
+
+func makeMCPSources(sources map[string]basecatalog.MCPSource) *catalog.MCPSourceCollection {
+	coll := mcpcatalog.NewMCPSourceCollection()
+	_ = coll.Merge("test", sources)
+	return coll
+}
+
+func TestFindMCPServers_SourceLabel(t *testing.T) {
+	openAIServer := &model.MCPServer{
+		Name:     "openai-assistant",
+		Provider: stringPointer("OpenAI"),
+	}
+
+	t.Run("matching label passes source ID to provider", func(t *testing.T) {
+		mcpSources := makeMCPSources(map[string]basecatalog.MCPSource{
+			"src-openai": {ID: "src-openai", Labels: []string{"openai"}, Enabled: apiutils.Of(true)},
+		})
+
+		mockProvider := newMockMCPProvider()
+		mockProvider.addServer("src-openai", openAIServer)
+
+		service := NewMCPCatalogServiceAPIService(mockProvider, mcpSources)
+		result, err := service.FindMCPServers(context.Background(), "", "", []string{"openai"}, "", "", false, 0, "10", model.ORDERBYFIELD_NAME, model.SORTORDER_ASC, "")
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, result.Code)
+		require.NotNil(t, mockProvider.capturedParams)
+		assert.Equal(t, []string{"src-openai"}, mockProvider.capturedParams.SourceIDs)
+	})
+
+	t.Run("non-matching label returns empty list without calling provider", func(t *testing.T) {
+		mcpSources := makeMCPSources(map[string]basecatalog.MCPSource{
+			"src-openai": {ID: "src-openai", Labels: []string{"openai"}, Enabled: apiutils.Of(true)},
+		})
+
+		mockProvider := newMockMCPProvider()
+		mockProvider.addServer("src-openai", openAIServer)
+
+		service := NewMCPCatalogServiceAPIService(mockProvider, mcpSources)
+		result, err := service.FindMCPServers(context.Background(), "", "", []string{"no-match"}, "", "", false, 0, "10", model.ORDERBYFIELD_NAME, model.SORTORDER_ASC, "")
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, result.Code)
+		serverList, ok := result.Body.(model.MCPServerList)
+		require.True(t, ok)
+		assert.Empty(t, serverList.Items)
+		assert.Nil(t, mockProvider.capturedParams)
+	})
+
+	t.Run("empty sourceLabel string is treated as no filter", func(t *testing.T) {
+		mcpSources := makeMCPSources(map[string]basecatalog.MCPSource{
+			"src-openai": {ID: "src-openai", Labels: []string{"openai"}, Enabled: apiutils.Of(true)},
+		})
+
+		mockProvider := newMockMCPProvider()
+		mockProvider.addServer("1", openAIServer)
+
+		service := NewMCPCatalogServiceAPIService(mockProvider, mcpSources)
+		result, err := service.FindMCPServers(context.Background(), "", "", []string{""}, "", "", false, 0, "10", model.ORDERBYFIELD_NAME, model.SORTORDER_ASC, "")
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, result.Code)
+		serverList, ok := result.Body.(model.MCPServerList)
+		require.True(t, ok)
+		// No filter applied, provider returns all servers
+		assert.Equal(t, int32(1), serverList.Size)
+	})
+
+	t.Run("nil mcpSources ignores sourceLabel", func(t *testing.T) {
+		mockProvider := newMockMCPProvider()
+		mockProvider.addServer("1", openAIServer)
+
+		service := NewMCPCatalogServiceAPIService(mockProvider, nil)
+		result, err := service.FindMCPServers(context.Background(), "", "", []string{"openai"}, "", "", false, 0, "10", model.ORDERBYFIELD_NAME, model.SORTORDER_ASC, "")
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, result.Code)
 	})
 }


### PR DESCRIPTION
## Description

The MCP catalog endpoint accepted sourceLabel but ignored it, returning all servers regardless of source.

## How Has This Been Tested?
On a local kind cluster with the demo MCP servers loaded.

Returns results from matching sources:
```
$ curl -s 'http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers?sourceLabel=Organization+MCP' | jq '.items[].name'
"github-mcp"
"aws-mcp"
"dynatrace-mcp"
"slack-mcp"
"jira-mcp"
```

Returns results from unlabeled sources when `sourceLabel` is `null`:
```
$ curl -s 'http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers?sourceLabel=null' | jq '.items[].name'
"prometheus-mcp"
"kubernetes-mcp"
"openshift-mcp"
"elasticsearch-mcp"
"openai-assistants-mcp"
"anthropic-claude-mcp"
"google-gemini-mcp"
```

Returns everything without a `sourceLabel`
```
 $ curl -s 'http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers?pageSize=15' | jq '.items[].name'
"dynatrace-mcp"
"github-mcp"
"slack-mcp"
"jira-mcp"
"aws-mcp"
"prometheus-mcp"
"kubernetes-mcp"
"openshift-mcp"
"elasticsearch-mcp"
"openai-assistants-mcp"
"anthropic-claude-mcp"
"google-gemini-mcp"
```

Returns nothing when given a `sourceLabel` that matches nothing:

```
$ curl -s 'http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers?sourceLabel=xx' | jq
{
  "items": [],
  "nextPageToken": "",
  "pageSize": 10,
  "size": 0
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
