### PR TITLE
fix(catalog): replace phantom yamlMCPArtifact struct with generated openapi.MCPArtifact

### DIFF
--- a/catalog/internal/catalog/mcpcatalog/providers.go
+++ b/catalog/internal/catalog/mcpcatalog/providers.go
@@ -118,7 +118,7 @@ type yamlMCPServer struct {
 	PublishedDate            *string                             `yaml:"publishedDate,omitempty"`
 	Transports               []string                            `yaml:"transports,omitempty"`
 	Tools                    []*yamlMCPTool                      `yaml:"tools,omitempty"`
-	Artifacts                []*yamlMCPArtifact                  `yaml:"artifacts,omitempty"`
+	Artifacts                []apimodels.MCPArtifact              `yaml:"artifacts,omitempty"`
 	DeploymentMode           *string                             `yaml:"deploymentMode,omitempty"`
 	Endpoints                *yamlMCPEndpoints                   `yaml:"endpoints,omitempty"`
 	RuntimeMetadata          *apimodels.MCPRuntimeMetadata       `yaml:"runtimeMetadata,omitempty"`
@@ -136,13 +136,6 @@ type yamlMCPTool struct {
 	Schema      *string            `yaml:"schema,omitempty"`
 	AccessType  *string            `yaml:"accessType,omitempty"`
 	Parameters  []yamlMCPParameter `yaml:"parameters,omitempty"`
-}
-
-// yamlMCPArtifact represents an MCP artifact (e.g., container image)
-type yamlMCPArtifact struct {
-	Name string `yaml:"name"`
-	URI  string `yaml:"uri"`
-	Type string `yaml:"type"`
 }
 
 // yamlMCPEndpoints represents MCP server endpoints
@@ -360,7 +353,7 @@ func (ys *yamlMCPServer) ToMCPServerProviderRecord() MCPServerProviderRecord {
 	// Validate and convert artifacts to JSON
 	if len(ys.Artifacts) > 0 {
 		for i, artifact := range ys.Artifacts {
-			if err := basecatalog.ValidateArtifactURI(artifact.URI); err != nil {
+			if err := basecatalog.ValidateArtifactURI(artifact.Uri); err != nil {
 				return MCPServerProviderRecord{Error: fmt.Errorf("server %q artifact %d: %w", ys.Name, i, err)}
 			}
 		}

--- a/catalog/internal/catalog/mcpcatalog/providers_test.go
+++ b/catalog/internal/catalog/mcpcatalog/providers_test.go
@@ -438,8 +438,8 @@ func TestYamlMCPArtifactURIValidation(t *testing.T) {
 			name: "artifact with valid oci URI passes",
 			server: &yamlMCPServer{
 				Name: "server-oci-artifact",
-				Artifacts: []*yamlMCPArtifact{
-					{Name: "container", URI: "oci://registry.example.com/image:v1", Type: "container"},
+				Artifacts: []apimodels.MCPArtifact{
+					{Uri: "oci://registry.example.com/image:v1"},
 				},
 			},
 		},
@@ -447,8 +447,8 @@ func TestYamlMCPArtifactURIValidation(t *testing.T) {
 			name: "artifact with valid https URI passes",
 			server: &yamlMCPServer{
 				Name: "server-https-artifact",
-				Artifacts: []*yamlMCPArtifact{
-					{Name: "model", URI: "https://example.com/model.bin", Type: "model"},
+				Artifacts: []apimodels.MCPArtifact{
+					{Uri: "https://example.com/model.bin"},
 				},
 			},
 		},
@@ -456,8 +456,8 @@ func TestYamlMCPArtifactURIValidation(t *testing.T) {
 			name: "artifact with valid s3 URI passes",
 			server: &yamlMCPServer{
 				Name: "server-s3-artifact",
-				Artifacts: []*yamlMCPArtifact{
-					{Name: "weights", URI: "s3://bucket/path/to/weights", Type: "weights"},
+				Artifacts: []apimodels.MCPArtifact{
+					{Uri: "s3://bucket/path/to/weights"},
 				},
 			},
 		},
@@ -465,8 +465,8 @@ func TestYamlMCPArtifactURIValidation(t *testing.T) {
 			name: "artifact with invalid URI (no scheme) is rejected",
 			server: &yamlMCPServer{
 				Name: "server-invalid-uri",
-				Artifacts: []*yamlMCPArtifact{
-					{Name: "bad", URI: "not-a-valid-uri", Type: "model"},
+				Artifacts: []apimodels.MCPArtifact{
+					{Uri: "not-a-valid-uri"},
 				},
 			},
 			wantErr:     true,
@@ -476,8 +476,8 @@ func TestYamlMCPArtifactURIValidation(t *testing.T) {
 			name: "artifact with unsupported scheme is rejected",
 			server: &yamlMCPServer{
 				Name: "server-ftp-artifact",
-				Artifacts: []*yamlMCPArtifact{
-					{Name: "bad", URI: "ftp://example.com/model.bin", Type: "model"},
+				Artifacts: []apimodels.MCPArtifact{
+					{Uri: "ftp://example.com/model.bin"},
 				},
 			},
 			wantErr:     true,
@@ -487,8 +487,8 @@ func TestYamlMCPArtifactURIValidation(t *testing.T) {
 			name: "artifact with empty URI is rejected",
 			server: &yamlMCPServer{
 				Name: "server-empty-uri",
-				Artifacts: []*yamlMCPArtifact{
-					{Name: "empty", URI: "", Type: "model"},
+				Artifacts: []apimodels.MCPArtifact{
+					{Uri: ""},
 				},
 			},
 			wantErr:     true,
@@ -498,9 +498,9 @@ func TestYamlMCPArtifactURIValidation(t *testing.T) {
 			name: "multiple artifacts with one invalid URI is rejected",
 			server: &yamlMCPServer{
 				Name: "server-mixed-artifacts",
-				Artifacts: []*yamlMCPArtifact{
-					{Name: "good", URI: "s3://bucket/valid", Type: "model"},
-					{Name: "bad", URI: "invalid-uri", Type: "model"},
+				Artifacts: []apimodels.MCPArtifact{
+					{Uri: "s3://bucket/valid"},
+					{Uri: "invalid-uri"},
 				},
 			},
 			wantErr:     true,
@@ -528,6 +528,40 @@ func TestYamlMCPArtifactURIValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestYamlMCPArtifactTimestampRoundTrip(t *testing.T) {
+	createTime := "1753292581000"
+	updateTime := "1774534350000"
+	server := &yamlMCPServer{
+		Name: "server-with-timestamps",
+		Artifacts: []apimodels.MCPArtifact{
+			{Uri: "oci://registry.example.com/image:v1", CreateTimeSinceEpoch: &createTime, LastUpdateTimeSinceEpoch: &updateTime},
+		},
+	}
+
+	record := server.ToMCPServerProviderRecord()
+	require.Nil(t, record.Error)
+	require.NotNil(t, record.Server.Properties)
+
+	var artifactsJSON string
+	for _, prop := range *record.Server.Properties {
+		if prop.Name == "artifacts" && prop.StringValue != nil {
+			artifactsJSON = *prop.StringValue
+		}
+	}
+	require.NotEmpty(t, artifactsJSON, "artifacts property should be set")
+
+	var artifacts []apimodels.MCPArtifact
+	err := json.Unmarshal([]byte(artifactsJSON), &artifacts)
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+
+	assert.Equal(t, "oci://registry.example.com/image:v1", artifacts[0].Uri)
+	require.NotNil(t, artifacts[0].CreateTimeSinceEpoch, "createTimeSinceEpoch should survive round-trip")
+	assert.Equal(t, "1753292581000", *artifacts[0].CreateTimeSinceEpoch)
+	require.NotNil(t, artifacts[0].LastUpdateTimeSinceEpoch, "lastUpdateTimeSinceEpoch should survive round-trip")
+	assert.Equal(t, "1774534350000", *artifacts[0].LastUpdateTimeSinceEpoch)
 }
 
 func TestYamlMCPServerLicenseTransformation(t *testing.T) {


### PR DESCRIPTION
## Description
The custom yamlMCPArtifact struct had fields (Name, Type) not present in the OpenAPI spec and was missing timestamp fields (createTimeSinceEpoch, lastUpdateTimeSinceEpoch) that are defined in the spec. This caused silent data loss of artifact timestamps through the entire MCP server YAML loader pipeline. Replacing it with the generated apimodels.MCPArtifact type ensures struct-to-JSON fidelity and prevents field drift.

Adds a round-trip test verifying timestamps survive ToMCPServerProviderRecord() serialization.

## How Has This Been Tested?
Unit tests
Loading manifest data

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
