### PR TITLE
feat(ui): add copy-to-clipboard button to markdown code blocks

### DIFF
--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -760,6 +760,35 @@ Granite 3.1 Instruct Models are primarily finetuned using instruction-response p
 		Language:    []string{"en"},
 		SourceId:    stringToPointer("huggingface"),
 		LibraryName: stringToPointer("transformers"),
+		Readme: stringToPointer(`# BERT Base Uncased
+
+BERT is a transformers model pretrained on a large corpus of English data.
+
+## Installation
+
+` + "```bash" + `
+pip install transformers torch
+` + "```" + `
+
+## Quick Start
+
+` + "```python" + `
+from transformers import BertTokenizer, BertModel
+
+tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+model = BertModel.from_pretrained('bert-base-uncased')
+
+text = "Replace this with your text"
+encoded = tokenizer(text, return_tensors='pt')
+output = model(**encoded)
+` + "```" + `
+
+## Using with Pipeline
+
+` + "```bash" + `
+python -c "from transformers import pipeline; nlp = pipeline('fill-mask', model='bert-base-uncased'); print(nlp('The capital of France is [MASK].'))"
+` + "```" + `
+`),
 	}
 
 	huggingFaceModel2 := models.CatalogModel{

--- a/clients/ui/frontend/src/app/shared/markdown/MarkdownComponent.scss
+++ b/clients/ui/frontend/src/app/shared/markdown/MarkdownComponent.scss
@@ -24,17 +24,19 @@
     }
   }
 
-  // Code blocks
-  pre {
+  // Code blocks — overlay the copy button on the code content
+  .pf-v6-c-code-block {
+    position: relative;
     margin: var(--pf-t--global--spacer--sm) 0;
-    padding: var(--pf-t--global--spacer--sm);
-    background-color: var(--pf-t--global--background--color--secondary--default);
-    overflow-x: auto;
 
-    code {
-      font-family: var(--pf-t--global--font--family--mono);
-      font-size: var(--pf-t--global--font--size--body--sm);
-      white-space: pre-wrap;
+    .pf-v6-c-code-block__header {
+      position: absolute;
+      top: var(--pf-t--global--spacer--xs);
+      right: var(--pf-t--global--spacer--xs);
+      z-index: 1;
+      background: none;
+      border: none;
+      padding: 0;
     }
   }
 

--- a/clients/ui/frontend/src/app/shared/markdown/MarkdownComponent.tsx
+++ b/clients/ui/frontend/src/app/shared/markdown/MarkdownComponent.tsx
@@ -60,31 +60,22 @@ const MarkdownComponent = ({
           );
         },
         summary: ({ children, ...props }) => <Content {...props}>{children}</Content>,
-        code: ({ node, className, children, ...props }) => {
+        pre: ({ children }) => {
           const code = React.Children.toArray(children)
+            .filter((child): child is React.ReactElement<{ children: React.ReactNode }> =>
+              React.isValidElement(child),
+            )
+            .flatMap((child) => React.Children.toArray(child.props.children))
             .map((child) => (typeof child === 'string' ? child : ''))
             .join('')
             .replace(/\n$/, '');
-
-          if (!node) {
-            return (
-              <code className={className} {...props}>
-                {children}
-              </code>
-            );
-          }
-
-          const isPre = 'tagName' in node && node.tagName === 'pre';
-          if (isPre) {
-            return <CodeBlockComponent {...props}>{code}</CodeBlockComponent>;
-          }
-
-          return (
-            <code className={className} {...props}>
-              {children}
-            </code>
-          );
+          return <CodeBlockComponent>{code}</CodeBlockComponent>;
         },
+        code: ({ className, children, ...props }) => (
+          <code className={className} {...props}>
+            {children}
+          </code>
+        ),
         h1: ({ children, ...props }) => (
           <Content component={shiftHeadingLevel(1, maxHeading)} {...props}>
             {children}

--- a/clients/ui/frontend/src/app/shared/markdown/__tests__/MarkdownComponent.spec.tsx
+++ b/clients/ui/frontend/src/app/shared/markdown/__tests__/MarkdownComponent.spec.tsx
@@ -69,4 +69,45 @@ describe('MarkdownComponent', () => {
     expect(receivedProps.components).toBeDefined();
     expect(typeof receivedProps.components).toBe('object');
   });
+
+  it('provides pre and code component mappers', () => {
+    render(<MarkdownComponent data="test" />);
+
+    const receivedProps = (ReactMarkdown as jest.Mock).mock.calls[0][0];
+    const { pre, code } = receivedProps.components;
+
+    expect(pre).toBeDefined();
+    expect(code).toBeDefined();
+  });
+
+  it('code mapper renders inline code element', () => {
+    render(<MarkdownComponent data="test" />);
+
+    const receivedProps = (ReactMarkdown as jest.Mock).mock.calls[0][0];
+    const CodeMapper = receivedProps.components.code;
+
+    const { container } = render(<CodeMapper className="language-js">const x = 1;</CodeMapper>);
+
+    const codeEl = container.querySelector('code');
+    expect(codeEl).toBeInTheDocument();
+    expect(codeEl).toHaveClass('language-js');
+    expect(codeEl).toHaveTextContent('const x = 1;');
+  });
+
+  it('pre mapper extracts text from code children', () => {
+    render(<MarkdownComponent data="test" />);
+
+    const receivedProps = (ReactMarkdown as jest.Mock).mock.calls[0][0];
+    const PreMapper = receivedProps.components.pre;
+
+    const { container } = render(
+      <PreMapper>
+        <code>pip install torch</code>
+      </PreMapper>,
+    );
+
+    expect(container.querySelector('.pf-v6-c-code-block')).toBeInTheDocument();
+    expect(screen.getByText('pip install torch')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
+  });
 });

--- a/clients/ui/frontend/src/app/shared/markdown/components/CodeBlockComponent.tsx
+++ b/clients/ui/frontend/src/app/shared/markdown/components/CodeBlockComponent.tsx
@@ -1,15 +1,48 @@
 import React from 'react';
-import { CodeBlock, CodeBlockCode } from '@patternfly/react-core';
+import {
+  CodeBlock,
+  CodeBlockAction,
+  CodeBlockCode,
+  ClipboardCopyButton,
+} from '@patternfly/react-core';
 
 type CodeBlockComponentProps = {
-  children: React.ReactNode;
-  className?: string;
+  children: string;
 };
 
-const CodeBlockComponent: React.FC<CodeBlockComponentProps> = ({ children, className }) => (
-  <CodeBlock className={className}>
-    <CodeBlockCode>{children}</CodeBlockCode>
-  </CodeBlock>
-);
+const CodeBlockComponent: React.FC<CodeBlockComponentProps> = ({ children }) => {
+  const [copied, setCopied] = React.useState(false);
+  const id = React.useId();
+
+  const handleCopy = React.useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(children);
+      setCopied(true);
+    } catch {
+      // clipboard write failed — don't show success
+    }
+  }, [children]);
+
+  const actions = (
+    <CodeBlockAction>
+      <ClipboardCopyButton
+        id={`copy-${id}`}
+        aria-label="Copy to clipboard"
+        onClick={handleCopy}
+        onTooltipHidden={() => setCopied(false)}
+        exitDelay={copied ? 1500 : 600}
+        variant="plain"
+      >
+        {copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
+      </ClipboardCopyButton>
+    </CodeBlockAction>
+  );
+
+  return (
+    <CodeBlock actions={actions}>
+      <CodeBlockCode>{children}</CodeBlockCode>
+    </CodeBlock>
+  );
+};
 
 export default CodeBlockComponent;

--- a/clients/ui/frontend/src/app/shared/markdown/components/__tests__/CodeBlockComponent.spec.tsx
+++ b/clients/ui/frontend/src/app/shared/markdown/components/__tests__/CodeBlockComponent.spec.tsx
@@ -1,9 +1,28 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 
 describe('CodeBlockComponent', () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+  });
+
   it('renders code content correctly', () => {
     const codeContent = 'const example = "test";';
     render(<CodeBlockComponent>{codeContent}</CodeBlockComponent>);
@@ -11,5 +30,41 @@ describe('CodeBlockComponent', () => {
     expect(screen.getByText(codeContent)).toBeInTheDocument();
     expect(screen.getByText(codeContent).closest('.pf-v6-c-code-block')).toBeInTheDocument();
     expect(screen.getByText(codeContent).closest('.pf-v6-c-code-block__code')).toBeInTheDocument();
+  });
+
+  it('renders copy to clipboard button', () => {
+    render(<CodeBlockComponent>some code</CodeBlockComponent>);
+
+    expect(screen.getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
+  });
+
+  it('copies content to clipboard on click', async () => {
+    const codeContent = 'pip install model-registry';
+    render(<CodeBlockComponent>{codeContent}</CodeBlockComponent>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(codeContent);
+  });
+
+  it('button remains accessible after successful copy', async () => {
+    render(<CodeBlockComponent>some code</CodeBlockComponent>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('some code');
+    expect(screen.getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
+  });
+
+  it('does not show copied state when clipboard write fails', async () => {
+    (navigator.clipboard.writeText as jest.Mock).mockRejectedValue(new Error('denied'));
+
+    render(<CodeBlockComponent>some code</CodeBlockComponent>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Description
Refactor code block rendering to use PatternFly's CodeBlock with a ClipboardCopyButton overlay, replacing the previous plain pre/code approach. The pre mapper now handles fenced code block detection while the code mapper handles inline code only.

- Add ClipboardCopyButton with success/failure state handling
- Overlay copy button on code content via absolute positioning
- Add mock readme data with fenced code blocks for testing
- Add tests for copy behavior, inline code mapper, and failure path

<img width="1893" height="771" alt="image" src="https://github.com/user-attachments/assets/6e09a29c-d3be-433c-9d1e-39115160683f" />


## How Has This Been Tested?
### Unit Tests (all passing)

**CodeBlockComponent** (`CodeBlockComponent.spec.tsx`) — 5 tests:
- Renders code content within PatternFly CodeBlock structure
- Renders copy-to-clipboard button
- Copies content to clipboard on click
- Button remains accessible after successful copy
- Does not show copied state when clipboard write fails

**MarkdownComponent** (`MarkdownComponent.spec.tsx`) — 3 new tests:
- Provides `pre` and `code` component mappers
- `code` mapper renders inline code element with correct class and content
- `pre` mapper extracts text from code children and renders CodeBlockComponent with copy button

### Full Test Suite
- All **579 frontend tests** pass (`npx jest`)
- **ESLint/Prettier** clean on all changed files
- **Go BFF build** compiles successfully with updated mock data

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
