### PR TITLE
fix(ui): fix flaky selectNamespace race condition in cypress test

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelRegistryView/registerAndStoreFields.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelRegistryView/registerAndStoreFields.ts
@@ -48,7 +48,9 @@ class RegisterAndStoreFields {
   }
 
   selectNamespace(name: string) {
-    this.findNamespaceSelectCombobox().scrollIntoView().click({ force: true });
+    this.findNamespaceSelectCombobox().should('not.be.disabled');
+    this.findNamespaceSelectCombobox().scrollIntoView().click();
+    cy.findByRole('listbox').should('be.visible');
     cy.findByRole('option', { name }).click();
   }
 
@@ -66,11 +68,12 @@ class RegisterAndStoreFields {
   }
 
   shouldHaveNamespaceOptions(namespaces: string[]) {
-    this.findNamespaceSelectCombobox().scrollIntoView().click({ force: true });
+    this.findNamespaceSelectCombobox().should('not.be.disabled');
+    this.findNamespaceSelectCombobox().scrollIntoView().click();
     namespaces.forEach((namespace) => {
       cy.findByRole('option', { name: namespace }).should('exist');
     });
-    this.findNamespaceSelectCombobox().scrollIntoView().click({ force: true });
+    this.findNamespaceSelectCombobox().scrollIntoView().click();
     return this;
   }
 


### PR DESCRIPTION
Wait for the namespace dropdown button to be enabled before clicking, removing force:true which bypassed actionability checks and caused intermittent failures when the namespace API response hadn't arrived yet.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

`selectNamespace` and `shouldHaveNamespaceOptions` use `click({ force: true })`, which bypasses Cypress's actionability checks. When the namespace API response hasn't arrived yet, the dropdown button is disabled (`isDisabled={namespaces.length === 0}`), but `force: true` clicks it anyway — no options render, and the test times out looking for `role="option"` elements.

This is timing-dependent: it only fails when the page takes slightly longer to load (e.g., after a preceding test navigates away from the register page).

All four failures produce the same error:
```
AssertionError: Timed out retrying after 10000ms: Unable to find an accessible element
with the role "option" and name "namespace-1"
  at RegisterAndStoreFields.selectNamespace (registerAndStoreFields.ts:52:7)
```

### failures

Three failures across unrelated commits spanning a month:

| Date | Run | Commit | Branch |
|------|-----|--------|--------|
| Mar 31 | [23800808381](https://github.com/kubeflow/model-registry/actions/runs/23800808381) | `3088da28` | main |
| Apr 10 | [24249576848](https://github.com/kubeflow/model-registry/actions/runs/24249576848) | `8f5d7803` | main |
| Apr 27 | [24991865315](https://github.com/kubeflow/model-registry/actions/runs/24991865315) | `6eb25cfb` | main |

### evidence this is a flaky test

[Run 25053512145](https://github.com/opendatahub-io/model-registry/actions/runs/25053512145) on commit `d911da74` — **identical code, identical CI, different results**:

| Attempt | Result | Details |
|---------|--------|---------|
| [2](https://github.com/opendatahub-io/model-registry/actions/runs/25053512145/attempts/2) | **failure** | `selectNamespace` — 1 failing, 381 passing |
| [3](https://github.com/opendatahub-io/model-registry/actions/runs/25053512145/attempts/3) | **success** | All 382 tests pass |

### Fix

1. Wait for the dropdown to be enabled before interacting (`.should('not.be.disabled')`)
2. Remove `force: true` so Cypress respects normal actionability checks
3. Verify the listbox is visible after clicking before selecting an option

## Tested locally

To ensure it doesn't break anything, I made sure this still passes:
```
cd clients/ui/frontend
npm run test:cypress-ci -- --spec "src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerAndStoreFields.cy.ts"
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
