### PR TITLE
Fix registry description overflow in settings table

### DIFF
--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistriesTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistriesTableRow.tsx
@@ -3,7 +3,12 @@ import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { FetchStateObject } from 'mod-arch-shared/dist/types/common';
-import { ModelRegistryKind, ResourceNameTooltip, RoleBindingKind } from 'mod-arch-shared';
+import {
+  ModelRegistryKind,
+  ResourceNameTooltip,
+  RoleBindingKind,
+  TruncatedText,
+} from 'mod-arch-shared';
 import { DeploymentMode, useModularArchContext } from 'mod-arch-core';
 import { ModelRegistryTableRowStatus } from './ModelRegistryTableRowStatus';
 
@@ -39,7 +44,10 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
           </strong>
         </ResourceNameTooltip>
         {mr.metadata.annotations?.['openshift.io/description'] && (
-          <p>{mr.metadata.annotations['openshift.io/description']}</p>
+          <TruncatedText
+            maxLines={2}
+            content={mr.metadata.annotations['openshift.io/description']}
+          />
         )}
       </Td>
       <Td dataLabel="Status" style={{ verticalAlign: 'middle' }}>


### PR DESCRIPTION
## Summary
- Replace raw `<p>` tag with `TruncatedText` component (maxLines=2) from `mod-arch-shared` in `ModelRegistriesTableRow`
- Prevents long registry descriptions from overflowing and breaking the table layout in Model Registry Settings
- Follows the same pattern used in `McpCatalogCard` for description truncation

## Test plan
- [ ] Create a model registry with a very long description (200+ characters)
- [ ] Verify the description is truncated to 2 lines in the settings table
- [ ] Verify hovering/clicking shows the full description (TruncatedText built-in behavior)
- [ ] Verify short descriptions still display normally without truncation
- [ ] Verify existing unit tests pass (`npm test -- --testPathPattern=settings`)
