### PR TITLE
Add feature flag for Tool calling configuration

### DIFF
--- a/clients/ui/frontend/src/app/hooks/useTempDevFeatureAvailable.ts
+++ b/clients/ui/frontend/src/app/hooks/useTempDevFeatureAvailable.ts
@@ -4,6 +4,7 @@
  * This hook provides a browser storage-backed feature flag that can be toggled
  * via the browser console using:
  *     window.setTempDevCatalogHuggingFaceApiKeyFeatureAvailable(true/false);
+ *     window.setTempDevToolCallingConfigurationFeatureAvailable(true/false);
  * The state persists across page reloads using browser storage.
  *
  * Each TempDevFeature and corresponding window.set* here should be removed once that feature is ready.
@@ -18,18 +19,27 @@ import { useBrowserStorage } from 'mod-arch-core';
 declare global {
   interface Window {
     setTempDevCatalogHuggingFaceApiKeyFeatureAvailable?: (enabled: boolean) => void;
+    setTempDevToolCallingConfigurationFeatureAvailable?: (enabled: boolean) => void;
   }
 }
 
 export enum TempDevFeature {
   CatalogHuggingFaceApiKey = 'tempDevCatalogHuggingFaceApiKeyFeatureAvailable',
+  ToolCallingConfiguration = 'tempDevToolCallingConfigurationFeatureAvailable',
 }
 
 export const useTempDevFeatureAvailable = (feature: TempDevFeature): boolean => {
   const [isAvailable, setIsAvailable] = useBrowserStorage(feature, false);
 
   React.useEffect(() => {
-    window.setTempDevCatalogHuggingFaceApiKeyFeatureAvailable = setIsAvailable;
+    switch (feature) {
+      case TempDevFeature.CatalogHuggingFaceApiKey:
+        window.setTempDevCatalogHuggingFaceApiKeyFeatureAvailable = setIsAvailable;
+        break;
+      case TempDevFeature.ToolCallingConfiguration:
+        window.setTempDevToolCallingConfigurationFeatureAvailable = setIsAvailable;
+        break;
+    }
   }, [feature, setIsAvailable]);
 
   return isAvailable;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to add temporary development feature flag for tool calling.


## How Has This Been Tested?
This can be tested in follow up PR - which will be using this feature flag to hide/show the tool calling configuration

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
