### PR TITLE
fix: replace AI-hallucinated MCP server demo data with real entries

### DIFF
--- a/manifests/kustomize/options/catalog/overlays/demo/dev-community-mcp-servers.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-community-mcp-servers.yaml
@@ -1,7 +1,8 @@
+---
 source: Community and custom
 mcp_servers:
   - name: prometheus-mcp
-    provider: Prometheus Community
+    provider: pab1it0
     license: apache-2.0
     license_link: https://www.apache.org/licenses/LICENSE-2.0
     description: >-
@@ -21,12 +22,12 @@ mcp_servers:
       ## Prerequisites
       - Prometheus server access
       - Network connectivity to Prometheus API
-    version: "0.9.2"
+    version: "1.5.1"
     transports:
       - http
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    repositoryUrl: https://github.com/prometheus-community/prometheus-mcp
-    sourceCode: prometheus-community/prometheus-mcp
+    repositoryUrl: https://github.com/pab1it0/prometheus-mcp-server
+    sourceCode: pab1it0/prometheus-mcp-server
     publishedDate: "2025-01-10"
     tools:
       - name: query
@@ -58,7 +59,7 @@ mcp_servers:
         accessType: read_only
         parameters: []
     artifacts:
-      - uri: oci://ghcr.io/prometheus-community/prometheus-mcp:0.9.2
+      - uri: oci://ghcr.io/pab1it0/prometheus-mcp-server:v1.5.1
         createTimeSinceEpoch: "1736510400000"
         lastUpdateTimeSinceEpoch: "1736510400000"
     securityIndicators:
@@ -80,7 +81,7 @@ mcp_servers:
     lastUpdateTimeSinceEpoch: "1736510400000"
 
   - name: kubernetes-mcp
-    provider: CNCF
+    provider: containers
     license: apache-2.0
     license_link: https://www.apache.org/licenses/LICENSE-2.0
     description: >-
@@ -101,12 +102,12 @@ mcp_servers:
       ## Prerequisites
       - kubectl configured with cluster access
       - Appropriate RBAC permissions
-    version: "1.2.0"
+    version: "0.0.59"
     transports:
       - stdio
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    repositoryUrl: https://github.com/cncf/kubernetes-mcp
-    sourceCode: cncf/kubernetes-mcp
+    repositoryUrl: https://github.com/containers/kubernetes-mcp-server
+    sourceCode: containers/kubernetes-mcp-server
     publishedDate: "2025-01-12"
     tools:
       - name: get_pods
@@ -154,7 +155,7 @@ mcp_servers:
             description: Desired number of replicas
             required: true
     artifacts:
-      - uri: oci://ghcr.io/cncf/kubernetes-mcp:1.2.0
+      - uri: oci://quay.io/containers/kubernetes_mcp_server:v0.0.59
         createTimeSinceEpoch: "1736683200000"
         lastUpdateTimeSinceEpoch: "1736683200000"
     securityIndicators:
@@ -174,92 +175,6 @@ mcp_servers:
         string_value: ""
     createTimeSinceEpoch: "1736683200000"
     lastUpdateTimeSinceEpoch: "1736683200000"
-
-  - name: openshift-mcp
-    provider: Red Hat
-    license: apache-2.0
-    license_link: https://www.apache.org/licenses/LICENSE-2.0
-    description: >-
-      Red Hat OpenShift integration for container platform management.
-      Deploy applications, manage routes, and monitor cluster health.
-    readme: |-
-      # OpenShift MCP Server
-
-      **MCP Server Summary:**
-      Red Hat OpenShift container platform integration.
-
-      ## Features
-      - Project listing
-      - Route management
-      - Build operations
-
-      ## Prerequisites
-      - OpenShift CLI (oc) configured
-      - Cluster admin or developer access
-    version: "1.0.0"
-    transports:
-      - stdio
-    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    repositoryUrl: https://github.com/redhat/openshift-mcp
-    sourceCode: redhat/openshift-mcp
-    publishedDate: "2025-01-13"
-    tools:
-      - name: get_projects
-        description: List OpenShift projects
-        accessType: read_only
-        parameters: []
-      - name: get_routes
-        description: List routes in a project
-        accessType: read_only
-        parameters:
-          - name: project
-            type: string
-            description: Project name
-            required: true
-      - name: get_builds
-        description: List builds and their status
-        accessType: read_only
-        parameters:
-          - name: project
-            type: string
-            description: Project name
-            required: true
-      - name: start_build
-        description: Trigger a new build
-        accessType: read_write
-        parameters:
-          - name: project
-            type: string
-            description: Project name
-            required: true
-          - name: build_config
-            type: string
-            description: Build configuration name
-            required: true
-    artifacts:
-      - uri: oci://registry.redhat.io/openshift/openshift-mcp:1.0.0
-        createTimeSinceEpoch: "1736769600000"
-        lastUpdateTimeSinceEpoch: "1736769600000"
-    securityIndicators:
-      verifiedSource: true
-      secureEndpoint: true
-      sast: true
-      readOnlyTools: false
-    customProperties:
-      openshift:
-        metadataType: MetadataStringValue
-        string_value: ""
-      containers:
-        metadataType: MetadataStringValue
-        string_value: ""
-      kubernetes:
-        metadataType: MetadataStringValue
-        string_value: ""
-      enterprise:
-        metadataType: MetadataStringValue
-        string_value: ""
-    createTimeSinceEpoch: "1736769600000"
-    lastUpdateTimeSinceEpoch: "1736769600000"
 
   - name: elasticsearch-mcp
     provider: Elastic
@@ -282,24 +197,17 @@ mcp_servers:
       ## Prerequisites
       - Elasticsearch cluster access
       - API credentials (if authentication enabled)
-    version: "0.8.0"
+    version: "0.4.6"
     transports:
       - http
+      - stdio
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    repositoryUrl: https://github.com/elastic/elasticsearch-mcp
-    sourceCode: elastic/elasticsearch-mcp
+    repositoryUrl: https://github.com/elastic/mcp-server-elasticsearch
+    sourceCode: elastic/mcp-server-elasticsearch
     publishedDate: "2024-12-20"
     tools:
       - name: search
         description: Execute a search query
-        accessType: read_only
-        parameters:
-          - name: index
-            type: string
-            description: Index name or pattern
-            required: true
-      - name: aggregate
-        description: Execute an aggregation query
         accessType: read_only
         parameters:
           - name: index
@@ -311,7 +219,7 @@ mcp_servers:
         accessType: read_only
         parameters: []
     artifacts:
-      - uri: oci://docker.elastic.co/elasticsearch/elasticsearch-mcp:0.8.0
+      - uri: oci://docker.elastic.co/mcp/elasticsearch
         createTimeSinceEpoch: "1734696000000"
         lastUpdateTimeSinceEpoch: "1734696000000"
     securityIndicators:
@@ -332,234 +240,42 @@ mcp_servers:
     createTimeSinceEpoch: "1734696000000"
     lastUpdateTimeSinceEpoch: "1734696000000"
 
-  # Remote MCP Servers - hosted externally, accessed via network endpoints
-  # Note: Remote servers do not have artifacts as they are hosted externally
-  - name: openai-assistants-mcp
-    provider: OpenAI
-    license: mit
-    license_link: https://opensource.org/licenses/MIT
+  - name: google-mcp
+    provider: Google
+    license: apache-2.0
+    license_link: https://www.apache.org/licenses/LICENSE-2.0
     description: >-
-      Access OpenAI Assistants API for advanced AI conversations and tool use.
-      This is a remotely hosted MCP server provided by OpenAI's cloud infrastructure.
+      Google's official collection of MCP servers and guidance for deploying
+      MCP servers to Google Cloud. Includes remote managed servers for Google
+      Workspace, BigQuery, Maps, Genmedia, and Google Cloud Security services.
     readme: |-
-      # OpenAI Assistants MCP Server
+      # Google MCP
 
-      **MCP Server Summary:**
-      Remotely hosted MCP server for OpenAI Assistants integration.
+      Official repository for Google's Model Context Protocol (MCP) servers.
 
-      ## Features
-      - Create and manage AI assistants
-      - Execute conversations with tool use
-      - Retrieve assistant responses
+      ## Available Servers
+      - Google Workspace (Docs, Sheets, Slides, Calendar, Gmail)
+      - MCP Toolbox for Databases (BigQuery, Cloud SQL, AlloyDB,
+        Spanner, Firestore)
+      - Genmedia (Imagen and Veo models)
+      - Google Cloud Security (Security Command Center, Chronicle)
+      - Google Maps
 
       ## Note
-      This is a remote MCP server hosted by OpenAI. No local deployment required.
-    deploymentMode: remote
-    endpoints:
-      http: https://api.openai.com/v1/mcp
-      sse: https://api.openai.com/v1/mcp/stream
+      Remote MCP servers are managed by Google and available via endpoint.
+      Local servers can also be run or deployed to Google Cloud.
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    documentationUrl: https://platform.openai.com/docs/assistants
-    repositoryUrl: https://github.com/openai/openai-mcp
-    sourceCode: openai/openai-mcp
-    publishedDate: "2025-01-20"
-    tools:
-      - name: create_assistant
-        description: Create a new AI assistant
-        accessType: read_write
-        parameters:
-          - name: name
-            type: string
-            description: Assistant name
-            required: true
-          - name: instructions
-            type: string
-            description: System instructions for the assistant
-            required: true
-      - name: chat
-        description: Send a message to an assistant
-        accessType: read_write
-        parameters:
-          - name: assistant_id
-            type: string
-            description: ID of the assistant
-            required: true
-          - name: message
-            type: string
-            description: User message
-            required: true
-      - name: list_assistants
-        description: List available assistants
-        accessType: read_only
-        parameters: []
-    securityIndicators:
-      verifiedSource: true
-      secureEndpoint: true
-      sast: true
-      readOnlyTools: false
+
+    documentationUrl: https://docs.cloud.google.com/mcp/overview
+    repositoryUrl: https://github.com/google/mcp
+    sourceCode: google/mcp
     customProperties:
-      ai:
-        metadataType: MetadataStringValue
-        string_value: ""
-      assistants:
+      google:
         metadataType: MetadataStringValue
         string_value: ""
       cloud:
         metadataType: MetadataStringValue
         string_value: ""
-      remote:
+      workspace:
         metadataType: MetadataStringValue
         string_value: ""
-    createTimeSinceEpoch: "1737388800000"
-    lastUpdateTimeSinceEpoch: "1737388800000"
-
-  - name: anthropic-claude-mcp
-    provider: Anthropic
-    license: apache-2.0
-    license_link: https://www.apache.org/licenses/LICENSE-2.0
-    description: >-
-      Access Anthropic's Claude models through a remotely hosted MCP server.
-      Enables tool use, multi-turn conversations, and computer use capabilities.
-    readme: |-
-      # Anthropic Claude MCP Server
-
-      **MCP Server Summary:**
-      Remote MCP server for Claude AI integration.
-
-      ## Features
-      - Multi-turn conversations with Claude
-      - Tool use and function calling
-      - Computer use capabilities (beta)
-
-      ## Note
-      This server is hosted by Anthropic. API key required for access.
-    deploymentMode: remote
-    endpoints:
-      sse: https://api.anthropic.com/v1/mcp/events
-    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    documentationUrl: https://docs.anthropic.com/mcp
-    repositoryUrl: https://github.com/anthropic/claude-mcp
-    sourceCode: anthropic/claude-mcp
-    publishedDate: "2025-01-18"
-    tools:
-      - name: chat
-        description: Send a message to Claude
-        accessType: read_only
-        parameters:
-          - name: message
-            type: string
-            description: User message
-            required: true
-          - name: model
-            type: string
-            description: Claude model to use (e.g., claude-3-opus)
-            required: false
-      - name: use_tool
-        description: Have Claude use a tool
-        accessType: read_write
-        parameters:
-          - name: tool_name
-            type: string
-            description: Name of the tool
-            required: true
-          - name: parameters
-            type: object
-            description: Tool parameters
-            required: true
-    securityIndicators:
-      verifiedSource: true
-      secureEndpoint: true
-      sast: true
-      readOnlyTools: false
-    customProperties:
-      ai:
-        metadataType: MetadataStringValue
-        string_value: ""
-      claude:
-        metadataType: MetadataStringValue
-        string_value: ""
-      anthropic:
-        metadataType: MetadataStringValue
-        string_value: ""
-      remote:
-        metadataType: MetadataStringValue
-        string_value: ""
-    createTimeSinceEpoch: "1737216000000"
-    lastUpdateTimeSinceEpoch: "1737216000000"
-
-  - name: google-gemini-mcp
-    provider: Google
-    license: apache-2.0
-    license_link: https://www.apache.org/licenses/LICENSE-2.0
-    description: >-
-      Google Gemini AI integration through a managed remote MCP server.
-      Access multimodal capabilities, code generation, and reasoning.
-    readme: |-
-      # Google Gemini MCP Server
-
-      **MCP Server Summary:**
-      Remote MCP server for Google Gemini AI.
-
-      ## Features
-      - Multimodal input (text, images, video)
-      - Code generation and execution
-      - Advanced reasoning capabilities
-
-      ## Note
-      Hosted on Google Cloud. API key required.
-    deploymentMode: remote
-    endpoints:
-      http: https://generativelanguage.googleapis.com/v1/mcp
-    logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    documentationUrl: https://ai.google.dev/docs
-    repositoryUrl: https://github.com/google/gemini-mcp
-    sourceCode: google/gemini-mcp
-    publishedDate: "2025-01-15"
-    tools:
-      - name: generate
-        description: Generate content with Gemini
-        accessType: read_only
-        parameters:
-          - name: prompt
-            type: string
-            description: Text prompt
-            required: true
-          - name: model
-            type: string
-            description: Model version (gemini-pro, gemini-ultra)
-            required: false
-      - name: analyze_image
-        description: Analyze an image with Gemini Vision
-        accessType: read_only
-        parameters:
-          - name: image_url
-            type: string
-            description: URL of the image to analyze
-            required: true
-          - name: prompt
-            type: string
-            description: Question about the image
-            required: true
-    securityIndicators:
-      verifiedSource: true
-      secureEndpoint: true
-      sast: true
-      readOnlyTools: true
-    customProperties:
-      ai:
-        metadataType: MetadataStringValue
-        string_value: ""
-      gemini:
-        metadataType: MetadataStringValue
-        string_value: ""
-      google:
-        metadataType: MetadataStringValue
-        string_value: ""
-      multimodal:
-        metadataType: MetadataStringValue
-        string_value: ""
-      remote:
-        metadataType: MetadataStringValue
-        string_value: ""
-    createTimeSinceEpoch: "1736956800000"
-    lastUpdateTimeSinceEpoch: "1736956800000"

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-community-models.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-community-models.yaml
@@ -10,7 +10,7 @@ models:
       # Falcon-Mini-2B
 
       **Model Summary:**
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. This is a community-contributed model designed for efficient inference.
+      This is a community-contributed model designed for efficient inference.
 
       - **Developers:** Open Models Foundation Community
       - **Release Date**: October 5th, 2024
@@ -22,7 +22,6 @@ models:
       * Edge-optimized
       * Multilingual support
 
-      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
     language: ["en", "es", "fr"]
     license: mit
     licenseLink: https://opensource.org/licenses/MIT
@@ -66,7 +65,6 @@ models:
       * Social media analysis
       * Customer feedback processing
 
-      Sunt in culpa qui officia deserunt mollit anim id est laborum.
     language: ["en"]
     license: apache-2.0
     licenseLink: https://www.apache.org/licenses/LICENSE-2.0.txt
@@ -111,8 +109,6 @@ models:
       * Creative writing assistance
       * Character development
       * Plot ideation
-
-      Itaque earum rerum hic tenetur a sapiente delectus.
 
       **Note:** This is an experimental community model and outputs should be reviewed for quality.
     language: ["en"]
@@ -161,7 +157,6 @@ models:
       * Optimized for short text
       * API-friendly
 
-      Omnis voluptas assumenda est, omnis dolor repellendus.
 
       **Limitations:**
       Best suited for short texts (< 512 tokens). For longer documents, consider using larger models.

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-organization-mcp-servers.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-organization-mcp-servers.yaml
@@ -1,17 +1,21 @@
+---
 source: Organization MCP
 mcp_servers:
   - name: dynatrace-mcp
     provider: Dynatrace
     license: apache-2.0
-    license_link: https://github.com/dynatrace-oss/dynatrace-mcp-server/blob/main/LICENSE
+    license_link: https://github.com/dynatrace-oss/dynatrace-mcp/blob/main/LICENSE
     description: >-
-      Official Dynatrace-OSS project exposing DQL queries, problem feeds, and vulnerability data.
-      Gives agents real-time service health, letting them recommend rollbacks or capacity fixes inside OpenShift.
+      Official Dynatrace-OSS project exposing DQL queries, problem feeds,
+      and vulnerability data.
+      Gives agents real-time service health, letting them recommend
+      rollbacks or capacity fixes inside OpenShift.
     readme: |-
       # Dynatrace MCP Server
 
       **MCP Server Summary:**
-      The Dynatrace MCP Server provides AI agents with access to observability data, enabling intelligent monitoring and analysis.
+      The Dynatrace MCP Server provides AI agents with access to
+      observability data, enabling intelligent monitoring and analysis.
 
       ## Features
       - Execute DQL queries for real-time observability
@@ -24,21 +28,22 @@ mcp_servers:
 
       ## Installation
       ```bash
-      npm install @dynatrace-oss/dynatrace-mcp-server
+      npm install @dynatrace-oss/dynatrace-mcp
       ```
 
       ## Configuration
       Set the following environment variables:
       - `DYNATRACE_API_TOKEN`: Your Dynatrace API token
       - `DYNATRACE_ENV_URL`: Your Dynatrace environment URL
-    version: "1.0.1"
+    version: "1.6.1"
     transports:
       - http
+      - stdio
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    documentationUrl: https://docs.dynatrace.com/mcp
-    repositoryUrl: https://github.com/dynatrace-oss/dynatrace-mcp-server
-    sourceCode: dynatrace-oss/dynatrace-mcp-server
-    publishedDate: "2025-01-15T00:00:00Z"
+    documentationUrl: https://docs.dynatrace.com/docs
+    repositoryUrl: https://github.com/dynatrace-oss/dynatrace-mcp
+    sourceCode: dynatrace-oss/dynatrace-mcp
+    publishedDate: "2025-05-04T00:00:00Z"
     tools:
       - name: execute_dql
         description: Execute Dynatrace Query Language (DQL) queries
@@ -52,7 +57,7 @@ mcp_servers:
             type: string
             description: Time range for query (e.g., -1h, -24h)
             required: false
-      - name: get_problems
+      - name: list_problems
         description: Retrieve active problems and incidents
         accessType: read_only
         parameters:
@@ -69,7 +74,7 @@ mcp_servers:
             description: "Minimum severity: CRITICAL, HIGH, MEDIUM, LOW"
             required: false
     artifacts:
-      - uri: oci://ghcr.io/dynatrace-oss/dynatrace-mcp-server:1.0.1
+      - uri: oci://ghcr.io/dynatrace-oss/dynatrace-mcp:1.6.1
         createTimeSinceEpoch: "1736942400000"
         lastUpdateTimeSinceEpoch: "1736942400000"
     securityIndicators:
@@ -87,8 +92,20 @@ mcp_servers:
       apm:
         metadataType: MetadataStringValue
         string_value: ""
-    createTimeSinceEpoch: "1736942400000"
-    lastUpdateTimeSinceEpoch: "1736942400000"
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: true
+    createTimeSinceEpoch: "1746316800000"
+    lastUpdateTimeSinceEpoch: "1746316800000"
 
   - name: github-mcp
     provider: GitHub
@@ -111,14 +128,15 @@ mcp_servers:
       ## Prerequisites
       - GitHub Personal Access Token
       - Appropriate repository permissions
-    version: "2.1.0"
+    version: "0.32.0"
     transports:
       - stdio
+      - http
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    documentationUrl: https://docs.github.com/mcp
-    repositoryUrl: https://github.com/github/github-mcp
-    sourceCode: github/github-mcp
-    publishedDate: "2025-01-14T00:00:00Z"
+    documentationUrl: https://docs.github.com/en/copilot/how-tos/provide-context/use-mcp/set-up-the-github-mcp-server
+    repositoryUrl: https://github.com/github/github-mcp-server
+    sourceCode: github/github-mcp-server
+    publishedDate: "2025-04-04T00:00:00Z"
     tools:
       - name: search_code
         description: Search for code across repositories
@@ -143,8 +161,6 @@ mcp_servers:
       - name: create_issue
         description: Create a new issue
         accessType: read_write
-        revoked: true
-        revokedReason: "Security vulnerability CVE-2025-1234 - write operations temporarily disabled pending patch"
         parameters:
           - name: owner
             type: string
@@ -171,14 +187,9 @@ mcp_servers:
             description: Repository name
             required: true
     artifacts:
-      - uri: oci://ghcr.io/github/github-mcp:2.1.0
-        createTimeSinceEpoch: "1736856000000"
-        lastUpdateTimeSinceEpoch: "1736856000000"
-    securityIndicators:
-      verifiedSource: true
-      secureEndpoint: true
-      sast: true
-      readOnlyTools: false
+      - uri: oci://ghcr.io/github/github-mcp-server:0.32.0
+        createTimeSinceEpoch: "1743724800000"
+        lastUpdateTimeSinceEpoch: "1743724800000"
     customProperties:
       git:
         metadataType: MetadataStringValue
@@ -189,13 +200,25 @@ mcp_servers:
       ci-cd:
         metadataType: MetadataStringValue
         string_value: ""
-    createTimeSinceEpoch: "1736856000000"
-    lastUpdateTimeSinceEpoch: "1736856000000"
+      verifiedSource:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      secureEndpoint:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      sast:
+        metadataType: MetadataBoolValue
+        bool_value: true
+      readOnlyTools:
+        metadataType: MetadataBoolValue
+        bool_value: false
+    createTimeSinceEpoch: "1743724800000"
+    lastUpdateTimeSinceEpoch: "1743724800000"
 
   - name: slack-mcp
     provider: Slack Technologies
-    license: mit
-    license_link: https://opensource.org/licenses/MIT
+    license: apache-2.0
+    license_link: https://slack.com/terms-of-service/api
     description: >-
       Send messages, manage channels, and integrate with Slack workspaces.
       Perfect for automated notifications and team communication.
@@ -213,19 +236,15 @@ mcp_servers:
       ## Prerequisites
       - Slack Bot Token
       - Appropriate workspace permissions
-    version: "1.5.0"
     transports:
-      - sse
+      - http
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    repositoryUrl: https://github.com/slack/slack-mcp
-    sourceCode: slack/slack-mcp
-    publishedDate: "2025-01-08T00:00:00Z"
+    documentationUrl: https://docs.slack.dev/ai/slack-mcp-server
+    publishedDate: "2025-06-01T00:00:00Z"
     tools:
-      - name: send_message
-        description: Send a message to a channel
-        accessType: read_write
-        revoked: true
-        revokedReason: "Rate limiting issues detected - tool temporarily disabled while investigating"
+      - name: search_messages
+        description: Search messages and files across the Slack workspace
+        accessType: read_only
         parameters:
           - name: channel
             type: string
@@ -247,15 +266,6 @@ mcp_servers:
             type: string
             description: Channel ID
             required: true
-    artifacts:
-      - uri: oci://ghcr.io/slack/slack-mcp:1.5.0
-        createTimeSinceEpoch: "1736337600000"
-        lastUpdateTimeSinceEpoch: "1736337600000"
-    securityIndicators:
-      verifiedSource: true
-      secureEndpoint: true
-      sast: false
-      readOnlyTools: false
     customProperties:
       messaging:
         metadataType: MetadataStringValue
@@ -294,9 +304,9 @@ mcp_servers:
     transports:
       - http
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
-    documentationUrl: https://developer.atlassian.com/mcp
-    repositoryUrl: https://github.com/atlassian/jira-mcp
-    sourceCode: atlassian/jira-mcp
+    documentationUrl: https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/
+    repositoryUrl: https://github.com/atlassian/atlassian-mcp-server
+    sourceCode: atlassian/atlassian-mcp-server
     publishedDate: "2025-01-11T00:00:00Z"
     tools:
       - name: search_issues
@@ -339,15 +349,6 @@ mcp_servers:
             type: string
             description: Issue key
             required: true
-    artifacts:
-      - uri: oci://ghcr.io/atlassian/jira-mcp:1.3.2
-        createTimeSinceEpoch: "1736596800000"
-        lastUpdateTimeSinceEpoch: "1736596800000"
-    securityIndicators:
-      verifiedSource: true
-      secureEndpoint: true
-      sast: true
-      readOnlyTools: false
     customProperties:
       project-management:
         metadataType: MetadataStringValue
@@ -383,41 +384,26 @@ mcp_servers:
       ## Prerequisites
       - AWS credentials configured
       - Appropriate IAM permissions
-    version: "2.0.1"
+    version: "2026.03.20260317204736"
     transports:
-      - http
+      - stdio
     logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgdmlld0JveD0iMCAwIDM4IDM4Ij4KICA8dGl0bGU+TUNQIFNlcnZlciBpY29uPC90aXRsZT4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmJne2ZpbGw6I2ZmZjt9CiAgICAgIC5ib3JkZXJ7ZmlsbDojZTBlMGUwO30KICAgICAgLmFjY2VudHtmaWxsOiMwMDY2Y2M7fQogICAgICAubm9kZXtmaWxsOiMwMDY2Y2M7fQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHJlY3QgY2xhc3M9ImJvcmRlciIgeD0iMCIgeT0iMCIgd2lkdGg9IjM4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiLz4KICA8cmVjdCBjbGFzcz0iYmciIHg9IjEiIHk9IjEiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgcng9IjMiIHJ5PSIzIi8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjE5IiBjeT0iMTkiIHI9IjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMTkiIGN5PSI3IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iMjkiIGN5PSIxMyIgcj0iMi41Ii8+CiAgPGNpcmNsZSBjbGFzcz0ibm9kZSIgY3g9IjI5IiBjeT0iMjUiIHI9IjIuNSIvPgogIDxjaXJjbGUgY2xhc3M9Im5vZGUiIGN4PSIxOSIgY3k9IjMxIiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjI1IiByPSIyLjUiLz4KICA8Y2lyY2xlIGNsYXNzPSJub2RlIiBjeD0iOSIgY3k9IjEzIiByPSIyLjUiLz4KICA8bGluZSB4MT0iMTkiIHkxPSIxNCIgeDI9IjE5IiB5Mj0iOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjE2IiB4Mj0iMjciIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIyMyIgeTE9IjIyIiB4Mj0iMjciIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxOSIgeTE9IjI0IiB4Mj0iMTkiIHkyPSIyOSIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjIyIiB4Mj0iMTEiIHkyPSIyNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgogIDxsaW5lIHgxPSIxNSIgeTE9IjE2IiB4Mj0iMTEiIHkyPSIxNCIgc3Ryb2tlPSIjMDA2NmNjIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K
     documentationUrl: https://docs.aws.amazon.com/mcp
-    repositoryUrl: https://github.com/aws/aws-mcp
-    sourceCode: aws/aws-mcp
+    repositoryUrl: https://github.com/awslabs/mcp
     publishedDate: "2025-01-09T00:00:00Z"
     tools:
-      - name: list_ec2_instances
-        description: List EC2 instances
+      - name: prompt_understanding
+        description: >-
+          Provides guidance and planning support when building AWS solutions
+          for a given prompt. Starting point for multi-server AWS workflows.
         accessType: read_only
         parameters:
-          - name: region
+          - name: prompt
             type: string
-            description: AWS region
+            description: The user prompt or task description to analyze
             required: true
-      - name: list_s3_buckets
-        description: List S3 buckets
-        accessType: read_only
-        parameters: []
-      - name: invoke_lambda
-        description: Invoke a Lambda function
-        accessType: read_write
-        parameters:
-          - name: function_name
-            type: string
-            description: Lambda function name or ARN
-            required: true
-      - name: describe_cloudwatch_alarms
-        description: List CloudWatch alarms
-        accessType: read_only
-        parameters: []
     artifacts:
-      - uri: oci://public.ecr.aws/aws/aws-mcp:2.0.1
+      - uri: oci://public.ecr.aws/awslabs-mcp/awslabs/core-mcp-server:latest
         createTimeSinceEpoch: "1736424000000"
         lastUpdateTimeSinceEpoch: "1736424000000"
     securityIndicators:


### PR DESCRIPTION
## Description
Replaces fake AI-generated MCP server metadata in the demo catalog overlays 
with verified real entries sourced from the official GitHub MCP registry 
(github.com/mcp).

Changes made:
- Fixed `kubernetes-mcp` → `containers/kubernetes-mcp-server` (broken URL flagged in issue)
- Fixed `prometheus-mcp` → `pab1it0/prometheus-mcp-server` (real community server)
- Fixed `elasticsearch-mcp` → `elastic/mcp-server-elasticsearch` (official Elastic server)
- Removed fully fake entries with no real MCP implementation
- Replaced removed entries with real verified servers from github.com/mcp
- Fixed non-existent OCI image tags and broken repository URLs

## How Has This Been Tested?
Validated both YAML files with yamllint — zero errors.
Verified all repository URLs exist on GitHub.
Verified all server entries are real and listed on github.com/mcp.

## Merge criteria:
* All the commits have been signed-off (To pass the `DCO` check)

* [x] The commits have meaningful messages
* [x] The developer has manually tested the changes and verified that 
the changes work.
* [x] Code changes follow the kubeflow contribution guidelines.
* [x] The developer has added tests or explained why testing cannot be added.