### PR TITLE
Remove redundant whitespace in Model Catalog

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
@@ -98,6 +98,7 @@ const HardwareConfigurationFilterToolbar: React.FC<HardwareConfigurationFilterTo
 
   return (
     <Toolbar
+      className="pf-v6-u-pb-0"
       {...(onResetAllFilters && hasVisibleChips
         ? { clearAllFilters: onResetAllFilters, clearFiltersButtonText: 'Reset all defaults' }
         : {})}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelBlocks.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelBlocks.tsx
@@ -67,7 +67,7 @@ const ModelCatalogSourceLabelBlocks: React.FC = () => {
   };
 
   return (
-    <ToggleGroup aria-label="Source label selection" className="pf-v6-u-pb-xl pf-v6-u-pt-xl">
+    <ToggleGroup aria-label="Source label selection" className="pf-v6-u-pb-md">
       {blocks.map((block) => (
         <ToggleGroupItem
           buttonId={block.id}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -130,6 +130,7 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
     <Stack hasGutter>
       <StackItem>
         <Toolbar
+          className="pf-v6-u-pb-0"
           // Use PatternFly's native clearAllFilters - it automatically shows/hides based on ToolbarFilter labels
           // When performance view is OFF, show reset button for basic filters
           // When performance view is ON, the HardwareConfigurationFilterToolbar handles resetting


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Remove the redundant whitespace in model catalog header. Now the header block have the same spacing of the MCP Catalog heading block.

- Before:
- - PF mode:

*Default catalog*
<img width="1708" height="405" alt="image" src="https://github.com/user-attachments/assets/d12d5646-35db-4f73-b82e-9e0aee2a24c8" />

*Default catalog with filter chips*
<img width="1698" height="415" alt="image" src="https://github.com/user-attachments/assets/5ce1f49c-1c3b-4908-8135-1125ac487c25" />

*Model performance view enabled* 
<img width="1864" height="462" alt="image" src="https://github.com/user-attachments/assets/b88edfaf-27b0-48a3-a3da-4fdaee6bb7c1" />

*Model performance view enabled with filter chips*
<img width="1888" height="538" alt="image" src="https://github.com/user-attachments/assets/3a4c3664-70ab-4c7b-8a7f-8b186269a455" />

- - non-PF mode

*Default catalog*
<img width="1750" height="394" alt="image" src="https://github.com/user-attachments/assets/9eebec30-9a99-43e0-81fa-7bd9facf1643" />

*Default catalog with filter chips*
<img width="1665" height="412" alt="image" src="https://github.com/user-attachments/assets/95d0cf35-0746-4386-8723-a64b1ff23dab" />

*Model performance view enabled* 
<img width="1754" height="509" alt="image" src="https://github.com/user-attachments/assets/ff93ddd3-8a0b-4a62-9c31-93d4a5fdb213" />

*Model performance view enabled with filter chips*
<img width="1879" height="587" alt="image" src="https://github.com/user-attachments/assets/1c3f1126-d21c-47a0-82cf-97cd32f96a60" />

- After:
- - PF mode:

*Default catalog*
<img width="1526" height="358" alt="Screenshot 2026-05-07 at 10 05 48" src="https://github.com/user-attachments/assets/13e25ccc-2ffd-4f04-a4af-0d7987bcd2c6" />

*Default catalog with filter chips*
<img width="1563" height="365" alt="image" src="https://github.com/user-attachments/assets/b6a572bc-a9a5-4c42-9a10-073ceb5a267f" />

*Model performance view enabled* 
<img width="1435" height="388" alt="Screenshot 2026-05-07 at 10 05 35" src="https://github.com/user-attachments/assets/4751c640-a6c0-450c-958a-31f81d2faafb" />

*Model performance view enabled with filter chips*
<img width="1692" height="478" alt="Screenshot 2026-05-07 at 10 06 10" src="https://github.com/user-attachments/assets/0c453f67-5ecd-45af-b3f1-cb1b12d212e7" />

- - non-PF mode:
*Default catalog*
<img width="1559" height="352" alt="Screenshot 2026-05-07 at 10 06 37" src="https://github.com/user-attachments/assets/20db84e3-f972-49c7-83be-a30ddec8f4a0" />

*Default catalog with filter chips*
<img width="1425" height="352" alt="image" src="https://github.com/user-attachments/assets/5ef50539-e4dc-4657-ac2c-795ad1890918" />

*Model performance view enabled* 
<img width="1392" height="405" alt="Screenshot 2026-05-07 at 10 06 44" src="https://github.com/user-attachments/assets/ca828ab1-8e56-4a01-ad81-4429bf5abcf3" />

*Model performance view enabled with filter chips*
<img width="1470" height="462" alt="Screenshot 2026-05-07 at 10 06 52" src="https://github.com/user-attachments/assets/d751a040-a040-4c67-9614-4a1655f938b0" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested, no tests added, just simple layout fixes

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
