### PR TITLE
fix(ui): use NotReadyError in useRegisteredModels hook

### DIFF
--- a/clients/ui/frontend/src/app/hooks/useRegisteredModels.ts
+++ b/clients/ui/frontend/src/app/hooks/useRegisteredModels.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useFetchState, FetchState, FetchStateCallbackPromise } from 'mod-arch-core';
+import { useFetchState, FetchState, FetchStateCallbackPromise, NotReadyError } from 'mod-arch-core';
 import { RegisteredModelList } from '~/app/types';
 import { useModelRegistryAPI } from '~/app/hooks/useModelRegistryAPI';
 
@@ -8,7 +8,7 @@ const useRegisteredModels = (): FetchState<RegisteredModelList> => {
   const callback = React.useCallback<FetchStateCallbackPromise<RegisteredModelList>>(
     (opts) => {
       if (!apiAvailable) {
-        return Promise.reject(new Error('API not yet available'));
+        return Promise.reject(new NotReadyError('API not yet available'));
       }
       return api.listRegisteredModels(opts);
     },


### PR DESCRIPTION
## Description

When the API isn't ready, `useRegisteredModels` rejects with a generic `Error`, which causes `useFetchState` to treat it as a hard failure. This can interfere with form display — for example, showing error states prematurely while the API is still initializing.

This PR changes the rejection to use `NotReadyError` (from `mod-arch-core`), which `useFetchState` recognizes as a transient "not ready" state and silently retries when the callback identity changes (i.e., when `apiAvailable` flips to `true`).

This matches the pattern already used in other hooks like `useModelVersionsByRegisteredModel`, `useRegisteredModelById`, etc.

### Follow-up

The `useModelVersionsByRegisteredModel` hook has the same issue on its `!apiAvailable` branch (uses `Error` instead of `NotReadyError`). That can be addressed in a separate PR.

## How Has This Been Tested?

Verified that `NotReadyError` is already exported from `mod-arch-core` and used across other hooks in the codebase. The change is a one-line error type swap with no behavioral difference except that `useFetchState` now correctly treats the "API not available" state as transient rather than a hard error.

## Test Impact

No new tests needed — this is a minimal error-type change. Existing tests for `useFetchState` in `mod-arch-core` already cover `NotReadyError` handling.

## Request review criteria

- [x] I have reviewed the [contributing guide](https://github.com/kubeflow/model-registry/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] My change requires an update to documentation
  - [ ] I have updated the documentation accordingly
- [x] My change does not require an update to documentation

Made with [Cursor](https://cursor.com)