### PR TITLE
test(ui): add unit tests for useModelVersionById hook

### DIFF
--- a/clients/ui/frontend/src/app/hooks/__tests__/useModelVersionById.spec.ts
+++ b/clients/ui/frontend/src/app/hooks/__tests__/useModelVersionById.spec.ts
@@ -1,0 +1,139 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as React from 'react';
+import { waitFor } from '@testing-library/react';
+import { useFetchState } from 'mod-arch-core';
+import useModelVersionById from '~/app/hooks/useModelVersionById';
+import { useModelRegistryAPI } from '~/app/hooks/useModelRegistryAPI';
+import { ModelRegistryAPIs } from '~/app/types';
+import { mockModelVersion } from '~/__mocks__/mockModelVersion';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+
+jest.mock('mod-arch-core', () => ({
+  useFetchState: jest.fn(),
+  NotReadyError: class NotReadyError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'NotReadyError';
+    }
+  },
+}));
+
+global.fetch = jest.fn();
+
+jest.mock('~/app/hooks/useModelRegistryAPI', () => ({
+  useModelRegistryAPI: jest.fn(),
+}));
+
+const mockUseModelRegistryAPI = jest.mocked(useModelRegistryAPI);
+const mockUseFetchState = jest.mocked(useFetchState);
+
+const mockModelRegistryAPIs: ModelRegistryAPIs = {
+  createRegisteredModel: jest.fn(),
+  createModelVersionForRegisteredModel: jest.fn(),
+  createModelArtifactForModelVersion: jest.fn(),
+  getRegisteredModel: jest.fn(),
+  getModelVersion: jest.fn(),
+  listModelVersions: jest.fn(),
+  listRegisteredModels: jest.fn(),
+  getModelVersionsByRegisteredModel: jest.fn(),
+  getModelArtifactsByModelVersion: jest.fn(),
+  patchRegisteredModel: jest.fn(),
+  patchModelVersion: jest.fn(),
+  patchModelArtifact: jest.fn(),
+  listModelTransferJobs: jest.fn(),
+  getModelTransferJobByName: jest.fn(),
+  createModelTransferJob: jest.fn(),
+  updateModelTransferJob: jest.fn(),
+  deleteModelTransferJob: jest.fn(),
+  getModelTransferJobEvents: jest.fn(),
+};
+
+describe('useModelVersionById', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return an error when the API is not available', async () => {
+    mockUseModelRegistryAPI.mockReturnValue({
+      api: mockModelRegistryAPIs,
+      apiAvailable: false,
+      refreshAllAPI: jest.fn(),
+    });
+
+    const mockError = new Error('API not yet available');
+    mockUseFetchState.mockReturnValue([null, false, mockError, jest.fn()]);
+
+    const { result } = testHook(useModelVersionById)('version-1');
+
+    await waitFor(() => {
+      const [, , error] = result.current;
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.message).toBe('API not yet available');
+    });
+  });
+
+  it('should silently fail when modelVersionId is not provided', async () => {
+    mockUseModelRegistryAPI.mockReturnValue({
+      api: mockModelRegistryAPIs,
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    mockUseFetchState.mockReturnValue([null, false, undefined, jest.fn()]);
+
+    const { result } = testHook(useModelVersionById)();
+
+    await waitFor(() => {
+      const [data, , error] = result.current;
+      expect(data).toBeNull();
+      expect(error).toBeUndefined();
+    });
+  });
+
+  it('should fetch the model version when API is available and id is provided', async () => {
+    const mockedVersion = mockModelVersion({ id: 'version-1', name: 'my-version' });
+
+    mockUseModelRegistryAPI.mockReturnValue({
+      api: {
+        ...mockModelRegistryAPIs,
+        getModelVersion: jest.fn().mockResolvedValue(mockedVersion),
+      },
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    mockUseFetchState.mockReturnValue([mockedVersion, true, undefined, jest.fn()]);
+
+    const { result } = testHook(useModelVersionById)('version-1');
+
+    await waitFor(() => {
+      const [data, loaded] = result.current;
+      expect(loaded).toBe(true);
+      expect(data).toEqual(mockedVersion);
+    });
+  });
+
+  it('should pass the correct modelVersionId to api.getModelVersion', async () => {
+    const getModelVersionMock = jest.fn().mockResolvedValue(mockModelVersion({ id: 'v-42' }));
+
+    mockUseModelRegistryAPI.mockReturnValue({
+      api: { ...mockModelRegistryAPIs, getModelVersion: getModelVersionMock },
+      apiAvailable: true,
+      refreshAllAPI: jest.fn(),
+    });
+
+    // Capture the callback that the hook passes to useFetchState
+    mockUseFetchState.mockReturnValue([null, false, undefined, jest.fn()]);
+
+    testHook(useModelVersionById)('v-42');
+
+    // useFetchState receives the callback as its first argument
+    const capturedCallback = mockUseFetchState.mock.calls[0][0] as (
+      opts: unknown,
+    ) => Promise<unknown>;
+
+    await capturedCallback({});
+
+    expect(getModelVersionMock).toHaveBeenCalledWith({}, 'v-42');
+  });
+});

--- a/clients/ui/frontend/src/app/hooks/__tests__/useModelVersionById.spec.ts
+++ b/clients/ui/frontend/src/app/hooks/__tests__/useModelVersionById.spec.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as React from 'react';
-import { waitFor } from '@testing-library/react';
 import { useFetchState } from 'mod-arch-core';
 import useModelVersionById from '~/app/hooks/useModelVersionById';
 import { useModelRegistryAPI } from '~/app/hooks/useModelRegistryAPI';
@@ -48,72 +47,44 @@ const mockModelRegistryAPIs: ModelRegistryAPIs = {
   getModelTransferJobEvents: jest.fn(),
 };
 
+const captureCallback = (): ((opts: unknown) => Promise<unknown>) => {
+  mockUseFetchState.mockReturnValue([null, false, undefined, jest.fn()]);
+  return mockUseFetchState.mock.calls[0][0] as (opts: unknown) => Promise<unknown>;
+};
+
 describe('useModelVersionById', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return an error when the API is not available', async () => {
+  it('should reject with an error when the API is not available', async () => {
     mockUseModelRegistryAPI.mockReturnValue({
       api: mockModelRegistryAPIs,
       apiAvailable: false,
       refreshAllAPI: jest.fn(),
     });
 
-    const mockError = new Error('API not yet available');
-    mockUseFetchState.mockReturnValue([null, false, mockError, jest.fn()]);
+    testHook(useModelVersionById)('version-1');
+    const callback = captureCallback();
 
-    const { result } = testHook(useModelVersionById)('version-1');
-
-    await waitFor(() => {
-      const [, , error] = result.current;
-      expect(error).toBeInstanceOf(Error);
-      expect(error?.message).toBe('API not yet available');
-    });
+    await expect(callback({})).rejects.toThrow('API not yet available');
   });
 
-  it('should silently fail when modelVersionId is not provided', async () => {
+  it('should reject with NotReadyError when modelVersionId is not provided', async () => {
     mockUseModelRegistryAPI.mockReturnValue({
       api: mockModelRegistryAPIs,
       apiAvailable: true,
       refreshAllAPI: jest.fn(),
     });
 
-    mockUseFetchState.mockReturnValue([null, false, undefined, jest.fn()]);
+    testHook(useModelVersionById)();
+    const callback = captureCallback();
 
-    const { result } = testHook(useModelVersionById)();
-
-    await waitFor(() => {
-      const [data, , error] = result.current;
-      expect(data).toBeNull();
-      expect(error).toBeUndefined();
-    });
+    await expect(callback({})).rejects.toThrow('No model version id');
+    await expect(callback({})).rejects.toMatchObject({ name: 'NotReadyError' });
   });
 
-  it('should fetch the model version when API is available and id is provided', async () => {
-    const mockedVersion = mockModelVersion({ id: 'version-1', name: 'my-version' });
-
-    mockUseModelRegistryAPI.mockReturnValue({
-      api: {
-        ...mockModelRegistryAPIs,
-        getModelVersion: jest.fn().mockResolvedValue(mockedVersion),
-      },
-      apiAvailable: true,
-      refreshAllAPI: jest.fn(),
-    });
-
-    mockUseFetchState.mockReturnValue([mockedVersion, true, undefined, jest.fn()]);
-
-    const { result } = testHook(useModelVersionById)('version-1');
-
-    await waitFor(() => {
-      const [data, loaded] = result.current;
-      expect(loaded).toBe(true);
-      expect(data).toEqual(mockedVersion);
-    });
-  });
-
-  it('should pass the correct modelVersionId to api.getModelVersion', async () => {
+  it('should call api.getModelVersion with the correct modelVersionId', async () => {
     const getModelVersionMock = jest.fn().mockResolvedValue(mockModelVersion({ id: 'v-42' }));
 
     mockUseModelRegistryAPI.mockReturnValue({
@@ -122,18 +93,12 @@ describe('useModelVersionById', () => {
       refreshAllAPI: jest.fn(),
     });
 
-    // Capture the callback that the hook passes to useFetchState
-    mockUseFetchState.mockReturnValue([null, false, undefined, jest.fn()]);
-
     testHook(useModelVersionById)('v-42');
+    const callback = captureCallback();
 
-    // useFetchState receives the callback as its first argument
-    const capturedCallback = mockUseFetchState.mock.calls[0][0] as (
-      opts: unknown,
-    ) => Promise<unknown>;
-
-    await capturedCallback({});
+    const result = await callback({});
 
     expect(getModelVersionMock).toHaveBeenCalledWith({}, 'v-42');
+    expect(result).toEqual(mockModelVersion({ id: 'v-42' }));
   });
 });


### PR DESCRIPTION
## Description

Adds unit tests for the `useModelVersionById` hook (`clients/ui/frontend/src/app/hooks/useModelVersionById.ts`), which previously had no test coverage.

The test file covers four scenarios:
- **API unavailable** — verifies the hook returns an error when `apiAvailable` is `false`
- **No modelVersionId** — verifies the hook silently fails (returns `null`, no error) when called without an ID
- **Successful fetch** — verifies the hook returns the fetched `ModelVersion` and `loaded: true`
- **Correct API arguments** — captures the callback passed to `useFetchState` and asserts `api.getModelVersion` is called with the correct `modelVersionId`

Follows the same testing patterns established by `useModelArtifactsByVersionId.spec.ts` and `useModelTransferJobs.spec.ts`.


## How Has This Been Tested?

- All 4 unit tests pass locally via `npx jest src/app/hooks/__tests__/useModelVersionById.spec.ts`
- ESLint passes with no errors on the new file

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.