### PR TITLE
fix(catalog): address PR review feedback for serving config descriptions

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -875,7 +875,7 @@ components:
               type: array
               items:
                 type: string
-              description: List of tasks that have been validated for this model.
+              description: List of tasks for this model which have been validated by the catalog provider.
             servingConfig:
               $ref: "#/components/schemas/ServingConfig"
         - $ref: "#/components/schemas/BaseModel"
@@ -1865,7 +1865,7 @@ components:
       type: string
     ServingConfig:
       description: >-
-        Serving and deployment configuration for the model. Each property represents a distinct configuration concern with its own typed schema. All properties are optional — only the configurations that have been validated for a given model should be present.
+        Serving and deployment configuration for the model. Each property represents a distinct configuration concern with its own typed schema. All properties are optional.
       type: object
       properties:
         toolCalling:
@@ -1878,23 +1878,23 @@ components:
       type: string
     ToolCallingConfig:
       description: >-
-        Validated vLLM tool-calling arguments for this model. When present, these values have been tested end-to-end (tool call request, correct tool_calls output, tool response round-trip) on the target hardware.
+        Tool-calling arguments for this model.
       type: object
       properties:
         toolCallParser:
           type: string
           description: >-
-            The --tool-call-parser argument value for vLLM serve.
+            The tool-call parser identifier for the serving runtime.
           example: granite
         chatTemplate:
           type: string
           description: >-
-            Path to the chat template file, as used with the --chat-template argument. For RHOAI deployments, paths are converted from examples/* to opt/app-root/template/*.
+            Path to the chat template file packaged with the model.
           example: opt/app-root/template/tool_chat_template_granite.jinja
         enableAutoToolChoice:
           type: boolean
           description: >-
-            Whether to pass --enable-auto-tool-choice to vLLM serve.
+            Whether to enable automatic tool choice in the serving runtime.
           default: true
         requiredArgs:
           type: array

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -721,7 +721,7 @@ components:
               type: array
               items:
                 type: string
-              description: List of tasks that have been validated for this model.
+              description: List of tasks for this model which have been validated by the catalog provider.
             servingConfig:
               $ref: "#/components/schemas/ServingConfig"
         - $ref: "#/components/schemas/BaseModel"
@@ -730,35 +730,30 @@ components:
       description: >-
         Serving and deployment configuration for the model. Each property
         represents a distinct configuration concern with its own typed schema.
-        All properties are optional — only the configurations that have been
-        validated for a given model should be present.
+        All properties are optional.
       type: object
       properties:
         toolCalling:
           $ref: "#/components/schemas/ToolCallingConfig"
     ToolCallingConfig:
       description: >-
-        Validated vLLM tool-calling arguments for this model. When present,
-        these values have been tested end-to-end (tool call request, correct
-        tool_calls output, tool response round-trip) on the target hardware.
+        Tool-calling arguments for this model.
       type: object
       properties:
         toolCallParser:
           type: string
           description: >-
-            The --tool-call-parser argument value for vLLM serve.
+            The tool-call parser identifier for the serving runtime.
           example: granite
         chatTemplate:
           type: string
           description: >-
-            Path to the chat template file, as used with the --chat-template
-            argument. For RHOAI deployments, paths are converted from
-            examples/* to opt/app-root/template/*.
+            Path to the chat template file packaged with the model.
           example: opt/app-root/template/tool_chat_template_granite.jinja
         enableAutoToolChoice:
           type: boolean
           description: >-
-            Whether to pass --enable-auto-tool-choice to vLLM serve.
+            Whether to enable automatic tool choice in the serving runtime.
           default: true
         requiredArgs:
           type: array

--- a/catalog/internal/catalog/modelcatalog/db_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog.go
@@ -386,7 +386,9 @@ func mapDBModelToAPIModel(m models.CatalogModel) apimodels.CatalogModel {
 			case "validated_tasks":
 				if prop.StringValue != nil {
 					var validatedTasks []string
-					if err := json.Unmarshal([]byte(*prop.StringValue), &validatedTasks); err == nil {
+					if err := json.Unmarshal([]byte(*prop.StringValue), &validatedTasks); err != nil {
+						glog.Warningf("failed to unmarshal validated_tasks for model %s: %v", res.Name, err)
+					} else {
 						res.ValidatedTasks = validatedTasks
 					}
 				}

--- a/catalog/pkg/openapi/model_catalog_model.go
+++ b/catalog/pkg/openapi/model_catalog_model.go
@@ -52,7 +52,7 @@ type CatalogModel struct {
 	LastUpdateTimeSinceEpoch *string `json:"lastUpdateTimeSinceEpoch,omitempty"`
 	// ID of the source this model belongs to.
 	SourceId *string `json:"source_id,omitempty"`
-	// List of tasks that have been validated for this model.
+	// List of tasks for this model which have been validated by the catalog provider.
 	ValidatedTasks []string       `json:"validatedTasks,omitempty"`
 	ServingConfig  *ServingConfig `json:"servingConfig,omitempty"`
 }

--- a/catalog/pkg/openapi/model_serving_config.go
+++ b/catalog/pkg/openapi/model_serving_config.go
@@ -17,7 +17,7 @@ import (
 // checks if the ServingConfig type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &ServingConfig{}
 
-// ServingConfig Serving and deployment configuration for the model. Each property represents a distinct configuration concern with its own typed schema. All properties are optional — only the configurations that have been validated for a given model should be present.
+// ServingConfig Serving and deployment configuration for the model. Each property represents a distinct configuration concern with its own typed schema. All properties are optional.
 type ServingConfig struct {
 	ToolCalling *ToolCallingConfig `json:"toolCalling,omitempty"`
 }

--- a/catalog/pkg/openapi/model_tool_calling_config.go
+++ b/catalog/pkg/openapi/model_tool_calling_config.go
@@ -17,13 +17,13 @@ import (
 // checks if the ToolCallingConfig type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &ToolCallingConfig{}
 
-// ToolCallingConfig Validated vLLM tool-calling arguments for this model. When present, these values have been tested end-to-end (tool call request, correct tool_calls output, tool response round-trip) on the target hardware.
+// ToolCallingConfig Tool-calling arguments for this model.
 type ToolCallingConfig struct {
-	// The --tool-call-parser argument value for vLLM serve.
+	// The tool-call parser identifier for the serving runtime.
 	ToolCallParser *string `json:"toolCallParser,omitempty"`
-	// Path to the chat template file, as used with the --chat-template argument. For RHOAI deployments, paths are converted from examples/_* to opt/app-root/template/_*.
+	// Path to the chat template file packaged with the model.
 	ChatTemplate *string `json:"chatTemplate,omitempty"`
-	// Whether to pass --enable-auto-tool-choice to vLLM serve.
+	// Whether to enable automatic tool choice in the serving runtime.
 	EnableAutoToolChoice *bool `json:"enableAutoToolChoice,omitempty"`
 	// Additional CLI arguments required for tool calling beyond the parser, template, and auto-tool-choice flags. Each entry is a complete argument (e.g., \"--config_format mistral\").
 	RequiredArgs []string `json:"requiredArgs,omitempty"`


### PR DESCRIPTION
## Description
Remove vLLM-specific and "validated" language from OpenAPI spec descriptions to make them engine-agnostic and accurately reflect catalog provider responsibility. Add glog warning for validated_tasks JSON unmarshal failures to match existing serving_config error handling pattern.

## How Has This Been Tested?
Unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
