### PR TITLE
fix(ui): forward incoming auth headers in webpack dev proxy

### DIFF
--- a/clients/ui/frontend/config/webpack.dev.js
+++ b/clients/ui/frontend/config/webpack.dev.js
@@ -26,36 +26,56 @@ const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/model-registry/' : PUBLIC_PATH;
 
-// Function to generate headers based on deployment mode
+// Get the kubeconfig token at startup as a fallback for standalone dev mode.
+const getKubeconfigToken = () => {
+  try {
+    const token = execSync(
+      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+    )
+      .toString()
+      .trim();
+    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+      .toString()
+      .trim();
+    // eslint-disable-next-line no-console
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
+  }
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
+
+// Build static proxy headers for auth methods that don't need dynamic forwarding.
 const getProxyHeaders = () => {
   if (AUTH_METHOD === 'internal') {
     return {
       'kubeflow-userid': 'user@example.com',
     };
   }
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync(
-        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-      )
-        .toString()
-        .trim();
-      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-        .toString()
-        .trim();
-      // eslint-disable-next-line no-console
-      console.info('Logged in as user:', username);
-      return {
-        Authorization: `Bearer ${token}`,
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
-  }
+  // For user_token, auth headers are set dynamically in onProxyReq below.
   return {};
+};
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the kubeconfig token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = smp.wrap(
@@ -94,6 +114,7 @@ module.exports = smp.wrap(
             },
             changeOrigin: true,
             headers: getProxyHeaders(),
+            onProxyReq,
           },
         ],
         devMiddleware: {


### PR DESCRIPTION
## Description

The webpack dev server's proxy was capturing the kubeconfig token at startup and setting it as a static `headers` config, which overwrote any auth headers forwarded by a host backend proxy (e.g. ODH Dashboard with dev impersonation). This meant that when running in federated mode with `AUTH_METHOD=user_token`, the BFF always operated with admin-level permissions regardless of which user the host backend was impersonating.

This PR switches to an `onProxyReq` callback that dynamically forwards incoming `authorization` headers when present, and falls back to the kubeconfig token captured at startup for standalone dev mode. This preserves the existing standalone behavior while enabling proper auth forwarding for federated setups.

### Before
- `getProxyHeaders()` ran `kubectl config view` at startup and returned static `Authorization` and `x-forwarded-access-token` headers
- These static headers overwrote any auth headers set by an upstream proxy

### After
- `getKubeconfigToken()` captures the kubeconfig token at startup as a fallback
- `getProxyHeaders()` returns `{}` for `user_token` mode (no static auth headers)
- `onProxyReq` callback dynamically:
  - Forwards incoming `authorization` header if present (federated mode with impersonation)
  - Falls back to the kubeconfig token if no incoming auth header (standalone mode)

## How Has This Been Tested?

Manual testing with ODH Dashboard federated dev mode:
1. Started ODH Dashboard backend with `DEV_IMPERSONATE_USER` configured
2. Started model-registry frontend + BFF in federated mode
3. Verified that BFF operations now use the impersonated user's token instead of the admin token

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.