### PR TITLE
fix(ui): MUI theme overlap in YamlSection

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/YamlSection.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { OpenDrawerRightIcon } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from 'mod-arch-shared';
+import { useThemeContext } from 'mod-arch-kubeflow';
 import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
@@ -33,6 +34,7 @@ const YamlSection: React.FC<YamlSectionProps> = ({
   setData,
   onToggleExpectedFormatDrawer,
 }) => {
+  const { isMUITheme } = useThemeContext();
   const [isYamlTouched, setIsYamlTouched] = React.useState(false);
   const [filename, setFilename] = React.useState('');
   const isYamlContentValid = validateYamlContent(formData.yamlContent);
@@ -83,6 +85,60 @@ const YamlSection: React.FC<YamlSectionProps> = ({
     </div>
   );
 
+  const expectedFormatButton = onToggleExpectedFormatDrawer ? (
+    <Button
+      variant="link"
+      isInline
+      onClick={onToggleExpectedFormatDrawer}
+      data-testid="view-expected-yaml-format-link"
+      icon={<OpenDrawerRightIcon />}
+      iconPosition="end"
+    >
+      {EXPECTED_YAML_FORMAT_LABEL}
+    </Button>
+  ) : null;
+
+  const descriptionTextNode = (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem>{HELP_TEXT.YAML}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  );
+
+  const hasError = isYamlTouched && !isYamlContentValid;
+  const helperTextNode = hasError ? (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem variant="error" data-testid="yaml-content-error">
+          {VALIDATION_MESSAGES.YAML_CONTENT_REQUIRED}
+        </HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  ) : undefined;
+
+  if (isMUITheme) {
+    return (
+      <FormSection data-testid="yaml-section">
+        {expectedFormatButton && (
+          <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+            <FlexItem>{expectedFormatButton}</FlexItem>
+          </Flex>
+        )}
+        {descriptionTextNode}
+        <FormGroup
+          className={hasError ? 'pf-m-error' : undefined}
+          label={FORM_LABELS.YAML_CONTENT}
+          isRequired
+          fieldId="yaml-content"
+        >
+          <FormFieldset component={yamlInput} field={FORM_LABELS.YAML_CONTENT} />
+        </FormGroup>
+        {helperTextNode}
+      </FormSection>
+    );
+  }
+
   return (
     <FormSection data-testid="yaml-section">
       <FormGroup
@@ -92,40 +148,15 @@ const YamlSection: React.FC<YamlSectionProps> = ({
             alignItems={{ default: 'alignItemsCenter' }}
           >
             <FlexItem>{FORM_LABELS.YAML_CONTENT}</FlexItem>
-            {onToggleExpectedFormatDrawer && (
-              <FlexItem>
-                <Button
-                  variant="link"
-                  isInline
-                  onClick={onToggleExpectedFormatDrawer}
-                  data-testid="view-expected-yaml-format-link"
-                  icon={<OpenDrawerRightIcon />}
-                  iconPosition="end"
-                >
-                  {EXPECTED_YAML_FORMAT_LABEL}
-                </Button>
-              </FlexItem>
-            )}
+            {expectedFormatButton && <FlexItem>{expectedFormatButton}</FlexItem>}
           </Flex>
         }
         isRequired
         fieldId="yaml-content"
       >
         <FormFieldset component={yamlInput} field="YAML" />
-        <FormHelperText>
-          <HelperText>
-            <HelperTextItem>{HELP_TEXT.YAML}</HelperTextItem>
-          </HelperText>
-        </FormHelperText>
-        {isYamlTouched && !isYamlContentValid && (
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem variant="error" data-testid="yaml-content-error">
-                {VALIDATION_MESSAGES.YAML_CONTENT_REQUIRED}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        )}
+        {descriptionTextNode}
+        {helperTextNode}
       </FormGroup>
     </FormSection>
   );


### PR DESCRIPTION
Fixes #2606 

In MUI theme mode, the YAML content section in `Model Catalog Sources` had two issues:
- view expected file format button was unclickable
- text elements overlapped within the form label area

## Description
Changes done in 
- MUI mode : simplified the `FormGroup` label to a plain string for correct floating label rendering & moved the "View expected file format" button outside the `FormGroup`. 
- PF mode: unchanged.

## How Has This Been Tested?
- modelCatalogSettings suite pass
- manual verification with `STYLE_THEME=mui-theme npm run start:dev`

    - before :

       <img width="704" height="381" alt="Screenshot 2026-04-19 at 9 46 11 PM" src="https://github.com/user-attachments/assets/a08f7652-3623-431d-83cc-99a656177194" />

    - after :

       <img width="707" height="376" alt="Screenshot 2026-04-19 at 9 55 27 PM" src="https://github.com/user-attachments/assets/d0d07cb1-ef88-4bc8-866d-9eb5e8773a02" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [x] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
