### PR TITLE
add fix for hide category toggle

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -486,14 +486,16 @@ describe('Performance Empty State', () => {
   });
 
   describe('Single Category Empty State Actions', () => {
-    it('should show single-category title and description when performance empty state is displayed', () => {
+    beforeEach(() => {
       initIntercepts({
         sources: [mockCatalogSource({ labels: ['Provider one'] })],
         hasValidatedModels: false,
       });
       setupFilteredModelsIntercept({ returnModelsForFilters: false });
       modelCatalog.visit();
+    });
 
+    it('should show single-category title and description when performance empty state is displayed', () => {
       modelCatalog.togglePerformanceView();
       modelCatalog.findPerformanceEmptyState().should('be.visible');
 
@@ -511,13 +513,6 @@ describe('Performance Empty State', () => {
     });
 
     it('should not show "View all models with performance data" button when single category', () => {
-      initIntercepts({
-        sources: [mockCatalogSource({ labels: ['Provider one'] })],
-        hasValidatedModels: false,
-      });
-      setupFilteredModelsIntercept({ returnModelsForFilters: false });
-      modelCatalog.visit();
-
       modelCatalog.togglePerformanceView();
       modelCatalog.findPerformanceEmptyState().should('be.visible');
 
@@ -528,13 +523,6 @@ describe('Performance Empty State', () => {
     });
 
     it('should turn off toggle when clicking "Turn off model performance view" in single category', () => {
-      initIntercepts({
-        sources: [mockCatalogSource({ labels: ['Provider one'] })],
-        hasValidatedModels: false,
-      });
-      setupFilteredModelsIntercept({ returnModelsForFilters: false });
-      modelCatalog.visit();
-
       modelCatalog.togglePerformanceView();
       modelCatalog.findPerformanceEmptyState().should('be.visible');
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -485,6 +485,66 @@ describe('Performance Empty State', () => {
     });
   });
 
+  describe('Single Category Empty State Actions', () => {
+    it('should show single-category title and description when performance empty state is displayed', () => {
+      initIntercepts({
+        sources: [mockCatalogSource({ labels: ['Provider one'] })],
+        hasValidatedModels: false,
+      });
+      setupFilteredModelsIntercept({ returnModelsForFilters: false });
+      modelCatalog.visit();
+
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findPerformanceEmptyState().should('be.visible');
+
+      modelCatalog
+        .findPerformanceEmptyState()
+        .should('contain.text', 'No performance data available.')
+        .and('not.contain.text', 'in selected category');
+
+      modelCatalog
+        .findPerformanceEmptyState()
+        .should(
+          'contain.text',
+          'No models have performance data available. Turn off model performance view to see all models.',
+        );
+    });
+
+    it('should not show "View all models with performance data" button when single category', () => {
+      initIntercepts({
+        sources: [mockCatalogSource({ labels: ['Provider one'] })],
+        hasValidatedModels: false,
+      });
+      setupFilteredModelsIntercept({ returnModelsForFilters: false });
+      modelCatalog.visit();
+
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findPerformanceEmptyState().should('be.visible');
+
+      modelCatalog
+        .findPerformanceEmptyState()
+        .contains('button', /View all models with performance data/i)
+        .should('not.exist');
+    });
+
+    it('should turn off toggle when clicking "Turn off model performance view" in single category', () => {
+      initIntercepts({
+        sources: [mockCatalogSource({ labels: ['Provider one'] })],
+        hasValidatedModels: false,
+      });
+      setupFilteredModelsIntercept({ returnModelsForFilters: false });
+      modelCatalog.visit();
+
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findPerformanceEmptyState().should('be.visible');
+
+      modelCatalog.findSetPerformanceOffLink().click();
+
+      modelCatalog.findPerformanceViewToggleValue().should('not.be.checked');
+      modelCatalog.findModelCatalogCards().should('have.length.at.least', 1);
+    });
+  });
+
   it('should work correctly when toggling performance view', () => {
     initIntercepts({
       sources: mockProviderAndCustomSources(),

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -501,7 +501,7 @@ describe('Performance Empty State', () => {
 
       modelCatalog
         .findPerformanceEmptyState()
-        .should('contain.text', 'No performance data available.')
+        .should('contain.text', 'No performance data available')
         .and('not.contain.text', 'in selected category');
 
       modelCatalog

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -220,25 +220,35 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
     return (
       <EmptyModelCatalogState
         testid="performance-empty-state"
-        title="No performance data available in selected category"
+        title={
+          isSingleCategory
+            ? 'No performance data available.'
+            : 'No performance data available in selected category'
+        }
         headerIcon={ChartBarIcon}
         variant={EmptyStateVariant.lg}
         description={
-          <>
-            No models in the{' '}
-            <strong>
-              {selectedSourceLabel === 'null'
-                ? CategoryName.otherModels
-                : generateCategoryName(selectedSourceLabel || '')}
-            </strong>{' '}
-            category have performance data. Select another model category, or turn off model
-            performance view to see models in the selected category.
-          </>
+          isSingleCategory ? (
+            'No models have performance data available. Turn off model performance view to see all models.'
+          ) : (
+            <>
+              No models in the{' '}
+              <strong>
+                {selectedSourceLabel === 'null'
+                  ? CategoryName.otherModels
+                  : generateCategoryName(selectedSourceLabel || '')}
+              </strong>{' '}
+              category have performance data. Select another model category, or turn off model
+              performance view to see models in the selected category.
+            </>
+          )
         }
         primaryAction={
-          <Button variant="primary" onClick={handleSelectAllModels}>
-            View all models with performance data
-          </Button>
+          isSingleCategory ? undefined : (
+            <Button variant="primary" onClick={handleSelectAllModels}>
+              View all models with performance data
+            </Button>
+          )
         }
         secondaryAction={
           <Button variant="link" onClick={handleDisablePerformanceView}>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -27,7 +27,6 @@ import {
   getLabelDescription,
   hasFiltersApplied,
   isValueDifferentFromDefault,
-  hasMultipleSourceCategories,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import ModelCatalogSortDropdown from '~/app/pages/modelCatalog/components/ModelCatalogSortDropdown';
 import EmptyModelCatalogState from '~/app/pages/modelCatalog/EmptyModelCatalogState';
@@ -267,7 +266,7 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
         testid="empty-model-catalog-state"
         title="No models available"
         headerIcon={SearchIcon}
-        description="No models are available in this category."
+        description="No models are available in this category"
       />
     );
   }
@@ -310,7 +309,7 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
             <Title headingLevel="h3" size="lg">
               {categoryTitle}
             </Title>
-            {performanceViewEnabled && !hasMultipleSourceCategories(catalogSources) && (
+            {performanceViewEnabled && (
               <ModelCatalogSortDropdown performanceViewEnabled={performanceViewEnabled} />
             )}
           </Flex>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -27,7 +27,9 @@ import {
   getLabelDescription,
   hasFiltersApplied,
   isValueDifferentFromDefault,
+  hasMultipleSourceCategories,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import ModelCatalogSortDropdown from '~/app/pages/modelCatalog/components/ModelCatalogSortDropdown';
 import EmptyModelCatalogState from '~/app/pages/modelCatalog/EmptyModelCatalogState';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
 import {
@@ -301,9 +303,17 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
       <ScrollViewOnMount shouldScroll scrollToTop />
       {isSingleCategory && categoryTitle && (
         <div className="pf-v6-u-mb-lg" data-testid="single-category-header">
-          <Title headingLevel="h3" size="lg">
-            {categoryTitle}
-          </Title>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <Title headingLevel="h3" size="lg">
+              {categoryTitle}
+            </Title>
+            {performanceViewEnabled && !hasMultipleSourceCategories(catalogSources) && (
+              <ModelCatalogSortDropdown performanceViewEnabled={performanceViewEnabled} />
+            )}
+          </Flex>
           {categoryDescription && (
             <Content component="p" className="pf-v6-u-color-200 pf-v6-u-mt-sm">
               {categoryDescription}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogGalleryView.tsx
@@ -223,7 +223,7 @@ const ModelCatalogGalleryView: React.FC<ModelCatalogPageProps> = ({
         testid="performance-empty-state"
         title={
           isSingleCategory
-            ? 'No performance data available.'
+            ? 'No performance data available'
             : 'No performance data available in selected category'
         }
         headerIcon={ChartBarIcon}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelBlocks.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelBlocks.tsx
@@ -62,11 +62,6 @@ const ModelCatalogSourceLabelBlocks: React.FC = () => {
     return null;
   }
 
-  const activeCategoryCount = blocks.length - 1;
-  if (activeCategoryCount <= 1) {
-    return null;
-  }
-
   const handleToggleClick = (label: string) => {
     updateSelectedSourceLabel(label);
   };

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -134,9 +134,9 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
           // When performance view is ON, the HardwareConfigurationFilterToolbar handles resetting
           {...(onResetAllFilters && !performanceViewEnabled && hasBasicFiltersApplied
             ? {
-              clearAllFilters: handleClearAllFilters,
-              clearFiltersButtonText: 'Reset all filters',
-            }
+                clearAllFilters: handleClearAllFilters,
+                clearFiltersButtonText: 'Reset all filters',
+              }
             : {})}
         >
           <ToolbarContent rowWrap={{ default: 'wrap' }}>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Content,
   Flex,
-  FlexItem,
   Stack,
   StackItem,
   Toolbar,
@@ -21,7 +20,10 @@ import ModelCatalogActiveFilters from '~/app/pages/modelCatalog/components/Model
 import HardwareConfigurationFilterToolbar from '~/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar';
 import ThemeAwareSearchInput from '~/app/pages/modelRegistry/screens/components/ThemeAwareSearchInput';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
-import { hasFiltersApplied } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import {
+  hasFiltersApplied,
+  hasMultipleSourceCategories,
+} from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import ModelCatalogSortDropdown from '~/app/pages/modelCatalog/components/ModelCatalogSortDropdown';
 import ModelCatalogSourceLabelBlocks from './ModelCatalogSourceLabelBlocks';
 
@@ -41,12 +43,18 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
   const [inputValue, setInputValue] = React.useState(searchTerm || '');
   const { isMUITheme } = useThemeContext();
   const {
+    catalogSources,
     filterData,
     performanceViewEnabled,
     performanceFiltersChangedOnDetailsPage,
     setPerformanceFiltersChangedOnDetailsPage,
     lastViewedModelName,
   } = React.useContext(ModelCatalogContext);
+
+  const hasMultipleCategories = React.useMemo(
+    () => hasMultipleSourceCategories(catalogSources),
+    [catalogSources],
+  );
 
   // Only show basic filters in the main chip bar - performance filters have their own section
   const filtersToShow = BASIC_FILTER_KEYS;
@@ -126,9 +134,9 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
           // When performance view is ON, the HardwareConfigurationFilterToolbar handles resetting
           {...(onResetAllFilters && !performanceViewEnabled && hasBasicFiltersApplied
             ? {
-                clearAllFilters: handleClearAllFilters,
-                clearFiltersButtonText: 'Reset all filters',
-              }
+              clearAllFilters: handleClearAllFilters,
+              clearFiltersButtonText: 'Reset all filters',
+            }
             : {})}
         >
           <ToolbarContent rowWrap={{ default: 'wrap' }}>
@@ -193,14 +201,17 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
           </StackItem>
         </>
       )}
-      <StackItem>
-        <Flex alignItems={{ default: 'alignItemsCenter' }}>
-          <ModelCatalogSourceLabelBlocks />
-          <FlexItem align={{ default: 'alignRight' }}>
+      {hasMultipleCategories && (
+        <StackItem>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <ModelCatalogSourceLabelBlocks />
             <ModelCatalogSortDropdown performanceViewEnabled={performanceViewEnabled} />
-          </FlexItem>
-        </Flex>
-      </StackItem>
+          </Flex>
+        </StackItem>
+      )}
       {shouldShowAlert && (
         <StackItem>
           <Alert

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -22,7 +22,7 @@ import ThemeAwareSearchInput from '~/app/pages/modelRegistry/screens/components/
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import {
   hasFiltersApplied,
-  hasMultipleSourceCategories,
+  getActiveSourceLabels,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import ModelCatalogSortDropdown from '~/app/pages/modelCatalog/components/ModelCatalogSortDropdown';
 import ModelCatalogSourceLabelBlocks from './ModelCatalogSourceLabelBlocks';
@@ -44,6 +44,7 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
   const { isMUITheme } = useThemeContext();
   const {
     catalogSources,
+    catalogLabels,
     filterData,
     performanceViewEnabled,
     performanceFiltersChangedOnDetailsPage,
@@ -52,8 +53,8 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
   } = React.useContext(ModelCatalogContext);
 
   const hasMultipleCategories = React.useMemo(
-    () => hasMultipleSourceCategories(catalogSources),
-    [catalogSources],
+    () => getActiveSourceLabels(catalogSources, catalogLabels).length > 1,
+    [catalogSources, catalogLabels],
   );
 
   // Only show basic filters in the main chip bar - performance filters have their own section

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Content,
   Flex,
+  FlexItem,
   Stack,
   StackItem,
   Toolbar,
@@ -193,12 +194,11 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
         </>
       )}
       <StackItem>
-        <Flex
-          justifyContent={{ default: 'justifyContentSpaceBetween' }}
-          alignItems={{ default: 'alignItemsCenter' }}
-        >
+        <Flex alignItems={{ default: 'alignItemsCenter' }}>
           <ModelCatalogSourceLabelBlocks />
-          <ModelCatalogSortDropdown performanceViewEnabled={performanceViewEnabled} />
+          <FlexItem align={{ default: 'alignRight' }}>
+            <ModelCatalogSortDropdown performanceViewEnabled={performanceViewEnabled} />
+          </FlexItem>
         </Flex>
       </StackItem>
       {shouldShowAlert && (

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -769,13 +769,6 @@ export const getActiveSourceLabels = (
   return orderedLabels;
 };
 
-export const hasMultipleSourceCategories = (catalogSources: CatalogSourceList | null): boolean => {
-  const enabledSources = filterEnabledCatalogSources(catalogSources);
-  const uniqueLabels = getUniqueSourceLabels(enabledSources);
-  const categoryCount = uniqueLabels.length + (hasSourcesWithoutLabels(enabledSources) ? 1 : 0);
-  return categoryCount > 1;
-};
-
 /**
  * Formats model type value for display in the UI.
  * Converts raw API values (generative, predictive, unknown) to user-friendly display labels.

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -769,6 +769,15 @@ export const getActiveSourceLabels = (
   return orderedLabels;
 };
 
+export const hasMultipleSourceCategories = (
+  catalogSources: CatalogSourceList | null,
+): boolean => {
+  const enabledSources = filterEnabledCatalogSources(catalogSources);
+  const uniqueLabels = getUniqueSourceLabels(enabledSources);
+  const categoryCount = uniqueLabels.length + (hasSourcesWithoutLabels(enabledSources) ? 1 : 0);
+  return categoryCount > 1;
+};
+
 /**
  * Formats model type value for display in the UI.
  * Converts raw API values (generative, predictive, unknown) to user-friendly display labels.

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -769,9 +769,7 @@ export const getActiveSourceLabels = (
   return orderedLabels;
 };
 
-export const hasMultipleSourceCategories = (
-  catalogSources: CatalogSourceList | null,
-): boolean => {
+export const hasMultipleSourceCategories = (catalogSources: CatalogSourceList | null): boolean => {
   const enabledSources = filterEnabledCatalogSources(catalogSources);
   const uniqueLabels = getUniqueSourceLabels(enabledSources);
   const categoryCount = uniqueLabels.length + (hasSourcesWithoutLabels(enabledSources) ? 1 : 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
In **Model performance view** when only a single category is available:
- Fix Sort position
- Fix text and actions when no performance data is available

Before:
- PF Mode:
 - - Sort position
<img width="1900" height="913" alt="before-PF-sort-position" src="https://github.com/user-attachments/assets/9fc922fb-55cf-4382-935a-9fcfe9872028" />
 - - No performance data available
<img width="1908" height="912" alt="before-PF-no-perf-data" src="https://github.com/user-attachments/assets/b9207c33-33e1-4be9-8aab-82fb48b95d0b" />

- Non-PF Mode:
 - Sort position
<img width="1906" height="924" alt="before-sort-position" src="https://github.com/user-attachments/assets/0933ece4-f468-444f-a439-474cebc8b99b" />
 -No performance data available
<img width="1917" height="815" alt="before-no-perf-data" src="https://github.com/user-attachments/assets/3e9102c2-c5d7-4b74-9830-424935352228" />

After:
- PF Mode:
 - Sort position
<img width="1896" height="862" alt="Screenshot 2026-05-05 at 12 20 07" src="https://github.com/user-attachments/assets/78471715-6dfe-431d-848d-41a92b8a2ef6" />
 -No performance data available
<img width="1910" height="866" alt="Screenshot 2026-05-05 at 11 34 16" src="https://github.com/user-attachments/assets/6fc35194-836c-4563-8f8c-152dc233e698" />


- Non-PF Mode:
 - Sort position
<img width="1918" height="870" alt="Screenshot 2026-05-05 at 11 24 58" src="https://github.com/user-attachments/assets/08b7a9e8-0c65-41b7-a7f7-3430a7633351" />
 -No performance data available
<img width="1913" height="865" alt="Screenshot 2026-05-05 at 11 34 42" src="https://github.com/user-attachments/assets/2d079f25-3ad2-4252-a9a4-2a9efd3776bc" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was manually tested, also added tests in cypress

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
