### PR TITLE
fix(catalog): stop drain select in collectRecordsFromChannel from counting batch-end markers

### DIFF
--- a/catalog/internal/catalog/modelcatalog/yaml_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog_test.go
@@ -631,8 +631,8 @@ func collectRecordsFromChannel(t *testing.T, records <-chan ModelProviderRecord,
 	cancel()
 
 	select {
-	case _, ok := <-records:
-		if ok {
+	case record, ok := <-records:
+		if ok && record.Model != nil {
 			t.Fatalf("received more than %d records", expected)
 		}
 	case <-time.After(500 * time.Millisecond):


### PR DESCRIPTION
## Description

The drain loop passed through ModelProviderRecord{} batch-end markers (Model == nil) instead of discarding them. After cancel(), emit()'s final select could send a marker before observing ctx.Done(); the drain loop then counted it as a real record, producing a spurious extra entry and causing the test to fail.

## How Has This Been Tested?

```
go test -count=1000 ./catalog/internal/catalog/modelcatalog -run TestYamlModelProviderLegacyExcludesMerged
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
