### PR TITLE
Model validation err handling

### DIFF
--- a/catalog/internal/catalog/modelcatalog/loader.go
+++ b/catalog/internal/catalog/modelcatalog/loader.go
@@ -329,9 +329,11 @@ func (l *ModelLoader) updateDatabase(ctx context.Context) error {
 					}
 				}
 
-				for _, handler := range l.handlers {
-					handler(ctx, record)
+			for _, handler := range l.handlers {
+				if err := handler(ctx, record); err != nil {
+					glog.Errorf("%s: event handler error: %v", *attr.Name, err)
 				}
+			}
 			}()
 		}
 	}()

--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -505,17 +505,26 @@ func createAccuracyMetricsArtifact(evalRecords []evaluationRecord, modelID int32
 	// Properties can be empty or contain general metadata
 	properties := []models.Properties{}
 
-	// Create custom properties - simple mapping of benchmark_name to score_value
-	customProperties := []models.Properties{}
-
+	// Create custom properties - simple mapping of benchmark_name to score_value.
+	// Deduplicate by benchmark name: if multiple evaluation records share the same
+	// benchmark, keep the last score encountered. This prevents DB constraint violations
+	// on the (artifact_id, name, is_custom_property) composite primary key.
+	benchmarkScores := make(map[string]float64, len(evalRecords))
 	for _, evalRecord := range evalRecords {
-		// Add the benchmark score as a named property (e.g., "aime24": 63.3333)
 		if score, ok := evalRecord.CustomProperties["score"].(float64); ok {
-			customProperties = append(customProperties, models.Properties{
-				Name:        evalRecord.Benchmark,
-				DoubleValue: &score,
-			})
+			if _, duplicate := benchmarkScores[evalRecord.Benchmark]; duplicate {
+				glog.Warningf("Duplicate benchmark %q for model %d, using latest score", evalRecord.Benchmark, modelID)
+			}
+			benchmarkScores[evalRecord.Benchmark] = score
 		}
+	}
+
+	customProperties := make([]models.Properties, 0, len(benchmarkScores)+1)
+	for benchmark, score := range benchmarkScores {
+		customProperties = append(customProperties, models.Properties{
+			Name:        benchmark,
+			DoubleValue: &score,
+		})
 	}
 
 	// Add overall_average custom property from metadata.json overall_accuracy field

--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -107,6 +107,11 @@ func (pr *performanceRecord) UnmarshalJSON(data []byte) error {
 	if id, ok := raw["id"].(string); ok {
 		pr.ID = id
 	}
+	if pr.ID == "" {
+		if configID, ok := raw["config_id"].(string); ok && configID != "" {
+			pr.ID = configID
+		}
+	}
 	if modelID, ok := raw["model_id"].(string); ok {
 		pr.ModelID = modelID
 	}

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -330,6 +330,88 @@ func TestOverallAccuracyToOverallAverage(t *testing.T) {
 	})
 }
 
+func TestCreateAccuracyMetricsArtifact_DuplicateBenchmarks(t *testing.T) {
+	t.Run("duplicate benchmarks are deduplicated using last score", func(t *testing.T) {
+		evalRecords := []evaluationRecord{
+			{Benchmark: "mmlu", CustomProperties: map[string]any{"score": 80.0}},
+			{Benchmark: "aime24", CustomProperties: map[string]any{"score": 63.3}},
+			{Benchmark: "mmlu", CustomProperties: map[string]any{"score": 85.0}},
+		}
+
+		artifact := createAccuracyMetricsArtifact(evalRecords, 1, 100, nil, nil, nil)
+
+		// Count occurrences of each benchmark name
+		benchmarkCounts := map[string]int{}
+		benchmarkScores := map[string]float64{}
+		for _, prop := range *artifact.CustomProperties {
+			benchmarkCounts[prop.Name]++
+			if prop.DoubleValue != nil {
+				benchmarkScores[prop.Name] = *prop.DoubleValue
+			}
+		}
+
+		// "mmlu" should appear exactly once (deduplicated)
+		if benchmarkCounts["mmlu"] != 1 {
+			t.Errorf("expected mmlu to appear once, got %d", benchmarkCounts["mmlu"])
+		}
+
+		// The last score (85.0) should win
+		if benchmarkScores["mmlu"] != 85.0 {
+			t.Errorf("expected mmlu score 85.0, got %v", benchmarkScores["mmlu"])
+		}
+
+		// "aime24" should still be present
+		if benchmarkCounts["aime24"] != 1 {
+			t.Errorf("expected aime24 to appear once, got %d", benchmarkCounts["aime24"])
+		}
+		if benchmarkScores["aime24"] != 63.3 {
+			t.Errorf("expected aime24 score 63.3, got %v", benchmarkScores["aime24"])
+		}
+	})
+
+	t.Run("no duplicates produces all benchmarks", func(t *testing.T) {
+		evalRecords := []evaluationRecord{
+			{Benchmark: "mmlu", CustomProperties: map[string]any{"score": 90.0}},
+			{Benchmark: "aime24", CustomProperties: map[string]any{"score": 63.3}},
+			{Benchmark: "gpqa", CustomProperties: map[string]any{"score": 72.5}},
+		}
+
+		artifact := createAccuracyMetricsArtifact(evalRecords, 1, 100, nil, nil, nil)
+
+		benchmarkNames := map[string]bool{}
+		for _, prop := range *artifact.CustomProperties {
+			benchmarkNames[prop.Name] = true
+		}
+
+		for _, expected := range []string{"mmlu", "aime24", "gpqa"} {
+			if !benchmarkNames[expected] {
+				t.Errorf("expected benchmark %q not found in custom properties", expected)
+			}
+		}
+	})
+
+	t.Run("all records with same benchmark produce single property", func(t *testing.T) {
+		evalRecords := []evaluationRecord{
+			{Benchmark: "mmlu", CustomProperties: map[string]any{"score": 80.0}},
+			{Benchmark: "mmlu", CustomProperties: map[string]any{"score": 82.0}},
+			{Benchmark: "mmlu", CustomProperties: map[string]any{"score": 85.0}},
+		}
+
+		artifact := createAccuracyMetricsArtifact(evalRecords, 1, 100, nil, nil, nil)
+
+		count := 0
+		for _, prop := range *artifact.CustomProperties {
+			if prop.Name == "mmlu" {
+				count++
+			}
+		}
+
+		if count != 1 {
+			t.Errorf("expected exactly 1 mmlu property, got %d", count)
+		}
+	})
+}
+
 func TestEvaluationRecordUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes an existing issue with performance metrics loading for model catalog. Today, if there are two properties with the same value for a model's metrics, the loader will silently fail and not load any of the values into the db. These changes will grab the last of the duplicated values and store it while logging an error in the pod. This prevents a full failure of metrics loading and gives the user insight into issues with performance data. 

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
This was tested by adding 3 "mmlu" values for one of the demo AI validated models (certified/production-llm-8b) and ensuring that the metrics for that model were still loaded and logged the issue.
<img width="1021" height="83" alt="Screenshot 2026-05-01 at 9 58 13 AM" src="https://github.com/user-attachments/assets/12696b1d-529f-4765-8541-6d816ba297f5" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
