### PR TITLE
fix: for non-kind cluster increase pagesize to consider all models wi…

### DIFF
--- a/catalog/clients/python/tests/conftest.py
+++ b/catalog/clients/python/tests/conftest.py
@@ -237,7 +237,7 @@ def api_client(user_token: str | None, verify_ssl: bool) -> Generator[CatalogAPI
 
 @pytest.fixture(scope="session")
 def model_with_artifacts(
-    request: pytest.FixtureRequest, api_client: CatalogAPIClient, verify_ssl: bool
+    request: pytest.FixtureRequest, api_client: CatalogAPIClient, verify_ssl: bool, kind_cluster: bool
 ) -> tuple[str, str]:
     """Get a model that has artifacts for testing.
 
@@ -254,7 +254,7 @@ def model_with_artifacts(
     if not verify_ssl:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-    models = api_client.get_models()
+    models = api_client.get_models(page_size=1000 if not kind_cluster else None)
     if not models.get("items"):
         pytest.fail("No models available - test data may not be loaded")
 


### PR DESCRIPTION
…th artifacts

Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
