### PR TITLE
fix(catalog): make performance metrics cache case-insensitive

### DIFF
--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -128,7 +128,7 @@ type PerformanceMetricsLoader struct {
 	metricsArtifactRepo   dbmodels.CatalogMetricsArtifactRepository
 	modelTypeID           int32
 	metricsArtifactTypeID int32
-	// Cache of model ID -> directory path mapping to avoid repeated directory scans
+	// Cache of lowercase model ID -> directory path for case-insensitive lookups
 	modelDirCache map[string]string
 }
 
@@ -179,7 +179,7 @@ func NewPerformanceMetricsLoader(path []string, modelRepo dbmodels.CatalogModelR
 	return loader, nil
 }
 
-// buildModelDirCache scans directories once and builds a cache of model ID -> directory path
+// buildModelDirCache scans directories once and builds a cache of lowercase model ID -> directory path
 func (pml *PerformanceMetricsLoader) buildModelDirCache() error {
 	modelCount := 0
 	for _, rootPath := range pml.path {
@@ -213,9 +213,14 @@ func (pml *PerformanceMetricsLoader) buildModelDirCache() error {
 				return nil // Continue with other directories
 			}
 
-			// Add to cache
-			pml.modelDirCache[metadata.ID] = dirPath
-			modelCount++
+			// Add to cache (lowercase key for case-insensitive matching)
+			cacheKey := strings.ToLower(metadata.ID)
+			if existing, ok := pml.modelDirCache[cacheKey]; ok {
+				glog.Warningf("Case-insensitive cache collision: %q (dir: %s) overwrites existing entry (dir: %s)", metadata.ID, dirPath, existing)
+			} else {
+				modelCount++
+			}
+			pml.modelDirCache[cacheKey] = dirPath
 			glog.V(3).Infof("Cached model directory: %s -> %s", metadata.ID, dirPath)
 
 			return nil
@@ -243,8 +248,8 @@ func (pml *PerformanceMetricsLoader) Load(ctx context.Context, record ModelProvi
 
 	// Namespaced name is source_id:model_name
 	namespacedName := *attrs.Name
-	// Resolve directory from cache: cache is keyed by metadata.ID (display name)
-	displayName := DisplayNameFromStoredName(namespacedName)
+	// Resolve directory from cache: cache is keyed by lowercase metadata.ID (display name)
+	displayName := strings.ToLower(DisplayNameFromStoredName(namespacedName))
 	dirPath, found := pml.modelDirCache[displayName]
 	if !found {
 		glog.V(2).Infof("No performance metrics directory found for model %s", namespacedName)

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -2,6 +2,8 @@ package modelcatalog
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -1178,6 +1180,130 @@ func TestMetadataJSONEdgeCases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildModelDirCache_CaseInsensitive(t *testing.T) {
+	// Create a temp directory structure with metadata.json files using mixed-case IDs
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name      string
+		metaID    string // ID written to metadata.json
+		lookupKey string // key used to look up in cache (simulates DisplayNameFromStoredName output)
+		wantFound bool
+	}{
+		{
+			name:      "exact case match",
+			metaID:    "sarvam-30b-FP8-Dynamic",
+			lookupKey: "sarvam-30b-fp8-dynamic",
+			wantFound: true,
+		},
+		{
+			name:      "all uppercase metadata ID",
+			metaID:    "MODEL-ABC-FP16",
+			lookupKey: "model-abc-fp16",
+			wantFound: true,
+		},
+		{
+			name:      "already lowercase",
+			metaID:    "already-lowercase",
+			lookupKey: "already-lowercase",
+			wantFound: true,
+		},
+		{
+			name:      "mixed case with org prefix",
+			metaID:    "RedHatAI/Granite-3B-Code",
+			lookupKey: "redhatai/granite-3b-code",
+			wantFound: true,
+		},
+		{
+			name:      "no match returns not found",
+			metaID:    "some-model",
+			lookupKey: "different-model",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a subdirectory with a metadata.json for this test case
+			modelDir := filepath.Join(tmpDir, tt.name)
+			if err := os.MkdirAll(modelDir, 0o755); err != nil {
+				t.Fatalf("failed to create model dir: %v", err)
+			}
+			metaContent := `{"id": "` + tt.metaID + `"}`
+			if err := os.WriteFile(filepath.Join(modelDir, "metadata.json"), []byte(metaContent), 0o644); err != nil {
+				t.Fatalf("failed to write metadata.json: %v", err)
+			}
+
+			// Build cache with only this directory
+			loader := &PerformanceMetricsLoader{
+				path:          []string{modelDir},
+				modelDirCache: make(map[string]string),
+			}
+			if err := loader.buildModelDirCache(); err != nil {
+				t.Fatalf("buildModelDirCache() error = %v", err)
+			}
+
+			// Lookup using the lowercased key (same as Load does)
+			_, found := loader.modelDirCache[strings.ToLower(tt.lookupKey)]
+			if found != tt.wantFound {
+				t.Errorf("cache lookup for %q: got found=%v, want found=%v (cache keys: %v)",
+					tt.lookupKey, found, tt.wantFound, cacheKeys(loader.modelDirCache))
+			}
+		})
+	}
+}
+
+func TestBuildModelDirCache_CollisionWarning(t *testing.T) {
+	// Two directories with metadata IDs that differ only by case should result
+	// in the second overwriting the first (last-write-wins). The collision
+	// warning is logged but we verify the cache ends up with a single entry.
+	tmpDir := t.TempDir()
+
+	dir1 := filepath.Join(tmpDir, "dir1")
+	dir2 := filepath.Join(tmpDir, "dir2")
+	for _, d := range []string{dir1, dir2} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("failed to create dir: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir1, "metadata.json"), []byte(`{"id": "Model-FP8"}`), 0o644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir2, "metadata.json"), []byte(`{"id": "model-fp8"}`), 0o644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	loader := &PerformanceMetricsLoader{
+		path:          []string{tmpDir},
+		modelDirCache: make(map[string]string),
+	}
+	if err := loader.buildModelDirCache(); err != nil {
+		t.Fatalf("buildModelDirCache() error = %v", err)
+	}
+
+	// Both IDs normalize to "model-fp8", so the cache should have exactly one entry
+	if len(loader.modelDirCache) != 1 {
+		t.Errorf("expected 1 cache entry after collision, got %d: %v", len(loader.modelDirCache), cacheKeys(loader.modelDirCache))
+	}
+	// filepath.Walk visits in lexicographic order, so dir2 (last-write) wins
+	cachedPath, found := loader.modelDirCache["model-fp8"]
+	if !found {
+		t.Fatalf("expected cache key %q, got keys: %v", "model-fp8", cacheKeys(loader.modelDirCache))
+	}
+	if cachedPath != dir2 {
+		t.Errorf("expected collision winner to be %s (last walked), got %s", dir2, cachedPath)
+	}
+}
+
+// cacheKeys returns all keys from a map for diagnostic output.
+func cacheKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func generateLongString(length int) string {


### PR DESCRIPTION
## Description
Model lookups were failing when metadata.json IDs had different casing than the stored display name. Normalize cache keys to lowercase using strings.ToLower() in both buildModelDirCache() (write) and Load() (read) to ensure case-insensitive matching.

Also adds collision detection with a warning log when two model IDs differ only by case, and fixes modelCount to only increment for genuinely new cache entries.

Includes comprehensive tests for case-insensitive lookups (5 table- driven cases) and collision last-write-wins behavior.

## How Has This Been Tested?
Unit testing

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
