### PR TITLE
Bugfix/issue 2136 envtest bind address

### DIFF
--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -73,6 +75,17 @@ func SetupEnvTest(input TestEnvInput) (*envtest.Environment, kubernetes.Interfac
 	// Fix for #2136: Configure ControlPlane to bind to 127.0.0.1 instead of
 	// platform-specific addresses (e.g., 192.168.127.254 on macOS) which don't
 	// exist inside Docker containers.
+	//
+	// Pre-allocate a free port on 127.0.0.1 and pass it as a real port number.
+	// envtest treats Port:"0" as a literal string (not auto-select), which causes
+	// kube-apiserver to reject it with "--secure-port 0 must be between 1 and 65535".
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to allocate free port on 127.0.0.1: %w", err)
+	}
+	freePort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
 	testEnv := &envtest.Environment{
 		BinaryAssetsDirectory: binaryAssetsDir,
 		ControlPlane: envtest.ControlPlane{
@@ -80,7 +93,7 @@ func SetupEnvTest(input TestEnvInput) (*envtest.Environment, kubernetes.Interfac
 				SecureServing: envtest.SecureServing{
 					ListenAddr: envtest.ListenAddr{
 						Address: "127.0.0.1",
-						Port:    "0", // Random available port
+						Port:    strconv.Itoa(freePort),
 					},
 				},
 			},

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -46,7 +46,7 @@ services:
     ports:
       - "8081:8081"
     volumes:
-      - ./catalog/internal/catalog/testdata:/testdata
+      - ./catalog/internal/catalog/modelcatalog/testdata:/testdata
     depends_on:
       - postgres
     profiles:


### PR DESCRIPTION
Fix #2136 

## Description
The docker container is starting and binding to 192.168.* address in some environments which does not work across which is corrected. Also the test mount for the model-catalog was wrong in the configuration. 

## How Has This Been Tested?
manually tested locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] The commits have meaningful messages
- [x ] The developer has manually tested the changes and verified that the changes work.
- [ x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
