### PR TITLE
fix(catalog): implement pagination on MCP server tools endpoint

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -2292,6 +2292,7 @@ components:
         type: integer
         format: int32
         default: 10
+        minimum: 0
         maximum: 100
       in: query
       required: false

--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -101,6 +101,7 @@ paths:
         in: path
         required: true
       - $ref: "#/components/parameters/includeTools"
+      - $ref: "#/components/parameters/toolLimit"
   /api/mcp_catalog/v1alpha1/mcp_servers/{server_id}/tools:
     description: >-
       The REST endpoint/path used to list zero or more `MCPTool` entities for an `MCPServer`.

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -2015,6 +2015,7 @@ components:
         type: integer
         format: int32
         default: 10
+        minimum: 0
         maximum: 100
       in: query
       required: false

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -297,6 +297,7 @@ paths:
         in: path
         required: true
       - $ref: "#/components/parameters/includeTools"
+      - $ref: "#/components/parameters/toolLimit"
   /api/mcp_catalog/v1alpha1/mcp_servers/{server_id}/tools:
     description: >-
       The REST endpoint/path used to list zero or more `MCPTool` entities for an `MCPServer`.

--- a/catalog/internal/catalog/mcpcatalog/api.go
+++ b/catalog/internal/catalog/mcpcatalog/api.go
@@ -33,8 +33,9 @@ type MCPCatalogProvider interface {
 
 	// GetMCPServer returns MCP server metadata for a single server by its ID.
 	// If includeTools is true, the server's tools are also included.
+	// toolLimit caps the number of tools returned; zero means no limit.
 	// If nothing is found with the ID provided it returns nil, without an error.
-	GetMCPServer(ctx context.Context, serverID string, includeTools bool) (*openapi.MCPServer, error)
+	GetMCPServer(ctx context.Context, serverID string, includeTools bool, toolLimit int32) (*openapi.MCPServer, error)
 
 	// ListMCPServerTools returns all tools for a specific MCP server.
 	// If no server is found with that ID, it returns nil. If the server is

--- a/catalog/internal/catalog/mcpcatalog/db_mcp.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp.go
@@ -179,7 +179,7 @@ func mergeFilterQueries(a, b string) string {
 	}
 }
 
-func (d *dbMCPCatalogImpl) GetMCPServer(ctx context.Context, serverID string, includeTools bool) (*openapi.MCPServer, error) {
+func (d *dbMCPCatalogImpl) GetMCPServer(ctx context.Context, serverID string, includeTools bool, toolLimit int32) (*openapi.MCPServer, error) {
 	id, err := apiutils.ValidateIDAsInt32(serverID, "server")
 	if err != nil {
 		return nil, fmt.Errorf("invalid server ID '%s': %w", serverID, api.ErrBadRequest)
@@ -201,6 +201,9 @@ func (d *dbMCPCatalogImpl) GetMCPServer(ctx context.Context, serverID string, in
 	if includeTools {
 		toolOptions := models.MCPServerToolListOptions{
 			ParentID: *dbServer.GetID(),
+		}
+		if toolLimit > 0 {
+			toolOptions.Pagination.PageSize = &toolLimit
 		}
 		tools, err := d.mcpServerToolRepo.List(toolOptions)
 		if err != nil {

--- a/catalog/internal/catalog/mcpcatalog/db_mcp.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp.go
@@ -284,27 +284,21 @@ func (d *dbMCPCatalogImpl) GetMCPServerTool(ctx context.Context, serverID string
 		return nil, fmt.Errorf("server not found with ID %s: %w", serverID, api.ErrNotFound)
 	}
 
-	// List all tools for the server and find the one with matching name
+	// Filter by name at the DB level. The DB stores qualified names (serverName@version:toolName)
+	// but the API exposes only the unqualified name, so we match by suffix using LIKE.
 	toolOptions := models.MCPServerToolListOptions{
 		ParentID: id,
+		ToolName: &toolName,
 	}
 	tools, err := d.mcpServerToolRepo.List(toolOptions)
 	if err != nil {
 		return nil, fmt.Errorf("error loading tools for server %s: %w", serverID, err)
 	}
 
-	// Find tool by name. DB stores tools with a qualified prefix (serverName@version:toolName)
-	// for uniqueness, but the API exposes only the unqualified tool name.
-	for _, tool := range tools.Items {
-		attrs := tool.GetAttributes()
-		if attrs == nil || attrs.Name == nil {
-			continue
-		}
-		if converter.UnqualifyToolName(*attrs.Name) == toolName {
-			apiTool := converter.ConvertDbMCPToolToOpenapi(tool)
-			return apiTool, nil
-		}
+	if len(tools.Items) == 0 {
+		return nil, fmt.Errorf("tool '%s' not found in server %s: %w", toolName, serverID, api.ErrNotFound)
 	}
 
-	return nil, fmt.Errorf("tool '%s' not found in server %s: %w", toolName, serverID, api.ErrNotFound)
+	apiTool := converter.ConvertDbMCPToolToOpenapi(tools.Items[0])
+	return apiTool, nil
 }

--- a/catalog/internal/catalog/mcpcatalog/db_mcp.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp.go
@@ -148,7 +148,7 @@ func (d *dbMCPCatalogImpl) ListMCPServers(ctx context.Context, params ListMCPSer
 				return openapi.MCPServerList{}, fmt.Errorf("error loading tools for server %d: %w", *dbServer.GetID(), err)
 			}
 
-			apiServer = converter.ConvertDbMCPServerWithToolsToOpenapi(dbServer, tools)
+			apiServer = converter.ConvertDbMCPServerWithToolsToOpenapi(dbServer, tools.Items)
 		} else {
 			apiServer = converter.ConvertDbMCPServerToOpenapi(dbServer)
 		}
@@ -206,7 +206,7 @@ func (d *dbMCPCatalogImpl) GetMCPServer(ctx context.Context, serverID string, in
 		if err != nil {
 			return nil, fmt.Errorf("error loading tools for server %s: %w", serverID, err)
 		}
-		apiServer = converter.ConvertDbMCPServerWithToolsToOpenapi(dbServer, tools)
+		apiServer = converter.ConvertDbMCPServerWithToolsToOpenapi(dbServer, tools.Items)
 	} else {
 		apiServer = converter.ConvertDbMCPServerToOpenapi(dbServer)
 	}
@@ -254,7 +254,7 @@ func (d *dbMCPCatalogImpl) ListMCPServerTools(ctx context.Context, serverID stri
 
 	// Convert to OpenAPI models
 	apiTools := make([]openapi.MCPTool, 0) // Initialize as empty slice, not nil
-	for _, dbTool := range tools {
+	for _, dbTool := range tools.Items {
 		apiTool := converter.ConvertDbMCPToolToOpenapi(dbTool)
 		if apiTool != nil {
 			apiTools = append(apiTools, *apiTool)
@@ -265,7 +265,7 @@ func (d *dbMCPCatalogImpl) ListMCPServerTools(ctx context.Context, serverID stri
 		Items:         apiTools,
 		Size:          int32(len(apiTools)),
 		PageSize:      params.PageSize,
-		NextPageToken: "", // TODO: Implement pagination token for tools
+		NextPageToken: tools.NextPageToken,
 	}, nil
 }
 
@@ -292,7 +292,7 @@ func (d *dbMCPCatalogImpl) GetMCPServerTool(ctx context.Context, serverID string
 
 	// Find tool by name. DB stores tools with a qualified prefix (serverName@version:toolName)
 	// for uniqueness, but the API exposes only the unqualified tool name.
-	for _, tool := range tools {
+	for _, tool := range tools.Items {
 		attrs := tool.GetAttributes()
 		if attrs == nil || attrs.Name == nil {
 			continue

--- a/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
@@ -98,7 +98,7 @@ func (m *mockMCPServerRepo) GetTypeID() int32 { return m.TypeID }
 
 // mockMCPServerToolRepo is a configurable MCPServerToolRepository for unit testing.
 type mockMCPServerToolRepo struct {
-	listResult  []models.MCPServerTool
+	listResult  *internalmodels.ListWrapper[models.MCPServerTool]
 	listErr     error
 	countResult int32
 	countErr    error
@@ -109,7 +109,7 @@ type mockMCPServerToolRepo struct {
 	capturedListOptions *models.MCPServerToolListOptions
 }
 
-func (m *mockMCPServerToolRepo) List(opts models.MCPServerToolListOptions) ([]models.MCPServerTool, error) {
+func (m *mockMCPServerToolRepo) List(opts models.MCPServerToolListOptions) (*internalmodels.ListWrapper[models.MCPServerTool], error) {
 	m.capturedListOptions = &opts
 	return m.listResult, m.listErr
 }
@@ -186,6 +186,10 @@ func makeTool(name string) models.MCPServerTool {
 	return &models.MCPServerToolImpl{
 		Attributes: &models.MCPServerToolAttributes{Name: serverName(name)},
 	}
+}
+
+func toolList(tools ...models.MCPServerTool) *internalmodels.ListWrapper[models.MCPServerTool] {
+	return &internalmodels.ListWrapper[models.MCPServerTool]{Items: tools}
 }
 
 func TestListMCPServers_NoNamedQuery(t *testing.T) {
@@ -443,7 +447,7 @@ func TestListMCPServers_IncludeToolsUsesAccurateCount(t *testing.T) {
 	repo := &mockMCPServerRepo{listResult: listWithServer(1, "test-server")}
 	toolRepo := &mockMCPServerToolRepo{
 		countResult: 5,
-		listResult:  []models.MCPServerTool{makeTool("tool-1"), makeTool("tool-2")},
+		listResult:  toolList(makeTool("tool-1"), makeTool("tool-2")),
 	}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
@@ -462,7 +466,7 @@ func TestListMCPServers_ToolLimitPassedAsPageSize(t *testing.T) {
 	repo := &mockMCPServerRepo{listResult: listWithServer(1, "test-server")}
 	toolRepo := &mockMCPServerToolRepo{
 		countResult: 5,
-		listResult:  []models.MCPServerTool{makeTool("tool-1")},
+		listResult:  toolList(makeTool("tool-1")),
 	}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
@@ -480,7 +484,7 @@ func TestListMCPServers_ZeroToolLimitDoesNotSetPageSize(t *testing.T) {
 	repo := &mockMCPServerRepo{listResult: listWithServer(1, "test-server")}
 	toolRepo := &mockMCPServerToolRepo{
 		countResult: 5,
-		listResult:  []models.MCPServerTool{makeTool("tool-1"), makeTool("tool-2")},
+		listResult:  toolList(makeTool("tool-1"), makeTool("tool-2")),
 	}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
@@ -500,7 +504,7 @@ func TestGetMCPServerTool_StripsQualifiedPrefix(t *testing.T) {
 	}
 	repo := &mockMCPServerRepo{getResult: serverEntity}
 	toolRepo := &mockMCPServerToolRepo{
-		listResult: []models.MCPServerTool{makeTool("dynatrace-mcp@1.6.1:list_problems")},
+		listResult: toolList(makeTool("dynatrace-mcp@1.6.1:list_problems")),
 	}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
@@ -517,7 +521,7 @@ func TestGetMCPServerTool_NotFound(t *testing.T) {
 	}
 	repo := &mockMCPServerRepo{getResult: serverEntity}
 	toolRepo := &mockMCPServerToolRepo{
-		listResult: []models.MCPServerTool{makeTool("dynatrace-mcp@1.6.1:list_problems")},
+		listResult: toolList(makeTool("dynatrace-mcp@1.6.1:list_problems")),
 	}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
@@ -534,7 +538,7 @@ func TestGetMCPServer_IncludeToolsUsesAccurateCount(t *testing.T) {
 	repo := &mockMCPServerRepo{getResult: serverEntity}
 	toolRepo := &mockMCPServerToolRepo{
 		countResult: 10,
-		listResult:  []models.MCPServerTool{makeTool("tool-1")},
+		listResult:  toolList(makeTool("tool-1")),
 	}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 

--- a/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
@@ -385,7 +385,7 @@ func TestGetMCPServer_ToolCountWithoutIncludeTools(t *testing.T) {
 	toolRepo := &mockMCPServerToolRepo{countResult: 7}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
-	result, err := cat.GetMCPServer(context.Background(), "1", false)
+	result, err := cat.GetMCPServer(context.Background(), "1", false, 0)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, int32(7), result.ToolCount)
@@ -401,7 +401,7 @@ func TestGetMCPServer_CountByParentIDError(t *testing.T) {
 	toolRepo := &mockMCPServerToolRepo{countErr: errors.New("db count error")}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
-	_, err := cat.GetMCPServer(context.Background(), "1", false)
+	_, err := cat.GetMCPServer(context.Background(), "1", false, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error counting tools")
 }
@@ -497,6 +497,43 @@ func TestListMCPServers_ZeroToolLimitDoesNotSetPageSize(t *testing.T) {
 	assert.Nil(t, toolRepo.capturedListOptions.PageSize, "PageSize should be nil when ToolLimit is 0")
 }
 
+func TestGetMCPServer_ToolLimitSetsPageSize(t *testing.T) {
+	serverEntity := &models.MCPServerImpl{
+		ID:         serverID(1),
+		Attributes: &models.MCPServerAttributes{Name: serverName("test-server")},
+	}
+	repo := &mockMCPServerRepo{getResult: serverEntity}
+	toolRepo := &mockMCPServerToolRepo{
+		countResult: 5,
+		listResult:  toolList(makeTool("tool-1")),
+	}
+	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
+
+	_, err := cat.GetMCPServer(context.Background(), "1", true, 3)
+	require.NoError(t, err)
+	require.NotNil(t, toolRepo.capturedListOptions, "List should have been called on tool repo")
+	require.NotNil(t, toolRepo.capturedListOptions.PageSize, "PageSize should be set when toolLimit > 0")
+	assert.Equal(t, int32(3), *toolRepo.capturedListOptions.PageSize)
+}
+
+func TestGetMCPServer_ZeroToolLimitOmitsPageSize(t *testing.T) {
+	serverEntity := &models.MCPServerImpl{
+		ID:         serverID(1),
+		Attributes: &models.MCPServerAttributes{Name: serverName("test-server")},
+	}
+	repo := &mockMCPServerRepo{getResult: serverEntity}
+	toolRepo := &mockMCPServerToolRepo{
+		countResult: 5,
+		listResult:  toolList(makeTool("tool-1"), makeTool("tool-2")),
+	}
+	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
+
+	_, err := cat.GetMCPServer(context.Background(), "1", true, 0)
+	require.NoError(t, err)
+	require.NotNil(t, toolRepo.capturedListOptions, "List should have been called on tool repo")
+	assert.Nil(t, toolRepo.capturedListOptions.PageSize, "PageSize should be nil when toolLimit is 0")
+}
+
 func TestGetMCPServerTool_StripsQualifiedPrefix(t *testing.T) {
 	serverEntity := &models.MCPServerImpl{
 		ID:         serverID(88),
@@ -542,7 +579,7 @@ func TestGetMCPServer_IncludeToolsUsesAccurateCount(t *testing.T) {
 	}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
-	result, err := cat.GetMCPServer(context.Background(), "1", true)
+	result, err := cat.GetMCPServer(context.Background(), "1", true, 0)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	// toolCount should reflect total (10), not len(returned tools) (1)

--- a/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp_test.go
@@ -557,14 +557,33 @@ func TestGetMCPServerTool_NotFound(t *testing.T) {
 		Attributes: &models.MCPServerAttributes{Name: serverName("dynatrace-mcp")},
 	}
 	repo := &mockMCPServerRepo{getResult: serverEntity}
+	// DB-level filter returns empty when tool name doesn't match.
 	toolRepo := &mockMCPServerToolRepo{
-		listResult: toolList(makeTool("dynatrace-mcp@1.6.1:list_problems")),
+		listResult: toolList(),
 	}
 	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
 
 	_, err := cat.GetMCPServerTool(context.Background(), "88", "nonexistent_tool")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestGetMCPServerTool_PassesToolNameFilter(t *testing.T) {
+	serverEntity := &models.MCPServerImpl{
+		ID:         serverID(88),
+		Attributes: &models.MCPServerAttributes{Name: serverName("dynatrace-mcp")},
+	}
+	repo := &mockMCPServerRepo{getResult: serverEntity}
+	toolRepo := &mockMCPServerToolRepo{
+		listResult: toolList(makeTool("dynatrace-mcp@1.6.1:list_problems")),
+	}
+	cat := newTestCatalogWithToolRepo(repo, toolRepo, nil)
+
+	_, err := cat.GetMCPServerTool(context.Background(), "88", "list_problems")
+	require.NoError(t, err)
+	require.NotNil(t, toolRepo.capturedListOptions, "List should have been called")
+	require.NotNil(t, toolRepo.capturedListOptions.ToolName, "ToolName should be set on list options")
+	assert.Equal(t, "list_problems", *toolRepo.capturedListOptions.ToolName)
 }
 
 func TestGetMCPServer_IncludeToolsUsesAccurateCount(t *testing.T) {

--- a/catalog/internal/catalog/mcpcatalog/loader_test.go
+++ b/catalog/internal/catalog/mcpcatalog/loader_test.go
@@ -150,10 +150,10 @@ func TestMCPLoaderBasicLoad(t *testing.T) {
 
 	// Verify tools were persisted to the database
 	require.NotNil(t, server.GetID())
-	tools, err := services.MCPServerToolRepository.List(mcpmodels.MCPServerToolListOptions{ParentID: *server.GetID()})
+	toolsList, err := services.MCPServerToolRepository.List(mcpmodels.MCPServerToolListOptions{ParentID: *server.GetID()})
 	require.NoError(t, err)
-	require.Len(t, tools, 1)
-	toolAttrs := tools[0].GetAttributes()
+	require.Len(t, toolsList.Items, 1)
+	toolAttrs := toolsList.Items[0].GetAttributes()
 	require.NotNil(t, toolAttrs)
 	assert.Equal(t, "test-server@1.0.0:test-tool", *toolAttrs.Name)
 }
@@ -224,13 +224,13 @@ func TestMCPLoaderToolAccessTypeAndParameters(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, server.GetID())
 
-	tools, err := services.MCPServerToolRepository.List(mcpmodels.MCPServerToolListOptions{ParentID: *server.GetID()})
+	toolsList, err := services.MCPServerToolRepository.List(mcpmodels.MCPServerToolListOptions{ParentID: *server.GetID()})
 	require.NoError(t, err)
-	require.Len(t, tools, 2)
+	require.Len(t, toolsList.Items, 2)
 
 	// Build a map for easy lookup
 	toolByName := make(map[string]mcpmodels.MCPServerTool)
-	for _, tool := range tools {
+	for _, tool := range toolsList.Items {
 		attrs := tool.GetAttributes()
 		require.NotNil(t, attrs)
 		toolByName[*attrs.Name] = tool

--- a/catalog/internal/catalog/mcpcatalog/models/mcp_server_tool.go
+++ b/catalog/internal/catalog/mcpcatalog/models/mcp_server_tool.go
@@ -35,7 +35,7 @@ type MCPServerToolImpl = dbmodels.BaseEntity[MCPServerToolAttributes]
 // MCPServerToolRepository defines the interface for MCP server tool persistence.
 type MCPServerToolRepository interface {
 	GetByID(id int32) (MCPServerTool, error)
-	List(listOptions MCPServerToolListOptions) ([]MCPServerTool, error)
+	List(listOptions MCPServerToolListOptions) (*dbmodels.ListWrapper[MCPServerTool], error)
 	CountByParentIDs(parentIDs []int32) (map[int32]int32, error)
 	Save(tool MCPServerTool, parentID *int32) (MCPServerTool, error)
 	DeleteByParentID(parentID int32) error

--- a/catalog/internal/catalog/mcpcatalog/models/mcp_server_tool.go
+++ b/catalog/internal/catalog/mcpcatalog/models/mcp_server_tool.go
@@ -10,6 +10,7 @@ import (
 type MCPServerToolListOptions struct {
 	dbmodels.Pagination
 	ParentID int32
+	ToolName *string
 }
 
 // GetRestEntityType implements the FilterApplier interface.

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kubeflow/model-registry/catalog/internal/catalog/mcpcatalog/models"
 	"github.com/kubeflow/model-registry/catalog/internal/db/filter"
@@ -69,7 +70,8 @@ func applyMCPServerToolListFilters(query *gorm.DB, listOptions *models.MCPServer
 		Where(fmt.Sprintf("%s.context_id = ?", associationTable), listOptions.ParentID)
 
 	if listOptions.ToolName != nil {
-		query = query.Where(fmt.Sprintf("%s.name LIKE ?", executionTable), fmt.Sprintf("%%:%s", *listOptions.ToolName))
+		escaped := strings.NewReplacer("%", "\\%", "_", "\\_").Replace(*listOptions.ToolName)
+		query = query.Where(fmt.Sprintf("%s.name LIKE ?", executionTable), fmt.Sprintf("%%:%s", escaped))
 	}
 
 	return query

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool.go
@@ -51,66 +51,22 @@ func (r *MCPServerToolRepositoryImpl) GetByID(id int32) (models.MCPServerTool, e
 	return r.GenericRepository.GetByID(id)
 }
 
-// List retrieves all tools for a given parent MCP server with optional filterQuery support.
-func (r *MCPServerToolRepositoryImpl) List(listOptions models.MCPServerToolListOptions) ([]models.MCPServerTool, error) {
-	config := r.GetConfig()
-
-	// 1. Build base query with Association join
-	var executions []schema.Execution
-	associationTable := utils.GetTableName(config.DB, &schema.Association{})
-	executionTable := utils.GetTableName(config.DB, &schema.Execution{})
-
-	query := config.DB.Table(executionTable).
-		Joins(fmt.Sprintf("INNER JOIN %s ON %s.execution_id = %s.id",
-			associationTable, associationTable, executionTable)).
-		Where(fmt.Sprintf("%s.context_id = ? AND %s.type_id = ?",
-			associationTable, executionTable), listOptions.ParentID, config.TypeID)
-
-	// 2. Apply filterQuery
-	query, err := service.ApplyFilterQuery(query, &listOptions, filter.NewCatalogEntityMappings())
-	if err != nil {
-		return nil, fmt.Errorf("error applying filter query: %w", err)
-	}
-
-	// 3. Apply pagination limit
-	if listOptions.Pagination.PageSize != nil {
-		query = query.Limit(int(*listOptions.Pagination.PageSize))
-	}
-
-	// 4. Execute query
-	err = query.Find(&executions).Error
-	if err != nil {
-		return nil, fmt.Errorf("error listing %s by parent: %w", config.EntityName, err)
-	}
-
-	// 5. Load properties for each execution
-	var tools []models.MCPServerTool
-	for _, exec := range executions {
-		var properties []schema.ExecutionProperty
-		if err := config.DB.Where("execution_id = ?", exec.ID).Find(&properties).Error; err != nil {
-			return nil, fmt.Errorf("error getting properties for %s: %w", config.EntityName, err)
-		}
-
-		tool := config.SchemaToEntity(exec, properties)
-		tools = append(tools, tool)
-	}
-
-	return tools, nil
+// List retrieves all tools for a given parent MCP server with optional filterQuery and pagination support.
+func (r *MCPServerToolRepositoryImpl) List(listOptions models.MCPServerToolListOptions) (*dbmodels.ListWrapper[models.MCPServerTool], error) {
+	return r.GenericRepository.List(&listOptions)
 }
 
-// applyMCPServerToolListFilters applies list filters to the query for MCP server tools.
+// applyMCPServerToolListFilters adds the Association join and parent ID filter so that
+// GenericRepository.List() returns only the tools belonging to a specific MCP server.
+// Note: type_id filtering is already applied by buildBaseQuery().
 func applyMCPServerToolListFilters(query *gorm.DB, listOptions *models.MCPServerToolListOptions) *gorm.DB {
+	associationTable := utils.GetTableName(query.Statement.DB, &schema.Association{})
 	executionTable := utils.GetTableName(query.Statement.DB, &schema.Execution{})
 
-	// Filter by parent ID (this should already be handled by the join, but we can add it here for completeness)
-	// Note: For MCPServerTool, filtering is primarily done through the Association join,
-	// but we can add property-based filters here if needed
-
-	// Example: Add text search in tool properties if Query field is added to ListOptions in the future
-	// This is a placeholder for future expansion
-	_ = executionTable // Prevent unused variable warning
-
-	return query
+	return query.
+		Joins(fmt.Sprintf("INNER JOIN %s ON %s.execution_id = %s.id",
+			associationTable, associationTable, executionTable)).
+		Where(fmt.Sprintf("%s.context_id = ?", associationTable), listOptions.ParentID)
 }
 
 // Save creates or updates an MCP server tool.

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool.go
@@ -63,10 +63,16 @@ func applyMCPServerToolListFilters(query *gorm.DB, listOptions *models.MCPServer
 	associationTable := utils.GetTableName(query.Statement.DB, &schema.Association{})
 	executionTable := utils.GetTableName(query.Statement.DB, &schema.Execution{})
 
-	return query.
+	query = query.
 		Joins(fmt.Sprintf("INNER JOIN %s ON %s.execution_id = %s.id",
 			associationTable, associationTable, executionTable)).
 		Where(fmt.Sprintf("%s.context_id = ?", associationTable), listOptions.ParentID)
+
+	if listOptions.ToolName != nil {
+		query = query.Where(fmt.Sprintf("%s.name LIKE ?", executionTable), fmt.Sprintf("%%:%s", *listOptions.ToolName))
+	}
+
+	return query
 }
 
 // Save creates or updates an MCP server tool.

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool_test.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server_tool_test.go
@@ -163,13 +163,13 @@ func TestMCPServerToolRepository(t *testing.T) {
 		require.NoError(t, err)
 
 		// List all tools for parent
-		tools, err := toolRepo.List(models.MCPServerToolListOptions{ParentID: parentID})
+		toolsList, err := toolRepo.List(models.MCPServerToolListOptions{ParentID: parentID})
 		require.NoError(t, err)
-		assert.Len(t, tools, 3)
+		assert.Len(t, toolsList.Items, 3)
 
 		// Verify tool names
-		toolNames := make([]string, len(tools))
-		for i, tool := range tools {
+		toolNames := make([]string, len(toolsList.Items))
+		for i, tool := range toolsList.Items {
 			toolNames[i] = *tool.GetAttributes().Name
 		}
 		assert.Contains(t, toolNames, "tool-1")
@@ -297,18 +297,18 @@ func TestMCPServerToolRepository(t *testing.T) {
 		}
 
 		// Verify 5 tools exist
-		tools, err := toolRepo.List(models.MCPServerToolListOptions{ParentID: parentID})
+		toolsList, err := toolRepo.List(models.MCPServerToolListOptions{ParentID: parentID})
 		require.NoError(t, err)
-		assert.Len(t, tools, 5)
+		assert.Len(t, toolsList.Items, 5)
 
 		// Delete all tools by parent ID
 		err = toolRepo.DeleteByParentID(parentID)
 		require.NoError(t, err)
 
 		// Verify all tools are deleted
-		tools, err = toolRepo.List(models.MCPServerToolListOptions{ParentID: parentID})
+		toolsList, err = toolRepo.List(models.MCPServerToolListOptions{ParentID: parentID})
 		require.NoError(t, err)
-		assert.Empty(t, tools)
+		assert.Empty(t, toolsList.Items)
 	})
 
 	t.Run("TestCascadeDeleteToolsWithParent", func(t *testing.T) {
@@ -344,9 +344,9 @@ func TestMCPServerToolRepository(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tools exist
-		tools, err := toolRepo.List(models.MCPServerToolListOptions{ParentID: parentID})
+		toolsList, err := toolRepo.List(models.MCPServerToolListOptions{ParentID: parentID})
 		require.NoError(t, err)
-		assert.Len(t, tools, 2)
+		assert.Len(t, toolsList.Items, 2)
 
 		// Delete tools first, then delete parent server
 		// Note: ML Metadata schema doesn't cascade delete Executions when Context is deleted
@@ -554,47 +554,59 @@ func TestMCPServerToolRepository(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// List with PageSize=1 should return exactly 1 tool
+		// List with PageSize=1 should return exactly 1 tool with a nextPageToken
 		pageSize1 := int32(1)
-		tools, err := toolRepo.List(models.MCPServerToolListOptions{
+		page1, err := toolRepo.List(models.MCPServerToolListOptions{
 			Pagination: dbmodels.Pagination{PageSize: &pageSize1},
 			ParentID:   parentID,
 		})
 		require.NoError(t, err)
-		assert.Len(t, tools, 1, "PageSize=1 should limit results to 1 tool")
+		assert.Len(t, page1.Items, 1, "PageSize=1 should limit results to 1 tool")
+		assert.NotEmpty(t, page1.NextPageToken, "should return a nextPageToken when more results exist")
+
+		// Using the token should return a different (next) page
+		page2, err := toolRepo.List(models.MCPServerToolListOptions{
+			Pagination: dbmodels.Pagination{PageSize: &pageSize1, NextPageToken: &page1.NextPageToken},
+			ParentID:   parentID,
+		})
+		require.NoError(t, err)
+		assert.Len(t, page2.Items, 1, "second page should also return 1 tool")
+		assert.NotEqual(t, *page1.Items[0].GetID(), *page2.Items[0].GetID(), "pages should contain different tools")
 
 		// List with PageSize=3 should return exactly 3 tools
 		pageSize3 := int32(3)
-		tools, err = toolRepo.List(models.MCPServerToolListOptions{
+		page3, err := toolRepo.List(models.MCPServerToolListOptions{
 			Pagination: dbmodels.Pagination{PageSize: &pageSize3},
 			ParentID:   parentID,
 		})
 		require.NoError(t, err)
-		assert.Len(t, tools, 3, "PageSize=3 should limit results to 3 tools")
+		assert.Len(t, page3.Items, 3, "PageSize=3 should limit results to 3 tools")
+		assert.NotEmpty(t, page3.NextPageToken, "should return a nextPageToken when more results exist")
 
-		// List with PageSize=10 (greater than total) should return all 5 tools
+		// List with PageSize=10 (greater than total) should return all 5 tools with no nextPageToken
 		pageSize10 := int32(10)
-		tools, err = toolRepo.List(models.MCPServerToolListOptions{
+		allTools, err := toolRepo.List(models.MCPServerToolListOptions{
 			Pagination: dbmodels.Pagination{PageSize: &pageSize10},
 			ParentID:   parentID,
 		})
 		require.NoError(t, err)
-		assert.Len(t, tools, 5, "PageSize=10 (greater than total) should return all 5 tools")
+		assert.Len(t, allTools.Items, 5, "PageSize=10 (greater than total) should return all 5 tools")
+		assert.Empty(t, allTools.NextPageToken, "should not return nextPageToken when all results fit")
 
 		// List without PageSize should still return all 5 tools
-		tools, err = toolRepo.List(models.MCPServerToolListOptions{
+		noPageSize, err := toolRepo.List(models.MCPServerToolListOptions{
 			ParentID: parentID,
 		})
 		require.NoError(t, err)
-		assert.Len(t, tools, 5, "No PageSize should return all tools")
+		assert.Len(t, noPageSize.Items, 5, "No PageSize should return all tools")
 	})
 
 	t.Run("TestListToolsForNonExistentParent", func(t *testing.T) {
 		// List tools for a non-existent parent ID
 		nonExistentParentID := int32(999999)
-		tools, err := toolRepo.List(models.MCPServerToolListOptions{ParentID: nonExistentParentID})
+		toolsList, err := toolRepo.List(models.MCPServerToolListOptions{ParentID: nonExistentParentID})
 		require.NoError(t, err)
-		assert.Empty(t, tools, "Should return empty slice for non-existent parent")
+		assert.Empty(t, toolsList.Items, "Should return empty slice for non-existent parent")
 	})
 
 	t.Run("TestDeleteToolsByNonExistentParentID", func(t *testing.T) {

--- a/catalog/internal/server/openapi/api.go
+++ b/catalog/internal/server/openapi/api.go
@@ -50,7 +50,7 @@ type ModelCatalogServiceAPIRouter interface {
 type MCPCatalogServiceAPIServicer interface {
 	FindMCPServers(context.Context, string, string, []string, string, string, bool, int32, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
 	FindMCPServersFilterOptions(context.Context) (ImplResponse, error)
-	GetMCPServer(context.Context, string, bool) (ImplResponse, error)
+	GetMCPServer(context.Context, string, bool, int32) (ImplResponse, error)
 	FindMCPServerTools(context.Context, string, string, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
 	GetMCPServerTool(context.Context, string, string) (ImplResponse, error)
 }

--- a/catalog/internal/server/openapi/api_mcp_catalog_service.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service.go
@@ -271,7 +271,24 @@ func (c *MCPCatalogServiceAPIController) GetMCPServer(w http.ResponseWriter, r *
 		var param bool = false
 		includeToolsParam = param
 	}
-	result, err := c.service.GetMCPServer(r.Context(), serverIdParam, includeToolsParam)
+	var toolLimitParam int32
+	if query.Has("toolLimit") {
+		param, err := parseNumericParameter[int32](
+			query.Get("toolLimit"),
+			WithParse[int32](parseInt32),
+			WithMaximum[int32](100),
+		)
+		if err != nil {
+			c.errorHandler(w, r, &ParsingError{Param: "toolLimit", Err: err}, nil)
+			return
+		}
+
+		toolLimitParam = param
+	} else {
+		var param int32 = 10
+		toolLimitParam = param
+	}
+	result, err := c.service.GetMCPServer(r.Context(), serverIdParam, includeToolsParam, toolLimitParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/catalog/internal/server/openapi/api_mcp_catalog_service.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service.go
@@ -181,6 +181,7 @@ func (c *MCPCatalogServiceAPIController) FindMCPServers(w http.ResponseWriter, r
 		param, err := parseNumericParameter[int32](
 			query.Get("toolLimit"),
 			WithParse[int32](parseInt32),
+			WithMinimum[int32](0),
 			WithMaximum[int32](100),
 		)
 		if err != nil {
@@ -276,6 +277,7 @@ func (c *MCPCatalogServiceAPIController) GetMCPServer(w http.ResponseWriter, r *
 		param, err := parseNumericParameter[int32](
 			query.Get("toolLimit"),
 			WithParse[int32](parseInt32),
+			WithMinimum[int32](0),
 			WithMaximum[int32](100),
 		)
 		if err != nil {

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service.go
@@ -87,8 +87,8 @@ func (m *MCPCatalogServiceAPIService) FindMCPServersFilterOptions(ctx context.Co
 }
 
 // GetMCPServer - Get an `MCPServer`.
-func (m *MCPCatalogServiceAPIService) GetMCPServer(ctx context.Context, serverID string, includeTools bool) (ImplResponse, error) {
-	server, err := m.mcpProvider.GetMCPServer(ctx, serverID, includeTools)
+func (m *MCPCatalogServiceAPIService) GetMCPServer(ctx context.Context, serverID string, includeTools bool, toolLimit int32) (ImplResponse, error) {
+	server, err := m.mcpProvider.GetMCPServer(ctx, serverID, includeTools, toolLimit)
 	if err != nil {
 		return ErrorResponse(api.ErrToStatus(err), err), err
 	}

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
@@ -114,7 +114,7 @@ func (m *mockMCPProvider) ListMCPServers(ctx context.Context, params catalog.Lis
 	}, nil
 }
 
-func (m *mockMCPProvider) GetMCPServer(ctx context.Context, serverID string, includeTools bool) (*model.MCPServer, error) {
+func (m *mockMCPProvider) GetMCPServer(ctx context.Context, serverID string, includeTools bool, toolLimit int32) (*model.MCPServer, error) {
 	if m.shouldErrorOnGetServer {
 		return nil, fmt.Errorf("mock error in GetMCPServer")
 	}
@@ -518,7 +518,7 @@ func TestGetMCPServer(t *testing.T) {
 			service := NewMCPCatalogServiceAPIService(mockProvider, nil)
 			ctx := context.Background()
 
-			result, err := service.GetMCPServer(ctx, tc.serverID, tc.includeTools)
+			result, err := service.GetMCPServer(ctx, tc.serverID, tc.includeTools, 0)
 
 			assert.Equal(t, tc.expectedStatus, result.Code)
 

--- a/catalog/pkg/openapi/api_mcp_catalog_service.go
+++ b/catalog/pkg/openapi/api_mcp_catalog_service.go
@@ -598,11 +598,18 @@ type ApiGetMCPServerRequest struct {
 	ApiService   *MCPCatalogServiceAPIService
 	serverId     string
 	includeTools *bool
+	toolLimit    *int32
 }
 
 // Whether to include the tools array in each MCP server result.
 func (r ApiGetMCPServerRequest) IncludeTools(includeTools bool) ApiGetMCPServerRequest {
 	r.includeTools = &includeTools
+	return r
+}
+
+// Maximum number of tools to include when includeTools is true.
+func (r ApiGetMCPServerRequest) ToolLimit(toolLimit int32) ApiGetMCPServerRequest {
+	r.toolLimit = &toolLimit
 	return r
 }
 
@@ -654,6 +661,13 @@ func (a *MCPCatalogServiceAPIService) GetMCPServerExecute(r ApiGetMCPServerReque
 		var defaultValue bool = false
 		parameterAddToHeaderOrQuery(localVarQueryParams, "includeTools", defaultValue, "form", "")
 		r.includeTools = &defaultValue
+	}
+	if r.toolLimit != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "toolLimit", r.toolLimit, "form", "")
+	} else {
+		var defaultValue int32 = 10
+		parameterAddToHeaderOrQuery(localVarQueryParams, "toolLimit", defaultValue, "form", "")
+		r.toolLimit = &defaultValue
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}


### PR DESCRIPTION
## Description
Implement pagination for the tools endpoint and add the `toolLimit` parameter for the MCP server detail endpoint.

## How Has This Been Tested?
On a local dev cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
