### PR TITLE
fix(ci): exclude terminating pods from deploy image check

### DIFF
--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -50,7 +50,8 @@ fi
 kubectl delete pod -n "$MR_NAMESPACE" --selector='component=model-registry-server'
 
 repeat_cmd_until "kubectl get pod -n "$MR_NAMESPACE" --selector='component=model-registry-server' \
--o jsonpath=\"{.items[*].spec.containers[?(@.name=='rest-container')].image}\" | tr ' ' '\n' | sort -u" "= $IMG" 500 "kubectl describe pod -n $MR_NAMESPACE --selector='component=model-registry-server'"
+--field-selector=status.phase=Running \
+-o jsonpath=\"{.items[*].spec.containers[?(@.name=='rest-container')].image}\" | tr ' ' '\n' | sort -u" 500 "kubectl describe pod -n $MR_NAMESPACE --selector='component=model-registry-server'" "=" "$IMG"
 
 if ! kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-registry-deployment --timeout=5m ; then
     kubectl events -A

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -5,9 +5,11 @@ set -o xtrace
 
 repeat_cmd_until() {
   local cmd=$1
-  local condition=$2
-  local max_wait_secs=$3
-  local debug_cmd=$4
+  local max_wait_secs=$2
+  local debug_cmd=$3
+  shift 3
+  local condition_args=("$@")
+
   local interval_secs=2
   local start_time=$(date +%s)
   local output
@@ -16,17 +18,20 @@ repeat_cmd_until() {
 
     current_time=$(date +%s)
     if (( (current_time - start_time) > max_wait_secs )); then
-      echo "Waited for expression "$1" to satisfy condition "$2" for $max_wait_secs seconds without luck. Returning with error."
+      echo "Waited for expression '$cmd' to satisfy condition '${condition_args[*]}' for $max_wait_secs seconds without luck. Returning with error."
       if [ -n "$debug_cmd" ]; then
         echo "Running debug command: $debug_cmd"
-        eval $debug_cmd
+        eval "$debug_cmd"
       fi
       return 1
     fi
 
-    output=$(eval $cmd)
+    output=$(eval "$cmd")
 
-    if eval '[ "$output"' "$condition" ']'; then
+    # Examples:
+    #   output="myimage:latest", args=("=" "myimage:latest") expands to: [ "myimage:latest" = "myimage:latest" ]
+    #   output="3", args=("-gt" "0") expands to: [ "3" -gt "0" ]
+    if [ "$output" "${condition_args[@]}" ]; then
       break
     else
       sleep $interval_secs

--- a/test/csi/e2e_test.sh
+++ b/test/csi/e2e_test.sh
@@ -267,7 +267,7 @@ EOF
     kubectl get all -n $kserve_namespace || true
 
     # wait for pod predictor to be initialized
-    repeat_cmd_until "kubectl get pod -n $kserve_namespace --selector='component=predictor' --output jsonpath='{.items[*].metadata.name}' | grep ${inference_service_name}-predictor | wc -l" "-gt 0" 60
+    repeat_cmd_until "kubectl get pod -n $kserve_namespace --selector='component=predictor' --output jsonpath='{.items[*].metadata.name}' | grep ${inference_service_name}-predictor | wc -l" 60 "" "-gt" "0"
 
     # If we failed to find the pod, show more debug info
     if [ $? -ne 0 ]; then

--- a/test/csi/test_utils.sh
+++ b/test/csi/test_utils.sh
@@ -13,8 +13,11 @@ wait_for_port() {
 
 repeat_cmd_until() {
   local cmd=$1
-  local condition=$2
-  local max_wait_secs=$3
+  local max_wait_secs=$2
+  local debug_cmd=$3
+  shift 3
+  local condition_args=("$@")
+
   local interval_secs=2
   local start_time=$(date +%s)
   local output
@@ -23,13 +26,17 @@ repeat_cmd_until() {
 
     current_time=$(date +%s)
     if (( (current_time - start_time) > max_wait_secs )); then
-      echo "Waited for expression "$1" to satisfy condition "$2" for $max_wait_secs seconds without luck. Returning with error."
+      echo "Waited for expression '$cmd' to satisfy condition '${condition_args[*]}' for $max_wait_secs seconds without luck. Returning with error."
+      if [ -n "$debug_cmd" ]; then
+        echo "Running debug command: $debug_cmd"
+        eval "$debug_cmd"
+      fi
       return 1
     fi
 
-    output=$(eval $cmd)
+    output=$(eval "$cmd")
 
-    if [ $output $condition ]; then
+    if [ "$output" "${condition_args[@]}" ]; then
       break
     else
       sleep $interval_secs


### PR DESCRIPTION
- Add --field-selector=status.phase=Running in deploy_on_kind.sh
- Redesign repeat_cmd_until to accept condition as separate varargs instead of a single string that relies on word splitting
- Align test/csi/test_utils.sh with scripts/utils.sh (add debug_cmd)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
