### PR TITLE
Fix the model type selector when the model type is unknown

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -1407,9 +1407,7 @@ describe('getCatalogModelTypePropertyForRegistration', () => {
     });
   });
 
-  it('returns empty object when model_type is absent or not a registerable value', () => {
-    expect(getCatalogModelTypePropertyForRegistration(undefined)).toEqual({});
-    expect(getCatalogModelTypePropertyForRegistration({})).toEqual({});
+  it('returns model_type metadata when catalog has unknown', () => {
     expect(
       getCatalogModelTypePropertyForRegistration({
         [CatalogModelCustomPropertyKey.MODEL_TYPE]: {
@@ -1417,7 +1415,17 @@ describe('getCatalogModelTypePropertyForRegistration', () => {
           string_value: ModelType.UNKNOWN,
         },
       }),
-    ).toEqual({});
+    ).toEqual({
+      [CatalogModelCustomPropertyKey.MODEL_TYPE]: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: ModelType.UNKNOWN,
+      },
+    });
+  });
+
+  it('returns empty object when model_type is absent or not a recognized value', () => {
+    expect(getCatalogModelTypePropertyForRegistration(undefined)).toEqual({});
+    expect(getCatalogModelTypePropertyForRegistration({})).toEqual({});
   });
 });
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -796,7 +796,8 @@ export const formatModelTypeDisplay = (modelTypeRaw: string | null): string => {
 
 /**
  * Returns model registry customProperties entries to prefill `model_type` when registering
- * from the catalog. Only generative/predictive are copied; unknown or missing values yield {}.
+ * from the catalog. Recognized values (generative, predictive, unknown) are copied;
+ * unrecognized or missing values yield {}.
  */
 export const getCatalogModelTypePropertyForRegistration = (
   customProperties?: ModelRegistryCustomProperties,

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/RegisterModelTypeField.tsx
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/RegisterModelTypeField.tsx
@@ -11,7 +11,7 @@ import {
   getModelTypeStoredValueFromCustomProperties,
 } from './registerModelTypeUtils';
 
-const MODEL_TYPE_SELECT_OPTIONS: SimpleSelectOption[] = [
+const SELECTABLE_OPTIONS: SimpleSelectOption[] = [
   {
     key: ModelType.GENERATIVE,
     label: formatModelTypeDisplay(ModelType.GENERATIVE),
@@ -38,6 +38,16 @@ const RegisterModelTypeField: React.FC<RegisterModelTypeFieldProps> = ({
 }) => {
   const stored = getModelTypeStoredValueFromCustomProperties(modelCustomProperties);
 
+  const selectOptions = React.useMemo<SimpleSelectOption[]>(() => {
+    if (isReadOnly && stored === ModelType.UNKNOWN) {
+      return [
+        ...SELECTABLE_OPTIONS,
+        { key: ModelType.UNKNOWN, label: formatModelTypeDisplay(ModelType.UNKNOWN) },
+      ];
+    }
+    return SELECTABLE_OPTIONS;
+  }, [isReadOnly, stored]);
+
   const handleChange = (key: string) => {
     if (key === ModelType.GENERATIVE || key === ModelType.PREDICTIVE) {
       onModelCustomPropertiesChange(buildCustomPropertiesWithModelType(modelCustomProperties, key));
@@ -50,7 +60,7 @@ const RegisterModelTypeField: React.FC<RegisterModelTypeFieldProps> = ({
         field="Model type"
         component={
           <SimpleSelect
-            options={MODEL_TYPE_SELECT_OPTIONS}
+            options={selectOptions}
             value={stored ?? undefined}
             onChange={handleChange}
             placeholder="Select model type"

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/__tests__/registerModelTypeUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/__tests__/registerModelTypeUtils.spec.ts
@@ -79,12 +79,15 @@ describe('registerModelTypeUtils', () => {
       ).toBeUndefined();
     });
 
-    it('returns undefined for STRING values that are not generative or predictive', () => {
+    it('returns unknown when string matches ModelType.UNKNOWN', () => {
       expect(
         getModelTypeStoredValueFromCustomProperties({
           [MODEL_TYPE_CUSTOM_PROPERTY_KEY]: stringProp(ModelType.UNKNOWN),
         }),
-      ).toBeUndefined();
+      ).toBe(ModelType.UNKNOWN);
+    });
+
+    it('returns undefined for unrecognized STRING values', () => {
       expect(
         getModelTypeStoredValueFromCustomProperties({
           [MODEL_TYPE_CUSTOM_PROPERTY_KEY]: stringProp('other'),

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/registerModelTypeUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/RegisterModel/registerModelTypeUtils.ts
@@ -3,7 +3,7 @@ import { ModelRegistryCustomProperties, ModelRegistryMetadataType } from '~/app/
 
 export const MODEL_TYPE_CUSTOM_PROPERTY_KEY = CatalogModelCustomPropertyKey.MODEL_TYPE;
 
-export type RegisterableModelType = ModelType.GENERATIVE | ModelType.PREDICTIVE;
+export type RegisterableModelType = ModelType.GENERATIVE | ModelType.PREDICTIVE | ModelType.UNKNOWN;
 
 /** Raw `model_type` string for display (any non-empty STRING metadata), or null if unset. */
 export const getModelTypeRawStringFromCustomProperties = (
@@ -25,7 +25,7 @@ export const getModelTypeStoredValueFromCustomProperties = (
     return undefined;
   }
   const v = prop.string_value.toLowerCase().trim();
-  if (v === ModelType.GENERATIVE || v === ModelType.PREDICTIVE) {
+  if (v === ModelType.GENERATIVE || v === ModelType.PREDICTIVE || v === ModelType.UNKNOWN) {
     return v;
   }
   return undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to fix the register flow from model catalog when the model type is unknown.
before:
<img width="984" height="168" alt="Screenshot 2026-05-05 at 4 40 05 PM" src="https://github.com/user-attachments/assets/d86a575a-7e8b-4931-9425-cd2de0db7e6c" />



after:
<img width="960" height="306" alt="Screenshot 2026-05-05 at 4 37 16 PM" src="https://github.com/user-attachments/assets/28ceff85-f357-4fca-9fe2-84f9cac1c397" />


## How Has This Been Tested?
To test in mock mode:
Update the static_mock_data.go file to have model_type as unknown and check the register flow from catalog.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
