### PR TITLE
fix: clear stale property columns on type change

### DIFF
--- a/internal/db/service/generic_repository.go
+++ b/internal/db/service/generic_repository.go
@@ -496,8 +496,7 @@ func (r *GenericRepository[TEntity, TSchema, TProp, TListOpts]) handleProperties
 		switch result.Error {
 		case nil:
 			// Update existing property
-			r.copyPropertyValues(&prop, &existingProp)
-			if err := tx.Model(&existingProp).Updates(prop).Error; err != nil {
+			if err := tx.Model(&existingProp).Select("*").Updates(prop).Error; err != nil {
 				return fmt.Errorf("error updating property %s: %w", r.getPropertyName(prop), err)
 			}
 		case gorm.ErrRecordNotFound:
@@ -555,35 +554,6 @@ func (r *GenericRepository[TEntity, TSchema, TProp, TListOpts]) getPropertyEntit
 		return p.ExecutionID
 	default:
 		panic(fmt.Sprintf("unsupported property type: %T", prop))
-	}
-}
-
-func (r *GenericRepository[TEntity, TSchema, TProp, TListOpts]) copyPropertyValues(src, dst *TProp) {
-	switch srcProp := any(src).(type) {
-	case *schema.ArtifactProperty:
-		dstProp := any(dst).(*schema.ArtifactProperty)
-		dstProp.IntValue = srcProp.IntValue
-		dstProp.DoubleValue = srcProp.DoubleValue
-		dstProp.StringValue = srcProp.StringValue
-		dstProp.BoolValue = srcProp.BoolValue
-		dstProp.ByteValue = srcProp.ByteValue
-		dstProp.ProtoValue = srcProp.ProtoValue
-	case *schema.ContextProperty:
-		dstProp := any(dst).(*schema.ContextProperty)
-		dstProp.IntValue = srcProp.IntValue
-		dstProp.DoubleValue = srcProp.DoubleValue
-		dstProp.StringValue = srcProp.StringValue
-		dstProp.BoolValue = srcProp.BoolValue
-		dstProp.ByteValue = srcProp.ByteValue
-		dstProp.ProtoValue = srcProp.ProtoValue
-	case *schema.ExecutionProperty:
-		dstProp := any(dst).(*schema.ExecutionProperty)
-		dstProp.IntValue = srcProp.IntValue
-		dstProp.DoubleValue = srcProp.DoubleValue
-		dstProp.StringValue = srcProp.StringValue
-		dstProp.BoolValue = srcProp.BoolValue
-		dstProp.ByteValue = srcProp.ByteValue
-		dstProp.ProtoValue = srcProp.ProtoValue
 	}
 }
 

--- a/internal/db/service/registered_model_test.go
+++ b/internal/db/service/registered_model_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubeflow/model-registry/internal/apiutils"
 	"github.com/kubeflow/model-registry/internal/db/models"
+	"github.com/kubeflow/model-registry/internal/db/schema"
 	"github.com/kubeflow/model-registry/internal/db/service"
 	"github.com/kubeflow/model-registry/internal/testutils"
 	"github.com/stretchr/testify/assert"
@@ -278,5 +279,68 @@ func TestRegisteredModelRepository(t *testing.T) {
 
 		assert.NotNil(t, retrieved.GetCustomProperties())
 		assert.Len(t, *retrieved.GetCustomProperties(), 2)
+	})
+
+	t.Run("TestCustomPropertyTypeChange", func(t *testing.T) {
+		// Create a model with an int custom property
+		registeredModel := &models.RegisteredModelImpl{
+			TypeID: apiutils.Of(int32(typeID)),
+			Attributes: &models.RegisteredModelAttributes{
+				Name: apiutils.Of("type-change-model"),
+			},
+			CustomProperties: &[]models.Properties{
+				{
+					Name:     "score",
+					IntValue: apiutils.Of(int32(42)),
+				},
+			},
+		}
+
+		saved, err := repo.Save(registeredModel)
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+
+		// Verify the int value was saved
+		retrieved, err := repo.GetByID(*saved.GetID())
+		require.NoError(t, err)
+		require.NotNil(t, retrieved.GetCustomProperties())
+		require.Len(t, *retrieved.GetCustomProperties(), 1)
+		scoreProp := (*retrieved.GetCustomProperties())[0]
+		require.NotNil(t, scoreProp.IntValue)
+		assert.Equal(t, int32(42), *scoreProp.IntValue)
+		assert.Nil(t, scoreProp.DoubleValue)
+
+		// Update the same property to a double value
+		registeredModel.ID = saved.GetID()
+		registeredModel.GetAttributes().CreateTimeSinceEpoch = saved.GetAttributes().CreateTimeSinceEpoch
+		registeredModel.CustomProperties = &[]models.Properties{
+			{
+				Name:        "score",
+				DoubleValue: apiutils.Of(3.14),
+			},
+		}
+
+		updated, err := repo.Save(registeredModel)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+
+		// Retrieve and verify through the repository
+		retrieved, err = repo.GetByID(*updated.GetID())
+		require.NoError(t, err)
+		require.NotNil(t, retrieved.GetCustomProperties())
+		require.Len(t, *retrieved.GetCustomProperties(), 1)
+		scoreProp = (*retrieved.GetCustomProperties())[0]
+		assert.NotNil(t, scoreProp.DoubleValue, "double_value should be set after type change")
+		assert.Equal(t, 3.14, *scoreProp.DoubleValue)
+		assert.Nil(t, scoreProp.IntValue, "int_value should be cleared after type change to double")
+
+		// Also verify directly in the database to rule out mapper masking
+		var dbProp schema.ContextProperty
+		err = sharedDB.Where("context_id = ? AND name = ? AND is_custom_property = ?",
+			*updated.GetID(), "score", true).First(&dbProp).Error
+		require.NoError(t, err)
+		assert.NotNil(t, dbProp.DoubleValue, "DB double_value column should be set")
+		assert.Equal(t, 3.14, *dbProp.DoubleValue)
+		assert.Nil(t, dbProp.IntValue, "DB int_value column should be NULL after type change")
 	})
 }


### PR DESCRIPTION
## Description

GORM's `Updates()` skips `nil` fields, so changing a custom property's type (e.g., int to double) left the old column populated. Use `Select("*")` to write all columns, including nils. Remove dead `copyPropertyValues` method.

## How Has This Been Tested?

Unit tests, and manual testing in the UI (changing a property to different types and verified that only the new value is stored in the database).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
