### PR TITLE
Add Hugging Face organization slug helper under Allowed organization

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -88,15 +88,22 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
     ) : undefined;
 
   const organizationFormGroup = (
-    <ThemeAwareFormGroupWrapper
-      label={FORM_LABELS.ORGANIZATION}
-      fieldId="organization"
-      isRequired
-      descriptionTextNode={organizationDescriptionTxtNode}
-      helperTextNode={organizationHelperTxtNode}
-    >
-      {organizationInput}
-    </ThemeAwareFormGroupWrapper>
+    <>
+      <ThemeAwareFormGroupWrapper
+        label={FORM_LABELS.ORGANIZATION}
+        fieldId="organization"
+        isRequired
+        descriptionTextNode={organizationDescriptionTxtNode}
+        helperTextNode={organizationHelperTxtNode}
+      >
+        {organizationInput}
+      </ThemeAwareFormGroupWrapper>
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem>{HELP_TEXT.ORGANIZATION_SLUG}</HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    </>
   );
 
   const accessTokenInput = (

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -100,7 +100,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
       </ThemeAwareFormGroupWrapper>
       <FormHelperText>
         <HelperText>
-          <HelperTextItem>{HELP_TEXT.ORGANIZATION_SLUG}</HelperTextItem>
+          <HelperTextItem>{HELPER_TEXT.ORGANIZATION_SLUG}</HelperTextItem>
         </HelperText>
       </FormHelperText>
     </>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -47,6 +47,8 @@ export const DESCRIPTION_TEXT = {
 export const HELPER_TEXT = {
   ACCESS_TOKEN: 'Enter your Hugging Face access token.',
   YAML: 'Upload or paste a YAML string.',
+  ORGANIZATION_SLUG:
+    'Hugging Face organization’s name is case-sensitive and match the organization’s URL, which may differ from the displayed name. Use the organization’s URL slug found in the URL (e.g., Input: meta-llama from huggingface.co/meta-llama).',
 } as const;
 
 export const PLACEHOLDERS = {

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -48,7 +48,7 @@ export const HELPER_TEXT = {
   ACCESS_TOKEN: 'Enter your Hugging Face access token.',
   YAML: 'Upload or paste a YAML string.',
   ORGANIZATION_SLUG:
-    'Hugging Face organization’s name is case-sensitive and match the organization’s URL, which may differ from the displayed name. Use the organization’s URL slug found in the URL (e.g., Input: meta-llama from huggingface.co/meta-llama).',
+    'Hugging Face organization’s name is case-sensitive and should match the organization’s URL, which may differ from the displayed name. Use the organization’s URL slug found in the URL (e.g., Input: meta-llama from huggingface.co/meta-llama).',
 } as const;
 
 export const PLACEHOLDERS = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR adds secondary helper text below the Allowed organization field on the Hugging Face catalog source form. This text will inform the administrator that the display name and organization name may differ and provide guidance on locating the correct organization name.

<img width="1118" height="440" alt="image" src="https://github.com/user-attachments/assets/621a9ba0-8aa7-46ea-a0a2-d943d0d094c9" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by navigating to `model-catalog-settings/add-source` and ensuring the helper text is visible under the organization input field.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
