### PR TITLE
Fix the "make compose/down" command when used with "postgres" db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,7 +451,7 @@ compose/up/postgres: ## Start services using docker-compose.yaml with PostgreSQL
 
 .PHONY: compose/down
 compose/down: ## Stop services using docker-compose.yaml
-	$(COMPOSE_CMD) down
+	$(COMPOSE_CMD) --profile mysql --profile postgres down
 
 .PHONY: compose/local/up
 compose/local/up: ## Start services using docker-compose-local.yaml with MySQL (builds from source)
@@ -467,8 +467,8 @@ compose/local/down: ## Stop services using docker-compose-local.yaml
 
 .PHONY: compose/clean
 compose/clean: ## Remove all Docker Compose volumes and networks
-	$(COMPOSE_CMD) down -v --remove-orphans
-	$(COMPOSE_CMD) -f docker-compose-local.yaml down -v --remove-orphans
+	$(COMPOSE_CMD) --profile mysql --profile postgres down -v --remove-orphans
+	$(COMPOSE_CMD) -f docker-compose-local.yaml --profile mysql --profile postgres down -v --remove-orphans
 
 ##@ Tools
 


### PR DESCRIPTION
`make compose/local/down` does not work when docker env started with postgres

## Description
This change adds the `--profile postgres` to  command to properly account for `postgres` instances

## How Has This Been Tested?
Yes, manually tested

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] The commits have meaningful messages
- [ x] The developer has manually tested the changes and verified that the changes work.
- [ x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).