### PR TITLE
Fix table sort being overridden when latency filter is active

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/useHardwareConfigColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/useHardwareConfigColumns.ts
@@ -131,23 +131,6 @@ export const useHardwareConfigColumns = (
     setSortDirection('asc');
   }, [activeLatencyField, manageColumnsResult, stickyColumns, manageableColumns]);
 
-  // Ensure sort is set correctly when columns are ready (handles initial mount case)
-  React.useEffect(() => {
-    if (!activeLatencyField || columns.length === 0) {
-      return;
-    }
-
-    const parsed = parseLatencyFilterKey(activeLatencyField);
-    const activePropertyKey = parsed.propertyKey;
-
-    // Only update if the column exists and sort isn't already set correctly
-    const columnExists = columns.some((col) => col.field === activePropertyKey);
-    if (columnExists && (sortColumnField !== activePropertyKey || sortDirection !== 'asc')) {
-      setSortColumnField(activePropertyKey);
-      setSortDirection('asc');
-    }
-  }, [activeLatencyField, columns, sortColumnField, sortDirection]);
-
   const sortState = React.useMemo(() => {
     const sortIndex =
       sortColumnField !== null ? columns.findIndex((col) => col.field === sortColumnField) : -1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR removed the effect that re-applied sort whenever sort state changed. Sort is still set when the latency filter changes (existing effect); user-chosen sort and direction are no longer overwritten.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was manually tested 


https://github.com/user-attachments/assets/f59aadff-94ec-4cb6-a6e9-2f1a9e7b6f31



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [X] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [X] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
