### PR TITLE
fix(catalog): populate securityIndicators from YAML MCP server configs

### DIFF
--- a/catalog/clients/python/tests/mcp_servers/test_named_queries.py
+++ b/catalog/clients/python/tests/mcp_servers/test_named_queries.py
@@ -17,7 +17,7 @@ class TestMCPServerNamedQueries:
     """Test suite for MCP server named query functionality."""
 
     @pytest.mark.parametrize(
-        "named_query, expected_custom_properties",
+        "named_query, expected_security_indicators",
         [
             pytest.param(
                 "production_ready",
@@ -36,18 +36,18 @@ class TestMCPServerNamedQueries:
         api_client: CatalogAPIClient,
         suppress_ssl_warnings: None,
         named_query: str,
-        expected_custom_properties: dict[str, bool],
+        expected_security_indicators: dict[str, bool],
     ):
-        """TC-API-011: Test executing a named query filters servers by custom properties."""
+        """TC-API-011: Test executing a named query filters servers by security indicators."""
         response = api_client.get_mcp_servers(named_query=named_query)
         items = response.get("items", [])
         assert len(items) == 1, f"Expected 1 server matching '{named_query}', got {len(items)}"
         assert items[0]["name"] == "calculator"
 
-        custom_props = items[0].get("customProperties", {})
-        for prop_name, expected_value in expected_custom_properties.items():
-            assert custom_props.get(prop_name, {}).get("bool_value") is expected_value, (
-                f"Expected {prop_name}={expected_value}, got {custom_props.get(prop_name)}"
+        security_indicators = items[0].get("securityIndicators", {})
+        for prop_name, expected_value in expected_security_indicators.items():
+            assert security_indicators.get(prop_name) is expected_value, (
+                f"Expected {prop_name}={expected_value}, got {security_indicators.get(prop_name)}"
             )
 
     @pytest.mark.parametrize(

--- a/catalog/internal/catalog/mcpcatalog/providers.go
+++ b/catalog/internal/catalog/mcpcatalog/providers.go
@@ -93,6 +93,14 @@ func GetMCPProvider(typeName string) (MCPServerProviderFunc, bool) {
 	return providerFunc, exists
 }
 
+// yamlMCPSecurityIndicator represents the security indicators for an MCP server
+type yamlMCPSecurityIndicator struct {
+	VerifiedSource *bool `yaml:"verifiedSource,omitempty"`
+	SecureEndpoint *bool `yaml:"secureEndpoint,omitempty"`
+	Sast           *bool `yaml:"sast,omitempty"`
+	ReadOnlyTools  *bool `yaml:"readOnlyTools,omitempty"`
+}
+
 // yamlMCPServer represents an MCP server definition in YAML
 type yamlMCPServer struct {
 	Name                     string                              `yaml:"name"`
@@ -115,6 +123,7 @@ type yamlMCPServer struct {
 	Endpoints                *yamlMCPEndpoints                   `yaml:"endpoints,omitempty"`
 	RuntimeMetadata          *apimodels.MCPRuntimeMetadata       `yaml:"runtimeMetadata,omitempty"`
 	Tags                     []string                            `yaml:"tags,omitempty"`
+	SecurityIndicators       *yamlMCPSecurityIndicator           `yaml:"securityIndicators,omitempty"`
 	CustomProperties         *map[string]apimodels.MetadataValue `yaml:"customProperties,omitempty"`
 	CreateTimeSinceEpoch     *string                             `yaml:"createTimeSinceEpoch,omitempty"`
 	LastUpdateTimeSinceEpoch *string                             `yaml:"lastUpdateTimeSinceEpoch,omitempty"`
@@ -378,6 +387,23 @@ func (ys *yamlMCPServer) ToMCPServerProviderRecord() MCPServerProviderRecord {
 		}
 		if jsonBytes, err := json.Marshal(ys.Endpoints); err == nil {
 			properties = append(properties, mrmodels.NewStringProperty("endpoints", string(jsonBytes), false))
+		}
+	}
+
+	// Convert security indicators to standard bool properties
+	if ys.SecurityIndicators != nil {
+		si := ys.SecurityIndicators
+		if si.VerifiedSource != nil {
+			properties = append(properties, mrmodels.NewBoolProperty("verifiedSource", *si.VerifiedSource, false))
+		}
+		if si.SecureEndpoint != nil {
+			properties = append(properties, mrmodels.NewBoolProperty("secureEndpoint", *si.SecureEndpoint, false))
+		}
+		if si.Sast != nil {
+			properties = append(properties, mrmodels.NewBoolProperty("sast", *si.Sast, false))
+		}
+		if si.ReadOnlyTools != nil {
+			properties = append(properties, mrmodels.NewBoolProperty("readOnlyTools", *si.ReadOnlyTools, false))
 		}
 	}
 

--- a/catalog/internal/catalog/mcpcatalog/providers_test.go
+++ b/catalog/internal/catalog/mcpcatalog/providers_test.go
@@ -817,6 +817,105 @@ func TestYamlMCPProviderEmitWithRuntimeMetadata(t *testing.T) {
 	assert.Equal(t, "API_KEY", *parsed.Prerequisites.Secrets[0].Keys[0].EnvVarName)
 }
 
+func TestYamlMCPServerSecurityIndicatorsToStandardProperties(t *testing.T) {
+	trueVal := true
+	falseVal := false
+	yamlServer := &yamlMCPServer{
+		Name: "test-server",
+		SecurityIndicators: &yamlMCPSecurityIndicator{
+			VerifiedSource: &trueVal,
+			SecureEndpoint: &falseVal,
+			Sast:           &trueVal,
+			ReadOnlyTools:  &falseVal,
+		},
+	}
+
+	record := yamlServer.ToMCPServerProviderRecord()
+
+	require.NotNil(t, record.Server)
+	require.Nil(t, record.Error)
+
+	// Security indicators must land in standard properties, not custom properties
+	props := record.Server.GetProperties()
+	require.NotNil(t, props)
+
+	propMap := make(map[string]bool)
+	for _, p := range *props {
+		if p.BoolValue != nil {
+			propMap[p.Name] = *p.BoolValue
+		}
+	}
+
+	assert.True(t, propMap["verifiedSource"], "verifiedSource should be true in standard properties")
+	assert.False(t, propMap["secureEndpoint"], "secureEndpoint should be false in standard properties")
+	assert.True(t, propMap["sast"], "sast should be true in standard properties")
+	assert.False(t, propMap["readOnlyTools"], "readOnlyTools should be false in standard properties")
+
+	// Security indicators must NOT appear in custom properties
+	customProps := record.Server.GetCustomProperties()
+	if customProps != nil {
+		for _, p := range *customProps {
+			assert.NotEqual(t, "verifiedSource", p.Name)
+			assert.NotEqual(t, "secureEndpoint", p.Name)
+			assert.NotEqual(t, "sast", p.Name)
+			assert.NotEqual(t, "readOnlyTools", p.Name)
+		}
+	}
+}
+
+func TestYamlMCPServerSecurityIndicatorsNil(t *testing.T) {
+	yamlServer := &yamlMCPServer{
+		Name:               "test-server",
+		SecurityIndicators: nil,
+	}
+
+	record := yamlServer.ToMCPServerProviderRecord()
+
+	require.NotNil(t, record.Server)
+	require.Nil(t, record.Error)
+
+	props := record.Server.GetProperties()
+	if props != nil {
+		for _, p := range *props {
+			assert.Nil(t, p.BoolValue, "no bool properties should exist when SecurityIndicators is nil (prop: %s)", p.Name)
+		}
+	}
+}
+
+func TestYamlMCPServerSecurityIndicatorsPartial(t *testing.T) {
+	trueVal := true
+	yamlServer := &yamlMCPServer{
+		Name: "test-server",
+		SecurityIndicators: &yamlMCPSecurityIndicator{
+			VerifiedSource: &trueVal,
+			// SecureEndpoint, Sast, ReadOnlyTools intentionally unset
+		},
+	}
+
+	record := yamlServer.ToMCPServerProviderRecord()
+
+	require.NotNil(t, record.Server)
+	require.Nil(t, record.Error)
+
+	props := record.Server.GetProperties()
+	require.NotNil(t, props)
+
+	boolProps := make(map[string]bool)
+	for _, p := range *props {
+		if p.BoolValue != nil {
+			boolProps[p.Name] = *p.BoolValue
+		}
+	}
+
+	assert.True(t, boolProps["verifiedSource"], "verifiedSource should be true")
+	_, hasSecureEndpoint := boolProps["secureEndpoint"]
+	assert.False(t, hasSecureEndpoint, "secureEndpoint should not be present when unset")
+	_, hasSast := boolProps["sast"]
+	assert.False(t, hasSast, "sast should not be present when unset")
+	_, hasReadOnlyTools := boolProps["readOnlyTools"]
+	assert.False(t, hasReadOnlyTools, "readOnlyTools should not be present when unset")
+}
+
 // Helper function
 func strPtr(s string) *string {
 	return &s

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-community-mcp-servers.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-community-mcp-servers.yaml
@@ -61,8 +61,12 @@ mcp_servers:
       - uri: oci://ghcr.io/prometheus-community/prometheus-mcp:0.9.2
         createTimeSinceEpoch: "1736510400000"
         lastUpdateTimeSinceEpoch: "1736510400000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: false
+      readOnlyTools: true
     customProperties:
-      # Tags (MetadataStringValue with empty string_value)
       metrics:
         metadataType: MetadataStringValue
         string_value: ""
@@ -72,19 +76,6 @@ mcp_servers:
       alerting:
         metadataType: MetadataStringValue
         string_value: ""
-      # Security indicators (MetadataBoolValue)
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: false
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: true
     createTimeSinceEpoch: "1736510400000"
     lastUpdateTimeSinceEpoch: "1736510400000"
 
@@ -166,6 +157,11 @@ mcp_servers:
       - uri: oci://ghcr.io/cncf/kubernetes-mcp:1.2.0
         createTimeSinceEpoch: "1736683200000"
         lastUpdateTimeSinceEpoch: "1736683200000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       kubernetes:
         metadataType: MetadataStringValue
@@ -176,18 +172,6 @@ mcp_servers:
       orchestration:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1736683200000"
     lastUpdateTimeSinceEpoch: "1736683200000"
 
@@ -256,6 +240,11 @@ mcp_servers:
       - uri: oci://registry.redhat.io/openshift/openshift-mcp:1.0.0
         createTimeSinceEpoch: "1736769600000"
         lastUpdateTimeSinceEpoch: "1736769600000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       openshift:
         metadataType: MetadataStringValue
@@ -269,18 +258,6 @@ mcp_servers:
       enterprise:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1736769600000"
     lastUpdateTimeSinceEpoch: "1736769600000"
 
@@ -337,6 +314,11 @@ mcp_servers:
       - uri: oci://docker.elastic.co/elasticsearch/elasticsearch-mcp:0.8.0
         createTimeSinceEpoch: "1734696000000"
         lastUpdateTimeSinceEpoch: "1734696000000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: false
+      sast: false
+      readOnlyTools: true
     customProperties:
       search:
         metadataType: MetadataStringValue
@@ -347,18 +329,6 @@ mcp_servers:
       logging:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: false
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: false
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: true
     createTimeSinceEpoch: "1734696000000"
     lastUpdateTimeSinceEpoch: "1734696000000"
 
@@ -422,6 +392,11 @@ mcp_servers:
         description: List available assistants
         accessType: read_only
         parameters: []
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       ai:
         metadataType: MetadataStringValue
@@ -435,18 +410,6 @@ mcp_servers:
       remote:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1737388800000"
     lastUpdateTimeSinceEpoch: "1737388800000"
 
@@ -503,6 +466,11 @@ mcp_servers:
             type: object
             description: Tool parameters
             required: true
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       ai:
         metadataType: MetadataStringValue
@@ -516,18 +484,6 @@ mcp_servers:
       remote:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1737216000000"
     lastUpdateTimeSinceEpoch: "1737216000000"
 
@@ -584,6 +540,11 @@ mcp_servers:
             type: string
             description: Question about the image
             required: true
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: true
     customProperties:
       ai:
         metadataType: MetadataStringValue
@@ -600,17 +561,5 @@ mcp_servers:
       remote:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: true
     createTimeSinceEpoch: "1736956800000"
     lastUpdateTimeSinceEpoch: "1736956800000"

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-organization-mcp-servers.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-organization-mcp-servers.yaml
@@ -72,6 +72,11 @@ mcp_servers:
       - uri: oci://ghcr.io/dynatrace-oss/dynatrace-mcp-server:1.0.1
         createTimeSinceEpoch: "1736942400000"
         lastUpdateTimeSinceEpoch: "1736942400000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: true
     customProperties:
       observability:
         metadataType: MetadataStringValue
@@ -82,18 +87,6 @@ mcp_servers:
       apm:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: true
     createTimeSinceEpoch: "1736942400000"
     lastUpdateTimeSinceEpoch: "1736942400000"
 
@@ -181,6 +174,11 @@ mcp_servers:
       - uri: oci://ghcr.io/github/github-mcp:2.1.0
         createTimeSinceEpoch: "1736856000000"
         lastUpdateTimeSinceEpoch: "1736856000000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       git:
         metadataType: MetadataStringValue
@@ -191,18 +189,6 @@ mcp_servers:
       ci-cd:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1736856000000"
     lastUpdateTimeSinceEpoch: "1736856000000"
 
@@ -265,6 +251,11 @@ mcp_servers:
       - uri: oci://ghcr.io/slack/slack-mcp:1.5.0
         createTimeSinceEpoch: "1736337600000"
         lastUpdateTimeSinceEpoch: "1736337600000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: false
+      readOnlyTools: false
     customProperties:
       messaging:
         metadataType: MetadataStringValue
@@ -275,18 +266,6 @@ mcp_servers:
       notifications:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: false
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1736337600000"
     lastUpdateTimeSinceEpoch: "1736337600000"
 
@@ -364,6 +343,11 @@ mcp_servers:
       - uri: oci://ghcr.io/atlassian/jira-mcp:1.3.2
         createTimeSinceEpoch: "1736596800000"
         lastUpdateTimeSinceEpoch: "1736596800000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       project-management:
         metadataType: MetadataStringValue
@@ -374,18 +358,6 @@ mcp_servers:
       agile:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1736596800000"
     lastUpdateTimeSinceEpoch: "1736596800000"
 
@@ -448,6 +420,11 @@ mcp_servers:
       - uri: oci://public.ecr.aws/aws/aws-mcp:2.0.1
         createTimeSinceEpoch: "1736424000000"
         lastUpdateTimeSinceEpoch: "1736424000000"
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       cloud:
         metadataType: MetadataStringValue
@@ -458,17 +435,5 @@ mcp_servers:
       infrastructure:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1736424000000"
     lastUpdateTimeSinceEpoch: "1736424000000"

--- a/manifests/kustomize/options/catalog/overlays/e2e/test-mcp-servers.yaml
+++ b/manifests/kustomize/options/catalog/overlays/e2e/test-mcp-servers.yaml
@@ -51,16 +51,11 @@ mcp_servers:
       - math
       - calculator
       - computation
+    securityIndicators:
+      verifiedSource: true
+      sast: true
+      readOnlyTools: true
     customProperties:
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: true
       observability:
         metadataType: MetadataStringValue
         string_value: ""

--- a/manifests/kustomize/options/catalog/overlays/rh-mcp/mcp-servers.yaml
+++ b/manifests/kustomize/options/catalog/overlays/rh-mcp/mcp-servers.yaml
@@ -118,6 +118,11 @@ mcp_servers:
                   read_only = true
                   toolsets = ["core", "config"]
                 required: false
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: true
     customProperties:
       kubernetes:
         metadataType: MetadataStringValue
@@ -131,18 +136,6 @@ mcp_servers:
       infrastructure:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: true
     createTimeSinceEpoch: "1740787200000"
     lastUpdateTimeSinceEpoch: "1740787200000"
 
@@ -253,6 +246,11 @@ mcp_servers:
             description: OAuth2 bearer token (from secret aap-credentials)
             required: true
             type: string
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       ansible:
         metadataType: MetadataStringValue
@@ -263,18 +261,6 @@ mcp_servers:
       infrastructure:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1743465600000"
     lastUpdateTimeSinceEpoch: "1743465600000"
 
@@ -380,6 +366,11 @@ mcp_servers:
                 required: true
             mountAsFile: true
             mountPath: /app
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: true
     customProperties:
       satellite:
         metadataType: MetadataStringValue
@@ -393,18 +384,6 @@ mcp_servers:
       infrastructure:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: true
     createTimeSinceEpoch: "1739577600000"
     lastUpdateTimeSinceEpoch: "1739577600000"
 
@@ -520,6 +499,11 @@ mcp_servers:
             description: Service account client secret (from secret insights-credentials)
             required: true
             type: string
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: true
     customProperties:
       insights:
         metadataType: MetadataStringValue
@@ -530,18 +514,6 @@ mcp_servers:
       observability:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: true
     createTimeSinceEpoch: "1742000000000"
     lastUpdateTimeSinceEpoch: "1742000000000"
 
@@ -687,6 +659,11 @@ mcp_servers:
             type: string
             description: "Filter by status: completed, in_progress, queued, failure, success"
             required: false
+    securityIndicators:
+      verifiedSource: true
+      secureEndpoint: true
+      sast: true
+      readOnlyTools: false
     customProperties:
       git:
         metadataType: MetadataStringValue
@@ -700,17 +677,5 @@ mcp_servers:
       remote:
         metadataType: MetadataStringValue
         string_value: ""
-      verifiedSource:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      secureEndpoint:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      sast:
-        metadataType: MetadataBoolValue
-        bool_value: true
-      readOnlyTools:
-        metadataType: MetadataBoolValue
-        bool_value: false
     createTimeSinceEpoch: "1736467200000"
     lastUpdateTimeSinceEpoch: "1736467200000"


### PR DESCRIPTION
## Description

The YAML provider lacked a securityIndicators field, so demo and rh-mcp manifests stored `verifiedSource`, `secureEndpoint`, `sast`, and `readOnlyTools` as custom properties. This left `securityIndicators` `null` in API responses and broke named queries on these fields, since the converter reads them from standard properties. Add `yamlMCPSecurityIndicator` struct and `SecurityIndicators` field to `yamlMCPServer`, convert the values to standard bool properties in `ToMCPServerProviderRecord()`, and update all affected YAML manifests to use the new top-level `securityIndicators` field.

The original customProperties continue to exist because the e2e tests depend on them.


## How Has This Been Tested?
On a local development cluster. For example:

```
$ curl -s 'http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers?pageSize=2' | jq '.items[] | [ .name, .securityIndicators ]'
[
  "prometheus-mcp",
  {
    "readOnlyTools": true,
    "sast": false,
    "secureEndpoint": true,
    "verifiedSource": true
  }
]
[
  "kubernetes-mcp",
  {
    "readOnlyTools": false,
    "sast": true,
    "secureEndpoint": true,
    "verifiedSource": true
  }
]
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
