### PR TITLE
fix: correct composite PK update for bool zero-value in handleProperties

### DIFF
--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -674,12 +674,26 @@ func enrichCatalogModelFromMetadata(existingModel dbmodels.CatalogModel, metadat
 		return nil // Nothing to update
 	}
 
-	// Add the new custom properties to existing model
-	existingCustomProperties := existingModel.GetCustomProperties()
-	if existingCustomProperties == nil {
-		existingCustomProperties = &customProperties
+	// Merge new custom properties into the model, new values overwrite existing ones with same name.
+	newNames := make(map[string]struct{}, len(customProperties))
+	for _, p := range customProperties {
+		newNames[p.Name] = struct{}{}
+	}
+	impl, ok := existingModel.(*dbmodels.CatalogModelImpl)
+	if !ok {
+		return fmt.Errorf("unexpected model type %T", existingModel)
+	}
+	if impl.CustomProperties == nil {
+		impl.CustomProperties = &customProperties
 	} else {
-		*existingCustomProperties = append(*existingCustomProperties, customProperties...)
+		filtered := (*impl.CustomProperties)[:0]
+		for _, p := range *impl.CustomProperties {
+			if _, overwritten := newNames[p.Name]; !overwritten {
+				filtered = append(filtered, p)
+			}
+		}
+		merged := append(filtered, customProperties...)
+		impl.CustomProperties = &merged
 	}
 
 	// Save the updated model

--- a/internal/db/service/registered_model_test.go
+++ b/internal/db/service/registered_model_test.go
@@ -343,4 +343,51 @@ func TestRegisteredModelRepository(t *testing.T) {
 		assert.Equal(t, 3.14, *dbProp.DoubleValue)
 		assert.Nil(t, dbProp.IntValue, "DB int_value column should be NULL after type change")
 	})
+
+	t.Run("TestSameNameRegularAndCustomProperty", func(t *testing.T) {
+		// Regression test: a model with the same property name as both a regular and custom property
+		// must be updatable without triggering a unique_violation (PostgreSQL error 23505).
+		// The bug was that GORM's Model(&existingProp).Select("*").Updates(prop) omitted
+		// is_custom_property=false from the WHERE clause (zero-value bool), causing the UPDATE
+		// to match both rows and try to set both to is_custom_property=false.
+		registeredModel := &models.RegisteredModelImpl{
+			TypeID: apiutils.Of(int32(typeID)),
+			Attributes: &models.RegisteredModelAttributes{
+				Name: apiutils.Of("same-name-prop-model"),
+			},
+			Properties: &[]models.Properties{
+				{Name: "score", StringValue: apiutils.Of("good")},
+			},
+			CustomProperties: &[]models.Properties{
+				{Name: "score", DoubleValue: apiutils.Of(0.95)},
+			},
+		}
+
+		saved, err := repo.Save(registeredModel)
+		require.NoError(t, err)
+
+		// Update the model — this is where the bug triggered
+		registeredModel.ID = saved.GetID()
+		registeredModel.GetAttributes().CreateTimeSinceEpoch = saved.GetAttributes().CreateTimeSinceEpoch
+		registeredModel.Properties = &[]models.Properties{
+			{Name: "score", StringValue: apiutils.Of("excellent")},
+		}
+		registeredModel.CustomProperties = &[]models.Properties{
+			{Name: "score", DoubleValue: apiutils.Of(0.99)},
+		}
+
+		updated, err := repo.Save(registeredModel)
+		require.NoError(t, err, "updating a model with same-name regular and custom property must not error")
+
+		retrieved, err := repo.GetByID(*updated.GetID())
+		require.NoError(t, err)
+
+		require.NotNil(t, retrieved.GetProperties())
+		require.Len(t, *retrieved.GetProperties(), 1)
+		assert.Equal(t, "excellent", *(*retrieved.GetProperties())[0].StringValue)
+
+		require.NotNil(t, retrieved.GetCustomProperties())
+		require.Len(t, *retrieved.GetCustomProperties(), 1)
+		assert.Equal(t, 0.99, *(*retrieved.GetCustomProperties())[0].DoubleValue)
+	})
 }

--- a/internal/platform/db/repository/generic_repository.go
+++ b/internal/platform/db/repository/generic_repository.go
@@ -414,7 +414,12 @@ func (r *GenericRepository[TEntity, TSchema, TProp, TListOpts]) handleProperties
 
 		switch result.Error {
 		case nil:
-			if err := tx.Model(&existingProp).Select("*").Updates(prop).Error; err != nil {
+			// Use explicit WHERE (all 3 PK columns) and select only value columns to avoid GORM
+			// skipping is_custom_property=false in WHERE (zero-value bool).
+			if err := tx.Where(r.config.PropertyFieldName+" = ? AND name = ? AND is_custom_property = ?",
+				r.getPropertyEntityID(prop), r.getPropertyName(prop), r.getPropertyIsCustom(prop)).
+				Select("int_value", "double_value", "string_value", "bool_value", "byte_value", "proto_value").
+				Updates(prop).Error; err != nil {
 				return fmt.Errorf("error updating property %s: %w", r.getPropertyName(prop), err)
 			}
 		case gorm.ErrRecordNotFound:
@@ -473,7 +478,6 @@ func (r *GenericRepository[TEntity, TSchema, TProp, TListOpts]) getPropertyEntit
 		panic(fmt.Sprintf("unsupported property type: %T", prop))
 	}
 }
-
 
 func (r *GenericRepository[TEntity, TSchema, TProp, TListOpts]) CreateDefaultPaginationToken(e TSchema, listOptions TListOpts) string {
 	entityID := r.getEntityID(e)


### PR DESCRIPTION
## Description

Select("*") introduced in aebe8f86 included PK columns in the SQL SET
clause. GORM skips zero-value PK fields when building the WHERE from
Model(), so is_custom_property=false (zero-value bool) was omitted.
When a property name existed as both regular and custom, the UPDATE
matched both rows and tried to set both to is_custom_property=false,
triggering a PostgreSQL unique_violation.

Replace Select("*") with an explicit WHERE covering all three PK columns
and a column list limited to the six value fields. This still clears
stale columns on type change (the original fix) without touching PKs.

Also fix two bugs in enrichCatalogModelFromMetadata: the nil branch set
a local variable instead of the model's CustomProperties field (silently
dropping enrichment on first run), and repeated enrichment accumulated
duplicate custom properties on restart.

## How Has This Been Tested?
On a local development cluster. Confirmed that the original bug is still not present and that the "duplicated key" error is no longer logged.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
