### PR TITLE
fix(catalog): fix MCP tool lookup by unqualified name

### DIFF
--- a/catalog/internal/catalog/mcpcatalog/db_mcp.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp.go
@@ -290,10 +290,14 @@ func (d *dbMCPCatalogImpl) GetMCPServerTool(ctx context.Context, serverID string
 		return nil, fmt.Errorf("error loading tools for server %s: %w", serverID, err)
 	}
 
-	// Find tool by name
+	// Find tool by name. DB stores tools with a qualified prefix (serverName@version:toolName)
+	// for uniqueness, but the API exposes only the unqualified tool name.
 	for _, tool := range tools {
 		attrs := tool.GetAttributes()
-		if attrs != nil && attrs.Name != nil && *attrs.Name == toolName {
+		if attrs == nil || attrs.Name == nil {
+			continue
+		}
+		if converter.UnqualifyToolName(*attrs.Name) == toolName {
 			apiTool := converter.ConvertDbMCPToolToOpenapi(tool)
 			return apiTool, nil
 		}

--- a/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
@@ -165,7 +165,12 @@ func listWithServer(id int32, name string) *internalmodels.ListWrapper[models.MC
 	return &internalmodels.ListWrapper[models.MCPServer]{Items: []models.MCPServer{server}}
 }
 
-func listWithServers(servers ...struct{ id int32; name string }) *internalmodels.ListWrapper[models.MCPServer] {
+type serverStub struct {
+	id   int32
+	name string
+}
+
+func listWithServers(servers ...serverStub) *internalmodels.ListWrapper[models.MCPServer] {
 	items := make([]models.MCPServer, 0, len(servers))
 	for _, s := range servers {
 		items = append(items, &models.MCPServerImpl{
@@ -413,9 +418,9 @@ func TestListMCPServers_ToolCountZero(t *testing.T) {
 func TestListMCPServers_MultipleServersWithDifferentToolCounts(t *testing.T) {
 	repo := &mockMCPServerRepo{
 		listResult: listWithServers(
-			struct{ id int32; name string }{1, "server-a"},
-			struct{ id int32; name string }{2, "server-b"},
-			struct{ id int32; name string }{3, "server-c"},
+			serverStub{1, "server-a"},
+			serverStub{2, "server-b"},
+			serverStub{3, "server-c"},
 		),
 	}
 	toolRepo := &mockMCPServerToolRepo{
@@ -485,6 +490,39 @@ func TestListMCPServers_ZeroToolLimitDoesNotSetPageSize(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, toolRepo.capturedListOptions, "List should have been called on tool repo")
 	assert.Nil(t, toolRepo.capturedListOptions.PageSize, "PageSize should be nil when ToolLimit is 0")
+}
+
+func TestGetMCPServerTool_StripsQualifiedPrefix(t *testing.T) {
+	serverEntity := &models.MCPServerImpl{
+		ID:         serverID(88),
+		Attributes: &models.MCPServerAttributes{Name: serverName("dynatrace-mcp")},
+	}
+	repo := &mockMCPServerRepo{getResult: serverEntity}
+	toolRepo := &mockMCPServerToolRepo{
+		listResult: []models.MCPServerTool{makeTool("dynatrace-mcp@1.6.1:list_problems")},
+	}
+	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
+
+	result, err := cat.GetMCPServerTool(context.Background(), "88", "list_problems")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "list_problems", result.Name)
+}
+
+func TestGetMCPServerTool_NotFound(t *testing.T) {
+	serverEntity := &models.MCPServerImpl{
+		ID:         serverID(88),
+		Attributes: &models.MCPServerAttributes{Name: serverName("dynatrace-mcp")},
+	}
+	repo := &mockMCPServerRepo{getResult: serverEntity}
+	toolRepo := &mockMCPServerToolRepo{
+		listResult: []models.MCPServerTool{makeTool("dynatrace-mcp@1.6.1:list_problems")},
+	}
+	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
+
+	_, err := cat.GetMCPServerTool(context.Background(), "88", "nonexistent_tool")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
 }
 
 func TestGetMCPServer_IncludeToolsUsesAccurateCount(t *testing.T) {

--- a/catalog/internal/converter/mcp_converter.go
+++ b/catalog/internal/converter/mcp_converter.go
@@ -280,6 +280,16 @@ func ConvertOpenapiMCPToolToDb(openapiTool *openapi.MCPTool) models.MCPServerToo
 	return dbTool
 }
 
+// UnqualifyToolName strips the "serverName@version:" prefix from a qualified
+// tool name, returning just the tool name portion. If the name contains no
+// colon, it is returned unchanged.
+func UnqualifyToolName(name string) string {
+	if idx := strings.LastIndex(name, ":"); idx != -1 {
+		return name[idx+1:]
+	}
+	return name
+}
+
 // ConvertDbMCPToolToOpenapi converts a database MCPServerTool to OpenAPI MCPTool.
 func ConvertDbMCPToolToOpenapi(dbTool models.MCPServerTool) *openapi.MCPTool {
 	attr := dbTool.GetAttributes()
@@ -298,12 +308,7 @@ func ConvertDbMCPToolToOpenapi(dbTool models.MCPServerTool) *openapi.MCPTool {
 		accessType = "read_only" // default fallback to prevent API contract violation
 	}
 
-	// Strip internal qualified prefix (serverName@version:) from tool name before returning to API.
-	// The DB stores tools as "server@version:toolName" for uniqueness, but the API should return just "toolName".
-	toolName := *attr.Name
-	if idx := strings.LastIndex(toolName, ":"); idx != -1 {
-		toolName = toolName[idx+1:]
-	}
+	toolName := UnqualifyToolName(*attr.Name)
 
 	// Create OpenAPI tool with required fields
 	openapiTool := openapi.NewMCPTool(toolName, accessType)


### PR DESCRIPTION
## Description

Tools are stored in the DB with a qualified prefix (`serverName@version:toolName`) for uniqueness, but the `GET /mcp_servers/{id}/tools/{toolName}` endpoint compared the raw DB name against the unqualified URL parameter, so lookups always failed unless the caller supplied the prefix.

Extract `UnqualifyToolName()` into the converter package and call it from both `ConvertDbMCPToolToOpenapi` and `GetMCPServerTool`, so the strip logic lives in one place.

## How Has This Been Tested?

In a dev cluster with the demo MCP catalog loaded:

```
$ curl -s 'http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers/88/tools/list_problems' | jq
{
  "accessType": "read_only",
  "createTimeSinceEpoch": "1775148770584",
  "customProperties": {},
  "description": "Retrieve active problems and incidents",
  "id": "641",
  "lastUpdateTimeSinceEpoch": "1775148770584",
  "name": "list_problems",
  "parameters": [
    {
      "description": "Filter by status: OPEN, RESOLVED, or ALL",
      "name": "status",
      "required": false,
      "type": "string"
    }
  ]
}
```

Before this change, it returned `tool 'list_problems' not found`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
