### PR TITLE
Rename default catalog sources ConfigMap to `default-catalog-sources`

### DIFF
--- a/clients/ui/bff/internal/integrations/kubernetes/client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/client.go
@@ -12,7 +12,7 @@ const ComponentLabelValue = "model-registry"
 const ComponentLabelValueCatalog = "model-catalog"
 
 const CatalogSourceKey = "sources.yaml"
-const CatalogSourceDefaultConfigMapName = "model-catalog-default-sources"
+const CatalogSourceDefaultConfigMapName = "default-catalog-sources"
 const CatalogSourceUserConfigMapName = "model-catalog-sources"
 
 type KubernetesClientInterface interface {

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -347,7 +347,7 @@ catalogs:
 	}
 
 	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
-		return fmt.Errorf("failed to create model-catalog-default-sources configmap: %w", err)
+		return fmt.Errorf("failed to create default-catalog-sources configmap: %w", err)
 	}
 
 	return nil

--- a/manifests/kustomize/options/catalog/overlays/odh/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/overlays/odh/kustomization.yaml
@@ -8,7 +8,7 @@ configMapGenerator:
 - behavior: create
   files:
   - sources.yaml=default-sources.yaml
-  name: model-catalog-default-sources
+  name: default-catalog-sources
   options:
     disableNameSuffixHash: true
 
@@ -34,7 +34,7 @@ patches:
       value:
         name: default-sources
         configMap:
-          name: model-catalog-default-sources
+          name: default-catalog-sources
     - op: add
       path: /spec/template/spec/containers/0/volumeMounts/1
       value:


### PR DESCRIPTION
## Description
Rename the default catalog sources ConfigMap from `model-catalog-default-sources` to `default-catalog-sources` to align with the naming convention established in the ODH downstream's model-registry-operator by https://github.com/opendatahub-io/model-registry-operator/pull/489 .

Updates:
- `CatalogSourceDefaultConfigMapName` constant in the BFF
- Test mock error message
- Kustomize overlay ConfigMap references

## How Has This Been Tested?
- All 31 BFF kubernetes integration tests pass (`go test ./clients/ui/bff/internal/integrations/kubernetes/... -count=1`)

## Merge criteria:
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.