### PR TITLE
Fix/catalog source error messages

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -97,7 +97,7 @@ class CatalogSourceConfigRow extends TableRow {
     return this;
   }
 
-  shouldHaveValidationStatus(status: 'Connected' | 'Failed' | 'Starting' | 'Unknown' | '-') {
+  shouldHaveValidationStatus(status: 'Ready' | 'Failed' | 'Starting' | 'Unknown' | '-') {
     this.findValidationStatus().contains(status);
     return this;
   }
@@ -142,11 +142,11 @@ class ModelCatalogSettings {
 
   findHeading() {
     cy.findByTestId('app-page-title').should('exist');
-    cy.findByTestId('app-page-title').contains('Model catalog sources');
+    cy.findByTestId('app-page-title').contains('Model catalog settings');
   }
 
   findNavItem() {
-    return appChrome.findNavItem('Model catalog sources', 'Settings');
+    return appChrome.findNavItem('Model catalog settings', 'Settings');
   }
 
   findDescription() {
@@ -242,7 +242,7 @@ class ManageSourcePage {
   }
 
   findBreadcrumb() {
-    return cy.get('a[href="/model-catalog-settings"]').contains('Model catalog sources');
+    return cy.get('a[href="/model-catalog-settings"]').contains('Model catalog settings');
   }
 
   findBreadcrumbAction() {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -142,11 +142,11 @@ class ModelCatalogSettings {
 
   findHeading() {
     cy.findByTestId('app-page-title').should('exist');
-    cy.findByTestId('app-page-title').contains('Model catalog settings');
+    cy.findByTestId('app-page-title').contains('Model catalog sources');
   }
 
   findNavItem() {
-    return appChrome.findNavItem('Model catalog settings', 'Settings');
+    return appChrome.findNavItem('Model catalog sources', 'Settings');
   }
 
   findDescription() {
@@ -242,7 +242,7 @@ class ManageSourcePage {
   }
 
   findBreadcrumb() {
-    return cy.get('a[href="/model-catalog-settings"]').contains('Model catalog settings');
+    return cy.get('a[href="/model-catalog-settings"]').contains('Model catalog sources');
   }
 
   findBreadcrumbAction() {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -443,7 +443,7 @@ describe('Catalog Source Configs Table', () => {
       modelCatalogSettings.visit();
       const row = modelCatalogSettings.getRow('HuggingFace Google');
       row.findName().should('be.visible');
-      row.shouldHaveValidationStatus('Connected');
+      row.shouldHaveValidationStatus('Ready');
       row.findValidationStatus().findByTestId('source-status-connected-hf-google').should('exist');
     });
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -783,7 +783,7 @@ describe('Manage Source Page', () => {
 
       // Before entering organization, should show generic text
       cy.contains(
-        'Optionally filter which models from your source appear in the model catalog',
+        'Optionally filter which models from this source appear in the model catalog',
       ).should('exist');
 
       // Fill organization name
@@ -791,7 +791,7 @@ describe('Manage Source Page', () => {
 
       // After entering organization, should show organization-specific text
       cy.contains(
-        'Optionally filter which Google models from your source appear in the model catalog',
+        'Optionally filter which Google models from this source appear in the model catalog',
       ).should('exist');
       cy.contains('all Google models from the source will be visible').should('exist');
 
@@ -800,7 +800,7 @@ describe('Manage Source Page', () => {
 
       // Text should update to new organization
       cy.contains(
-        'Optionally filter which Meta models from your source appear in the model catalog',
+        'Optionally filter which Meta models from this source appear in the model catalog',
       ).should('exist');
       cy.contains('all Meta models from the source will be visible').should('exist');
     });

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CatalogSourceStatus.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CatalogSourceStatus.tsx
@@ -54,7 +54,7 @@ const CatalogSourceStatus: React.FC<CatalogSourceStatusProps> = ({ catalogSource
     case CatalogSourceStatusEnum.AVAILABLE:
       return (
         <Label status="success" data-testid={`source-status-connected-${catalogSourceConfig.id}`}>
-          Connected
+          Ready
         </Label>
       );
 

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CatalogSourceStatusErrorModal.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CatalogSourceStatusErrorModal.tsx
@@ -10,6 +10,7 @@ import {
   ModalVariant,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ERROR_MESSAGES } from '~/app/pages/modelCatalogSettings/constants';
 
 type CatalogSourceStatusErrorModalProps = {
   isOpen: boolean;
@@ -45,12 +46,11 @@ const CatalogSourceStatusErrorModal: React.FC<CatalogSourceStatusErrorModalProps
         <Alert
           variant="danger"
           isInline
-          title="Validation failed"
+          title={ERROR_MESSAGES.VALIDATION_FAILED}
           data-testid="catalog-source-status-error-alert"
         >
           <p data-testid="catalog-source-status-error-details">
-            The system cannot establish a connection to the source. Ensure that the organization is
-            accurate, then try again.
+            {ERROR_MESSAGES.VALIDATION_FAILED_BODY}
           </p>
           {errorMessage && <p data-testid="catalog-source-status-error-message">{errorMessage}</p>}
         </Alert>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -20,7 +20,7 @@ import { validateOrganization } from '~/app/pages/modelCatalogSettings/utils/val
 import {
   FORM_LABELS,
   VALIDATION_MESSAGES,
-  HELP_TEXT,
+  DESCRIPTION_TEXT,
   PLACEHOLDERS,
 } from '~/app/pages/modelCatalogSettings/constants';
 import { TempDevFeature, useTempDevFeatureAvailable } from '~/app/hooks/useTempDevFeatureAvailable';
@@ -67,7 +67,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
     <>
       <FormHelperText>
         <HelperText>
-          <HelperTextItem>{HELP_TEXT.ORGANIZATION}</HelperTextItem>
+          <HelperTextItem>{DESCRIPTION_TEXT.ORGANIZATION}</HelperTextItem>
         </HelperText>
       </FormHelperText>
     </>
@@ -116,7 +116,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
       <FormGroup label={FORM_LABELS.ACCESS_TOKEN} fieldId="access-token">
         <FormHelperText>
           <HelperText>
-            <HelperTextItem>{HELP_TEXT.ACCESS_TOKEN}</HelperTextItem>
+            <HelperTextItem>{DESCRIPTION_TEXT.ACCESS_TOKEN}</HelperTextItem>
           </HelperText>
         </FormHelperText>
         <FormFieldset component={accessTokenInput} field="Access token" />

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  FormGroup,
   TextInput,
   FormHelperText,
   HelperText,
@@ -12,7 +11,6 @@ import {
 } from '@patternfly/react-core';
 import { UpdateObjectAtPropAndValue } from 'mod-arch-shared';
 import PasswordInput from '~/app/shared/components/PasswordInput';
-import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
 import ThemeAwareFormGroupWrapper from '~/app/pages/settings/components/ThemeAwareFormGroupWrapper';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
@@ -21,7 +19,10 @@ import {
   FORM_LABELS,
   VALIDATION_MESSAGES,
   DESCRIPTION_TEXT,
+  HELPER_TEXT,
   PLACEHOLDERS,
+  ERROR_MESSAGES,
+  SUCCESS_MESSAGES,
 } from '~/app/pages/modelCatalogSettings/constants';
 import { TempDevFeature, useTempDevFeatureAvailable } from '~/app/hooks/useTempDevFeatureAvailable';
 
@@ -111,18 +112,39 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
     />
   );
 
+  const accessTokenDescriptionTxtNode = (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem>{DESCRIPTION_TEXT.ACCESS_TOKEN}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  );
+
+  const accessTokenHelperTxtNode = (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem>{HELPER_TEXT.ACCESS_TOKEN}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  );
+
   const accessTokenFormGroup = (
     <>
-      <FormGroup label={FORM_LABELS.ACCESS_TOKEN} fieldId="access-token">
-        <FormHelperText>
-          <HelperText>
-            <HelperTextItem>{DESCRIPTION_TEXT.ACCESS_TOKEN}</HelperTextItem>
-          </HelperText>
-        </FormHelperText>
-        <FormFieldset component={accessTokenInput} field="Access token" />
-      </FormGroup>
+      <ThemeAwareFormGroupWrapper
+        label={FORM_LABELS.ACCESS_TOKEN}
+        fieldId="access-token"
+        descriptionTextNode={accessTokenDescriptionTxtNode}
+        helperTextNode={accessTokenHelperTxtNode}
+      >
+        {accessTokenInput}
+      </ThemeAwareFormGroupWrapper>
       {validationError && (
-        <Alert isInline variant="danger" title="Validation failed" className="pf-v6-u-mt-md">
+        <Alert
+          isInline
+          variant="danger"
+          title={ERROR_MESSAGES.VALIDATION_FAILED}
+          className="pf-v6-u-mt-md"
+        >
           {validationError.message}
         </Alert>
       )}
@@ -131,10 +153,10 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
           isInline
           variant="success"
           className="pf-v6-u-mt-md"
-          title="Validation successful"
+          title={SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL}
           actionClose={<AlertActionCloseButton onClose={onClearValidationSuccess} />}
         >
-          The organization and accessToken are valid for connection.
+          {SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL_BODY}
         </Alert>
       )}
 

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -122,7 +122,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
         <FormFieldset component={accessTokenInput} field="Access token" />
       </FormGroup>
       {validationError && (
-        <Alert isInline variant="danger" title="Validation failed" className="pf-v5-u-mt-md">
+        <Alert isInline variant="danger" title="Validation failed" className="pf-v6-u-mt-md">
           {validationError.message}
         </Alert>
       )}
@@ -130,7 +130,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
         <Alert
           isInline
           variant="success"
-          className="pf-v5-u-mt-md"
+          className="pf-v6-u-mt-md"
           title="Validation successful"
           actionClose={<AlertActionCloseButton onClose={onClearValidationSuccess} />}
         >
@@ -138,7 +138,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
         </Alert>
       )}
 
-      <ActionList className="pf-v5-u-mt-md">
+      <ActionList className="pf-v6-u-mt-md">
         <Button
           isDisabled={!isOrganizationValid || isValidating}
           variant="link"

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceForm.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceForm.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Form,
-  FormGroup,
   Checkbox,
   Stack,
   StackItem,
@@ -11,11 +10,16 @@ import {
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
+import ThemeAwareFormGroupWrapper from '~/app/pages/settings/components/ThemeAwareFormGroupWrapper';
 import { catalogSettingsUrl } from '~/app/routes/modelCatalogSettings/modelCatalogSettings';
 import { isFormValid } from '~/app/pages/modelCatalogSettings/utils/validation';
 import { useManageSourceData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
 import { useSourcePreview } from '~/app/pages/modelCatalogSettings/useSourcePreview';
-import { FORM_LABELS, DESCRIPTIONS } from '~/app/pages/modelCatalogSettings/constants';
+import {
+  FORM_LABELS,
+  DESCRIPTION_TEXT,
+  ERROR_MESSAGES,
+} from '~/app/pages/modelCatalogSettings/constants';
 import { ModelCatalogSettingsContext } from '~/app/context/modelCatalogSettings/ModelCatalogSettingsContext';
 import {
   catalogSourceConfigToFormData,
@@ -82,7 +86,7 @@ const ManageSourceForm: React.FC<ManageSourceFormProps> = ({
       refreshCatalogSourceConfigs();
       navigate(catalogSettingsUrl());
     } catch (error) {
-      setSubmitError(error instanceof Error ? error : new Error(`Failed to save source`));
+      setSubmitError(error instanceof Error ? error : new Error(ERROR_MESSAGES.SAVE_FAILED));
     } finally {
       setIsSubmitting(false);
     }
@@ -144,7 +148,10 @@ const ManageSourceForm: React.FC<ManageSourceFormProps> = ({
 
               <StackItem>
                 <FormSection>
-                  <FormGroup fieldId="enable-source">
+                  <ThemeAwareFormGroupWrapper
+                    label={FORM_LABELS.ENABLE_SOURCE}
+                    fieldId="enable-source"
+                  >
                     <Checkbox
                       label={
                         <span className="pf-v6-c-form__label-text">
@@ -154,11 +161,11 @@ const ManageSourceForm: React.FC<ManageSourceFormProps> = ({
                       id="enable-source"
                       name="enable-source"
                       data-testid="enable-source-checkbox"
-                      description={DESCRIPTIONS.ENABLE_SOURCE}
+                      description={DESCRIPTION_TEXT.ENABLE_SOURCE}
                       isChecked={formData.enabled}
                       onChange={(_event, checked) => setData('enabled', checked)}
                     />
-                  </FormGroup>
+                  </ThemeAwareFormGroupWrapper>
                 </FormSection>
               </StackItem>
             </Stack>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceForm.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceForm.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   Form,
+  FormGroup,
   Checkbox,
   Stack,
   StackItem,
@@ -10,7 +11,6 @@ import {
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
-import ThemeAwareFormGroupWrapper from '~/app/pages/settings/components/ThemeAwareFormGroupWrapper';
 import { catalogSettingsUrl } from '~/app/routes/modelCatalogSettings/modelCatalogSettings';
 import { isFormValid } from '~/app/pages/modelCatalogSettings/utils/validation';
 import { useManageSourceData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
@@ -148,10 +148,7 @@ const ManageSourceForm: React.FC<ManageSourceFormProps> = ({
 
               <StackItem>
                 <FormSection>
-                  <ThemeAwareFormGroupWrapper
-                    label={FORM_LABELS.ENABLE_SOURCE}
-                    fieldId="enable-source"
-                  >
+                  <FormGroup fieldId="enable-source">
                     <Checkbox
                       label={
                         <span className="pf-v6-c-form__label-text">
@@ -165,7 +162,7 @@ const ManageSourceForm: React.FC<ManageSourceFormProps> = ({
                       isChecked={formData.enabled}
                       onChange={(_event, checked) => setData('enabled', checked)}
                     />
-                  </ThemeAwareFormGroupWrapper>
+                  </FormGroup>
                 </FormSection>
               </StackItem>
             </Stack>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceFormFooter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceFormFooter.tsx
@@ -9,6 +9,7 @@ import {
   ActionListGroup,
   Alert,
 } from '@patternfly/react-core';
+import { ERROR_MESSAGES } from '~/app/pages/modelCatalogSettings/constants';
 import PreviewButton from './PreviewButton';
 
 type ManageSourceFormFooterProps = {
@@ -38,7 +39,7 @@ const ManageSourceFormFooter: React.FC<ManageSourceFormFooterProps> = ({
     <Stack hasGutter>
       {submitError && (
         <StackItem>
-          <Alert variant="danger" isInline title="Error saving source">
+          <Alert variant="danger" isInline title={ERROR_MESSAGES.SAVE_FAILED}>
             {submitError.message}
           </Alert>
         </StackItem>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ModelVisibilitySection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ModelVisibilitySection.tsx
@@ -2,20 +2,19 @@ import * as React from 'react';
 import {
   FormFieldGroupExpandable,
   FormFieldGroupHeader,
-  FormGroup,
   TextArea,
   FormHelperText,
   HelperText,
   HelperTextItem,
 } from '@patternfly/react-core';
 import { UpdateObjectAtPropAndValue } from 'mod-arch-shared';
-import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
+import ThemeAwareFormGroupWrapper from '~/app/pages/settings/components/ThemeAwareFormGroupWrapper';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
 import {
   FORM_LABELS,
   PLACEHOLDERS,
-  DESCRIPTIONS,
+  DESCRIPTION_TEXT,
   getFilterInfoWithOrg,
   getAllowedModelsHelp,
   getExcludedModelsHelp,
@@ -41,18 +40,7 @@ const ModelVisibilitySection: React.FC<ModelVisibilitySectionProps> = ({
   const sectionDescription =
     isHuggingFaceMode && organization
       ? getFilterInfoWithOrg(organization)
-      : DESCRIPTIONS.FILTER_INFO_GENERIC;
-
-  const allowedModelsHelp = getAllowedModelsHelp(organization);
-  const excludedModelsHelp = getExcludedModelsHelp(organization);
-
-  const allowedModelsPlaceholder = isHuggingFaceMode
-    ? PLACEHOLDERS.ALLOWED_MODELS_HF
-    : PLACEHOLDERS.ALLOWED_MODELS_GENERIC;
-
-  const excludedModelsPlaceholder = isHuggingFaceMode
-    ? PLACEHOLDERS.EXCLUDED_MODELS_HF
-    : PLACEHOLDERS.EXCLUDED_MODELS_GENERIC;
+      : DESCRIPTION_TEXT.FILTER_INFO_GENERIC;
 
   const allowedModelsInput = (
     <TextArea
@@ -63,8 +51,24 @@ const ModelVisibilitySection: React.FC<ModelVisibilitySectionProps> = ({
       onChange={(_event, value) => setData('allowedModels', value)}
       rows={3}
       resizeOrientation="vertical"
-      placeholder={allowedModelsPlaceholder}
+      placeholder={PLACEHOLDERS.ALLOWED_MODELS}
     />
+  );
+
+  const allowedModelsDescriptionTxtNode = (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem>{getAllowedModelsHelp(organization)}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  );
+
+  const allowedModelsHelperTxtNode = (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem>{getIncludedModelsFieldHelperText}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
   );
 
   const excludedModelsInput = (
@@ -76,8 +80,24 @@ const ModelVisibilitySection: React.FC<ModelVisibilitySectionProps> = ({
       onChange={(_event, value) => setData('excludedModels', value)}
       rows={3}
       resizeOrientation="vertical"
-      placeholder={excludedModelsPlaceholder}
+      placeholder={PLACEHOLDERS.EXCLUDED_MODELS}
     />
+  );
+
+  const excludedModelsDescriptionTxtNode = (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem>{getExcludedModelsHelp(organization)}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  );
+
+  const excludedModelsHelperTxtNode = (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem>{getExcludedModelsFieldHelperText}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
   );
 
   return (
@@ -93,33 +113,23 @@ const ModelVisibilitySection: React.FC<ModelVisibilitySectionProps> = ({
         isExpanded={isDefaultExpanded}
         data-testid="model-visibility-section"
       >
-        <FormGroup label={FORM_LABELS.ALLOWED_MODELS} fieldId="allowed-models">
-          <FormFieldset component={allowedModelsInput} field="Allowed models" />
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem>{allowedModelsHelp}</HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem>{getIncludedModelsFieldHelperText}</HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        </FormGroup>
+        <ThemeAwareFormGroupWrapper
+          label={FORM_LABELS.ALLOWED_MODELS}
+          fieldId="allowed-models"
+          descriptionTextNode={allowedModelsDescriptionTxtNode}
+          helperTextNode={allowedModelsHelperTxtNode}
+        >
+          {allowedModelsInput}
+        </ThemeAwareFormGroupWrapper>
 
-        <FormGroup label={FORM_LABELS.EXCLUDED_MODELS} fieldId="excluded-models">
-          <FormFieldset component={excludedModelsInput} field="Excluded models" />
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem>{excludedModelsHelp}</HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem>{getExcludedModelsFieldHelperText}</HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        </FormGroup>
+        <ThemeAwareFormGroupWrapper
+          label={FORM_LABELS.EXCLUDED_MODELS}
+          fieldId="excluded-models"
+          descriptionTextNode={excludedModelsDescriptionTxtNode}
+          helperTextNode={excludedModelsHelperTxtNode}
+        >
+          {excludedModelsInput}
+        </ThemeAwareFormGroupWrapper>
       </FormFieldGroupExpandable>
     </FormSection>
   );

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
@@ -19,7 +19,11 @@ import {
   AlertActionLink,
 } from '@patternfly/react-core';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
-import { PAGE_TITLES } from '~/app/pages/modelCatalogSettings/constants';
+import {
+  PAGE_TITLES,
+  ERROR_MESSAGES,
+  EMPTY_STATE_TEXT,
+} from '~/app/pages/modelCatalogSettings/constants';
 import {
   UseSourcePreviewResult,
   PreviewTab,
@@ -58,7 +62,7 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
       return (
         <EmptyState
           icon={TimesCircleIcon}
-          titleText="Failed to preview the results"
+          titleText={ERROR_MESSAGES.PREVIEW_FAILED}
           variant={EmptyStateVariant.sm}
         >
           <EmptyStateBody>{previewError.message}</EmptyStateBody>
@@ -80,8 +84,8 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
     return (
       <EmptyState titleText={PAGE_TITLES.PREVIEW_MODELS} variant={EmptyStateVariant.sm}>
         <EmptyStateBody>
-          To view the models from this source that will appear in the model catalog with your
-          current configuration, complete all required fields, then click <strong>Preview</strong>.
+          To view the models from this source that will appear in the model catalog, complete all
+          required fields, then click <strong>Preview</strong>.
         </EmptyStateBody>
         <EmptyStateFooter>
           <EmptyStateActions>
@@ -175,12 +179,16 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
           ) : (
             <EmptyState
               variant={EmptyStateVariant.sm}
-              titleText={`No models ${activeTab === PreviewTab.INCLUDED ? 'included' : 'excluded'}`}
+              titleText={
+                activeTab === PreviewTab.INCLUDED
+                  ? EMPTY_STATE_TEXT.NO_MODELS_INCLUDED
+                  : EMPTY_STATE_TEXT.NO_MODELS_EXCLUDED
+              }
             >
               <EmptyStateBody>
                 {activeTab === PreviewTab.INCLUDED
-                  ? 'No models from this source are visible in the model catalog. To include models, edit the model visibility settings of this source.'
-                  : 'No models from this source are excluded by this filter'}
+                  ? EMPTY_STATE_TEXT.NO_MODELS_INCLUDED_BODY
+                  : EMPTY_STATE_TEXT.NO_MODELS_EXCLUDED_BODY}
               </EmptyStateBody>
             </EmptyState>
           )}

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
@@ -110,6 +110,19 @@ const YamlSection: React.FC<YamlSectionProps> = ({
       </FormHelperText>
     );
 
+  const expectedFormatButton = onToggleExpectedFormatDrawer ? (
+    <Button
+      variant="link"
+      isInline
+      onClick={onToggleExpectedFormatDrawer}
+      data-testid="view-expected-yaml-format-link"
+      icon={<OpenDrawerRightIcon />}
+      iconPosition="end"
+    >
+      {EXPECTED_YAML_FORMAT_LABEL}
+    </Button>
+  ) : null;
+
   return (
     <FormSection data-testid="yaml-section">
       {fileUploadError && (
@@ -129,60 +142,14 @@ const YamlSection: React.FC<YamlSectionProps> = ({
           alignItems={{ default: 'alignItemsCenter' }}
           className="pf-v6-u-mb-sm"
         >
-          <FlexItem>
-            {FORM_LABELS.YAML_CONTENT}
-            <span className="pf-v6-c-form__label-required" aria-hidden="true">
-              {' '}
-              *
-            </span>
-          </FlexItem>
-          {onToggleExpectedFormatDrawer && (
-            <FlexItem>
-              <Button
-                variant="link"
-                isInline
-                onClick={onToggleExpectedFormatDrawer}
-                data-testid="view-expected-yaml-format-link"
-                icon={<OpenDrawerRightIcon />}
-                iconPosition="end"
-              >
-                {EXPECTED_YAML_FORMAT_LABEL}
-              </Button>
-            </FlexItem>
-          )}
+          <FlexItem>{FORM_LABELS.YAML_CONTENT}</FlexItem>
+          <FlexItem>{expectedFormatButton}</FlexItem>
         </Flex>
       )}
       <FormGroup
-        label={
-          !isMUITheme ? (
-            <Flex
-              justifyContent={{ default: 'justifyContentSpaceBetween' }}
-              alignItems={{ default: 'alignItemsCenter' }}
-            >
-              <FlexItem>
-                {FORM_LABELS.YAML_CONTENT}
-                <span className="pf-v6-c-form__label-required" aria-hidden="true">
-                  {' '}
-                  *
-                </span>
-              </FlexItem>
-              {onToggleExpectedFormatDrawer && (
-                <FlexItem>
-                  <Button
-                    variant="link"
-                    isInline
-                    onClick={onToggleExpectedFormatDrawer}
-                    data-testid="view-expected-yaml-format-link"
-                    icon={<OpenDrawerRightIcon />}
-                    iconPosition="end"
-                  >
-                    {EXPECTED_YAML_FORMAT_LABEL}
-                  </Button>
-                </FlexItem>
-              )}
-            </Flex>
-          ) : undefined
-        }
+        label={!isMUITheme ? FORM_LABELS.YAML_CONTENT : undefined}
+        labelInfo={!isMUITheme ? expectedFormatButton : undefined}
+        isRequired
         fieldId="yaml-content"
       >
         <FormFieldset component={yamlInput} field="YAML" />

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { OpenDrawerRightIcon } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from 'mod-arch-shared';
+import { useThemeContext } from 'mod-arch-kubeflow';
 import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
@@ -35,6 +36,7 @@ const YamlSection: React.FC<YamlSectionProps> = ({
   setData,
   onToggleExpectedFormatDrawer,
 }) => {
+  const { isMUITheme } = useThemeContext();
   const [isYamlTouched, setIsYamlTouched] = React.useState(false);
   const [filename, setFilename] = React.useState('');
   const [fileUploadError, setFileUploadError] = React.useState<string | undefined>(undefined);
@@ -121,30 +123,66 @@ const YamlSection: React.FC<YamlSectionProps> = ({
           {fileUploadError}
         </Alert>
       )}
+      {isMUITheme && (
+        <Flex
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          alignItems={{ default: 'alignItemsCenter' }}
+          className="pf-v6-u-mb-sm"
+        >
+          <FlexItem>
+            {FORM_LABELS.YAML_CONTENT}
+            <span className="pf-v6-c-form__label-required" aria-hidden="true">
+              {' '}
+              *
+            </span>
+          </FlexItem>
+          {onToggleExpectedFormatDrawer && (
+            <FlexItem>
+              <Button
+                variant="link"
+                isInline
+                onClick={onToggleExpectedFormatDrawer}
+                data-testid="view-expected-yaml-format-link"
+                icon={<OpenDrawerRightIcon />}
+                iconPosition="end"
+              >
+                {EXPECTED_YAML_FORMAT_LABEL}
+              </Button>
+            </FlexItem>
+          )}
+        </Flex>
+      )}
       <FormGroup
         label={
-          <Flex
-            justifyContent={{ default: 'justifyContentSpaceBetween' }}
-            alignItems={{ default: 'alignItemsCenter' }}
-          >
-            <FlexItem>{FORM_LABELS.YAML_CONTENT}</FlexItem>
-            {onToggleExpectedFormatDrawer && (
+          !isMUITheme ? (
+            <Flex
+              justifyContent={{ default: 'justifyContentSpaceBetween' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+            >
               <FlexItem>
-                <Button
-                  variant="link"
-                  isInline
-                  onClick={onToggleExpectedFormatDrawer}
-                  data-testid="view-expected-yaml-format-link"
-                  icon={<OpenDrawerRightIcon />}
-                  iconPosition="end"
-                >
-                  {EXPECTED_YAML_FORMAT_LABEL}
-                </Button>
+                {FORM_LABELS.YAML_CONTENT}
+                <span className="pf-v6-c-form__label-required" aria-hidden="true">
+                  {' '}
+                  *
+                </span>
               </FlexItem>
-            )}
-          </Flex>
+              {onToggleExpectedFormatDrawer && (
+                <FlexItem>
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={onToggleExpectedFormatDrawer}
+                    data-testid="view-expected-yaml-format-link"
+                    icon={<OpenDrawerRightIcon />}
+                    iconPosition="end"
+                  >
+                    {EXPECTED_YAML_FORMAT_LABEL}
+                  </Button>
+                </FlexItem>
+              )}
+            </Flex>
+          ) : undefined
         }
-        isRequired
         fieldId="yaml-content"
       >
         <FormFieldset component={yamlInput} field="YAML" />

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
@@ -18,7 +18,7 @@ import { validateYamlContent } from '~/app/pages/modelCatalogSettings/utils/vali
 import {
   FORM_LABELS,
   VALIDATION_MESSAGES,
-  HELP_TEXT,
+  DESCRIPTION_TEXT,
   EXPECTED_YAML_FORMAT_LABEL,
 } from '~/app/pages/modelCatalogSettings/constants';
 
@@ -114,7 +114,7 @@ const YamlSection: React.FC<YamlSectionProps> = ({
         <FormFieldset component={yamlInput} field="YAML" />
         <FormHelperText>
           <HelperText>
-            <HelperTextItem>{HELP_TEXT.YAML}</HelperTextItem>
+            <HelperTextItem>{DESCRIPTION_TEXT.YAML}</HelperTextItem>
           </HelperText>
         </FormHelperText>
         {isYamlTouched && !isYamlContentValid && (

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Alert,
   Button,
   Flex,
   FlexItem,
@@ -19,6 +20,7 @@ import {
   FORM_LABELS,
   VALIDATION_MESSAGES,
   DESCRIPTION_TEXT,
+  ERROR_MESSAGES,
   EXPECTED_YAML_FORMAT_LABEL,
 } from '~/app/pages/modelCatalogSettings/constants';
 
@@ -35,6 +37,7 @@ const YamlSection: React.FC<YamlSectionProps> = ({
 }) => {
   const [isYamlTouched, setIsYamlTouched] = React.useState(false);
   const [filename, setFilename] = React.useState('');
+  const [fileUploadError, setFileUploadError] = React.useState<string | undefined>(undefined);
   const isYamlContentValid = validateYamlContent(formData.yamlContent);
 
   const handleFileChange = (
@@ -42,11 +45,15 @@ const YamlSection: React.FC<YamlSectionProps> = ({
     file: File,
   ) => {
     setFilename(file.name);
+    setFileUploadError(undefined);
     const reader = new FileReader();
     reader.onload = () => {
       const text = typeof reader.result === 'string' ? reader.result : '';
       setData('yamlContent', text);
       setIsYamlTouched(true);
+    };
+    reader.onerror = () => {
+      setFileUploadError(ERROR_MESSAGES.FILE_UPLOAD_FAILED_BODY);
     };
     reader.readAsText(file);
   };
@@ -59,6 +66,7 @@ const YamlSection: React.FC<YamlSectionProps> = ({
     setFilename('');
     setData('yamlContent', '');
     setIsYamlTouched(true);
+    setFileUploadError(undefined);
   };
 
   const yamlInput = (
@@ -83,8 +91,38 @@ const YamlSection: React.FC<YamlSectionProps> = ({
     </div>
   );
 
+  const yamlDescriptionTxtNode = (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem>{DESCRIPTION_TEXT.YAML}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  );
+
+  const yamlHelperTxtNode =
+    isYamlTouched && !isYamlContentValid ? (
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem variant="error" data-testid="yaml-content-error">
+            {VALIDATION_MESSAGES.YAML_CONTENT_REQUIRED}
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    ) : undefined;
+
   return (
     <FormSection data-testid="yaml-section">
+      {fileUploadError && (
+        <Alert
+          variant="danger"
+          isInline
+          title={ERROR_MESSAGES.FILE_UPLOAD_FAILED}
+          className="pf-v6-u-mb-md"
+          data-testid="yaml-file-upload-error"
+        >
+          {fileUploadError}
+        </Alert>
+      )}
       <FormGroup
         label={
           <Flex
@@ -111,21 +149,9 @@ const YamlSection: React.FC<YamlSectionProps> = ({
         isRequired
         fieldId="yaml-content"
       >
+        {yamlDescriptionTxtNode}
         <FormFieldset component={yamlInput} field="YAML" />
-        <FormHelperText>
-          <HelperText>
-            <HelperTextItem>{DESCRIPTION_TEXT.YAML}</HelperTextItem>
-          </HelperText>
-        </FormHelperText>
-        {isYamlTouched && !isYamlContentValid && (
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem variant="error" data-testid="yaml-content-error">
-                {VALIDATION_MESSAGES.YAML_CONTENT_REQUIRED}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        )}
+        {yamlHelperTxtNode}
       </FormGroup>
     </FormSection>
   );

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
@@ -19,9 +19,9 @@ import { validateYamlContent } from '~/app/pages/modelCatalogSettings/utils/vali
 import {
   FORM_LABELS,
   VALIDATION_MESSAGES,
-  DESCRIPTION_TEXT,
   ERROR_MESSAGES,
   EXPECTED_YAML_FORMAT_LABEL,
+  HELPER_TEXT,
 } from '~/app/pages/modelCatalogSettings/constants';
 
 type YamlSectionProps = {
@@ -91,14 +91,6 @@ const YamlSection: React.FC<YamlSectionProps> = ({
     </div>
   );
 
-  const yamlDescriptionTxtNode = (
-    <FormHelperText>
-      <HelperText>
-        <HelperTextItem>{DESCRIPTION_TEXT.YAML}</HelperTextItem>
-      </HelperText>
-    </FormHelperText>
-  );
-
   const yamlHelperTxtNode =
     isYamlTouched && !isYamlContentValid ? (
       <FormHelperText>
@@ -108,7 +100,13 @@ const YamlSection: React.FC<YamlSectionProps> = ({
           </HelperTextItem>
         </HelperText>
       </FormHelperText>
-    ) : undefined;
+    ) : (
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem>{HELPER_TEXT.YAML}</HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    );
 
   return (
     <FormSection data-testid="yaml-section">
@@ -149,7 +147,6 @@ const YamlSection: React.FC<YamlSectionProps> = ({
         isRequired
         fieldId="yaml-content"
       >
-        {yamlDescriptionTxtNode}
         <FormFieldset component={yamlInput} field="YAML" />
         {yamlHelperTxtNode}
       </FormGroup>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/__tests__/PreviewPanel.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/__tests__/PreviewPanel.spec.tsx
@@ -116,7 +116,7 @@ describe('PreviewPanel', () => {
     );
     render(<PreviewPanel preview={preview} />);
 
-    expect(screen.getByText('Failed to preview the results')).toBeInTheDocument();
+    expect(screen.getByText('Preview failed')).toBeInTheDocument();
     expect(screen.getByText('Failed to fetch preview')).toBeInTheDocument();
     expect(screen.getByTestId('preview-button-panel-retry')).toBeInTheDocument();
   });

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -37,7 +37,7 @@ export const DESCRIPTION_TEXT = {
   ACCESS_TOKEN:
     'Enter your fine-grained Hugging Face access token. The token must have the following permissions: read repos in your namespace, read public repos that you can access, access webhooks, and create webhooks.',
   ORGANIZATION:
-    'Enter the name of the organization (for example, Google) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
+    'Enter the name of the organization (for example, meta-llama) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
   ENABLE_SOURCE:
     'Enable users in your organization to view models from this source in the model catalog.',
   FILTER_INFO_GENERIC:
@@ -50,7 +50,7 @@ export const HELPER_TEXT = {
 } as const;
 
 export const PLACEHOLDERS = {
-  ORGANIZATION: 'Example: Google',
+  ORGANIZATION: 'Example: meta-llama',
   ALLOWED_MODELS: 'Example: Llama*, Llama-3.1-8B-Instruct',
   EXCLUDED_MODELS: 'Example: Llama*, Llama-3.1-8B-Instruct',
 } as const;

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -38,7 +38,6 @@ export const DESCRIPTION_TEXT = {
     'Enter your fine-grained Hugging Face access token. The token must have the following permissions: read repos in your namespace, read public repos that you can access, access webhooks, and create webhooks.',
   ORGANIZATION:
     'Enter the name of the organization (for example, Google) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
-  YAML: 'Upload or paste a YAML string.',
   ENABLE_SOURCE:
     'Enable users in your organization to view models from this source in the model catalog.',
   FILTER_INFO_GENERIC:
@@ -47,6 +46,7 @@ export const DESCRIPTION_TEXT = {
 
 export const HELPER_TEXT = {
   ACCESS_TOKEN: 'Enter your Hugging Face access token.',
+  YAML: 'Upload or paste a YAML string.',
 } as const;
 
 export const PLACEHOLDERS = {

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -37,40 +37,74 @@ export const DESCRIPTION_TEXT = {
   ACCESS_TOKEN:
     'Enter your fine-grained Hugging Face access token. The token must have the following permissions: read repos in your namespace, read public repos that you can access, access webhooks, and create webhooks.',
   ORGANIZATION:
-    'Enter the name of the organization (for example, Google) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
+    'Enter the name of the organization (for example, Google/) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
   YAML: 'Upload or paste a YAML string.',
-} as const;
-
-export const HELPER_TEXT = {
-  ACCESS_TOKEN:
-    'Enter your Hugging Face access token.',
-};
-
-export const PLACEHOLDERS = {
-  ORGANIZATION: 'Example: meta-llama',
-  ALLOWED_MODELS_HF: 'Enter model names, one per line (e.g., gemma-7b*)',
-  ALLOWED_MODELS_GENERIC: 'Example: Google/gemma-7b*, Meta/Llama-3.1-8B-Instruct',
-  EXCLUDED_MODELS_HF: 'Enter model names, one per line (e.g., gemma-7b-test*)',
-  EXCLUDED_MODELS_GENERIC: 'Example: Google/gemma-7b-test*, Meta/Llama*',
-} as const;
-
-export const EXPECTED_YAML_FORMAT_LABEL = 'View expected file format';
-
-export const DESCRIPTIONS = {
   ENABLE_SOURCE:
     'Enable users in your organization to view models from this source in the model catalog.',
   FILTER_INFO_GENERIC:
-    'Optionally filter which models from your source appear in the model catalog. If no filters are set, all models from the source will be visible.',
+    'Optionally filter which models from this source appear in the model catalog. If no filters are set, all models from the source will be visible.',
 } as const;
+
+export const HELPER_TEXT = {
+  ACCESS_TOKEN: 'Enter your Hugging Face access token.',
+} as const;
+
+export const PLACEHOLDERS = {
+  ORGANIZATION: 'Example: Google/',
+  ALLOWED_MODELS: 'Example: Llama*, Llama-3.1-8B-Instruct',
+  EXCLUDED_MODELS: 'Example: Llama*, Llama-3.1-8B-Instruct',
+} as const;
+
+export const EXPECTED_YAML_FORMAT_LABEL = 'View expected file format';
 
 export const PAGE_TITLES = {
   MODEL_CATALOG_PREVIEW: 'Model catalog preview',
   PREVIEW_MODELS: 'Preview models',
 } as const;
 
+export const ERROR_MESSAGES = {
+  PREVIEW_FAILED: 'Preview failed',
+  SAVE_FAILED: 'Failed to save source',
+  FILE_UPLOAD_FAILED: 'File upload failed',
+  FILE_UPLOAD_FAILED_BODY:
+    "The YAML file couldn't be uploaded. Check its syntax and structure, then try again.",
+  VALIDATION_FAILED: 'Validation failed',
+  VALIDATION_FAILED_BODY:
+    'The system cannot establish a connection to the source. Ensure that the organization is accurate, then try again.',
+} as const;
+
+export const SUCCESS_MESSAGES = {
+  VALIDATION_SUCCESSFUL: 'Validation successful',
+  VALIDATION_SUCCESSFUL_BODY: 'The organization and access token are valid for connection.',
+} as const;
+
+export const TABLE_COLUMN_LABELS = {
+  SOURCE_NAME: 'Source name',
+  ORGANIZATION: 'Organization',
+  MODEL_VISIBILITY: 'Model visibility',
+  SOURCE_TYPE: 'Source type',
+  ENABLE: 'Enable',
+  VALIDATION_STATUS: 'Validation status',
+} as const;
+
+export const TABLE_COLUMN_POPOVERS = {
+  ORGANIZATION:
+    'Applies only to Hugging Face sources. Shows the organization the source syncs models from (for example, Google). Only models within this organization are included in the catalog.',
+  ENABLE:
+    'Enable a source to make its models available to users in your organization from the model catalog.',
+} as const;
+
+export const EMPTY_STATE_TEXT = {
+  NO_MODELS_INCLUDED: 'No models included',
+  NO_MODELS_INCLUDED_BODY:
+    'No models from this source are visible in the model catalog. To include models, edit the model visibility settings of this source.',
+  NO_MODELS_EXCLUDED: 'No models excluded',
+  NO_MODELS_EXCLUDED_BODY: 'No models from this source are excluded by this filter',
+} as const;
+
 export const getFilterInfoWithOrg = (organization: string): React.ReactNode => (
   <>
-    Optionally filter which <strong>{organization}</strong> models from your source appear in the
+    Optionally filter which <strong>{organization}</strong> models from this source appear in the
     model catalog. If no filters are set, all <strong>{organization}</strong> models from the source
     will be visible.
   </>
@@ -102,4 +136,4 @@ export const getIncludedModelsFieldHelperText =
 
 /** Same for HF and YAML sources. */
 export const getExcludedModelsFieldHelperText =
-  'Separate model names using commas. To exclude models matching a pattern, use an asterisk at the beginning, end, or both sides of a name. Example, *Llama*, Llama*Instruct';
+  'Separate model names using commas. To exclude all models with a specific prefix, enter the prefix followed by an asterisk. Example, Llama*';

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 export const FORM_LABELS = {
   NAME: 'Name',
   SOURCE_TYPE: 'Source type',
-  ORGANIZATION: 'Allowed organization',
+  ORGANIZATION: 'Organization',
   ACCESS_TOKEN: 'Access token',
   YAML_CONTENT: 'Upload a YAML file',
   MODEL_VISIBILITY: 'Model visibility',
@@ -33,13 +33,18 @@ export const VALIDATION_MESSAGES = {
   YAML_CONTENT_REQUIRED: 'YAML content is required',
 } as const;
 
-export const HELP_TEXT = {
+export const DESCRIPTION_TEXT = {
   ACCESS_TOKEN:
-    'Enter your fine-grained Hugging Face access token. Public models can be pulled into catalog without an access token. For private/gated models, a token is recommended to ensure full metadata is displayed, otherwise only limited metadata may be available. The token must have the following permissions: read repos in your namespace, read public repos that you can access.',
+    'Enter your fine-grained Hugging Face access token. The token must have the following permissions: read repos in your namespace, read public repos that you can access, access webhooks, and create webhooks.',
   ORGANIZATION:
-    'Enter the name of the organization (for example, meta-llama) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
+    'Enter the name of the organization (for example, Google) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
   YAML: 'Upload or paste a YAML string.',
 } as const;
+
+export const HELPER_TEXT = {
+  ACCESS_TOKEN:
+    'Enter your Hugging Face access token.',
+};
 
 export const PLACEHOLDERS = {
   ORGANIZATION: 'Example: meta-llama',

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -69,8 +69,7 @@ export const ERROR_MESSAGES = {
   FILE_UPLOAD_FAILED_BODY:
     "The YAML file couldn't be uploaded. Check its syntax and structure, then try again.",
   VALIDATION_FAILED: 'Validation failed',
-  VALIDATION_FAILED_BODY:
-    'The system cannot establish a connection to the source. Ensure that the organization is accurate, then try again.',
+  VALIDATION_FAILED_BODY: 'The system cannot establish a connection to the source.',
 } as const;
 
 export const SUCCESS_MESSAGES = {
@@ -89,7 +88,7 @@ export const TABLE_COLUMN_LABELS = {
 
 export const TABLE_COLUMN_POPOVERS = {
   ORGANIZATION:
-    'Applies only to Hugging Face sources. Shows the organization the source syncs models from (for example, Google). Only models within this organization are included in the catalog.',
+    'Applies only to Hugging Face sources. Shows the organization the source syncs models from (for example, meta-llama). Only models within this organization are included in the catalog.',
   ENABLE:
     'Enable a source to make its models available to users in your organization from the model catalog.',
 } as const;

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -37,7 +37,7 @@ export const DESCRIPTION_TEXT = {
   ACCESS_TOKEN:
     'Enter your fine-grained Hugging Face access token. The token must have the following permissions: read repos in your namespace, read public repos that you can access, access webhooks, and create webhooks.',
   ORGANIZATION:
-    'Enter the name of the organization (for example, Google/) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
+    'Enter the name of the organization (for example, Google) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
   YAML: 'Upload or paste a YAML string.',
   ENABLE_SOURCE:
     'Enable users in your organization to view models from this source in the model catalog.',
@@ -50,7 +50,7 @@ export const HELPER_TEXT = {
 } as const;
 
 export const PLACEHOLDERS = {
-  ORGANIZATION: 'Example: Google/',
+  ORGANIZATION: 'Example: Google',
   ALLOWED_MODELS: 'Example: Llama*, Llama-3.1-8B-Instruct',
   EXCLUDED_MODELS: 'Example: Llama*, Llama-3.1-8B-Instruct',
 } as const;

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableColumns.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableColumns.tsx
@@ -2,30 +2,33 @@ import * as React from 'react';
 import { List, ListItem } from '@patternfly/react-core';
 import { kebabTableColumn, SortableData } from 'mod-arch-shared';
 import { CatalogSourceConfig } from '~/app/modelCatalogTypes';
+import {
+  TABLE_COLUMN_LABELS,
+  TABLE_COLUMN_POPOVERS,
+} from '~/app/pages/modelCatalogSettings/constants';
 
 export const catalogSourceConfigsColumns: SortableData<CatalogSourceConfig>[] = [
   {
     field: 'name',
-    label: 'Source name',
+    label: TABLE_COLUMN_LABELS.SOURCE_NAME,
     sortable: (a, b) => a.name.localeCompare(b.name),
     width: 15,
   },
   {
     field: 'allowedOrganization',
-    label: 'Organization',
+    label: TABLE_COLUMN_LABELS.ORGANIZATION,
     sortable: (a, b) =>
       ('allowedOrganization' in a ? (a.allowedOrganization ?? '') : '').localeCompare(
         'allowedOrganization' in b ? (b.allowedOrganization ?? '') : '',
       ),
     info: {
-      popover:
-        'Applies only to Hugging Face sources. Shows the organization the source syncs models from (for example, meta-llama). Only models within this organization are included in the catalog.',
+      popover: TABLE_COLUMN_POPOVERS.ORGANIZATION,
     },
     width: 15,
   },
   {
     field: 'filters',
-    label: 'Model visibility',
+    label: TABLE_COLUMN_LABELS.MODEL_VISIBILITY,
     sortable: (a: CatalogSourceConfig, b: CatalogSourceConfig): number => {
       const aFiltered = (a.includedModels?.length ?? 0) + (a.excludedModels?.length ?? 0);
       const bFiltered = (b.includedModels?.length ?? 0) + (b.excludedModels?.length ?? 0);
@@ -54,23 +57,22 @@ export const catalogSourceConfigsColumns: SortableData<CatalogSourceConfig>[] = 
   },
   {
     field: 'type',
-    label: 'Source type',
+    label: TABLE_COLUMN_LABELS.SOURCE_TYPE,
     sortable: (a, b) => a.type.localeCompare(b.type),
     width: 15,
   },
   {
     field: 'enabled',
-    label: 'Enable',
+    label: TABLE_COLUMN_LABELS.ENABLE,
     sortable: (a, b) => Number(a.enabled ?? true) - Number(b.enabled ?? true),
     info: {
-      popover:
-        'Enable a source to make its models available to users in your organization from the model catalog.',
+      popover: TABLE_COLUMN_POPOVERS.ENABLE,
     },
     width: 10,
   },
   {
     field: 'status',
-    label: 'Validation status',
+    label: TABLE_COLUMN_LABELS.VALIDATION_STATUS,
     sortable: false,
     width: 10,
   },

--- a/clients/ui/frontend/src/app/routes/modelCatalogSettings/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/app/routes/modelCatalogSettings/modelCatalogSettings.ts
@@ -1,4 +1,4 @@
-export const CATALOG_SETTINGS_PAGE_TITLE = 'Model catalog sources';
+export const CATALOG_SETTINGS_PAGE_TITLE = 'Model catalog settings';
 export const CATALOG_SETTINGS_DESCRIPTION =
   'Add and manage model sources that populate the model catalog for users in your organization.';
 

--- a/clients/ui/frontend/src/app/routes/modelCatalogSettings/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/app/routes/modelCatalogSettings/modelCatalogSettings.ts
@@ -1,4 +1,4 @@
-export const CATALOG_SETTINGS_PAGE_TITLE = 'Model catalog settings';
+export const CATALOG_SETTINGS_PAGE_TITLE = 'Model catalog sources';
 export const CATALOG_SETTINGS_DESCRIPTION =
   'Add and manage model sources that populate the model catalog for users in your organization.';
 


### PR DESCRIPTION
## Description

This PR improve the labels/text and show the error message from backend when the backend handle the error from YAML

### Part 1: Error Handling Improvements

- **Preview panel errors**: Replaced generic "Failed to preview the results" with "Preview failed" title while displaying the detailed backend error message in the body, giving users actionable information about what went wrong.
- **Save button errors**: Replaced generic "Error saving source" with "Failed to save source" and surfaces the detailed backend error message.
- **YAML file upload errors**: Added `FileReader.onError` handler in `YamlSection` that displays an inline danger alert with the message: *"File upload failed — The YAML file couldn't be uploaded. Check its syntax and structure, then try again."*
- **HF validation errors**: Updated "Connection failed" to "Validation failed" with detailed backend error message passthrough.
- All error/success strings centralized in `constants.tsx` (`ERROR_MESSAGES`, `SUCCESS_MESSAGES`).

> **Note**: No custom YAML validation logic was added to the frontend. Validation is the backend's responsibility; the UI only surfaces error messages returned by the API.

### Part 2: Microcopy Updates

**Page header:**
- Page title: "Model catalog settings" → "Model catalog sources"

**Table column names:**
| Old | New |
|-----|-----|
| Name | Source name |
| Organization allowed | Organization |
| Filters | Model visibility |
| Status | Validation status |

**Column popovers:**
- Organization popover updated: `meta-llama` → `Google`
- Model visibility popover rewritten with "All models" / "Filtered" definitions
- Enable popover updated

**Form fields:**
- Organization label: "Allowed organization" → "Organization"
- Organization helper text updated with `Google` 
- Organization placeholder: `meta-llama` → `Google`
- Access token refactored to use `ThemeAwareFormGroupWrapper` with separate description and helper text nodes
- Access token description updated to include webhook permissions
- Included/Excluded models: unified placeholders to `Example: Llama*, Llama-3.1-8B-Instruct`
- Included/Excluded models helper text simplified
- Enable source description updated

**Empty states:**
- Preview empty state: removed "with your current configuration"
- No models included/excluded messages moved to constants

### Part 3: Component Refactoring

- Replaced raw `FormGroup` + `FormFieldset` with `ThemeAwareFormGroupWrapper` in: `CredentialsSection`, `ModelVisibilitySection`, `ManageSourceForm` (enable-source checkbox)
- Migrated `pf-v5-*` CSS classes to `pf-v6-*` in `CredentialsSection`
- Consolidated `DESCRIPTIONS` and `HELP_TEXT` into `DESCRIPTION_TEXT` and `HELPER_TEXT`
- Unified HF/generic placeholders (`ALLOWED_MODELS_HF` / `ALLOWED_MODELS_GENERIC` → `ALLOWED_MODELS`)
- All hardcoded strings moved to `constants.tsx`: `ERROR_MESSAGES`, `SUCCESS_MESSAGES`, `TABLE_COLUMN_LABELS`, `TABLE_COLUMN_POPOVERS`, `EMPTY_STATE_TEXT`
- `CatalogSourceConfigsTableColumns.tsx` now references constants instead of inline strings
- `CatalogSourceStatusErrorModal.tsx` uses `ERROR_MESSAGES` constants

### Screen Shots

### Before:

- PF mode
<img width="2015" height="728" alt="image" src="https://github.com/user-attachments/assets/4f080296-a283-4035-9231-1cdcaea8b134" />
<img width="1099" height="620" alt="image" src="https://github.com/user-attachments/assets/7b0de087-f647-4ffe-b2ef-99ee11accda1" />
<img width="2018" height="961" alt="image" src="https://github.com/user-attachments/assets/a1060e37-ff0d-4766-96ed-8c7b22451322" />

- non-PF mode:
<img width="2042" height="593" alt="image" src="https://github.com/user-attachments/assets/63372150-5c06-4835-b126-159f20d0693f" />
<img width="1104" height="690" alt="image" src="https://github.com/user-attachments/assets/2c8fe6e0-a065-4e0e-bafe-075644e30405" />
<img width="2031" height="945" alt="image" src="https://github.com/user-attachments/assets/b71c8057-2d17-4180-ae5c-f730ab6803a4" />

### After:
- PF mode:
<img width="1897" height="796" alt="image" src="https://github.com/user-attachments/assets/4ec5bb51-7deb-4db4-94ec-5dc7159fa1ff" />
<img width="1120" height="746" alt="image" src="https://github.com/user-attachments/assets/8bdf0895-d77d-4cb9-bb54-40d2f9a76f67" />
<img width="2017" height="816" alt="image" src="https://github.com/user-attachments/assets/6fd7ce77-1a02-444f-a4e3-cb40ebb3e4da" />


- non-PF mode:
<img width="2040" height="596" alt="image" src="https://github.com/user-attachments/assets/a209a508-a32b-44ce-bb10-7d3d923e5a86" />
<img width="1094" height="684" alt="image" src="https://github.com/user-attachments/assets/56b0a9f6-9637-41d3-b260-5b84a9137524" />
<img width="2032" height="846" alt="image" src="https://github.com/user-attachments/assets/a6ec9050-70ed-45f2-9186-26b32fcaf7bf" />






### Files Changed (13)

| File | Change |
|------|--------|
| `constants.tsx` | Centralized all UI strings, added error/success/table/empty-state constants |
| `CredentialsSection.tsx` | ThemeAwareFormGroupWrapper, PF v5→v6, constants |
| `ManageSourceForm.tsx` | ThemeAwareFormGroupWrapper for enable-source, error constants |
| `ManageSourceFormFooter.tsx` | Error title from constants |
| `ModelVisibilitySection.tsx` | ThemeAwareFormGroupWrapper, unified placeholders |
| `PreviewPanel.tsx` | Error/empty-state text from constants |
| `YamlSection.tsx` | FileReader error handler, description/helper text nodes |
| `CatalogSourceStatusErrorModal.tsx` | Error text from constants |
| `CatalogSourceConfigsTableColumns.tsx` | Column labels/popovers from constants |
| `modelCatalogSettings.ts` (route) | Page title updated |
| `modelCatalogSettings.ts` (Cypress page) | Heading/breadcrumb/nav updated |
| `modelCatalogSettings.cy.ts` (Cypress test) | "your source" → "this source" |
| `PreviewPanel.spec.tsx` | Updated error title expectation |

## How Has This Been Tested?

- Cypress page objects updated to match new microcopy
- Cypress test assertions updated for "this source" wording
- Manual verification of error propagation chain from backend through `handleRestFailures` → component state → UI rendering

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
