### PR TITLE
fix: replace compose configs with volume mount for postgres init SQL

### DIFF
--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -111,6 +111,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./scripts/pginit.sql:/docker-entrypoint-initdb.d/pginit.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d model_registry"]
       interval: 10s
@@ -119,16 +120,7 @@ services:
       start_period: 20s
     profiles:
       - postgres
-    configs:
-      - source: pginit
-        target: /docker-entrypoint-initdb.d/pginit.sql
 
 volumes:
   mysql_data:
   postgres_data:
-
-configs:
-  pginit:
-    content: |
-      CREATE DATABASE model_catalog;
-      GRANT ALL PRIVILEGES ON model_catalog TO postgres;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -105,6 +105,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./scripts/pginit.sql:/docker-entrypoint-initdb.d/pginit.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d model_registry"]
       interval: 10s
@@ -113,16 +114,7 @@ services:
       start_period: 20s
     profiles:
       - postgres
-    configs:
-      - source: pginit
-        target: /docker-entrypoint-initdb.d/pginit.sql
 
 volumes:
   mysql_data:
   postgres_data:
-
-configs:
-  pginit:
-    content: |
-      CREATE DATABASE model_catalog;
-      GRANT ALL PRIVILEGES ON model_catalog TO postgres;

--- a/scripts/pginit.sql
+++ b/scripts/pginit.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE model_catalog;
+GRANT ALL PRIVILEGES ON DATABASE model_catalog TO postgres;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes compose for podman users. Depends on https://github.com/kubeflow/model-registry/pull/2466 

The `configs` top-level key with inline `content` is not supported by Podman Compose, causing `compose up` to fail. Move the postgres init SQL to a file (`scripts/pginit.sql`) and mount it via a bind volume, which is compatible with both Docker Compose and Podman Compose.
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran `make compose/local/up/postgres`.  All 4 containers started up successfully.  UI loads in the browser
<!--- Include details of your testing environment, and the tests you ran to -->
testing environment: Fedora with podman and podman-compose installed.
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
