### PR TITLE
fix(ui): DeleteModal and MCP details view changes

### DIFF
--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpServerDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpServerDetailsView.tsx
@@ -205,7 +205,7 @@ const McpServerDetailsView: React.FC<McpServerDetailsViewProps> = ({ server }) =
                 )}
                 {(server.sourceCode || server.repositoryUrl) && (
                   <DescriptionListGroup>
-                    <DescriptionListTerm>Source Code</DescriptionListTerm>
+                    <DescriptionListTerm>Source code</DescriptionListTerm>
                     <DescriptionListDescription>
                       {server.repositoryUrl ? (
                         <ExternalLink

--- a/clients/ui/frontend/src/app/shared/components/DeleteModal.tsx
+++ b/clients/ui/frontend/src/app/shared/components/DeleteModal.tsx
@@ -25,6 +25,8 @@ type DeleteModalProps = {
   children: React.ReactNode;
   testId?: string;
   genericLabel?: boolean;
+  /** When true, append a required indicator (*) after the confirmation prompt. */
+  confirmationRequiredIndicator?: boolean;
 };
 
 const DeleteModal: React.FC<DeleteModalProps> = ({
@@ -38,6 +40,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
   submitButtonLabel = 'Delete',
   testId,
   genericLabel,
+  confirmationRequiredIndicator = false,
 }) => {
   const [value, setValue] = React.useState('');
 
@@ -70,7 +73,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
               <FlexItem>
                 Type <strong>{deleteNameSanitized}</strong> to confirm
-                {genericLabel ? '' : ' deletion'}:
+                {genericLabel ? '' : ' deletion'}:{confirmationRequiredIndicator ? ' *' : ''}
               </FlexItem>
 
               <TextInput
@@ -109,6 +112,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
           isLoading={deleting}
           isDisabled={deleting || value.trim() !== deleteNameSanitized}
           onClick={() => onBeforeClose(true)}
+          data-testid="delete-modal-confirm-button"
         >
           {submitButtonLabel}
         </Button>


### PR DESCRIPTION
## Description


**`DeleteModal.tsx`** 
- Added an optional `confirmationRequiredIndicator` prop (defaults to `false`) that appends a required indicator (`*`) after the confirmation prompt text when enabled. This supports downstream consumers (e.g., MCP deployment deletion) that need to visually mark the confirmation field as required.
- Added `data-testid="delete-modal-confirm-button"` on the danger/confirm `Button` to improve testability — downstream Cypress tests target this selector.

**`McpServerDetailsView.tsx`**:
- Fixed microcopy: changed "Source Code" → "Source code" in the `DescriptionListTerm` to follow sentence-case convention consistent with other labels on the page (e.g., "Deployment mode", "Transport type").
<img width="350" height="100" alt="Screenshot 2026-04-10 at 10 52 43 AM" src="https://github.com/user-attachments/assets/2416a715-982c-4d76-a554-1b8668174c72" />


## How Has This Been Tested?
- Manual code review confirmed backward compatibility (optional prop with default, additive test ID).

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.