### PR TITLE
fix(catalog): change HF org examples from google to meta-llama

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -37,12 +37,12 @@ export const HELP_TEXT = {
   ACCESS_TOKEN:
     'Enter your fine-grained Hugging Face access token. Public models can be pulled into catalog without an access token. For private/gated models, a token is recommended to ensure full metadata is displayed, otherwise only limited metadata may be available. The token must have the following permissions: read repos in your namespace, read public repos that you can access.',
   ORGANIZATION:
-    'Enter the name of the organization (for example, google) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
+    'Enter the name of the organization (for example, meta-llama) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
   YAML: 'Upload or paste a YAML string.',
 } as const;
 
 export const PLACEHOLDERS = {
-  ORGANIZATION: 'Example: google',
+  ORGANIZATION: 'Example: meta-llama',
   ALLOWED_MODELS_HF: 'Enter model names, one per line (e.g., gemma-7b*)',
   ALLOWED_MODELS_GENERIC: 'Example: Google/gemma-7b*, Meta/Llama-3.1-8B-Instruct',
   EXCLUDED_MODELS_HF: 'Enter model names, one per line (e.g., gemma-7b-test*)',

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableColumns.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableColumns.tsx
@@ -19,7 +19,7 @@ export const catalogSourceConfigsColumns: SortableData<CatalogSourceConfig>[] = 
       ),
     info: {
       popover:
-        'Applies only to Hugging Face sources. Shows the organization the source syncs models from (for example, google). Only models within this organization are included in the catalog.',
+        'Applies only to Hugging Face sources. Shows the organization the source syncs models from (for example, meta-llama). Only models within this organization are included in the catalog.',
     },
     width: 15,
   },


### PR DESCRIPTION
## Description

Updates example Hugging Face organization from 'google' to 'meta-llama' in catalog settings to avoid confusion with Google brand capitalization.

The lowercase 'google' could appear as incorrect use of the Google brand, while 'meta-llama' is clearer as an example organization name on Hugging Face.

**Changes:**
- Updated help text for organization field
- Updated placeholder text (Example: meta-llama)
- Updated table column info popover text

## How Has This Been Tested?

Manual verification:
1. Navigate to Catalog Settings
2. Create or edit a Hugging Face source
3. Verify help text shows 'meta-llama' as example
4. Verify placeholder shows 'Example: meta-llama'
5. Verify table info popover text updated

## Merge criteria:
- All the commits have been signed-off (To pass the DCO check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the kubeflow contribution guidelines.
- [ ] **For first time contributors**: Please reach out to the Reviewers to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)