### PR TITLE
Fix search bar for Model and MCP Catalog

### DIFF
--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogSourceLabelSelector.tsx
@@ -83,17 +83,21 @@ const McpCatalogSourceLabelSelector: React.FC<McpCatalogSourceLabelSelectorProps
           {...(toolbarClearAllProps ?? {})}
         >
           <ToolbarContent rowWrap={{ default: 'wrap' }}>
-            <Flex>
-              <ToolbarToggleGroup breakpoint="md" toggleIcon={<FilterIcon />}>
-                <ToolbarGroup variant="filter-group" gap={{ default: 'gapMd' }} alignItems="center">
-                  <ToolbarItem>
+            <Flex style={{ flex: 1 }}>
+              <ToolbarToggleGroup style={{ flex: 1 }} breakpoint="md" toggleIcon={<FilterIcon />}>
+                <ToolbarGroup
+                  style={{ flex: 1 }}
+                  variant="filter-group"
+                  gap={{ default: 'gapMd' }}
+                  alignItems="center"
+                >
+                  <ToolbarItem style={{ flex: 1 }}>
                     <ThemeAwareSearchInput
                       data-testid="mcp-catalog-search-input"
                       aria-label="Search with submit button"
                       className="toolbar-fieldset-wrapper"
                       placeholder="Search MCP servers..."
                       value={inputValue}
-                      style={{ width: '100%', maxWidth: '600px' }}
                       onChange={handleSearchInputChange}
                       onSearch={handleSearchInputSearch}
                       onClear={handleClear}

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogSourceLabelSelector.tsx
@@ -96,7 +96,7 @@ const McpCatalogSourceLabelSelector: React.FC<McpCatalogSourceLabelSelectorProps
                       data-testid="mcp-catalog-search-input"
                       aria-label="Search with submit button"
                       className="toolbar-fieldset-wrapper"
-                      placeholder="Search MCP servers..."
+                      placeholder="Search by name, keyword, or description"
                       value={inputValue}
                       onChange={handleSearchInputChange}
                       onSearch={handleSearchInputSearch}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -131,19 +131,22 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
             : {})}
         >
           <ToolbarContent rowWrap={{ default: 'wrap' }}>
-            <Flex>
-              <ToolbarToggleGroup breakpoint="md" toggleIcon={<FilterIcon />}>
-                <ToolbarGroup variant="filter-group" gap={{ default: 'gapMd' }} alignItems="center">
-                  <ToolbarItem>
+            <Flex style={{ flex: 1 }}>
+              <ToolbarToggleGroup style={{ flex: 1 }} breakpoint="md" toggleIcon={<FilterIcon />}>
+                <ToolbarGroup
+                  variant="filter-group"
+                  style={{ flex: 1 }}
+                  gap={{ default: 'gapMd' }}
+                  alignItems="center"
+                  className="toolbar-fieldset-wrapper"
+                >
+                  <ToolbarItem style={{ flex: 1 }}>
                     <ThemeAwareSearchInput
                       data-testid="search-input"
                       aria-label="Search with submit button"
                       className="toolbar-fieldset-wrapper"
                       placeholder="Filter by name, description and provider"
                       value={inputValue}
-                      style={{
-                        minWidth: '600px',
-                      }}
                       onChange={handleSearchInputChange}
                       onSearch={handleSearchInputSearch}
                       onClear={handleClear}

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/FormFieldset.scss
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/FormFieldset.scss
@@ -1,0 +1,9 @@
+.toolbar-fieldset-wrapper {
+  flex: 1 1 0;
+  min-width: 0;
+
+  > .pf-v6-c-input-group__item:not(.pf-m-search-action) {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+}

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/FormFieldset.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/FormFieldset.tsx
@@ -1,5 +1,6 @@
 import { useThemeContext } from 'mod-arch-kubeflow';
 import React, { CSSProperties, ReactNode } from 'react';
+import './FormFieldset.scss';
 
 interface FormFieldsetProps {
   component: ReactNode;

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ThemeAwareSearchInput.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/components/ThemeAwareSearchInput.tsx
@@ -41,6 +41,7 @@ const ThemeAwareSearchInput: React.FC<ThemeAwareSearchInputProps> = ({
             data-testid={dataTestId}
             style={{
               ...style,
+              width: '100%',
               paddingBlockStart: 'var(--pf-t--global--spacer--control--vertical--default)',
               paddingBlockEnd: 'var(--pf-t--global--spacer--control--vertical--default)',
             }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The search bar in the Model Catalog and MCP Catalog pages was not stretching to fill the available toolbar width. This caused the placeholder text and search input to be cut off, making it difficult for users to see what they were typing or reading.

Root cause: The `FormFieldset` component (used for MUI theme rendering) was replacing its base CSS class instead of concatenating it

- Updated ModelCatalogSourceLabelSelector and McpCatalogSourceLabelSelector toolbar layout to use flex: 1 at each nesting level (`Flex` → `ToolbarToggleGroup` → `ToolbarGroup` → `ToolbarItem`), allowing the search bar to stretch to fill the available space
- Removed hardcoded `minWidth/maxWidth` constraints that conflicted with the flex layout

Non-PF mode:
<img width="1708" height="436" alt="image" src="https://github.com/user-attachments/assets/1729774f-b11d-41ed-ba52-b1fe75e5a776" />
<img width="1889" height="377" alt="image" src="https://github.com/user-attachments/assets/fe1962a0-eee4-4b96-bd35-045af8b40cb5" />

PF mode:

<img width="1499" height="325" alt="image" src="https://github.com/user-attachments/assets/6f62c6fb-a42c-4a69-9519-8f9848683a06" />
<img width="1414" height="289" alt="image" src="https://github.com/user-attachments/assets/5c285fd0-78fc-4d12-8826-8994269a7bfe" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested, no unit or cypress test are added since it was just style rendering issue

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
