### PR TITLE
fix(ui): catalog fix search bar overflow without losing fill width

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -131,19 +131,35 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
             : {})}
         >
           <ToolbarContent rowWrap={{ default: 'wrap' }}>
-            <Flex>
-              <ToolbarToggleGroup breakpoint="md" toggleIcon={<FilterIcon />}>
-                <ToolbarGroup variant="filter-group" gap={{ default: 'gapMd' }} alignItems="center">
-                  <ToolbarItem>
+            <Flex style={{ flex: 1 }}>
+              <ToolbarToggleGroup breakpoint="md" toggleIcon={<FilterIcon />} style={{ flex: 1 }}>
+                <ToolbarGroup
+                  variant="filter-group"
+                  gap={{ default: 'gapMd' }}
+                  alignItems="center"
+                  style={{ flex: 1 }}
+                >
+                  <ToolbarItem style={{ flex: '1 1 auto', minWidth: 0 }}>
+                    <style>{`
+                      .catalog-search-input {
+                        flex: 1 1 0;
+                        min-width: 0;
+                      }
+                      .catalog-search-input .pf-v6-c-form-control,
+                      .catalog-search-input .pf-v6-c-form-control > input {
+                        width: 100%;
+                      }
+                      .catalog-search-input > .pf-v6-c-input-group__item:not(.pf-m-search-action) {
+                        flex: 1 1 0;
+                        min-width: 0;
+                      }
+                    `}</style>
                     <ThemeAwareSearchInput
                       data-testid="search-input"
                       aria-label="Search with submit button"
-                      className="toolbar-fieldset-wrapper"
+                      className="catalog-search-input"
                       placeholder="Filter by name, description and provider"
                       value={inputValue}
-                      style={{
-                        minWidth: '600px',
-                      }}
                       onChange={handleSearchInputChange}
                       onSearch={handleSearchInputSearch}
                       onClear={handleClear}


### PR DESCRIPTION
## Description

The search bar in the Model Catalog overflows horizontally when text is entered, because `minWidth: '600px'` is set on the search input via an inline style, preventing it from ever shrinking to fit its parent container.

### Root Cause

Two issues compound to cause the problem:

1. **Parent flex chain doesn't propagate growth:** `Flex`, `ToolbarToggleGroup`, and `ToolbarGroup` all have default `flex-grow: 0`, so the `ToolbarItem` cannot grow beyond its content size — even though the toolbar itself has hundreds of pixels of available width.

2. **Hardcoded `minWidth: 600px`:** Forces the search input to be at least 600px wide regardless of available space, which causes horizontal overflow on constrained viewports or when long text is entered.

### Fix

- Add `style={{ flex: 1 }}` to `Flex`, `ToolbarToggleGroup`, and `ToolbarGroup` so the entire parent chain allows the search `ToolbarItem` to grow to fill the available toolbar width.
- Add `style={{ flex: '1 1 auto', minWidth: 0 }}` on the search `ToolbarItem` so it can both grow and shrink.
- Replace the `minWidth: '600px'` inline style with CSS class rules that make the search input fill available space in **both MUI and PatternFly themes**:
  - `.catalog-search-input { flex: 1 1 0; min-width: 0 }` — makes the wrapper grow
  - `.catalog-search-input .pf-v6-c-form-control, .catalog-search-input .pf-v6-c-form-control > input { width: 100% }` — fills in MUI theme
  - `.catalog-search-input > .pf-v6-c-input-group__item:not(.pf-m-search-action) { flex: 1 1 0; min-width: 0 }` — fills in PatternFly theme
- Remove the unused `toolbar-fieldset-wrapper` className.

## How Has This Been Tested?

- `npm run test:lint` — 0 errors, 0 warnings
- `npm run test:type-check` — no TypeScript errors
- `npm run test:unit` — all 554 tests pass
- Ran `make dev-start` (mocked standalone BFF + frontend) and validated with Playwright MCP:
  - **Before:** search input is ~170px wide in MUI theme; in PF theme it's 600px min-width and overflows
  - **After:** search bar fills full toolbar width in both themes, stays contained with long text input (no overflow)

### Before

<img width="1512" height="714" alt="upstream-before-fix-mui" src="https://github.com/user-attachments/assets/9abb2261-3920-4d02-84a2-4a44c6cc6725" />
<img width="1512" height="714" alt="upstream-before-fix-overflow" src="https://github.com/user-attachments/assets/913c7055-8f25-4ae8-a1f8-e9eed95b9f68" />

The search bar uses ~170px in MUI standalone mode (truncated placeholder).

### After

<img width="1512" height="714" alt="upstream-after-fix-mui" src="https://github.com/user-attachments/assets/3b7a716e-a402-40a4-8ec2-e4f2e887e1c6" />
<img width="1512" height="714" alt="upstream-after-fix-overflow" src="https://github.com/user-attachments/assets/b7792a8d-ff4a-4b3b-944e-1644996888b8" />

The search bar fills the full available toolbar width. Long text stays contained.

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

Made with [Cursor](https://cursor.com)