### PR TITLE
chore: address deprecation warning for asyncio.iscoroutinefunction() and ensure poll_for_ready() does correct accounting of polling time

### DIFF
--- a/clients/python/src/model_registry/types/pager.py
+++ b/clients/python/src/model_registry/types/pager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from dataclasses import dataclass, field
 from typing import Generic, TypeVar, cast
@@ -25,7 +25,7 @@ class Pager(Generic[T], Iterator[T], AsyncIterator[T]):
 
     def __post_init__(self):
         self.restart()
-        if asyncio.iscoroutinefunction(self.page_fn):
+        if inspect.iscoroutinefunction(self.page_fn):
             self.__next__ = NotImplemented  # type: ignore[method-assign]
             self.next_page = self._anext_page
             self.next_item = self._anext_item

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -73,9 +73,6 @@ def pytest_report_teststatus(report, config):
             print(f"\nTEST: {test_name} STATUS: \033[0;31mFAILED\033[0m")
 
 
-start_time = time.time()
-
-
 @pytest.fixture(scope="session")
 def root(request) -> Path:
     return (request.config.rootpath / "../..").resolve()  # resolves to absolute path
@@ -103,13 +100,14 @@ def verify_ssl() -> bool:
 
 
 def poll_for_ready(user_token, verify_ssl):
+    poll_start = time.time()
     params = {
         "url": REGISTRY_URL,
         "headers": {"Authorization": f"Bearer {user_token}", } if user_token else None,
         "verify": verify_ssl
     }
     while True:
-        elapsed_time = time.time() - start_time
+        elapsed_time = time.time() - poll_start
         if elapsed_time >= MAX_POLL_TIME:
             print("Polling timed out.")
             break


### PR DESCRIPTION
Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
asyncio.iscoroutinefunction() which is deprecated in Python 3.14+ in favor of inspect.iscoroutinefunction() - updated the reference
poll_for_ready had a bug where the while loop for subsequent tests would exit prematurely always
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
