### PR TITLE
fix(bff): use base64-encoded auth in destination secrets for model transfer jobs

### DIFF
--- a/clients/ui/bff/internal/repositories/model_transfer_jobs.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -952,8 +953,7 @@ func buildSourceSecret(generateNamePrefix string, payload models.ModelTransferJo
 }
 
 func buildDestinationSecret(generateNamePrefix string, payload models.ModelTransferJob, jobID string) (*corev1.Secret, error) {
-	// NOTE: Due to async-upload bug, auth is NOT base64 encoded here
-	auth := fmt.Sprintf("%s:%s", payload.Destination.Username, payload.Destination.Password)
+	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", payload.Destination.Username, payload.Destination.Password)))
 
 	registry := payload.Destination.Registry
 	if registry == "" {


### PR DESCRIPTION
## Description

The BFF had a workaround in `buildDestinationSecret` where the `auth` field in `.dockerconfigjson` secrets was written as plain text `username:password` instead of the standard base64-encoded format. This was due to a bug in the async-upload job ([`config.py:L240-L241`](https://github.com/kubeflow/model-registry/blob/main/jobs/async-upload/job/config.py#L240-L241)) that parsed auth with a simple string split rather than base64 decoding.

The async-upload job has since been fixed to accept both base64-encoded and plain text auth (backwards compatible). This PR removes the workaround and uses the standard Docker config encoding (`base64("username:password")`).

### Changes
- Added `encoding/base64` import
- Base64-encode the auth value in `buildDestinationSecret` using `base64.StdEncoding.EncodeToString`
- Removed the workaround comment

## How Has This Been Tested?

- All 62 existing BFF repository tests pass (`go test ./internal/repositories/ -count=1`)
- The test mock in `base_testenv.go` already uses base64-encoded auth (`bW9jazptb2Nr`), confirming alignment with the expected format

## Test Impact

No new tests needed — existing integration tests cover the `CreateModelTransferJob` flow that exercises `buildDestinationSecret`. The mock destination secret was already using the correct base64 format.

## Merge criteria:

- [x] All the commits have been _signed-off_ (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the kubeflow contribution guidelines.