### PR TITLE
chore: bring up downstream changes from the manifests

### DIFF
--- a/manifests/kustomize/options/istio/istio-authorization-policy.yaml
+++ b/manifests/kustomize/options/istio/istio-authorization-policy.yaml
@@ -8,4 +8,20 @@ spec:
     matchLabels:
       component: model-registry-server
   rules:
-  - {}
+  # Allow all requests from the ingress gateway.
+  # External users are authenticated by oauth2-proxy/authservice at the gateway,
+  # which injects the kubeflow-userid header.
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
+  # Allow internal requests with a valid Kubernetes JWT (authorization header)
+  # but strictly block any request that also carries a kubeflow-userid header,
+  # preventing identity spoofing from within the cluster.
+  - when:
+    - key: request.headers[authorization]
+      values:
+      - "*"
+    - key: request.headers[kubeflow-userid]
+      notValues:
+      - "*"


### PR DESCRIPTION
## Description

https://github.com/kubeflow/manifests/pull/3318 modified the istio authorization policy. Applying the same change here to keep the two repos in sync.

## How Has This Been Tested?
Tested in the manifests repo.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
