### PR TITLE
Add validated configuration filter section for model catalog

### DIFF
--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -1730,6 +1730,13 @@ func GetFilterOptionMocks() map[string]models.FilterOption {
 		},
 	}
 
+	filterOptions["validatedTasks"] = models.FilterOption{
+		Type: FilterOptionTypeString,
+		Values: []interface{}{
+			"tool-calling",
+		},
+	}
+
 	filterOptions["language"] = models.FilterOption{
 		Type: FilterOptionTypeString,
 		Values: []interface{}{

--- a/clients/ui/frontend/src/__mocks__/mockCatalogFilterOptionsList.ts
+++ b/clients/ui/frontend/src/__mocks__/mockCatalogFilterOptionsList.ts
@@ -5,6 +5,7 @@ import {
   ModelCatalogNumberFilterKey,
   ModelCatalogProvider,
   ModelCatalogTask,
+  ValidatedConfiguration,
   AllLanguageCode,
   UseCaseOptionValue,
   DEFAULT_PERFORMANCE_FILTERS_QUERY_NAME,
@@ -113,7 +114,7 @@ export const mockCatalogFilterOptionsList = (
     },
     [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: {
       type: 'string',
-      values: [ModelCatalogTask.TOOL_CALLING],
+      values: [ValidatedConfiguration.TOOL_CALLING],
     },
     [ModelCatalogStringFilterKey.HARDWARE_TYPE]: {
       type: 'string',

--- a/clients/ui/frontend/src/__mocks__/mockCatalogFilterOptionsList.ts
+++ b/clients/ui/frontend/src/__mocks__/mockCatalogFilterOptionsList.ts
@@ -111,6 +111,10 @@ export const mockCatalogFilterOptionsList = (
         ModelCatalogTensorType.MXFP4,
       ],
     },
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: {
+      type: 'string',
+      values: [ModelCatalogTask.TOOL_CALLING],
+    },
     [ModelCatalogStringFilterKey.HARDWARE_TYPE]: {
       type: 'string',
       values: ['GPU', 'CPU', 'TPU', 'FPGA'],

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -15,7 +15,6 @@ import type {
 import type {
   CatalogFilterOptionsList,
   CatalogArtifactList,
-  CatalogLabelList,
   CatalogModel,
   CatalogModelList,
   CatalogSourceList,
@@ -192,11 +191,6 @@ declare global {
           type: 'POST /api/:apiVersion/model_registry/:modelRegistryName/model_transfer_jobs',
           options: { path: { modelRegistryName: string; apiVersion: string } },
           response: ApiResponse<ModelTransferJob>,
-        ) => Cypress.Chainable<null>) &
-        ((
-          type: 'GET /api/:apiVersion/model_catalog/labels',
-          options: { path: { apiVersion: string } },
-          response: ApiResponse<CatalogLabelList>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/:apiVersion/mcp_catalog/mcp_servers',

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -15,6 +15,7 @@ import type {
 import type {
   CatalogFilterOptionsList,
   CatalogArtifactList,
+  CatalogLabelList,
   CatalogModel,
   CatalogModelList,
   CatalogSourceList,
@@ -191,6 +192,11 @@ declare global {
           type: 'POST /api/:apiVersion/model_registry/:modelRegistryName/model_transfer_jobs',
           options: { path: { modelRegistryName: string; apiVersion: string } },
           response: ApiResponse<ModelTransferJob>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/:apiVersion/model_catalog/labels',
+          options: { path: { apiVersion: string } },
+          response: ApiResponse<CatalogLabelList>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/:apiVersion/mcp_catalog/mcp_servers',

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
@@ -21,7 +21,7 @@ import type { CatalogLabelList, CatalogModel, CatalogSource } from '~/app/modelC
 import type { ModelRegistryCustomProperties } from '~/app/types';
 import { ModelRegistryMetadataType } from '~/app/types';
 import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
-import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
+import { ValidatedConfiguration } from '~/concepts/modelCatalog/const';
 
 /**
  * Options for setting up model catalog intercepts
@@ -108,7 +108,7 @@ export const createMockModelsForLabel = (
         source_id: source.id,
         customProperties,
         ...(isValidated && {
-          validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+          validatedTasks: [ValidatedConfiguration.TOOL_CALLING],
           servingConfig: {
             toolCalling: {
               args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
@@ -173,7 +173,7 @@ export const interceptAllModels = (modelsPerCategory: number, useValidatedModel:
         source_id: 'sample-source',
         customProperties,
         ...(isValidated && {
-          validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+          validatedTasks: [ValidatedConfiguration.TOOL_CALLING],
           servingConfig: {
             toolCalling: {
               args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -356,13 +356,8 @@ describe('Model Catalog Page', () => {
       window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
     });
 
-    it('should display filter and checkbox', () => {
-      initIntercepts({});
-      modelCatalog.visit();
-      modelCatalog.findFilter('Validated configuration').scrollIntoView().should('be.visible');
-      modelCatalog
-        .findFilterCheckbox('Validated configuration', 'tool-calling')
-        .should('be.visible');
+    afterEach(() => {
+      window.localStorage.removeItem(TempDevFeature.ToolCallingConfiguration);
     });
 
     it('checkbox should filter models', () => {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -354,13 +354,8 @@ describe('Model Catalog Page', () => {
     window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
     initIntercepts({});
     modelCatalog.visit();
-    modelCatalog
-      .findFilter('Validated configuration')
-      .scrollIntoView()
-      .should('be.visible');
-    modelCatalog
-      .findFilterCheckbox('Validated configuration', 'tool-calling')
-      .should('be.visible');
+    modelCatalog.findFilter('Validated configuration').scrollIntoView().should('be.visible');
+    modelCatalog.findFilterCheckbox('Validated configuration', 'tool-calling').should('be.visible');
   });
 
   it('validated configuration filter checkbox should work', () => {
@@ -379,9 +374,7 @@ describe('Model Catalog Page', () => {
       .click();
 
     cy.wait('@getFilteredModels').then((interception) => {
-      expect(interception.request.url).to.include(
-        'validatedTasks%3D%27tool-calling%27',
-      );
+      expect(interception.request.url).to.include('validatedTasks%3D%27tool-calling%27');
     });
   });
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -18,6 +18,7 @@ import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/c
 import { mockCatalogFilterOptionsList } from '~/__mocks__/mockCatalogFilterOptionsList';
 import { SourceLabel, type CatalogSource } from '~/app/modelCatalogTypes';
 import { ModelRegistryMetadataType } from '~/app/types';
+import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
 
 type FilteredModelsInterceptConfig = {
   returnModelsForFilters?: boolean;
@@ -339,6 +340,73 @@ describe('Model Catalog Page', () => {
       const { url } = lastInterception.request;
       expect(url).to.include('tasks%3D%27text-generation%27');
       expect(url).to.include('tensor_type.string_value%3D%27FP16%27');
+      expect(url).to.include('provider%3D%27Google%27');
+    });
+  });
+
+  it('should not display validated configuration filter when feature flag is off', () => {
+    initIntercepts({});
+    modelCatalog.visit();
+    modelCatalog.findFilter('Validated configuration').should('not.exist');
+  });
+
+  it('should display validated configuration filter when feature flag is on', () => {
+    window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
+    initIntercepts({});
+    modelCatalog.visit();
+    modelCatalog
+      .findFilter('Validated configuration')
+      .scrollIntoView()
+      .should('be.visible');
+    modelCatalog
+      .findFilterCheckbox('Validated configuration', 'tool-calling')
+      .should('be.visible');
+  });
+
+  it('validated configuration filter checkbox should work', () => {
+    window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
+    initIntercepts({ includeAllModelsIntercept: true });
+
+    setupFilteredModelsIntercept({
+      returnModelsForFilters: true,
+      modelsToReturn: [mockCatalogModel({})],
+    });
+
+    modelCatalog.visit();
+    modelCatalog
+      .findFilterCheckbox('Validated configuration', 'tool-calling')
+      .scrollIntoView()
+      .click();
+
+    cy.wait('@getFilteredModels').then((interception) => {
+      expect(interception.request.url).to.include(
+        'validatedTasks%3D%27tool-calling%27',
+      );
+    });
+  });
+
+  it('validated configuration filter combined with other filters should work', () => {
+    window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
+
+    initIntercepts({ includeAllModelsIntercept: true });
+
+    setupFilteredModelsIntercept({
+      returnModelsForFilters: true,
+      modelsToReturn: [mockCatalogModel({})],
+    });
+
+    modelCatalog.visit();
+    modelCatalog
+      .findFilterCheckbox('Validated configuration', 'tool-calling')
+      .scrollIntoView()
+      .click();
+    cy.wait('@getFilteredModels');
+
+    modelCatalog.findFilterCheckbox('Provider', 'Google').click();
+
+    cy.wait('@getFilteredModels').then((interception) => {
+      const { url } = interception.request;
+      expect(url).to.include('validatedTasks%3D%27tool-calling%27');
       expect(url).to.include('provider%3D%27Google%27');
     });
   });

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -19,6 +19,7 @@ import { mockCatalogFilterOptionsList } from '~/__mocks__/mockCatalogFilterOptio
 import { SourceLabel, type CatalogSource } from '~/app/modelCatalogTypes';
 import { ModelRegistryMetadataType } from '~/app/types';
 import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
+import { ModelCatalogStringFilterKey } from '~/concepts/modelCatalog/const';
 
 type FilteredModelsInterceptConfig = {
   returnModelsForFilters?: boolean;
@@ -350,57 +351,128 @@ describe('Model Catalog Page', () => {
     modelCatalog.findFilter('Validated configuration').should('not.exist');
   });
 
-  it('should display validated configuration filter when feature flag is on', () => {
-    window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
-    initIntercepts({});
-    modelCatalog.visit();
-    modelCatalog.findFilter('Validated configuration').scrollIntoView().should('be.visible');
-    modelCatalog.findFilterCheckbox('Validated configuration', 'tool-calling').should('be.visible');
-  });
-
-  it('validated configuration filter checkbox should work', () => {
-    window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
-    initIntercepts({ includeAllModelsIntercept: true });
-
-    setupFilteredModelsIntercept({
-      returnModelsForFilters: true,
-      modelsToReturn: [mockCatalogModel({})],
+  describe('Validated Configuration Filter (feature flag on)', () => {
+    beforeEach(() => {
+      window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
     });
 
-    modelCatalog.visit();
-    modelCatalog
-      .findFilterCheckbox('Validated configuration', 'tool-calling')
-      .scrollIntoView()
-      .click();
-
-    cy.wait('@getFilteredModels').then((interception) => {
-      expect(interception.request.url).to.include('validatedTasks%3D%27tool-calling%27');
-    });
-  });
-
-  it('validated configuration filter combined with other filters should work', () => {
-    window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
-
-    initIntercepts({ includeAllModelsIntercept: true });
-
-    setupFilteredModelsIntercept({
-      returnModelsForFilters: true,
-      modelsToReturn: [mockCatalogModel({})],
+    it('should display filter and checkbox', () => {
+      initIntercepts({});
+      modelCatalog.visit();
+      modelCatalog.findFilter('Validated configuration').scrollIntoView().should('be.visible');
+      modelCatalog
+        .findFilterCheckbox('Validated configuration', 'tool-calling')
+        .should('be.visible');
     });
 
-    modelCatalog.visit();
-    modelCatalog
-      .findFilterCheckbox('Validated configuration', 'tool-calling')
-      .scrollIntoView()
-      .click();
-    cy.wait('@getFilteredModels');
+    it('checkbox should filter models', () => {
+      initIntercepts({ includeAllModelsIntercept: true });
+      setupFilteredModelsIntercept({
+        returnModelsForFilters: true,
+        modelsToReturn: [mockCatalogModel({})],
+      });
 
-    modelCatalog.findFilterCheckbox('Provider', 'Google').click();
+      modelCatalog.visit();
+      modelCatalog
+        .findFilterCheckbox('Validated configuration', 'tool-calling')
+        .scrollIntoView()
+        .click();
 
-    cy.wait('@getFilteredModels').then((interception) => {
-      const { url } = interception.request;
-      expect(url).to.include('validatedTasks%3D%27tool-calling%27');
-      expect(url).to.include('provider%3D%27Google%27');
+      cy.wait('@getFilteredModels').then((interception) => {
+        expect(interception.request.url).to.include('validatedTasks%3D%27tool-calling%27');
+      });
+    });
+
+    it('should work combined with other filters', () => {
+      initIntercepts({ includeAllModelsIntercept: true });
+      setupFilteredModelsIntercept({
+        returnModelsForFilters: true,
+        modelsToReturn: [mockCatalogModel({})],
+      });
+
+      modelCatalog.visit();
+      modelCatalog
+        .findFilterCheckbox('Validated configuration', 'tool-calling')
+        .scrollIntoView()
+        .click();
+      cy.wait('@getFilteredModels');
+
+      modelCatalog.findFilterCheckbox('Provider', 'Google').click();
+
+      cy.wait('@getFilteredModels').then((interception) => {
+        const { url } = interception.request;
+        expect(url).to.include('validatedTasks%3D%27tool-calling%27');
+        expect(url).to.include('provider%3D%27Google%27');
+      });
+    });
+
+    it('should not show helper text when only one option exists', () => {
+      initIntercepts({});
+      modelCatalog.visit();
+      modelCatalog
+        .findFilterCheckbox('Validated configuration', 'tool-calling')
+        .scrollIntoView()
+        .click();
+      cy.contains('Showing models with all selected configurations').should('not.exist');
+    });
+
+    describe('with multiple options', () => {
+      const multiOptionFilterOptions = mockCatalogFilterOptionsList({
+        filters: {
+          ...mockCatalogFilterOptionsList().filters,
+          [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: {
+            type: 'string',
+            values: ['tool-calling', 'text-generation', 'question-answering'],
+          },
+        },
+      });
+
+      const initMultiOptionIntercepts = (props: HandlersProps) => {
+        initIntercepts(props);
+        cy.interceptApi(
+          `GET /api/:apiVersion/model_catalog/models/filter_options`,
+          {
+            path: { apiVersion: MODEL_CATALOG_API_VERSION },
+            query: { namespace: 'kubeflow' },
+          },
+          multiOptionFilterOptions,
+        );
+      };
+
+      it('should show helper text when an option is selected', () => {
+        initMultiOptionIntercepts({});
+        modelCatalog.visit();
+        modelCatalog
+          .findFilterCheckbox('Validated configuration', 'tool-calling')
+          .scrollIntoView()
+          .click();
+        cy.contains('Showing models with all selected configurations').should('be.visible');
+      });
+
+      it('should send AND conditions instead of IN for multiple selections', () => {
+        initMultiOptionIntercepts({ includeAllModelsIntercept: true });
+        setupFilteredModelsIntercept({
+          returnModelsForFilters: true,
+          modelsToReturn: [mockCatalogModel({})],
+        });
+
+        modelCatalog.visit();
+        modelCatalog
+          .findFilterCheckbox('Validated configuration', 'tool-calling')
+          .scrollIntoView()
+          .click();
+        cy.wait('@getFilteredModels');
+
+        modelCatalog.findFilterCheckbox('Validated configuration', 'text-generation').click();
+
+        cy.wait('@getFilteredModels').then((interception) => {
+          const { url } = interception.request;
+          expect(url).to.include('validatedTasks%3D%27tool-calling%27');
+          expect(url).to.include('AND');
+          expect(url).to.include('validatedTasks%3D%27text-generation%27');
+          expect(url).to.not.include('IN');
+        });
+      });
     });
   });
 });

--- a/clients/ui/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
+++ b/clients/ui/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
@@ -93,6 +93,7 @@ export const ModelCatalogContext = React.createContext<ModelCatalogContextType>(
     [ModelCatalogStringFilterKey.USE_CASE]: [],
     [ModelCatalogNumberFilterKey.MAX_RPS]: undefined,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: [],
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: [],
   },
   updateSelectedSource: () => undefined,
   selectedSourceLabel: undefined,
@@ -139,6 +140,7 @@ export const ModelCatalogContextProvider: React.FC<ModelCatalogContextProviderPr
     [ModelCatalogStringFilterKey.USE_CASE]: [],
     [ModelCatalogNumberFilterKey.MAX_RPS]: undefined,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: [],
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: [],
   });
   const [filterOptions, filterOptionsLoaded, filterOptionsLoadError] =
     useCatalogFilterOptionList(apiState);
@@ -202,6 +204,7 @@ export const ModelCatalogContextProvider: React.FC<ModelCatalogContextProviderPr
     baseSetFilterData(ModelCatalogStringFilterKey.LICENSE, []);
     baseSetFilterData(ModelCatalogStringFilterKey.LANGUAGE, []);
     baseSetFilterData(ModelCatalogStringFilterKey.TENSOR_TYPE, []);
+    baseSetFilterData(ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION, []);
   }, [baseSetFilterData]);
 
   /**

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -295,6 +295,7 @@ export type ModelCatalogStringFilterValueType = {
   [ModelCatalogStringFilterKey.LICENSE]: string;
   [ModelCatalogStringFilterKey.LANGUAGE]: AllLanguageCode;
   [ModelCatalogStringFilterKey.TENSOR_TYPE]: ModelCatalogTensorType;
+  [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: string;
   [ModelCatalogStringFilterKey.HARDWARE_TYPE]: string;
   [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: string;
   [ModelCatalogStringFilterKey.USE_CASE]: UseCaseOptionValue;
@@ -361,6 +362,7 @@ export type ModelCatalogFilterStates = {
   [ModelCatalogStringFilterKey.LICENSE]: string[];
   [ModelCatalogStringFilterKey.LANGUAGE]: AllLanguageCode[];
   [ModelCatalogStringFilterKey.TENSOR_TYPE]: ModelCatalogTensorType[];
+  [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: string[];
   [ModelCatalogStringFilterKey.HARDWARE_TYPE]: string[];
   [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: string[];
   [ModelCatalogStringFilterKey.USE_CASE]: UseCaseOptionValue[];

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -12,17 +12,22 @@ import TensorTypeFilter from './globalFilters/TensorTypeFilter';
 import ValidatedConfigurationFilter from './globalFilters/ValidatedConfigurationFilter';
 
 const ModelCatalogFilters: React.FC = () => {
-  const { filterOptions, filterOptionsLoaded, filterOptionsLoadError, setFilterData } =
+  const { filterOptions, filterOptionsLoaded, filterOptionsLoadError, filterData, setFilterData } =
     React.useContext(ModelCatalogContext);
   const toolCallingFeatureAvailable = useTempDevFeatureAvailable(
     TempDevFeature.ToolCallingConfiguration,
   );
 
   React.useEffect(() => {
-    if (!toolCallingFeatureAvailable) {
+    if (
+      !toolCallingFeatureAvailable &&
+      filterData[ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION].length > 0
+    ) {
       setFilterData(ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION, []);
     }
-  }, [toolCallingFeatureAvailable, setFilterData]);
+    // Only react to flag changes, not filterData changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolCallingFeatureAvailable]);
 
   const filters = filterOptions?.filters;
   if (!filterOptionsLoaded) {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -2,10 +2,7 @@ import * as React from 'react';
 import { Stack, Spinner, Alert } from '@patternfly/react-core';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { ModelCatalogStringFilterKey } from '~/concepts/modelCatalog/const';
-import {
-  TempDevFeature,
-  useTempDevFeatureAvailable,
-} from '~/app/hooks/useTempDevFeatureAvailable';
+import { TempDevFeature, useTempDevFeatureAvailable } from '~/app/hooks/useTempDevFeatureAvailable';
 import ModelPerformanceViewToggleCard from './ModelPerformanceViewToggleCard';
 import TaskFilter from './globalFilters/TaskFilter';
 import ProviderFilter from './globalFilters/ProviderFilter';

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -12,11 +12,18 @@ import TensorTypeFilter from './globalFilters/TensorTypeFilter';
 import ValidatedConfigurationFilter from './globalFilters/ValidatedConfigurationFilter';
 
 const ModelCatalogFilters: React.FC = () => {
-  const { filterOptions, filterOptionsLoaded, filterOptionsLoadError } =
+  const { filterOptions, filterOptionsLoaded, filterOptionsLoadError, setFilterData } =
     React.useContext(ModelCatalogContext);
   const toolCallingFeatureAvailable = useTempDevFeatureAvailable(
     TempDevFeature.ToolCallingConfiguration,
   );
+
+  React.useEffect(() => {
+    if (!toolCallingFeatureAvailable) {
+      setFilterData(ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION, []);
+    }
+  }, [toolCallingFeatureAvailable, setFilterData]);
+
   const filters = filterOptions?.filters;
   if (!filterOptionsLoaded) {
     return <Spinner />;

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -2,16 +2,24 @@ import * as React from 'react';
 import { Stack, Spinner, Alert } from '@patternfly/react-core';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { ModelCatalogStringFilterKey } from '~/concepts/modelCatalog/const';
+import {
+  TempDevFeature,
+  useTempDevFeatureAvailable,
+} from '~/app/hooks/useTempDevFeatureAvailable';
 import ModelPerformanceViewToggleCard from './ModelPerformanceViewToggleCard';
 import TaskFilter from './globalFilters/TaskFilter';
 import ProviderFilter from './globalFilters/ProviderFilter';
 import LicenseFilter from './globalFilters/LicenseFilter';
 import LanguageFilter from './globalFilters/LanguageFilter';
 import TensorTypeFilter from './globalFilters/TensorTypeFilter';
+import ValidatedConfigurationFilter from './globalFilters/ValidatedConfigurationFilter';
 
 const ModelCatalogFilters: React.FC = () => {
   const { filterOptions, filterOptionsLoaded, filterOptionsLoadError } =
     React.useContext(ModelCatalogContext);
+  const toolCallingFeatureAvailable = useTempDevFeatureAvailable(
+    TempDevFeature.ToolCallingConfiguration,
+  );
   const filters = filterOptions?.filters;
   if (!filterOptionsLoaded) {
     return <Spinner />;
@@ -31,6 +39,11 @@ const ModelCatalogFilters: React.FC = () => {
     <Stack hasGutter>
       <ModelPerformanceViewToggleCard />
       <TaskFilter filters={getFilterProps(ModelCatalogStringFilterKey.TASK)} />
+      {toolCallingFeatureAvailable && (
+        <ValidatedConfigurationFilter
+          filters={getFilterProps(ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION)}
+        />
+      )}
       <ProviderFilter filters={getFilterProps(ModelCatalogStringFilterKey.PROVIDER)} />
       <LicenseFilter filters={getFilterProps(ModelCatalogStringFilterKey.LICENSE)} />
       <LanguageFilter filters={getFilterProps(ModelCatalogStringFilterKey.LANGUAGE)} />

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ValidatedConfigurationFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ValidatedConfigurationFilter.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { Divider, StackItem } from '@patternfly/react-core';
+import { Content, ContentVariants, Divider, StackItem } from '@patternfly/react-core';
 import ModelCatalogStringFilter from '~/app/pages/modelCatalog/components/ModelCatalogStringFilter';
+import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import {
   ModelCatalogStringFilterKey,
-  MODEL_CATALOG_TASK_NAME_MAPPING,
+  MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING,
 } from '~/concepts/modelCatalog/const';
 import { CatalogFilterOptions, ModelCatalogStringFilterOptions } from '~/app/modelCatalogTypes';
 
@@ -14,7 +15,11 @@ type ValidatedConfigurationFilterProps = {
 };
 
 const ValidatedConfigurationFilter: React.FC<ValidatedConfigurationFilterProps> = ({ filters }) => {
+  const { filterData } = React.useContext(ModelCatalogContext);
   const validatedConfiguration = filters?.[filterKey];
+  const filterValues = validatedConfiguration?.values ?? [];
+  const hasMultipleOptions = filterValues.length > 1;
+  const hasSelection = filterData[filterKey].length > 0;
 
   if (!validatedConfiguration) {
     return null;
@@ -26,9 +31,14 @@ const ValidatedConfigurationFilter: React.FC<ValidatedConfigurationFilterProps> 
         <ModelCatalogStringFilter<ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION>
           title="Validated configuration"
           filterKey={filterKey}
-          filterToNameMapping={MODEL_CATALOG_TASK_NAME_MAPPING}
+          filterToNameMapping={MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING}
           filters={validatedConfiguration}
         />
+        {hasMultipleOptions && hasSelection && (
+          <Content component={ContentVariants.small} className="pf-v6-u-mt-sm">
+            Showing models with all selected configurations
+          </Content>
+        )}
       </StackItem>
       <Divider />
     </>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ValidatedConfigurationFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ValidatedConfigurationFilter.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Divider, StackItem } from '@patternfly/react-core';
+import ModelCatalogStringFilter from '~/app/pages/modelCatalog/components/ModelCatalogStringFilter';
+import {
+  ModelCatalogStringFilterKey,
+  MODEL_CATALOG_TASK_NAME_MAPPING,
+} from '~/concepts/modelCatalog/const';
+import { CatalogFilterOptions, ModelCatalogStringFilterOptions } from '~/app/modelCatalogTypes';
+
+const filterKey = ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION;
+
+type ValidatedConfigurationFilterProps = {
+  filters?: Extract<CatalogFilterOptions, Partial<ModelCatalogStringFilterOptions>>;
+};
+
+const ValidatedConfigurationFilter: React.FC<ValidatedConfigurationFilterProps> = ({ filters }) => {
+  const validatedConfiguration = filters?.[filterKey];
+
+  if (!validatedConfiguration) {
+    return null;
+  }
+
+  return (
+    <>
+      <StackItem>
+        <ModelCatalogStringFilter<ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION>
+          title="Validated configuration"
+          filterKey={filterKey}
+          filterToNameMapping={MODEL_CATALOG_TASK_NAME_MAPPING}
+          filters={validatedConfiguration}
+        />
+      </StackItem>
+      <Divider />
+    </>
+  );
+};
+
+export default ValidatedConfigurationFilter;

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -174,6 +174,10 @@ describe('filtersToFilterQuery', () => {
           ModelCatalogTensorType.MXFP4,
         ],
       },
+      [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: {
+        type: 'string',
+        values: ['tool-calling', 'text-generation', 'question-answering'],
+      },
       [ModelCatalogStringFilterKey.HARDWARE_TYPE]: {
         type: 'string',
         values: ['GPU', 'CPU', 'TPU', 'FPGA'],
@@ -351,6 +355,38 @@ describe('filtersToFilterQuery', () => {
         ),
       ).toBe(
         "tasks='text-to-text' AND provider='Google' AND tensor_type.string_value IN ('FP16','INT8')",
+      );
+    });
+  });
+
+  describe('match-all (AND logic) filters', () => {
+    it('handles a single validated configuration value', () => {
+      expect(
+        filtersToFilterQuery(mockFormData({ validatedTasks: ['tool-calling'] }), mockFilterOptions),
+      ).toBe("validatedTasks='tool-calling'");
+    });
+
+    it('handles multiple validated configuration values with AND logic instead of IN', () => {
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ validatedTasks: ['tool-calling', 'text-generation'] }),
+          mockFilterOptions,
+        ),
+      ).toBe("validatedTasks='tool-calling' AND validatedTasks='text-generation'");
+    });
+
+    it('handles validated configuration combined with other OR-logic filters', () => {
+      expect(
+        filtersToFilterQuery(
+          mockFormData({
+            tasks: [ModelCatalogTask.TEXT_TO_TEXT, ModelCatalogTask.IMAGE_TO_TEXT],
+            validatedTasks: ['tool-calling', 'text-generation'],
+            provider: [ModelCatalogProvider.GOOGLE],
+          }),
+          mockFilterOptions,
+        ),
+      ).toBe(
+        "tasks IN ('text-to-text','image-to-text') AND provider='Google' AND validatedTasks='tool-calling' AND validatedTasks='text-generation'",
       );
     });
   });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -54,6 +54,7 @@ describe('filtersToFilterQuery', () => {
     hardware_configuration = [],
     use_case = [],
     tensor_type = [],
+    validatedTasks = [],
     rps_mean = undefined,
     ttft_mean = undefined,
   }: {
@@ -66,6 +67,7 @@ describe('filtersToFilterQuery', () => {
     use_case?: UseCaseOptionValue[];
     rps_mean?: number;
     tensor_type?: ModelCatalogTensorType[];
+    validatedTasks?: string[];
     ttft_mean?: number;
   }): ModelCatalogFilterStates => ({
     [ModelCatalogStringFilterKey.TASK]: tasks,
@@ -77,6 +79,7 @@ describe('filtersToFilterQuery', () => {
     [ModelCatalogStringFilterKey.USE_CASE]: use_case,
     [ModelCatalogNumberFilterKey.MAX_RPS]: rps_mean,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: tensor_type,
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: validatedTasks,
     'artifacts.ttft_mean.double_value': ttft_mean,
   });
 
@@ -803,6 +806,7 @@ describe('hasFiltersApplied', () => {
     use_case = [],
     tensor_type = [],
     rps_mean = undefined,
+    validatedTasks = [],
     ttft_mean = undefined,
   }: {
     tasks?: ModelCatalogTask[];
@@ -813,6 +817,7 @@ describe('hasFiltersApplied', () => {
     hardware_configuration?: string[];
     use_case?: UseCaseOptionValue[];
     tensor_type?: ModelCatalogTensorType[];
+    validatedTasks?: string[];
     rps_mean?: number;
     ttft_mean?: number;
   }): ModelCatalogFilterStates => ({
@@ -825,6 +830,7 @@ describe('hasFiltersApplied', () => {
     [ModelCatalogStringFilterKey.USE_CASE]: use_case,
     [ModelCatalogNumberFilterKey.MAX_RPS]: rps_mean,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: tensor_type,
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: validatedTasks,
     'artifacts.ttft_mean.double_value': ttft_mean,
   });
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -34,6 +34,7 @@ import {
   CatalogModelCustomPropertyKey,
   ModelType,
   ModelCatalogTask,
+  MATCH_ALL_FILTER_KEYS,
 } from '~/concepts/modelCatalog/const';
 import { isSourceStatusWithModels } from '~/concepts/modelCatalogSettings/const';
 import { ModelRegistryCustomProperties, ModelRegistryMetadataType } from '~/app/types';
@@ -350,6 +351,10 @@ const wrapInQuotes = (v: string): string => `'${v.replace(/'/g, "''")}'`;
 const eqFilter = (k: string, v: string) => `${k}=${wrapInQuotes(v)}`;
 const inFilter = (k: string, values: string[]) =>
   `${k} IN (${values.map((v) => wrapInQuotes(v)).join(',')})`;
+const andFilter = (k: string, values: string[]) => values.map((v) => eqFilter(k, v)).join(' AND ');
+
+const isMatchAllFilter = (filterId: string): boolean =>
+  MATCH_ALL_FILTER_KEYS.some((key) => key === filterId);
 
 /**
  * Check if a filter key has the artifacts.* prefix.
@@ -443,7 +448,7 @@ const serializeFilterEntry = (
       case 1:
         return eqFilter(queryKey, data[0]);
       default:
-        return inFilter(queryKey, data);
+        return isMatchAllFilter(filterId) ? andFilter(queryKey, data) : inFilter(queryKey, data);
     }
   }
 

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -189,7 +189,10 @@ export enum ValidatedConfiguration {
   TOOL_CALLING = 'tool-calling',
 }
 
-export const MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING: Record<string, string> = {
+export const MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING: Record<
+  ValidatedConfiguration,
+  string
+> = {
   [ValidatedConfiguration.TOOL_CALLING]: 'Tool calling',
 };
 

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -185,6 +185,14 @@ export const MODEL_CATALOG_TASK_NAME_MAPPING = {
   [ModelCatalogTask.VIDEO_TO_TEXT]: 'Video-to-text',
 };
 
+export enum ValidatedConfiguration {
+  TOOL_CALLING = 'tool-calling',
+}
+
+export const MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING: Record<string, string> = {
+  [ValidatedConfiguration.TOOL_CALLING]: 'Tool calling',
+};
+
 export const MODEL_CATALOG_TASK_DESCRIPTION = {
   [ModelCatalogTask.AUDIO_TO_TEXT]: 'Audio transcription and speech recognition models',
   [ModelCatalogTask.IMAGE_TEXT_TO_TEXT]: 'Multimodal models that process both images and text',
@@ -444,6 +452,16 @@ export const BASIC_FILTER_KEYS: ModelCatalogFilterKey[] = [
   ModelCatalogStringFilterKey.TASK,
   ModelCatalogStringFilterKey.LANGUAGE,
   ModelCatalogStringFilterKey.TENSOR_TYPE,
+  ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION,
+];
+
+/**
+ * Filters that use AND logic when multiple values are selected.
+ * Standard filters use OR (IN operator): items matching ANY selected value.
+ * AND filters require items to match ALL selected values.
+ * Add a filter key here to switch it from OR to AND behavior.
+ */
+export const MATCH_ALL_FILTER_KEYS: ModelCatalogStringFilterKey[] = [
   ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION,
 ];
 

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -4,6 +4,7 @@ export enum ModelCatalogStringFilterKey {
   LICENSE = 'license',
   LANGUAGE = 'language',
   TENSOR_TYPE = 'tensor_type.string_value',
+  VALIDATED_CONFIGURATION = 'validatedTasks',
   // Performance filter keys use backend format
   HARDWARE_TYPE = 'artifacts.hardware_type.string_value',
   HARDWARE_CONFIGURATION = 'artifacts.hardware_configuration.string_value',
@@ -443,6 +444,7 @@ export const BASIC_FILTER_KEYS: ModelCatalogFilterKey[] = [
   ModelCatalogStringFilterKey.TASK,
   ModelCatalogStringFilterKey.LANGUAGE,
   ModelCatalogStringFilterKey.TENSOR_TYPE,
+  ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION,
 ];
 
 /**
@@ -549,6 +551,7 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
   [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: 'Hardware',
   [ModelCatalogStringFilterKey.USE_CASE]: 'Workload type',
   [ModelCatalogStringFilterKey.TENSOR_TYPE]: 'Tensor type',
+  [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: 'Validated configuration',
   // Number filter keys
   [ModelCatalogNumberFilterKey.MAX_RPS]: 'Max RPS',
   // Latency field names - all use "Latency" as category name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to add new filter section called validated configuration to the model catalog filter section

<img width="605" height="715" alt="Screenshot 2026-05-13 at 6 02 40 PM" src="https://github.com/user-attachments/assets/c72cb2d5-2552-4f93-8376-725dd1998eac" />


## How Has This Been Tested?
Turn on the temporary feature flag on console and you will see the Validated configuration filter section on model catalog landing page

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
