### PR TITLE
feat(ui): make federated dev server ports configurable

### DIFF
--- a/clients/ui/Makefile
+++ b/clients/ui/Makefile
@@ -59,6 +59,9 @@ dev-bff-kubeflow:
 	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=kubeflow DEV_MODE_MODEL_REGISTRY_PORT=8085 DEV_MODE_CATALOG_PORT=8086
 
 ########### Dev Federated ###########
+FEDERATED_FRONTEND_PORT ?= 9100
+FEDERATED_BFF_PORT ?= 4000
+
 .PHONY: dev-start-federated
 dev-start-federated:
 	@trap 'exit 0' INT; \
@@ -66,11 +69,11 @@ dev-start-federated:
 
 .PHONY: dev-frontend-federated
 dev-frontend-federated:
-	cd frontend && AUTH_METHOD=user_token DEPLOYMENT_MODE=federated STYLE_THEME=patternfly PORT=9100 npm run start:dev
+	cd frontend && AUTH_METHOD=user_token DEPLOYMENT_MODE=federated STYLE_THEME=patternfly PORT=$(FEDERATED_FRONTEND_PORT) npm run start:dev
 
 .PHONY: dev-bff-federated
 dev-bff-federated:
-	cd bff && make run PORT=4000 MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false MOCK_MR_CATALOG_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=federated DEV_MODE_MODEL_REGISTRY_PORT=8085 DEV_MODE_CATALOG_PORT=8086 AUTH_METHOD=user_token AUTH_TOKEN_HEADER=x-forwarded-access-token AUTH_TOKEN_PREFIX="" INSECURE_SKIP_VERIFY=true
+	cd bff && make run PORT=$(FEDERATED_BFF_PORT) MOCK_K8S_CLIENT=false MOCK_MR_CLIENT=false MOCK_MR_CATALOG_CLIENT=false DEV_MODE=true DEPLOYMENT_MODE=federated DEV_MODE_MODEL_REGISTRY_PORT=8085 DEV_MODE_CATALOG_PORT=8086 AUTH_METHOD=user_token AUTH_TOKEN_HEADER=x-forwarded-access-token AUTH_TOKEN_PREFIX="" INSECURE_SKIP_VERIFY=true
 
 ############ Build ############
 

--- a/clients/ui/Makefile
+++ b/clients/ui/Makefile
@@ -69,7 +69,7 @@ dev-start-federated:
 
 .PHONY: dev-frontend-federated
 dev-frontend-federated:
-	cd frontend && AUTH_METHOD=user_token DEPLOYMENT_MODE=federated STYLE_THEME=patternfly PORT=$(FEDERATED_FRONTEND_PORT) npm run start:dev
+	cd frontend && AUTH_METHOD=user_token DEPLOYMENT_MODE=federated STYLE_THEME=patternfly PORT=$(FEDERATED_FRONTEND_PORT) PROXY_PORT=$(FEDERATED_BFF_PORT) npm run start:dev
 
 .PHONY: dev-bff-federated
 dev-bff-federated:


### PR DESCRIPTION
## Description
- Add `FEDERATED_FRONTEND_PORT` and `FEDERATED_BFF_PORT` Make variables with conditional assignment (`?=`) to `clients/ui/Makefile`
- Defaults remain unchanged (9100 for frontend, 4000 for BFF)
- Pass `PROXY_PORT=$(FEDERATED_BFF_PORT)` to the frontend dev server so the webpack proxy connects to the correct BFF port when overridden
- Allows overriding ports via environment variables, enabling multiple federated dev environments to run simultaneously on different ports

**Motivation:** When working with multiple git worktrees (e.g. working with agents on multiple branches or reviewing/testing multiple PRs), each worktree needs its own set of dev servers. Currently the federated dev targets hardcode `PORT=9100` and `PORT=4000`, so only one instance can run at a time. This change makes the ports configurable while preserving the existing defaults.

## How Has This Been Tested?
- Run `make dev-start-federated` with no env vars — should behave identically to before (ports 9100 and 4000)
- Run `FEDERATED_FRONTEND_PORT=9200 FEDERATED_BFF_PORT=4100 make dev-start-federated` — should start on the overridden ports and the frontend proxy should connect to port 4100

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)