### PR TITLE
Add tool calling support to Model catalog

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -2321,11 +2321,35 @@ components:
         libraryName:
           type: string
           example: transformers
+        validatedTasks:
+          type: array
+          description: >-
+            List of tasks that have been validated end-to-end for this model.
+            Follows the same naming convention as `tasks`.
+          items:
+            type: string
+          example:
+            - tool-calling
+        servingConfig:
+          $ref: "#/components/schemas/ServingConfig"
         customProperties:
           description: User provided custom properties which are not defined by its type.
           type: object
           additionalProperties:
             $ref: "#/components/schemas/MetadataValue"
+    ServingConfig:
+      description: Validated serving configurations for a model.
+      type: object
+      properties:
+        toolCalling:
+          $ref: "#/components/schemas/ToolCallingConfig"
+    ToolCallingConfig:
+      description: Tool calling configuration for vLLM serving runtime.
+      type: object
+      properties:
+        args:
+          type: string
+          description: CLI arguments to pass to the serving runtime for tool calling support.
     BaseResourceDates:
       description: Common timestamp fields for resources
       type: object

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -361,13 +361,19 @@ func GetCatalogModelMocks() []models.CatalogModel {
 		Name:             "repo1/granite-8b-code-instruct",
 		Description:      stringToPointer("Granite-8B-Code-Instruct is a 8B parameter model fine tuned from\nGranite-8B-Code-Base on a combination of permissively licensed instruction\ndata to enhance instruction following capabilities including logical\nreasoning and problem-solving skills."),
 		Provider:         stringToPointer("provider1"),
-		Tasks:            []string{"text-generation", "image-to-text"},
+		Tasks:            []string{"text-generation", "image-to-text", "tool-calling"},
+		ValidatedTasks:   []string{"tool-calling"},
 		License:          stringToPointer("Apache 2.0"),
 		LicenseLink:      stringToPointer("https://www.apache.org/licenses/LICENSE-2.0.txt"),
 		Maturity:         stringToPointer("Technology preview"),
 		Language:         []string{"ar", "cs", "de", "en", "es", "fr", "it", "ja", "ko", "nl", "pt", "zh"},
 		CustomProperties: catalogCustomPropertiesWithVariant(graniteVariantGroupId, "FP16"),
-		Logo:             stringToPointer("data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4="),
+		ServingConfig: &models.ServingConfig{
+			ToolCalling: &models.ToolCallingConfig{
+				Args: stringToPointer("--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja"),
+			},
+		},
+		Logo: stringToPointer("data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4="),
 		Readme: stringToPointer(`---
 pipeline_tag: text-generation
 inference: false

--- a/clients/ui/bff/internal/models/catalog_model_list.go
+++ b/clients/ui/bff/internal/models/catalog_model_list.go
@@ -4,6 +4,14 @@ import (
 	"github.com/kubeflow/model-registry/pkg/openapi"
 )
 
+type ToolCallingConfig struct {
+	Args *string `json:"args,omitempty"`
+}
+
+type ServingConfig struct {
+	ToolCalling *ToolCallingConfig `json:"toolCalling,omitempty"`
+}
+
 type CatalogModel struct {
 	CreateTimeSinceEpoch     *string                           `json:"createTimeSinceEpoch,omitempty"`
 	CustomProperties         *map[string]openapi.MetadataValue `json:"customProperties,omitempty"`
@@ -20,6 +28,8 @@ type CatalogModel struct {
 	Readme                   *string                           `json:"readme,omitempty"`
 	SourceId                 *string                           `json:"source_id,omitempty"`
 	Tasks                    []string                          `json:"tasks,omitempty"`
+	ValidatedTasks           []string                          `json:"validatedTasks,omitempty"`
+	ServingConfig            *ServingConfig                    `json:"servingConfig,omitempty"`
 }
 
 type CatalogModelList struct {

--- a/clients/ui/frontend/src/__mocks__/mockCatalogModelList.ts
+++ b/clients/ui/frontend/src/__mocks__/mockCatalogModelList.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import { CatalogModel, CatalogModelList } from '~/app/modelCatalogTypes';
 import { ModelRegistryMetadataType } from '~/app/types';
+import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
 
 export const mockCatalogModel = (partial?: Partial<CatalogModel>): CatalogModel => ({
   source_id: 'sample-source',
@@ -373,7 +374,8 @@ export const mockCatalogModelList = (partial?: Partial<CatalogModelList>): Catal
 // Mock models for testing
 export const mockValidatedModel = mockCatalogModel({
   name: 'validated-model',
-  tasks: ['text-generation'],
+  tasks: [ModelCatalogTask.TEXT_GENERATION, ModelCatalogTask.TOOL_CALLING],
+  validatedTasks: [ModelCatalogTask.TOOL_CALLING],
   customProperties: {
     model_type: {
       metadataType: ModelRegistryMetadataType.STRING,
@@ -382,6 +384,11 @@ export const mockValidatedModel = mockCatalogModel({
     validated: {
       metadataType: ModelRegistryMetadataType.STRING,
       string_value: '',
+    },
+  },
+  servingConfig: {
+    toolCalling: {
+      args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
     },
   },
 });

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -136,7 +136,7 @@ class ModelCatalog {
   }
 
   findTaskLabel() {
-    return cy.contains('text-generation');
+    return cy.contains('Text generation');
   }
 
   findProviderLabel() {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -421,6 +421,19 @@ class ModelCatalog {
     return cy.get('[data-testid^="compression-variant-"]');
   }
 
+  // Validated Configurations Card
+  findValidatedConfigurationsCard() {
+    return cy.findByTestId('validated-configurations-card');
+  }
+
+  findToolCallingCard() {
+    return cy.findByTestId('tool-calling-card');
+  }
+
+  findToolCallingToggle() {
+    return cy.get('#tool-calling-toggle');
+  }
+
   // Performance Empty State
   findPerformanceEmptyState() {
     return cy.findByTestId('performance-empty-state');

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
@@ -21,6 +21,7 @@ import type { CatalogLabelList, CatalogModel, CatalogSource } from '~/app/modelC
 import type { ModelRegistryCustomProperties } from '~/app/types';
 import { ModelRegistryMetadataType } from '~/app/types';
 import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
 
 /**
  * Options for setting up model catalog intercepts
@@ -91,22 +92,29 @@ export const createMockModelsForLabel = (
 ): ReturnType<typeof mockCatalogModelList> =>
   mockCatalogModelList({
     items: Array.from({ length: modelsPerCategory }, (_, i) => {
-      const customProperties =
-        i === 0 && useValidatedModel
-          ? ({
-              validated: {
-                metadataType: ModelRegistryMetadataType.STRING,
-                string_value: '',
-              },
-            } as ModelRegistryCustomProperties)
-          : undefined;
-      const name =
-        i === 0 && useValidatedModel ? 'validated-model' : `${label.toLowerCase()}-model-${i + 1}`;
+      const isValidated = i === 0 && useValidatedModel;
+      const customProperties = isValidated
+        ? ({
+            validated: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: '',
+            },
+          } as ModelRegistryCustomProperties)
+        : undefined;
+      const name = isValidated ? 'validated-model' : `${label.toLowerCase()}-model-${i + 1}`;
 
       return mockCatalogModel({
         name,
         source_id: source.id,
         customProperties,
+        ...(isValidated && {
+          validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+          servingConfig: {
+            toolCalling: {
+              args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
+            },
+          },
+        }),
       });
     }),
   });
@@ -150,20 +158,28 @@ export const interceptModelsByLabel = (
 export const interceptAllModels = (modelsPerCategory: number, useValidatedModel: boolean): void => {
   const allModelsResponse = mockCatalogModelList({
     items: Array.from({ length: modelsPerCategory }, (_, i) => {
-      const customProperties =
-        i === 0 && useValidatedModel
-          ? ({
-              validated: {
-                metadataType: ModelRegistryMetadataType.STRING,
-                string_value: '',
-              },
-            } as ModelRegistryCustomProperties)
-          : undefined;
-      const name = i === 0 && useValidatedModel ? 'validated-model' : `all-models-model-${i + 1}`;
+      const isValidated = i === 0 && useValidatedModel;
+      const customProperties = isValidated
+        ? ({
+            validated: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: '',
+            },
+          } as ModelRegistryCustomProperties)
+        : undefined;
+      const name = isValidated ? 'validated-model' : `all-models-model-${i + 1}`;
       return mockCatalogModel({
         name,
         source_id: 'sample-source',
         customProperties,
+        ...(isValidated && {
+          validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+          servingConfig: {
+            toolCalling: {
+              args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
+            },
+          },
+        }),
       });
     }),
   });

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogCard.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogCard.cy.ts
@@ -29,7 +29,7 @@ describe('ModelCatalogCard Component', () => {
 
     it('should display correct source labels', () => {
       modelCatalog.findFirstModelCatalogCard().within(() => {
-        modelCatalog.findSourceLabel().should('contain.text', 'source 2text-generationprovider1');
+        modelCatalog.findSourceLabel().should('contain.text', 'source 2Text generationprovider1');
       });
     });
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -10,6 +10,8 @@ import {
 import { mockCatalogModelArtifact, mockCatalogModel } from '~/__mocks__';
 import { ModelRegistryMetadataType } from '~/app/types';
 import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
+import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
 
 describe('Model Catalog Details Page', () => {
   beforeEach(() => {
@@ -310,5 +312,70 @@ describe('Model Catalog Details Page - Edge Cases', () => {
     modelCatalog.findBreadcrumb().should('exist');
 
     cy.findByRole('progressbar').should('exist');
+  });
+});
+
+describe('Model Catalog Details Page - Validated Configurations Card', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/model-registry/api/v1/model_registry*', [
+      mockModelRegistry({ name: 'modelregistry-sample' }),
+    ]).as('getModelRegistries');
+  });
+
+  describe('with feature flag enabled', () => {
+    beforeEach(() => {
+      window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
+      setupValidatedModelIntercepts({});
+      interceptArtifactsList();
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.findBreadcrumb().should('exist');
+    });
+
+    it('should display the validated configurations card with tool calling content', () => {
+      modelCatalog.findValidatedConfigurationsCard().should('be.visible');
+      modelCatalog
+        .findValidatedConfigurationsCard()
+        .should('contain.text', 'Validated configurations');
+      modelCatalog.findToolCallingCard().should('be.visible');
+      modelCatalog.findToolCallingCard().should('contain.text', 'Tool Calling');
+    });
+
+    it('should show CLI args inside the tool calling card when expanded', () => {
+      modelCatalog.findToolCallingToggle().click();
+      modelCatalog.findToolCallingCard().should('contain.text', '--enable-auto-tool-choice');
+      modelCatalog.findToolCallingCard().should('contain.text', '--tool-call-parser granite');
+    });
+  });
+
+  describe('with feature flag disabled', () => {
+    it('should not display the validated configurations card', () => {
+      window.localStorage.removeItem(TempDevFeature.ToolCallingConfiguration);
+      setupValidatedModelIntercepts({});
+      interceptArtifactsList();
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.findBreadcrumb().should('exist');
+      modelCatalog.findValidatedConfigurationsCard().should('not.exist');
+    });
+  });
+
+  describe('for a non-validated model', () => {
+    it('should not display the validated configurations card', () => {
+      window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
+      setupModelCatalogIntercepts({
+        customNonValidatedModel: mockCatalogModel({
+          name: 'non-validated-model',
+          tasks: [ModelCatalogTask.TEXT_GENERATION],
+        }),
+      });
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.findBreadcrumb().should('exist');
+      modelCatalog.findValidatedConfigurationsCard().should('not.exist');
+    });
   });
 });

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -35,6 +35,14 @@ export type CatalogSource = {
 
 export type CatalogSourceList = PaginationParams & { items?: CatalogSource[] };
 
+export type ToolCallingConfig = {
+  args?: string;
+};
+
+export type ServingConfig = {
+  toolCalling?: ToolCallingConfig;
+};
+
 export type CatalogModel = {
   source_id?: string;
   name: string;
@@ -44,6 +52,7 @@ export type CatalogModel = {
   language?: string[];
   logo?: string;
   tasks?: string[];
+  validatedTasks?: string[];
   libraryName?: string;
   license?: string;
   licenseLink?: string;
@@ -51,6 +60,7 @@ export type CatalogModel = {
   createTimeSinceEpoch?: string;
   lastUpdateTimeSinceEpoch?: string;
   customProperties?: ModelRegistryCustomProperties;
+  servingConfig?: ServingConfig;
 };
 
 export type PaginationParams = {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
@@ -12,13 +12,14 @@ import {
   Popover,
   Skeleton,
 } from '@patternfly/react-core';
-import { ChartBarIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { CatalogModel, CatalogSource } from '~/app/modelCatalogTypes';
 import { catalogModelDetailsFromModel } from '~/app/routes/modelCatalog/catalogModel';
 import { getLabels } from '~/app/pages/modelRegistry/screens/utils';
 import { isModelValidated, getModelName } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { MODEL_CATALOG_POPOVER_MESSAGES } from '~/concepts/modelCatalog/const';
+import { useTempDevFeatureAvailable, TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
 import ModelCatalogLabels from './ModelCatalogLabels';
 import ModelCatalogCardBody from './ModelCatalogCardBody';
 
@@ -28,9 +29,9 @@ type ModelCatalogCardProps = {
 };
 
 const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) => {
-  // Extract labels from customProperties and check for validated label
   const allLabels = model.customProperties ? getLabels(model.customProperties) : [];
   const isValidated = isModelValidated(model);
+  const isToolCallingEnabled = useTempDevFeatureAvailable(TempDevFeature.ToolCallingConfiguration);
 
   return (
     <Card isFullHeight data-testid="model-catalog-card" key={`${model.name}/${model.source_id}`}>
@@ -50,7 +51,7 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
             <FlexItem align={{ default: 'alignRight' }}>
               {isValidated ? (
                 <Popover bodyContent={MODEL_CATALOG_POPOVER_MESSAGES.VALIDATED}>
-                  <Label color="purple" isClickable icon={<ChartBarIcon />}>
+                  <Label variant="outline" isClickable status="success" icon={<CheckCircleIcon />}>
                     Validated
                   </Label>
                 </Popover>
@@ -81,6 +82,7 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
       <CardFooter>
         <ModelCatalogLabels
           tasks={model.tasks ?? []}
+          validatedTasks={isToolCallingEnabled ? model.validatedTasks : undefined}
           provider={model.provider}
           labels={allLabels.filter((label) => label !== 'validated')}
           numLabels={isValidated ? 2 : 3}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogLabels.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogLabels.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react';
-import { Label, LabelGroup } from '@patternfly/react-core';
+import { Icon, Label, LabelGroup } from '@patternfly/react-core';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import { MODEL_CATALOG_TASK_NAME_MAPPING, ModelCatalogTask } from '~/concepts/modelCatalog/const';
+
+const isModelCatalogTask = (task: string): task is ModelCatalogTask =>
+  Object.values<string>(ModelCatalogTask).includes(task);
+
+const getTaskDisplayName = (task: string): string =>
+  isModelCatalogTask(task) ? MODEL_CATALOG_TASK_NAME_MAPPING[task] : task;
 
 type ModelCatalogLabelsProps = {
   tasks?: string[];
+  validatedTasks?: string[];
   provider?: string;
   labels?: string[];
   numLabels: number;
@@ -10,16 +19,31 @@ type ModelCatalogLabelsProps = {
 
 const ModelCatalogLabels: React.FC<ModelCatalogLabelsProps> = ({
   tasks = [],
+  validatedTasks,
   provider,
   labels = [],
   numLabels,
 }) => (
   <LabelGroup numLabels={numLabels} isCompact>
-    {tasks.map((task) => (
-      <Label data-testid="model-catalog-label" key={task} variant="outline">
-        {task}
-      </Label>
-    ))}
+    {tasks.map((task) => {
+      const isValidatedTask = validatedTasks?.includes(task);
+      return (
+        <Label
+          data-testid="model-catalog-label"
+          key={task}
+          variant="outline"
+          icon={
+            isValidatedTask ? (
+              <Icon status="success">
+                <CheckCircleIcon />
+              </Icon>
+            ) : undefined
+          }
+        >
+          {getTaskDisplayName(task)}
+        </Label>
+      );
+    })}
     {provider && (
       <Label isCompact variant="outline">
         {provider}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -17,7 +17,7 @@ import {
   Skeleton,
   Label,
 } from '@patternfly/react-core';
-import { ChartBarIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon } from '@patternfly/react-icons';
 import { ApplicationsPage } from 'mod-arch-shared';
 import {
   decodeParams,
@@ -43,7 +43,6 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
   const params = useParams<CatalogModelDetailsParams>();
   const decodedParams = decodeParams(params);
   const navigate = useNavigate();
-
   const state = useCatalogModel(
     decodedParams.sourceId || '',
     encodeURIComponent(`${decodedParams.modelName}`),
@@ -148,7 +147,12 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
                     <FlexItem>{getModelName(model.name)}</FlexItem>
                     {isModelValidated(model) && (
                       <Popover bodyContent={MODEL_CATALOG_POPOVER_MESSAGES.VALIDATED}>
-                        <Label color="purple" isClickable icon={<ChartBarIcon />}>
+                        <Label
+                          variant="outline"
+                          isClickable
+                          status="success"
+                          icon={<CheckCircleIcon />}
+                        >
                           Validated
                         </Label>
                       </Popover>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Card,
   CardBody,
+  CardExpandableContent,
   CardHeader,
   Content,
   DescriptionList,
@@ -41,9 +42,12 @@ import {
   getModelArtifactUri,
   hasModelArtifacts,
   isModelValidated,
+  hasValidatedToolCalling,
   formatModelTypeDisplay,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { CatalogModelCustomPropertyKey } from '~/concepts/modelCatalog/const';
+import { useTempDevFeatureAvailable, TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
+import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 
 type ModelDetailsViewProps = {
   model: CatalogModel;
@@ -58,14 +62,13 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
   artifactLoaded,
   artifactsLoadError,
 }) => {
-  // Extract all labels from customProperties
   const allLabels = model.customProperties ? getLabels(model.customProperties) : [];
   const isValidated = isModelValidated(model);
+  const isToolCallingEnabled = useTempDevFeatureAvailable(TempDevFeature.ToolCallingConfiguration);
+  const isToolCallingValidated = isToolCallingEnabled && hasValidatedToolCalling(model);
 
-  // Extract validated_on platforms
   const validatedOnPlatforms = getValidatedOnPlatforms(model.customProperties);
 
-  // Extract model type from customProperties
   const modelTypeRaw = model.customProperties
     ? getCustomPropString(model.customProperties, CatalogModelCustomPropertyKey.MODEL_TYPE)
     : null;
@@ -75,7 +78,6 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
     [modelTypeRaw],
   );
 
-  // Extract tensor type and size from customProperties
   const tensorType = model.customProperties
     ? getCustomPropString(model.customProperties, CatalogModelCustomPropertyKey.TENSOR_TYPE)
     : '';
@@ -83,11 +85,12 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
     ? getCustomPropString(model.customProperties, CatalogModelCustomPropertyKey.SIZE)
     : '';
 
-  // Extract architectures from artifacts with memoization to prevent unnecessary recalculations
   const architectures = React.useMemo(
     () => (artifactLoaded ? getArchitecturesFromArtifacts(artifacts.items) : []),
     [artifactLoaded, artifacts.items],
   );
+
+  const [isToolCallingExpanded, setIsToolCallingExpanded] = React.useState(false);
 
   return (
     <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
@@ -132,124 +135,186 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
           </Stack>
         </SidebarContent>
         <SidebarPanel width={{ default: 'width_33' }}>
-          <Card>
-            <CardHeader>
-              <Title headingLevel="h2" size="lg">
-                Model details
-              </Title>
-            </CardHeader>
-            <CardBody>
-              <DescriptionList>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Labels</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <ModelCatalogLabels
-                      tasks={model.tasks ?? []}
-                      labels={allLabels.filter((label) => label !== 'validated')}
-                      numLabels={isValidated ? 2 : 3}
-                    />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Model type</DescriptionListTerm>
-                  <DescriptionListDescription data-testid="model-type">
-                    {modelTypeDisplay}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Tensor type</DescriptionListTerm>
-                  <DescriptionListDescription>{tensorType || 'N/A'}</DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Size</DescriptionListTerm>
-                  <DescriptionListDescription>{size || 'N/A'}</DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>License</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <ExternalLink
-                      text="Agreement"
-                      to={model.licenseLink || ''}
-                      testId="model-license-link"
-                    />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Provider</DescriptionListTerm>
-                  <DescriptionListDescription>{model.provider || 'N/A'}</DescriptionListDescription>
-                </DescriptionListGroup>
-                {validatedOnPlatforms.length > 0 && (
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>
-                      Certified platforms{' '}
-                      <Popover bodyContent="The model has been tested and verified to operate correctly on the specified enterprise platforms.">
-                        <Button
-                          variant="plain"
-                          aria-label="More info for validated on"
-                          className="pf-v6-u-p-xs"
-                          icon={<HelpIcon />}
+          <Stack hasGutter>
+            {isToolCallingValidated && (
+              <StackItem>
+                <Card data-testid="validated-configurations-card">
+                  <CardHeader>
+                    <Title headingLevel="h2" size="lg">
+                      Validated configurations
+                    </Title>
+                  </CardHeader>
+                  <CardBody>
+                    <Content component="p" className="pf-v6-u-mb-md">
+                      These configurations have been tested and validated for this model. Use them
+                      as runtime arguments when deploying.
+                    </Content>
+                    <Card
+                      id="tool-calling-card"
+                      isExpanded={isToolCallingExpanded}
+                      data-testid="tool-calling-card"
+                    >
+                      <CardHeader
+                        onExpand={() => setIsToolCallingExpanded((prev) => !prev)}
+                        toggleButtonProps={{
+                          id: 'tool-calling-toggle',
+                          'aria-label': 'Tool Calling',
+                          'aria-expanded': isToolCallingExpanded,
+                        }}
+                      >
+                        <Stack>
+                          <StackItem>
+                            <Title headingLevel="h3" size="md">
+                              Tool Calling
+                            </Title>
+                          </StackItem>
+                          <StackItem>
+                            <Content component="small">
+                              Enables agentic workflows and function calling capabilities.
+                            </Content>
+                          </StackItem>
+                        </Stack>
+                      </CardHeader>
+                      <CardExpandableContent>
+                        <CardBody>
+                          <CodeBlockComponent>
+                            {model.servingConfig?.toolCalling?.args ?? ''}
+                          </CodeBlockComponent>
+                        </CardBody>
+                      </CardExpandableContent>
+                    </Card>
+                  </CardBody>
+                </Card>
+              </StackItem>
+            )}
+            <StackItem>
+              <Card>
+                <CardHeader>
+                  <Title headingLevel="h2" size="lg">
+                    Model details
+                  </Title>
+                </CardHeader>
+                <CardBody>
+                  <DescriptionList>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Labels</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <ModelCatalogLabels
+                          tasks={model.tasks ?? []}
+                          validatedTasks={isToolCallingEnabled ? model.validatedTasks : undefined}
+                          labels={allLabels.filter((label) => label !== 'validated')}
+                          numLabels={isValidated ? 2 : 3}
                         />
-                      </Popover>
-                    </DescriptionListTerm>
-                    <DescriptionListDescription>
-                      <LabelGroup numLabels={5} isCompact>
-                        {validatedOnPlatforms.map((platform) => (
-                          <Label data-testid="validated-on-label" key={platform} variant="outline">
-                            {platform}
-                          </Label>
-                        ))}
-                      </LabelGroup>
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                )}
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Model location</DescriptionListTerm>
-                  {artifactsLoadError ? (
-                    <Alert variant="danger" isInline title={artifactsLoadError.name}>
-                      {artifactsLoadError.message}
-                    </Alert>
-                  ) : !artifactLoaded ? (
-                    <Spinner size="sm" />
-                  ) : artifacts.items.length > 0 && hasModelArtifacts(artifacts.items) ? (
-                    <DescriptionListDescription>
-                      <InlineTruncatedClipboardCopy
-                        testId="source-image-location"
-                        textToCopy={getModelArtifactUri(artifacts.items) || ''}
-                      />
-                    </DescriptionListDescription>
-                  ) : (
-                    <p className={text.textColorDisabled}>No artifacts available</p>
-                  )}
-                </DescriptionListGroup>
-                {architectures.length > 0 && (
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Architecture</DescriptionListTerm>
-                    <DescriptionListDescription data-testid="model-architecture">
-                      {architectures.join(', ')}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                )}
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Last modified</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <Icon isInline style={{ marginRight: 4 }}>
-                      <OutlinedClockIcon />
-                    </Icon>
-                    <ModelTimestamp timeSinceEpoch={model.lastUpdateTimeSinceEpoch} />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Published</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <Icon isInline style={{ marginRight: 4 }}>
-                      <OutlinedClockIcon />
-                    </Icon>
-                    <ModelTimestamp timeSinceEpoch={model.createTimeSinceEpoch} />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              </DescriptionList>
-            </CardBody>
-          </Card>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Model type</DescriptionListTerm>
+                      <DescriptionListDescription data-testid="model-type">
+                        {modelTypeDisplay}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Tensor type</DescriptionListTerm>
+                      <DescriptionListDescription>{tensorType || 'N/A'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Size</DescriptionListTerm>
+                      <DescriptionListDescription>{size || 'N/A'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>License</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <ExternalLink
+                          text="Agreement"
+                          to={model.licenseLink || ''}
+                          testId="model-license-link"
+                        />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Provider</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {model.provider || 'N/A'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {validatedOnPlatforms.length > 0 && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>
+                          Certified platforms{' '}
+                          <Popover bodyContent="The model has been tested and verified to operate correctly on the specified enterprise platforms.">
+                            <Button
+                              variant="plain"
+                              aria-label="More info for validated on"
+                              className="pf-v6-u-p-xs"
+                              icon={<HelpIcon />}
+                            />
+                          </Popover>
+                        </DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <LabelGroup numLabels={5} isCompact>
+                            {validatedOnPlatforms.map((platform) => (
+                              <Label
+                                data-testid="validated-on-label"
+                                key={platform}
+                                variant="outline"
+                              >
+                                {platform}
+                              </Label>
+                            ))}
+                          </LabelGroup>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Model location</DescriptionListTerm>
+                      {artifactsLoadError ? (
+                        <Alert variant="danger" isInline title={artifactsLoadError.name}>
+                          {artifactsLoadError.message}
+                        </Alert>
+                      ) : !artifactLoaded ? (
+                        <Spinner size="sm" />
+                      ) : artifacts.items.length > 0 && hasModelArtifacts(artifacts.items) ? (
+                        <DescriptionListDescription>
+                          <InlineTruncatedClipboardCopy
+                            testId="source-image-location"
+                            textToCopy={getModelArtifactUri(artifacts.items) || ''}
+                          />
+                        </DescriptionListDescription>
+                      ) : (
+                        <p className={text.textColorDisabled}>No artifacts available</p>
+                      )}
+                    </DescriptionListGroup>
+                    {architectures.length > 0 && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Architecture</DescriptionListTerm>
+                        <DescriptionListDescription data-testid="model-architecture">
+                          {architectures.join(', ')}
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Last modified</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Icon isInline style={{ marginRight: 4 }}>
+                          <OutlinedClockIcon />
+                        </Icon>
+                        <ModelTimestamp timeSinceEpoch={model.lastUpdateTimeSinceEpoch} />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Published</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Icon isInline style={{ marginRight: 4 }}>
+                          <OutlinedClockIcon />
+                        </Icon>
+                        <ModelTimestamp timeSinceEpoch={model.createTimeSinceEpoch} />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </DescriptionList>
+                </CardBody>
+              </Card>
+            </StackItem>
+          </Stack>
         </SidebarPanel>
       </Sidebar>
     </PageSection>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -38,6 +38,7 @@ import {
   getModelName,
   getCatalogModelTypePropertyForRegistration,
   getActiveSourceLabels,
+  hasValidatedToolCalling,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { mockCatalogModelArtifact } from '~/__mocks__/mockCatalogModelArtifactList';
 import { ModelRegistryMetadataType } from '~/app/types';
@@ -1652,5 +1653,59 @@ describe('getActiveSourceLabels', () => {
 
     const result = getActiveSourceLabels(sources, catalogLabels);
     expect(result).toEqual(['Red Hat', 'Partner', 'Community']);
+  });
+});
+
+describe('hasValidatedToolCalling', () => {
+  it('should return true when model has tool-calling in validatedTasks and servingConfig.toolCalling', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+        servingConfig: { toolCalling: { args: '--some-args' } },
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false when validatedTasks is missing', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        servingConfig: { toolCalling: { args: '--some-args' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when validatedTasks does not include tool-calling', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: ['text-generation'],
+        servingConfig: { toolCalling: { args: '--some-args' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when servingConfig is missing', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when servingConfig.toolCalling is missing', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+        servingConfig: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when both validatedTasks and servingConfig are missing', () => {
+    expect(hasValidatedToolCalling({ name: 'test-model' })).toBe(false);
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -33,6 +33,7 @@ import {
   SortField,
   CatalogModelCustomPropertyKey,
   ModelType,
+  ModelCatalogTask,
 } from '~/concepts/modelCatalog/const';
 import { isSourceStatusWithModels } from '~/concepts/modelCatalogSettings/const';
 import { ModelRegistryCustomProperties, ModelRegistryMetadataType } from '~/app/types';
@@ -187,6 +188,10 @@ export const shouldShowValidatedInsights = (
   model: CatalogModel,
   artifacts: CatalogArtifacts[],
 ): boolean => isModelValidated(model) && hasPerformanceArtifacts(artifacts);
+
+export const hasValidatedToolCalling = (model: CatalogModel): boolean =>
+  model.validatedTasks?.includes(ModelCatalogTask.TOOL_CALLING) === true &&
+  model.servingConfig?.toolCalling != null;
 
 export const useCatalogStringFilterState = <K extends ModelCatalogStringFilterKey>(
   filterKey: K,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
<img width="220" height="283" alt="Screenshot 2026-05-11 at 1 13 03 PM" src="https://github.com/user-attachments/assets/59422f86-0ad8-4545-a92d-178951622a62" />
<img width="1082" height="425" alt="Screenshot 2026-05-11 at 1 12 51 PM" src="https://github.com/user-attachments/assets/287b535b-89ff-4b5a-af45-5122e120f35d" />

Add validated configurations card to model details page with expandable tool calling section behind a feature flag. Update
"Validated" label to "Validated by Red Hat" with green check icon, and show validated task labels with check indicators.
- Add ServingConfig/ToolCallingConfig types to BFF and frontend
- Add validatedTasks field to CatalogModel
- Add hasValidatedToolCalling utility
- Gate all new UI behind TempDevFeature.ToolCallingConfiguration
- Format task labels for human-readable display
- Update BFF, frontend, and Cypress mocks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Switch on the feature flag on the browser console and check for the labels in the model card and the tool calling validation configurations in the catalog details page as shown in the screenshots.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
