### PR TITLE
hide cat toogle in case only one cat is available

### DIFF
--- a/clients/ui/frontend/src/__mocks__/mockCatalogSourceList.ts
+++ b/clients/ui/frontend/src/__mocks__/mockCatalogSourceList.ts
@@ -56,6 +56,25 @@ export const mockCatalogSourceActive = (): CatalogSource => ({
   status: 'available',
 });
 
+export const mockTwoProviderSources = (): CatalogSource[] => [
+  mockCatalogSource({ labels: ['Provider one'] }),
+  mockCatalogSource({
+    id: 'source-2',
+    name: 'Provider Two Source',
+    labels: ['Provider two'],
+  }),
+];
+
+export const mockProviderAndCustomSources = (): CatalogSource[] => [
+  mockCatalogSource({ labels: ['Provider one'] }),
+  mockCatalogSource({ id: 'custom-source', name: 'Custom Source', labels: [] }),
+];
+
+export const mockDefaultSources = (): CatalogSource[] => [
+  mockCatalogSource({}),
+  mockCatalogSource({ id: 'source-2', name: 'source 2' }),
+];
+
 export const mockCatalogSourceList = (partial?: Partial<CatalogSourceList>): CatalogSourceList => ({
   items: [
     mockCatalogSourceActive(),

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -10,11 +10,13 @@ import {
   mockCatalogPerformanceMetricsArtifact,
   mockCatalogSource,
   mockCatalogSourceList,
+  mockDefaultSources,
+  mockProviderAndCustomSources,
+  mockTwoProviderSources,
 } from '~/__mocks__';
-import type { CatalogSource } from '~/app/modelCatalogTypes';
 import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
 import { mockCatalogFilterOptionsList } from '~/__mocks__/mockCatalogFilterOptionsList';
-import { SourceLabel } from '~/app/modelCatalogTypes';
+import { SourceLabel, type CatalogSource } from '~/app/modelCatalogTypes';
 import { ModelRegistryMetadataType } from '~/app/types';
 
 type FilteredModelsInterceptConfig = {
@@ -90,7 +92,7 @@ const calculateExpectedCategoryCount = (sources: CatalogSource[]): number => {
 };
 
 const initIntercepts = ({
-  sources = [mockCatalogSource({}), mockCatalogSource({ id: 'source-2', name: 'source 2' })],
+  sources = mockDefaultSources(),
   modelsPerCategory = 4,
   hasValidatedModels = false,
   includeAllModelsIntercept = true,
@@ -269,15 +271,9 @@ describe('Model Catalog Page', () => {
   });
 
   it('checkbox should work', () => {
-    // Calculate expected category count based on sources
-    const defaultSources = [
-      mockCatalogSource({}),
-      mockCatalogSource({ id: 'source-2', name: 'source 2' }),
-    ];
+    const expectedCategoryCount = calculateExpectedCategoryCount(mockDefaultSources());
 
-    const expectedCategoryCount = calculateExpectedCategoryCount(defaultSources);
-
-    initIntercepts({ sources: defaultSources, includeAllModelsIntercept: false });
+    initIntercepts({ sources: mockDefaultSources(), includeAllModelsIntercept: false });
 
     setupFilteredModelsIntercept({
       returnModelsForFilters: true,
@@ -322,14 +318,9 @@ describe('Model Catalog Page', () => {
   });
 
   it('tensor type filter combined with other filters should work', () => {
-    const defaultSources = [
-      mockCatalogSource({}),
-      mockCatalogSource({ id: 'source-2', name: 'source 2' }),
-    ];
+    const expectedCategoryCount = calculateExpectedCategoryCount(mockDefaultSources());
 
-    const expectedCategoryCount = calculateExpectedCategoryCount(defaultSources);
-
-    initIntercepts({ sources: defaultSources, includeAllModelsIntercept: false });
+    initIntercepts({ sources: mockDefaultSources(), includeAllModelsIntercept: false });
 
     setupFilteredModelsIntercept({
       returnModelsForFilters: true,
@@ -357,10 +348,7 @@ describe('Performance Empty State', () => {
   describe('Community & Custom Section', () => {
     it('should show performance empty state when toggle is ON', () => {
       initIntercepts({
-        sources: [
-          mockCatalogSource({ labels: ['Provider one'] }),
-          mockCatalogSource({ id: 'custom-source', name: 'Custom Source', labels: [] }),
-        ],
+        sources: mockProviderAndCustomSources(),
         hasValidatedModels: true,
       });
       setupFilteredModelsIntercept({ returnModelsForFilters: false });
@@ -380,10 +368,7 @@ describe('Performance Empty State', () => {
 
     it('should show models when toggle is OFF', () => {
       initIntercepts({
-        sources: [
-          mockCatalogSource({ labels: ['Provider one'] }),
-          mockCatalogSource({ id: 'custom-source', name: 'Custom Source', labels: [] }),
-        ],
+        sources: mockProviderAndCustomSources(),
       });
       modelCatalog.visit();
 
@@ -397,14 +382,7 @@ describe('Performance Empty State', () => {
   describe('Labeled Section Without Validated Models', () => {
     it('should show performance empty state when toggle is ON and no validated models', () => {
       initIntercepts({
-        sources: [
-          mockCatalogSource({ labels: ['Provider one'] }),
-          mockCatalogSource({
-            id: 'source-2',
-            name: 'Provider Two Source',
-            labels: ['Provider two'],
-          }),
-        ],
+        sources: mockTwoProviderSources(),
         hasValidatedModels: false,
       });
       // No user filters/search; this scenario should hit the special "No performance data" state.
@@ -421,14 +399,7 @@ describe('Performance Empty State', () => {
 
     it('should show models when toggle is OFF', () => {
       initIntercepts({
-        sources: [
-          mockCatalogSource({ labels: ['Provider one'] }),
-          mockCatalogSource({
-            id: 'source-2',
-            name: 'Provider Two Source',
-            labels: ['Provider two'],
-          }),
-        ],
+        sources: mockTwoProviderSources(),
         hasValidatedModels: false,
       });
       modelCatalog.visit();
@@ -442,14 +413,7 @@ describe('Performance Empty State', () => {
   describe('Labeled Section With Validated Models', () => {
     it('should show models when toggle is ON and section has validated models', () => {
       initIntercepts({
-        sources: [
-          mockCatalogSource({ labels: ['Provider one'] }),
-          mockCatalogSource({
-            id: 'source-2',
-            name: 'Provider Two Source',
-            labels: ['Provider two'],
-          }),
-        ],
+        sources: mockTwoProviderSources(),
         hasValidatedModels: true,
       });
       modelCatalog.visit();
@@ -465,10 +429,7 @@ describe('Performance Empty State', () => {
   describe('Empty State Actions', () => {
     it('should turn off toggle when clicking "Turn Model performance view off"', () => {
       initIntercepts({
-        sources: [
-          mockCatalogSource({ labels: ['Provider one'] }),
-          mockCatalogSource({ id: 'custom-source', name: 'Custom Source', labels: [] }),
-        ],
+        sources: mockProviderAndCustomSources(),
         hasValidatedModels: true,
       });
       setupFilteredModelsIntercept({ returnModelsForFilters: false });
@@ -486,10 +447,7 @@ describe('Performance Empty State', () => {
 
     it('should navigate to All models when clicking "View all models with performance data"', () => {
       initIntercepts({
-        sources: [
-          mockCatalogSource({ labels: ['Provider one'] }),
-          mockCatalogSource({ id: 'custom-source', name: 'Custom Source', labels: [] }),
-        ],
+        sources: mockProviderAndCustomSources(),
         hasValidatedModels: true,
       });
       setupFilteredModelsIntercept({ returnModelsForFilters: false });
@@ -506,14 +464,7 @@ describe('Performance Empty State', () => {
 
     it('should show performance empty state after clicking Reset filters when toggle is ON', () => {
       initIntercepts({
-        sources: [
-          mockCatalogSource({ labels: ['Provider one'] }),
-          mockCatalogSource({
-            id: 'source-2',
-            name: 'Provider Two Source',
-            labels: ['Provider two'],
-          }),
-        ],
+        sources: mockTwoProviderSources(),
         hasValidatedModels: false,
       });
       setupFilteredModelsIntercept({ returnModelsForFilters: false });
@@ -536,10 +487,7 @@ describe('Performance Empty State', () => {
 
   it('should work correctly when toggling performance view', () => {
     initIntercepts({
-      sources: [
-        mockCatalogSource({ labels: ['Provider one'] }),
-        mockCatalogSource({ id: 'custom-source', name: 'Custom Source', labels: [] }),
-      ],
+      sources: mockProviderAndCustomSources(),
       hasValidatedModels: true,
     });
     setupFilteredModelsIntercept({ returnModelsForFilters: false });
@@ -563,14 +511,7 @@ describe('Performance Empty State', () => {
 
   it('should show "No results found" when toggle is ON and user applies filter that returns 0 results', () => {
     initIntercepts({
-      sources: [
-        mockCatalogSource({ labels: ['Provider one'] }),
-        mockCatalogSource({
-          id: 'source-2',
-          name: 'Provider Two Source',
-          labels: ['Provider two'],
-        }),
-      ],
+      sources: mockTwoProviderSources(),
       hasValidatedModels: true,
     });
     setupFilteredModelsIntercept({ returnModelsForFilters: false });
@@ -591,14 +532,7 @@ describe('Performance Empty State', () => {
 describe('All Models Section', () => {
   it('should show models in All models section even when toggle is ON', () => {
     initIntercepts({
-      sources: [
-        mockCatalogSource({ labels: ['Provider one'] }),
-        mockCatalogSource({
-          id: 'source-2',
-          name: 'Provider Two Source',
-          labels: ['Provider two'],
-        }),
-      ],
+      sources: mockTwoProviderSources(),
       hasValidatedModels: true,
     });
     modelCatalog.visit();

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -397,7 +397,14 @@ describe('Performance Empty State', () => {
   describe('Labeled Section Without Validated Models', () => {
     it('should show performance empty state when toggle is ON and no validated models', () => {
       initIntercepts({
-        sources: [mockCatalogSource({ labels: ['Provider one'] })],
+        sources: [
+          mockCatalogSource({ labels: ['Provider one'] }),
+          mockCatalogSource({
+            id: 'source-2',
+            name: 'Provider Two Source',
+            labels: ['Provider two'],
+          }),
+        ],
         hasValidatedModels: false,
       });
       // No user filters/search; this scenario should hit the special "No performance data" state.
@@ -414,7 +421,14 @@ describe('Performance Empty State', () => {
 
     it('should show models when toggle is OFF', () => {
       initIntercepts({
-        sources: [mockCatalogSource({ labels: ['Provider one'] })],
+        sources: [
+          mockCatalogSource({ labels: ['Provider one'] }),
+          mockCatalogSource({
+            id: 'source-2',
+            name: 'Provider Two Source',
+            labels: ['Provider two'],
+          }),
+        ],
         hasValidatedModels: false,
       });
       modelCatalog.visit();
@@ -428,7 +442,14 @@ describe('Performance Empty State', () => {
   describe('Labeled Section With Validated Models', () => {
     it('should show models when toggle is ON and section has validated models', () => {
       initIntercepts({
-        sources: [mockCatalogSource({ labels: ['Provider one'] })],
+        sources: [
+          mockCatalogSource({ labels: ['Provider one'] }),
+          mockCatalogSource({
+            id: 'source-2',
+            name: 'Provider Two Source',
+            labels: ['Provider two'],
+          }),
+        ],
         hasValidatedModels: true,
       });
       modelCatalog.visit();
@@ -485,7 +506,14 @@ describe('Performance Empty State', () => {
 
     it('should show performance empty state after clicking Reset filters when toggle is ON', () => {
       initIntercepts({
-        sources: [mockCatalogSource({ labels: ['Provider one'] })],
+        sources: [
+          mockCatalogSource({ labels: ['Provider one'] }),
+          mockCatalogSource({
+            id: 'source-2',
+            name: 'Provider Two Source',
+            labels: ['Provider two'],
+          }),
+        ],
         hasValidatedModels: false,
       });
       setupFilteredModelsIntercept({ returnModelsForFilters: false });
@@ -535,7 +563,14 @@ describe('Performance Empty State', () => {
 
   it('should show "No results found" when toggle is ON and user applies filter that returns 0 results', () => {
     initIntercepts({
-      sources: [mockCatalogSource({ labels: ['Provider one'] })],
+      sources: [
+        mockCatalogSource({ labels: ['Provider one'] }),
+        mockCatalogSource({
+          id: 'source-2',
+          name: 'Provider Two Source',
+          labels: ['Provider two'],
+        }),
+      ],
       hasValidatedModels: true,
     });
     setupFilteredModelsIntercept({ returnModelsForFilters: false });
@@ -556,7 +591,14 @@ describe('Performance Empty State', () => {
 describe('All Models Section', () => {
   it('should show models in All models section even when toggle is ON', () => {
     initIntercepts({
-      sources: [mockCatalogSource({ labels: ['Provider one'] })],
+      sources: [
+        mockCatalogSource({ labels: ['Provider one'] }),
+        mockCatalogSource({
+          id: 'source-2',
+          name: 'Provider Two Source',
+          labels: ['Provider two'],
+        }),
+      ],
       hasValidatedModels: true,
     });
     modelCatalog.visit();
@@ -567,5 +609,37 @@ describe('All Models Section', () => {
     modelCatalog.findAllModelsToggle().click();
     modelCatalog.findModelCatalogCards().should('have.length.at.least', 1);
     modelCatalog.findPerformanceEmptyState().should('not.exist');
+  });
+});
+
+describe('Single Category Behavior', () => {
+  it('should hide category toggle when only one category is active', () => {
+    initIntercepts({
+      sources: [mockCatalogSource({ labels: ['Provider one'] })],
+    });
+    modelCatalog.visit();
+
+    cy.findByTestId('label-Provider one').should('not.exist');
+    cy.findByTestId('all').should('not.exist');
+  });
+
+  it('should auto-select the single active category and show its models', () => {
+    initIntercepts({
+      sources: [mockCatalogSource({ labels: ['Provider one'] })],
+    });
+    modelCatalog.visit();
+
+    modelCatalog.findModelCatalogCards().should('have.length.at.least', 1);
+  });
+
+  it('should show full grid view for the auto-selected single category', () => {
+    initIntercepts({
+      sources: [mockCatalogSource({ labels: ['Provider one'] })],
+      hasValidatedModels: true,
+    });
+    modelCatalog.visit();
+
+    modelCatalog.togglePerformanceView();
+    modelCatalog.findModelCatalogCards().should('have.length.at.least', 1);
   });
 });

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalog.tsx
@@ -94,7 +94,10 @@ const McpCatalog: React.FC = () => {
                   {isAllServersView && !isSingleCategory ? (
                     <McpCatalogAllServersView searchTerm={searchQuery} />
                   ) : (
-                    <McpCatalogGalleryView handleFilterReset={handleResetAllFilters} />
+                    <McpCatalogGalleryView
+                      handleFilterReset={handleResetAllFilters}
+                      isSingleCategory={isSingleCategory}
+                    />
                   )}
                 </PageSection>
               </Stack>

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalog.tsx
@@ -38,10 +38,16 @@ const McpCatalog: React.FC = () => {
   const hasNoCategories = activeCategories.length === 0;
 
   React.useEffect(() => {
-    if (catalogSourcesLoaded && isSingleCategory) {
+    if (catalogSourcesLoaded && isSingleCategory && selectedSourceLabel !== activeCategories[0]) {
       setSelectedSourceLabel(activeCategories[0]);
     }
-  }, [catalogSourcesLoaded, isSingleCategory, activeCategories, setSelectedSourceLabel]);
+  }, [
+    catalogSourcesLoaded,
+    isSingleCategory,
+    activeCategories,
+    selectedSourceLabel,
+    setSelectedSourceLabel,
+  ]);
 
   const handleSearch = React.useCallback(
     (term: string) => {
@@ -97,6 +103,7 @@ const McpCatalog: React.FC = () => {
                     <McpCatalogGalleryView
                       handleFilterReset={handleResetAllFilters}
                       isSingleCategory={isSingleCategory}
+                      singleCategoryLabel={isSingleCategory ? activeCategories[0] : undefined}
                     />
                   )}
                 </PageSection>

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalog.tsx
@@ -1,21 +1,47 @@
 import * as React from 'react';
 import { PageSection, Sidebar, SidebarContent, SidebarPanel, Stack } from '@patternfly/react-core';
 import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-shared';
+import { SearchIcon } from '@patternfly/react-icons';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
 import { McpCatalogContext } from '~/app/context/mcpCatalog/McpCatalogContext';
 import { hasMcpFiltersApplied } from '~/app/pages/mcpCatalog/utils/mcpCatalogUtils';
 import McpCatalogFilters from '~/app/pages/mcpCatalog/components/McpCatalogFilters';
 import { MCP_CATALOG_TITLE, MCP_CATALOG_DESCRIPTION } from '~/app/pages/mcpCatalog/const';
+import { getActiveSourceLabels } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import EmptyModelCatalogState from '~/app/pages/modelCatalog/EmptyModelCatalogState';
 import McpCatalogSourceLabelSelector from './McpCatalogSourceLabelSelector';
 import McpCatalogAllServersView from './McpCatalogAllServersView';
 import McpCatalogGalleryView from './McpCatalogGalleryView';
 
 const McpCatalog: React.FC = () => {
-  const { searchQuery, setSearchQuery, clearAllFilters, selectedSourceLabel, filters } =
-    React.useContext(McpCatalogContext);
+  const {
+    searchQuery,
+    setSearchQuery,
+    clearAllFilters,
+    selectedSourceLabel,
+    setSelectedSourceLabel,
+    filters,
+    catalogSources,
+    catalogLabels,
+    catalogSourcesLoaded,
+  } = React.useContext(McpCatalogContext);
 
   const filtersApplied = hasMcpFiltersApplied(filters, searchQuery);
   const isAllServersView = selectedSourceLabel === undefined && !filtersApplied;
+
+  const activeCategories = React.useMemo(
+    () => getActiveSourceLabels(catalogSources, catalogLabels),
+    [catalogSources, catalogLabels],
+  );
+
+  const isSingleCategory = activeCategories.length === 1;
+  const hasNoCategories = activeCategories.length === 0;
+
+  React.useEffect(() => {
+    if (catalogSourcesLoaded && isSingleCategory) {
+      setSelectedSourceLabel(activeCategories[0]);
+    }
+  }, [catalogSourcesLoaded, isSingleCategory, activeCategories, setSelectedSourceLabel]);
 
   const handleSearch = React.useCallback(
     (term: string) => {
@@ -44,28 +70,37 @@ const McpCatalog: React.FC = () => {
         loaded
         provideChildrenPadding
       >
-        <Sidebar hasBorder hasGutter>
-          <SidebarPanel variant="sticky">
-            <McpCatalogFilters />
-          </SidebarPanel>
-          <SidebarContent>
-            <Stack hasGutter>
-              <McpCatalogSourceLabelSelector
-                searchTerm={searchQuery}
-                onSearch={handleSearch}
-                onClearSearch={handleClearSearch}
-                onResetAllFilters={handleResetAllFilters}
-              />
-              <PageSection isFilled padding={{ default: 'noPadding' }}>
-                {isAllServersView ? (
-                  <McpCatalogAllServersView searchTerm={searchQuery} />
-                ) : (
-                  <McpCatalogGalleryView handleFilterReset={handleResetAllFilters} />
-                )}
-              </PageSection>
-            </Stack>
-          </SidebarContent>
-        </Sidebar>
+        {catalogSourcesLoaded && hasNoCategories ? (
+          <EmptyModelCatalogState
+            testid="empty-mcp-catalog-no-categories"
+            title="No MCP servers available"
+            headerIcon={SearchIcon}
+            description="There are no MCP server categories available. Configure sources in settings to get started."
+          />
+        ) : (
+          <Sidebar hasBorder hasGutter>
+            <SidebarPanel variant="sticky">
+              <McpCatalogFilters />
+            </SidebarPanel>
+            <SidebarContent>
+              <Stack hasGutter>
+                <McpCatalogSourceLabelSelector
+                  searchTerm={searchQuery}
+                  onSearch={handleSearch}
+                  onClearSearch={handleClearSearch}
+                  onResetAllFilters={handleResetAllFilters}
+                />
+                <PageSection isFilled padding={{ default: 'noPadding' }}>
+                  {isAllServersView && !isSingleCategory ? (
+                    <McpCatalogAllServersView searchTerm={searchQuery} />
+                  ) : (
+                    <McpCatalogGalleryView handleFilterReset={handleResetAllFilters} />
+                  )}
+                </PageSection>
+              </Stack>
+            </SidebarContent>
+          </Sidebar>
+        )}
       </ApplicationsPage>
     </>
   );

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogGalleryView.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Bullseye,
   Button,
+  Content,
   EmptyState,
   Flex,
   Grid,
@@ -13,8 +14,15 @@ import {
 import { SearchIcon } from '@patternfly/react-icons';
 import { McpCatalogContext } from '~/app/context/mcpCatalog/McpCatalogContext';
 import { useMcpServersBySourceLabelWithAPI } from '~/app/hooks/mcpServerCatalog/useMcpServersBySourceLabel';
-import { MCP_CATALOG_GRID_SPAN } from '~/app/pages/mcpCatalog/const';
+import {
+  MCP_CATALOG_GRID_SPAN,
+  OTHER_MCP_SERVERS_DISPLAY_NAME,
+} from '~/app/pages/mcpCatalog/const';
 import { mcpFiltersToFilterQuery } from '~/app/pages/mcpCatalog/utils/mcpCatalogUtils';
+import {
+  getLabelDisplayName,
+  getLabelDescription,
+} from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import EmptyModelCatalogState from '~/app/pages/modelCatalog/EmptyModelCatalogState';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
 import McpCatalogCard from '~/app/pages/mcpCatalog/components/McpCatalogCard';
@@ -23,11 +31,21 @@ const PAGE_SIZE = 10;
 
 type McpCatalogGalleryViewProps = {
   handleFilterReset: () => void;
+  isSingleCategory?: boolean;
 };
 
-const McpCatalogGalleryView: React.FC<McpCatalogGalleryViewProps> = ({ handleFilterReset }) => {
-  const { mcpApiState, selectedSourceLabel, searchQuery, filters, catalogLabelsLoaded } =
-    React.useContext(McpCatalogContext);
+const McpCatalogGalleryView: React.FC<McpCatalogGalleryViewProps> = ({
+  handleFilterReset,
+  isSingleCategory = false,
+}) => {
+  const {
+    mcpApiState,
+    selectedSourceLabel,
+    searchQuery,
+    filters,
+    catalogLabels,
+    catalogLabelsLoaded,
+  } = React.useContext(McpCatalogContext);
 
   const filterQuery = React.useMemo(() => mcpFiltersToFilterQuery(filters), [filters]);
 
@@ -80,9 +98,33 @@ const McpCatalogGalleryView: React.FC<McpCatalogGalleryViewProps> = ({ handleFil
     );
   }
 
+  const categoryTitle = isSingleCategory
+    ? getLabelDisplayName(
+        selectedSourceLabel || '',
+        catalogLabels,
+        OTHER_MCP_SERVERS_DISPLAY_NAME,
+        'servers',
+      )
+    : undefined;
+  const categoryDescription = isSingleCategory
+    ? getLabelDescription(selectedSourceLabel || '', catalogLabels)
+    : undefined;
+
   return (
     <>
       <ScrollViewOnMount shouldScroll scrollToTop />
+      {isSingleCategory && categoryTitle && (
+        <div className="pf-v6-u-mb-lg" data-testid="single-category-header">
+          <Title headingLevel="h3" size="lg">
+            {categoryTitle}
+          </Title>
+          {categoryDescription && (
+            <Content component="p" className="pf-v6-u-color-200 pf-v6-u-mt-sm">
+              {categoryDescription}
+            </Content>
+          )}
+        </div>
+      )}
       <Grid hasGutter>
         {items.map((server) => (
           <GridItem

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogGalleryView.tsx
@@ -32,11 +32,13 @@ const PAGE_SIZE = 10;
 type McpCatalogGalleryViewProps = {
   handleFilterReset: () => void;
   isSingleCategory?: boolean;
+  singleCategoryLabel?: string;
 };
 
 const McpCatalogGalleryView: React.FC<McpCatalogGalleryViewProps> = ({
   handleFilterReset,
   isSingleCategory = false,
+  singleCategoryLabel,
 }) => {
   const {
     mcpApiState,
@@ -98,16 +100,17 @@ const McpCatalogGalleryView: React.FC<McpCatalogGalleryViewProps> = ({
     );
   }
 
+  const effectiveCategoryLabel = singleCategoryLabel || selectedSourceLabel || '';
   const categoryTitle = isSingleCategory
     ? getLabelDisplayName(
-        selectedSourceLabel || '',
+        effectiveCategoryLabel,
         catalogLabels,
         OTHER_MCP_SERVERS_DISPLAY_NAME,
         'servers',
       )
     : undefined;
   const categoryDescription = isSingleCategory
-    ? getLabelDescription(selectedSourceLabel || '', catalogLabels)
+    ? getLabelDescription(effectiveCategoryLabel, catalogLabels)
     : undefined;
 
   return (

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogSourceLabelBlocks.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogSourceLabelBlocks.tsx
@@ -64,6 +64,11 @@ const McpCatalogSourceLabelBlocks: React.FC = () => {
     return null;
   }
 
+  const activeCategoryCount = blocks.length - 1;
+  if (activeCategoryCount <= 1) {
+    return null;
+  }
+
   const isSelected = (block: SourceLabelBlock) =>
     block.label === undefined
       ? selectedSourceLabel === undefined

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
@@ -34,10 +34,16 @@ const ModelCatalog: React.FC = () => {
   const hasNoCategories = activeCategories.length === 0;
 
   React.useEffect(() => {
-    if (catalogSourcesLoaded && isSingleCategory) {
+    if (catalogSourcesLoaded && isSingleCategory && selectedSourceLabel !== activeCategories[0]) {
       updateSelectedSourceLabel(activeCategories[0]);
     }
-  }, [catalogSourcesLoaded, isSingleCategory, activeCategories, updateSelectedSourceLabel]);
+  }, [
+    catalogSourcesLoaded,
+    isSingleCategory,
+    activeCategories,
+    selectedSourceLabel,
+    updateSelectedSourceLabel,
+  ]);
 
   const isAllModelsView =
     selectedSourceLabel === CategoryName.allModels && !searchTerm && !filtersApplied;
@@ -93,6 +99,7 @@ const ModelCatalog: React.FC = () => {
                     searchTerm={searchTerm}
                     handleFilterReset={handleFilterReset}
                     isSingleCategory={isSingleCategory}
+                    singleCategoryLabel={isSingleCategory ? activeCategories[0] : undefined}
                   />
                 )}
               </PageSection>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
@@ -92,6 +92,7 @@ const ModelCatalog: React.FC = () => {
                   <ModelCatalogGalleryView
                     searchTerm={searchTerm}
                     handleFilterReset={handleFilterReset}
+                    isSingleCategory={isSingleCategory}
                   />
                 )}
               </PageSection>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
@@ -1,19 +1,44 @@
 import * as React from 'react';
 import { PageSection, Sidebar, SidebarContent, SidebarPanel } from '@patternfly/react-core';
 import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-shared';
+import { SearchIcon } from '@patternfly/react-icons';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
 import ModelCatalogFilters from '~/app/pages/modelCatalog/components/ModelCatalogFilters';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { CategoryName } from '~/app/modelCatalogTypes';
 import { useHasVisibleFiltersApplied } from '~/app/hooks/modelCatalog/useHasVisibleFiltersApplied';
+import { getActiveSourceLabels } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import EmptyModelCatalogState from '~/app/pages/modelCatalog/EmptyModelCatalogState';
 import ModelCatalogSourceLabelSelectorNavigator from './ModelCatalogSourceLabelSelectorNavigator';
 import ModelCatalogAllModelsView from './ModelCatalogAllModelsView';
 import ModelCatalogGalleryView from './ModelCatalogGalleryView';
 
 const ModelCatalog: React.FC = () => {
   const [searchTerm, setSearchTerm] = React.useState('');
-  const { selectedSourceLabel, clearAllFilters } = React.useContext(ModelCatalogContext);
+  const {
+    selectedSourceLabel,
+    updateSelectedSourceLabel,
+    clearAllFilters,
+    catalogSources,
+    catalogLabels,
+    catalogSourcesLoaded,
+  } = React.useContext(ModelCatalogContext);
   const filtersApplied = useHasVisibleFiltersApplied();
+
+  const activeCategories = React.useMemo(
+    () => getActiveSourceLabels(catalogSources, catalogLabels),
+    [catalogSources, catalogLabels],
+  );
+
+  const isSingleCategory = activeCategories.length === 1;
+  const hasNoCategories = activeCategories.length === 0;
+
+  React.useEffect(() => {
+    if (catalogSourcesLoaded && isSingleCategory) {
+      updateSelectedSourceLabel(activeCategories[0]);
+    }
+  }, [catalogSourcesLoaded, isSingleCategory, activeCategories, updateSelectedSourceLabel]);
+
   const isAllModelsView =
     selectedSourceLabel === CategoryName.allModels && !searchTerm && !filtersApplied;
 
@@ -41,29 +66,38 @@ const ModelCatalog: React.FC = () => {
         loaded
         provideChildrenPadding
       >
-        <Sidebar hasBorder hasGutter>
-          <SidebarPanel variant="sticky">
-            <ModelCatalogFilters />
-          </SidebarPanel>
-          <SidebarContent>
-            <ModelCatalogSourceLabelSelectorNavigator
-              searchTerm={searchTerm}
-              onSearch={handleSearch}
-              onClearSearch={handleClearSearch}
-              onResetAllFilters={handleFilterReset}
-            />
-            <PageSection isFilled padding={{ default: 'noPadding' }}>
-              {isAllModelsView ? (
-                <ModelCatalogAllModelsView searchTerm={searchTerm} />
-              ) : (
-                <ModelCatalogGalleryView
-                  searchTerm={searchTerm}
-                  handleFilterReset={handleFilterReset}
-                />
-              )}
-            </PageSection>
-          </SidebarContent>
-        </Sidebar>
+        {catalogSourcesLoaded && hasNoCategories ? (
+          <EmptyModelCatalogState
+            testid="empty-model-catalog-no-categories"
+            title="No models available"
+            headerIcon={SearchIcon}
+            description="There are no model categories available. Configure model sources in settings to get started."
+          />
+        ) : (
+          <Sidebar hasBorder hasGutter>
+            <SidebarPanel variant="sticky">
+              <ModelCatalogFilters />
+            </SidebarPanel>
+            <SidebarContent>
+              <ModelCatalogSourceLabelSelectorNavigator
+                searchTerm={searchTerm}
+                onSearch={handleSearch}
+                onClearSearch={handleClearSearch}
+                onResetAllFilters={handleFilterReset}
+              />
+              <PageSection isFilled padding={{ default: 'noPadding' }}>
+                {isAllModelsView && !isSingleCategory ? (
+                  <ModelCatalogAllModelsView searchTerm={searchTerm} />
+                ) : (
+                  <ModelCatalogGalleryView
+                    searchTerm={searchTerm}
+                    handleFilterReset={handleFilterReset}
+                  />
+                )}
+              </PageSection>
+            </SidebarContent>
+          </Sidebar>
+        )}
       </ApplicationsPage>
     </>
   );

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   Bullseye,
   Button,
+  Content,
   EmptyState,
   EmptyStateVariant,
   Flex,
@@ -22,6 +23,8 @@ import {
   getActiveLatencyFieldName,
   getSortParams,
   generateCategoryName,
+  getLabelDisplayName,
+  getLabelDescription,
   hasFiltersApplied,
   isValueDifferentFromDefault,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
@@ -38,11 +41,13 @@ import {
 type ModelCatalogPageProps = {
   searchTerm: string;
   handleFilterReset: () => void;
+  isSingleCategory?: boolean;
 };
 
 const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
   searchTerm,
   handleFilterReset,
+  isSingleCategory = false,
 }) => {
   const {
     selectedSourceLabel,
@@ -51,6 +56,7 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
     filterOptionsLoaded,
     filterOptionsLoadError,
     catalogSources,
+    catalogLabels,
     catalogLabelsLoaded,
     catalogLabelsLoadError,
     setPerformanceViewEnabled,
@@ -270,9 +276,28 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
     );
   }
 
+  const categoryTitle = isSingleCategory
+    ? getLabelDisplayName(selectedSourceLabel || '', catalogLabels)
+    : undefined;
+  const categoryDescription = isSingleCategory
+    ? getLabelDescription(selectedSourceLabel || '', catalogLabels)
+    : undefined;
+
   return (
     <>
       <ScrollViewOnMount shouldScroll scrollToTop />
+      {isSingleCategory && categoryTitle && (
+        <div className="pf-v6-u-mb-lg" data-testid="single-category-header">
+          <Title headingLevel="h3" size="lg">
+            {categoryTitle}
+          </Title>
+          {categoryDescription && (
+            <Content component="p" className="pf-v6-u-color-200 pf-v6-u-mt-sm">
+              {categoryDescription}
+            </Content>
+          )}
+        </div>
+      )}
       <Grid hasGutter>
         {catalogModels.items.map((model: CatalogModel) => (
           <GridItem key={`${model.name}/${model.source_id}`} sm={6} md={6} lg={6} xl={6} xl2={3}>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -42,12 +42,14 @@ type ModelCatalogPageProps = {
   searchTerm: string;
   handleFilterReset: () => void;
   isSingleCategory?: boolean;
+  singleCategoryLabel?: string;
 };
 
 const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
   searchTerm,
   handleFilterReset,
   isSingleCategory = false,
+  singleCategoryLabel,
 }) => {
   const {
     selectedSourceLabel,
@@ -276,11 +278,12 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
     );
   }
 
+  const effectiveCategoryLabel = singleCategoryLabel || selectedSourceLabel || '';
   const categoryTitle = isSingleCategory
-    ? getLabelDisplayName(selectedSourceLabel || '', catalogLabels)
+    ? getLabelDisplayName(effectiveCategoryLabel, catalogLabels)
     : undefined;
   const categoryDescription = isSingleCategory
-    ? getLabelDescription(selectedSourceLabel || '', catalogLabels)
+    ? getLabelDescription(effectiveCategoryLabel, catalogLabels)
     : undefined;
 
   return (

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelBlocks.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelBlocks.tsx
@@ -62,6 +62,11 @@ const ModelCatalogSourceLabelBlocks: React.FC = () => {
     return null;
   }
 
+  const activeCategoryCount = blocks.length - 1;
+  if (activeCategoryCount <= 1) {
+    return null;
+  }
+
   const handleToggleClick = (label: string) => {
     updateSelectedSourceLabel(label);
   };

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -32,6 +32,7 @@ import {
   hasFiltersApplied,
   getArchitecturesFromArtifacts,
   getModelName,
+  getActiveSourceLabels,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { mockCatalogModelArtifact } from '~/__mocks__/mockCatalogModelArtifactList';
 import { ModelRegistryMetadataType } from '~/app/types';
@@ -1381,5 +1382,193 @@ describe('getModelName', () => {
   it('should handle model names with hyphens and underscores', () => {
     const result = getModelName('my_org/my-model_v1');
     expect(result).toBe('my-model_v1');
+  });
+});
+
+describe('getActiveSourceLabels', () => {
+  const createSource = (overrides: Partial<CatalogSource> = {}): CatalogSource => ({
+    id: 'source-1',
+    name: 'Test Source',
+    labels: ['Red Hat'],
+    enabled: true,
+    status: CatalogSourceStatus.AVAILABLE,
+    ...overrides,
+  });
+
+  const createSourceList = (items: CatalogSource[] = []): CatalogSourceList => ({
+    items,
+    size: items.length,
+    pageSize: 10,
+    nextPageToken: '',
+  });
+
+  it('returns empty array when catalogSources is null', () => {
+    expect(getActiveSourceLabels(null, null)).toEqual([]);
+  });
+
+  it('returns empty array when no sources are enabled or available', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        enabled: false,
+        status: CatalogSourceStatus.DISABLED,
+      }),
+      createSource({
+        id: '2',
+        enabled: true,
+        status: CatalogSourceStatus.ERROR,
+      }),
+    ]);
+    expect(getActiveSourceLabels(sources, null)).toEqual([]);
+  });
+
+  it('returns a single label when only one category exists', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+    ]);
+    expect(getActiveSourceLabels(sources, null)).toEqual(['Red Hat']);
+  });
+
+  it('returns multiple labels when multiple categories exist', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '2',
+        labels: ['Community'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+    ]);
+    const result = getActiveSourceLabels(sources, null);
+    expect(result).toHaveLength(2);
+    expect(result).toContain('Red Hat');
+    expect(result).toContain('Community');
+  });
+
+  it('includes "null" label for sources without labels', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '2',
+        labels: [],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+    ]);
+    const result = getActiveSourceLabels(sources, null);
+    expect(result).toContain('Red Hat');
+    expect(result).toContain('null');
+  });
+
+  it('excludes disabled sources from active categories', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '2',
+        labels: ['Excluded'],
+        enabled: false,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+    ]);
+    const result = getActiveSourceLabels(sources, null);
+    expect(result).toEqual(['Red Hat']);
+  });
+
+  it('excludes sources with error status', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '2',
+        labels: ['Error Source'],
+        enabled: true,
+        status: CatalogSourceStatus.ERROR,
+      }),
+    ]);
+    const result = getActiveSourceLabels(sources, null);
+    expect(result).toEqual(['Red Hat']);
+  });
+
+  it('includes partially-available sources', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '2',
+        labels: ['Partial'],
+        enabled: true,
+        status: CatalogSourceStatus.PARTIALLY_AVAILABLE,
+      }),
+    ]);
+    const result = getActiveSourceLabels(sources, null);
+    expect(result).toHaveLength(2);
+    expect(result).toContain('Red Hat');
+    expect(result).toContain('Partial');
+  });
+
+  it('deduplicates labels from multiple sources with the same label', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '2',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+    ]);
+    const result = getActiveSourceLabels(sources, null);
+    expect(result).toEqual(['Red Hat']);
+  });
+
+  it('returns only "null" label when all sources have no labels', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: [],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '2',
+        labels: [],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+    ]);
+    const result = getActiveSourceLabels(sources, null);
+    expect(result).toEqual(['null']);
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -2,6 +2,8 @@
 /* eslint-disable camelcase */
 import {
   CatalogFilterOptionsList,
+  CatalogLabel,
+  CatalogLabelList,
   CatalogSource,
   CatalogSourceList,
   ModelCatalogFilterStates,
@@ -1570,5 +1572,43 @@ describe('getActiveSourceLabels', () => {
     ]);
     const result = getActiveSourceLabels(sources, null);
     expect(result).toEqual(['null']);
+  });
+
+  it('orders labels by catalogLabels priority when catalogLabels is provided', () => {
+    const sources = createSourceList([
+      createSource({
+        id: '1',
+        labels: ['Community'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '2',
+        labels: ['Red Hat'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+      createSource({
+        id: '3',
+        labels: ['Partner'],
+        enabled: true,
+        status: CatalogSourceStatus.AVAILABLE,
+      }),
+    ]);
+
+    const createLabel = (name: string | null): CatalogLabel => ({
+      name,
+      displayName: name ?? undefined,
+    });
+
+    const catalogLabels: CatalogLabelList = {
+      items: [createLabel('Red Hat'), createLabel('Partner'), createLabel('Community')],
+      size: 3,
+      pageSize: 10,
+      nextPageToken: '',
+    };
+
+    const result = getActiveSourceLabels(sources, catalogLabels);
+    expect(result).toEqual(['Red Hat', 'Partner', 'Community']);
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -750,6 +750,21 @@ export const orderLabelsByPriority = (
   return orderedLabels;
 };
 
+export const getActiveSourceLabels = (
+  catalogSources: CatalogSourceList | null,
+  catalogLabels: CatalogLabelList | null,
+): string[] => {
+  const enabledSources = filterEnabledCatalogSources(catalogSources);
+  const uniqueLabels = getUniqueSourceLabels(enabledSources);
+  const orderedLabels = orderLabelsByPriority(uniqueLabels, catalogLabels);
+
+  if (hasSourcesWithoutLabels(enabledSources)) {
+    return [...orderedLabels, SourceLabel.other];
+  }
+
+  return orderedLabels;
+};
+
 /**
  * Formats model type value for display in the UI.
  * Converts raw API values (generative, predictive, unknown) to user-friendly display labels.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When only one category is available for Model Catalog or MCP Catalog, the grid only show 4 cards and need to click in a link/toggle to show all the cards from that category.
These changes are made for when this happens, it shows all the cards available in that category (until the load more button appear) 

- Added `getActiveSourceLabels` utility function
- Implemented conditional rendering logic

With this changes the behaviour will be:
1. **Multiple active categories**: Normal behaviour with category toggle visible
2. **Single active category**: Toggle hidden, category auto-selected via useEffect
3. **No active categories**: Empty state displayed

Before:
- non-PF mode:
<img width="1861" height="939" alt="before-model-non-pf" src="https://github.com/user-attachments/assets/75a3aa51-23ea-4339-868a-f328e4985bef" />
<img width="1865" height="914" alt="before-mcp-non-pf" src="https://github.com/user-attachments/assets/656e263e-e32b-4e43-9133-7622f6c8fec6" />

- PF mode:
<img width="1840" height="946" alt="before-mcp-pf" src="https://github.com/user-attachments/assets/29027475-247b-4d5d-8182-8fcc643a27f0" />
<img width="1834" height="947" alt="before-model-pf" src="https://github.com/user-attachments/assets/12d8c912-9d29-4a92-87e2-c8f708c9d2d7" />

After:
- non-PF mode:
<img width="1861" height="979" alt="after-mcp-non-pf" src="https://github.com/user-attachments/assets/6c9218d6-2460-4735-9468-fe478490a673" />
<img width="1863" height="982" alt="after-model-non-pf" src="https://github.com/user-attachments/assets/25523f16-95ea-4213-83c4-a9e1647605f6" />

- PF mode:
<img width="1842" height="1197" alt="after-model-pf" src="https://github.com/user-attachments/assets/a1607f2b-e9ea-4dac-b776-9feff9171c74" />
<img width="1847" height="1197" alt="after-mcp-pf" src="https://github.com/user-attachments/assets/7a808cdf-87b3-4117-ba3d-5c81d481a259" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested, also crated unit tests and 3 new cypress tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
