### PR TITLE
fix(catalog): enforce non-root security context on catalog overlay initContainers

### DIFF
--- a/manifests/kustomize/options/catalog/overlays/demo/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/kustomization.yaml
@@ -65,6 +65,8 @@ patches:
               mountPath: /demo-perf-data
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
             capabilities:
               drop:
                 - ALL

--- a/manifests/kustomize/options/catalog/overlays/odh/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/overlays/odh/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - ../../base
 
 configMapGenerator:
-- behavior: add
+- behavior: create
   files:
   - sources.yaml=default-sources.yaml
   name: model-catalog-default-sources
@@ -57,6 +57,8 @@ patches:
               mountPath: /shared-data
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
## Description

The demo and odh catalog overlay initContainers were missing `runAsNonRoot` and `runAsUser` in their security contexts, causing `Init:CreateContainerConfigError` when the pod-level `runAsNonRoot: true` is enforced by the base deployment (`manifests/kustomize/options/catalog/base/deployment.yaml`).

### Root Cause

The base catalog deployment sets `runAsNonRoot: true` at the pod level. Kubernetes enforces this on **all** containers in the pod, including initContainers. Both the `demo` and `odh` overlays patched in initContainers without specifying a non-root user:

- **demo overlay**: `perf-data-init` uses `busybox`, which defaults to UID 0 (root)
- **odh overlay**: `catalog-data-init` uses `quay.io/opendatahub/odh-model-metadata-collection`, same missing constraint

### Changes

| File | Change |
|------|--------|
| `manifests/kustomize/options/catalog/overlays/demo/kustomization.yaml` | Added `runAsNonRoot: true` and `runAsUser: 65534` to `perf-data-init` initContainer |
| `manifests/kustomize/options/catalog/overlays/odh/kustomization.yaml` | Added `runAsNonRoot: true` and `runAsUser: 65534` to `catalog-data-init` initContainer |
| `manifests/kustomize/options/catalog/overlays/odh/kustomization.yaml` | Fixed invalid kustomize `behavior: add` → `behavior: create` (the ConfigMap `model-catalog-default-sources` does not exist in the base, so `create` is the correct value) |

UID 65534 (`nobody`) is sufficient because both initContainers only read from configMap mounts and write to `emptyDir` volumes.

### Context

Raised as a result of: https://github.com/kubeflow/manifests/pull/3318#issuecomment-4222633850

The downstream manifests PR (kubeflow/manifests#3318) was blocked on this upstream issue — the demo overlay's `perf-data-init` container fails with `Init:CreateContainerConfigError` due to the UID 0 / `runAsNonRoot` conflict.

## How Has This Been Tested?

- Verified that the base deployment enforces `runAsNonRoot: true` at the pod level
- Confirmed that both initContainers only need read access to configMap mounts and write access to `emptyDir` volumes, both of which work with UID 65534
- Confirmed that the `model-catalog-default-sources` ConfigMap does not exist in the base kustomization, making `create` the correct `behavior` value (not `merge` or `replace`)

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- N/A — manifest-only changes, no UI impact.