### PR TITLE
Fix model transfer jobs to support gateway-based registry URLs

### DIFF
--- a/clients/ui/bff/internal/repositories/model_transfer_jobs.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs.go
@@ -1166,7 +1166,28 @@ func registryOriginOnly(serverAddress string) string {
 	if scheme == "" {
 		scheme = "http"
 	}
-	return scheme + "://" + host
+
+	// Ensure port is explicit so the Python ModelRegistry client (which uses
+	// urlparse) does not append it after the path, producing a malformed URL.
+	port := u.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	hostPort := host + ":" + port
+
+	// Preserve any routing prefix (e.g. /model-registry/<name>) that the
+	// gateway needs, but strip the MR API path suffix (/api/...).
+	path := u.Path
+	if idx := strings.Index(path, "/api/"); idx >= 0 {
+		path = path[:idx]
+	}
+	path = strings.TrimRight(path, "/")
+
+	return scheme + "://" + hostPort + path
 }
 
 func cloneDestSecretFromExisting(generateNamePrefix, namespace, jobID string, oldSecret *corev1.Secret) *corev1.Secret {

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
@@ -631,6 +631,69 @@ func TestGetAllModelTransferJobs_NormalRunningJobNotOverridden(t *testing.T) {
 	}
 }
 
+func TestRegistryOriginOnly(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ClusterIP with explicit port",
+			input:    "http://10.43.0.100:8080/api/model_registry/v1alpha3",
+			expected: "http://10.43.0.100:8080",
+		},
+		{
+			name:     "Route-based HTTPS (no explicit port)",
+			input:    "https://my-registry-rest.apps.example.com/api/model_registry/v1alpha3",
+			expected: "https://my-registry-rest.apps.example.com:443",
+		},
+		{
+			name:     "Route-based HTTPS with explicit port",
+			input:    "https://my-registry-rest.apps.example.com:443/api/model_registry/v1alpha3",
+			expected: "https://my-registry-rest.apps.example.com:443",
+		},
+		{
+			name:     "Gateway-based URL preserves path prefix",
+			input:    "https://gateway.apps.example.com/model-registry/my-registry/api/model_registry/v1alpha3",
+			expected: "https://gateway.apps.example.com:443/model-registry/my-registry",
+		},
+		{
+			name:     "Gateway-based URL with explicit port preserves path prefix",
+			input:    "https://gateway.apps.example.com:443/model-registry/my-registry/api/model_registry/v1alpha3",
+			expected: "https://gateway.apps.example.com:443/model-registry/my-registry",
+		},
+		{
+			name:     "HTTP defaults to port 80",
+			input:    "http://gateway.apps.example.com/model-registry/my-registry/api/model_registry/v1alpha3",
+			expected: "http://gateway.apps.example.com:80/model-registry/my-registry",
+		},
+		{
+			name:     "URL with no path",
+			input:    "https://my-registry-rest.apps.example.com",
+			expected: "https://my-registry-rest.apps.example.com:443",
+		},
+		{
+			name:     "unparseable input returned as-is",
+			input:    "://bad-url",
+			expected: "://bad-url",
+		},
+		{
+			name:     "bare hostname returned as-is",
+			input:    "just-a-hostname",
+			expected: "just-a-hostname",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := registryOriginOnly(tc.input)
+			if got != tc.expected {
+				t.Errorf("registryOriginOnly(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
 var _ = Describe("resolveAsyncUploadImage", func() {
 	var (
 		client  k8s.KubernetesClientInterface


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to fix model transfer jobs to support the gateway based url. 
Updated registryOriginOnly to preserve the gateway path prefix and embed an explicit port so the upstream Python client constructs the correct URL.

I need to test this fix midstream before merging.

## How Has This Been Tested?
Try to create a model transfer job with valid creds and see that the creation goes through. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
