### PR TITLE
fix: toolLimit query parameter has no effect on MCP servers listing endpoint

### DIFF
--- a/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
@@ -104,9 +104,12 @@ type mockMCPServerToolRepo struct {
 	// countByID allows per-parent-ID count results for multi-server tests.
 	// When set, CountByParentIDs uses this map instead of countResult.
 	countByID map[int32]int32
+	// capturedListOptions stores the last MCPServerToolListOptions passed to List.
+	capturedListOptions *models.MCPServerToolListOptions
 }
 
-func (m *mockMCPServerToolRepo) List(_ models.MCPServerToolListOptions) ([]models.MCPServerTool, error) {
+func (m *mockMCPServerToolRepo) List(opts models.MCPServerToolListOptions) ([]models.MCPServerTool, error) {
+	m.capturedListOptions = &opts
 	return m.listResult, m.listErr
 }
 func (m *mockMCPServerToolRepo) GetByID(_ int32) (models.MCPServerTool, error) {
@@ -447,6 +450,41 @@ func TestListMCPServers_IncludeToolsUsesAccurateCount(t *testing.T) {
 	// toolCount should reflect total (5), not len(returned tools) (2)
 	assert.Equal(t, int32(5), result.Items[0].ToolCount)
 	assert.Len(t, result.Items[0].Tools, 2)
+}
+
+func TestListMCPServers_ToolLimitPassedAsPageSize(t *testing.T) {
+	repo := &mockMCPServerRepo{listResult: listWithServer(1, "test-server")}
+	toolRepo := &mockMCPServerToolRepo{
+		countResult: 5,
+		listResult:  []models.MCPServerTool{makeTool("tool-1")},
+	}
+	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
+
+	_, err := cat.ListMCPServers(context.Background(), ListMCPServersParams{
+		IncludeTools: true,
+		ToolLimit:    3,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, toolRepo.capturedListOptions, "List should have been called on tool repo")
+	require.NotNil(t, toolRepo.capturedListOptions.PageSize, "PageSize should be set when ToolLimit > 0")
+	assert.Equal(t, int32(3), *toolRepo.capturedListOptions.PageSize)
+}
+
+func TestListMCPServers_ZeroToolLimitDoesNotSetPageSize(t *testing.T) {
+	repo := &mockMCPServerRepo{listResult: listWithServer(1, "test-server")}
+	toolRepo := &mockMCPServerToolRepo{
+		countResult: 5,
+		listResult:  []models.MCPServerTool{makeTool("tool-1"), makeTool("tool-2")},
+	}
+	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
+
+	_, err := cat.ListMCPServers(context.Background(), ListMCPServersParams{
+		IncludeTools: true,
+		ToolLimit:    0,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, toolRepo.capturedListOptions, "List should have been called on tool repo")
+	assert.Nil(t, toolRepo.capturedListOptions.PageSize, "PageSize should be nil when ToolLimit is 0")
 }
 
 func TestGetMCPServer_IncludeToolsUsesAccurateCount(t *testing.T) {

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool.go
@@ -72,13 +72,18 @@ func (r *MCPServerToolRepositoryImpl) List(listOptions models.MCPServerToolListO
 		return nil, fmt.Errorf("error applying filter query: %w", err)
 	}
 
-	// 3. Execute query
+	// 3. Apply pagination limit
+	if listOptions.Pagination.PageSize != nil {
+		query = query.Limit(int(*listOptions.Pagination.PageSize))
+	}
+
+	// 4. Execute query
 	err = query.Find(&executions).Error
 	if err != nil {
 		return nil, fmt.Errorf("error listing %s by parent: %w", config.EntityName, err)
 	}
 
-	// 4. Load properties for each execution
+	// 5. Load properties for each execution
 	var tools []models.MCPServerTool
 	for _, exec := range executions {
 		var properties []schema.ExecutionProperty

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool_test.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool_test.go
@@ -525,6 +525,70 @@ func TestMCPServerToolRepository(t *testing.T) {
 		assert.ErrorIs(t, err, ErrMCPServerToolNameEmpty)
 	})
 
+	t.Run("TestListToolsByParent_WithPageSize", func(t *testing.T) {
+		// Create parent server
+		parentServer := &models.MCPServerImpl{
+			Attributes: &models.MCPServerAttributes{
+				Name: apiutils.Of("server-with-tools-pagesize"),
+			},
+			Properties: &[]dbmodels.Properties{
+				{Name: "source_id", StringValue: apiutils.Of("source-pagesize")},
+				{Name: "version", StringValue: apiutils.Of("1.0.0")},
+			},
+		}
+		savedServer, err := serverRepo.Save(parentServer)
+		require.NoError(t, err)
+		parentID := *savedServer.GetID()
+
+		// Create 5 tools for the server
+		for i := 1; i <= 5; i++ {
+			tool := &models.MCPServerToolImpl{
+				Attributes: &models.MCPServerToolAttributes{
+					Name: apiutils.Of(fmt.Sprintf("pagesize-tool-%d", i)),
+				},
+				Properties: &[]dbmodels.Properties{
+					{Name: "accessType", StringValue: apiutils.Of("read-only")},
+				},
+			}
+			_, err := toolRepo.Save(tool, &parentID)
+			require.NoError(t, err)
+		}
+
+		// List with PageSize=1 should return exactly 1 tool
+		pageSize1 := int32(1)
+		tools, err := toolRepo.List(models.MCPServerToolListOptions{
+			Pagination: dbmodels.Pagination{PageSize: &pageSize1},
+			ParentID:   parentID,
+		})
+		require.NoError(t, err)
+		assert.Len(t, tools, 1, "PageSize=1 should limit results to 1 tool")
+
+		// List with PageSize=3 should return exactly 3 tools
+		pageSize3 := int32(3)
+		tools, err = toolRepo.List(models.MCPServerToolListOptions{
+			Pagination: dbmodels.Pagination{PageSize: &pageSize3},
+			ParentID:   parentID,
+		})
+		require.NoError(t, err)
+		assert.Len(t, tools, 3, "PageSize=3 should limit results to 3 tools")
+
+		// List with PageSize=10 (greater than total) should return all 5 tools
+		pageSize10 := int32(10)
+		tools, err = toolRepo.List(models.MCPServerToolListOptions{
+			Pagination: dbmodels.Pagination{PageSize: &pageSize10},
+			ParentID:   parentID,
+		})
+		require.NoError(t, err)
+		assert.Len(t, tools, 5, "PageSize=10 (greater than total) should return all 5 tools")
+
+		// List without PageSize should still return all 5 tools
+		tools, err = toolRepo.List(models.MCPServerToolListOptions{
+			ParentID: parentID,
+		})
+		require.NoError(t, err)
+		assert.Len(t, tools, 5, "No PageSize should return all tools")
+	})
+
 	t.Run("TestListToolsForNonExistentParent", func(t *testing.T) {
 		// List tools for a non-existent parent ID
 		nonExistentParentID := int32(999999)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
