### PR TITLE
Fix: "Clear all filters" appear in Model performance view

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -753,3 +753,23 @@ describe('Single Category Behavior', () => {
     modelCatalog.findModelCatalogCards().should('have.length.at.least', 1);
   });
 });
+
+describe('Clear All Filters Button Behavior', () => {
+  it('should not show clear all filters button when performance view is activated with filters applied', () => {
+    initIntercepts({
+      sources: mockDefaultSources(),
+    });
+    setupFilteredModelsIntercept({ returnModelsForFilters: true, modelsToReturn: [] });
+
+    modelCatalog.visit();
+
+    modelCatalog.findFilterShowMoreButton('Task').click();
+    modelCatalog.findFilterCheckbox('Task', 'audio-to-text').click();
+
+    cy.wait('@getFilteredModels');
+
+    modelCatalog.togglePerformanceView();
+
+    cy.findByRole('button', { name: /Clear all filters/i }).should('not.exist');
+  });
+});

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogActiveFilters.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogActiveFilters.tsx
@@ -32,9 +32,17 @@ import { formatLatency } from '~/app/pages/modelCatalog/utils/performanceMetrics
 
 type ModelCatalogActiveFiltersProps = {
   filtersToShow: ModelCatalogFilterKey[];
+  /** When true, all ToolbarFilter labels are forced to empty arrays. This keeps the
+   *  ToolbarFilter components mounted so their parent Toolbar's internal filter count
+   *  stays at zero — working around PF's missing componentWillUnmount cleanup
+   *  (https://github.com/patternfly/patternfly-react/issues/12247). */
+  forceHideLabels?: boolean;
 };
 
-const ModelCatalogActiveFilters: React.FC<ModelCatalogActiveFiltersProps> = ({ filtersToShow }) => {
+const ModelCatalogActiveFilters: React.FC<ModelCatalogActiveFiltersProps> = ({
+  filtersToShow,
+  forceHideLabels = false,
+}) => {
   const {
     filterData,
     setFilterData,
@@ -200,7 +208,7 @@ const ModelCatalogActiveFilters: React.FC<ModelCatalogActiveFiltersProps> = ({ f
                 key: filterKey,
                 name: MODEL_CATALOG_FILTER_CATEGORY_NAMES[filterKey],
               }}
-              labels={latencyLabels}
+              labels={forceHideLabels ? [] : latencyLabels}
               deleteLabel={(category) => {
                 const categoryKeyValue = typeof category === 'string' ? category : category.key;
                 handleClearCategory(categoryKeyValue);
@@ -262,7 +270,7 @@ const ModelCatalogActiveFilters: React.FC<ModelCatalogActiveFiltersProps> = ({ f
           <ToolbarFilter
             key={filterKey}
             categoryName={categoryLabelGroup}
-            labels={labels}
+            labels={forceHideLabels ? [] : labels}
             deleteLabel={(category, label) => {
               const categoryKeyValue = typeof category === 'string' ? category : category.key;
               const labelKey = typeof label === 'string' ? label : label.key;

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelSelector.tsx
@@ -179,9 +179,13 @@ const ModelCatalogSourceLabelSelector: React.FC<ModelCatalogSourceLabelSelectorP
                 </ToolbarGroup>
               </ToolbarToggleGroup>
               {/* When toggle is OFF, show basic filter chips in the main toolbar */}
-              {/* When toggle is ON, all chips are shown in HardwareConfigurationFilterToolbar below */}
-              {!performanceViewEnabled && onResetAllFilters && hasBasicFiltersApplied && (
-                <ModelCatalogActiveFilters filtersToShow={filtersToShow} />
+              {/* When toggle is ON, keep ToolbarFilters mounted with empty labels to work around */}
+              {/* PF ToolbarFilter not cleaning up filter count on unmount (PF#12247) */}
+              {onResetAllFilters && (
+                <ModelCatalogActiveFilters
+                  filtersToShow={filtersToShow}
+                  forceHideLabels={performanceViewEnabled}
+                />
               )}
             </Flex>
           </ToolbarContent>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When in Model Catalog and select a sidebar filter and after that, enables the Model performance view, the "Clear all filters" appear.
<img width="1322" height="600" alt="image" src="https://github.com/user-attachments/assets/b1b612a3-7a2a-4100-a1a7-c5a43a3002e0" />

After
non-PF:
<img width="1872" height="545" alt="image" src="https://github.com/user-attachments/assets/2c50f4a9-9de1-4efa-99f6-2595b83f13e5" />

PF:
<img width="1626" height="541" alt="image" src="https://github.com/user-attachments/assets/ec74baea-1df8-4175-b6a9-947a6e4f9e81" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cypress added to verify if follow the steps to reproduce the bug if the "Clear all filters" text appear

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
