### PR TITLE
fix(manifests): upstream Istio AuthorizationPolicy from kubeflow/manifests

### DIFF
--- a/manifests/kustomize/options/istio/istio-authorization-policy.yaml
+++ b/manifests/kustomize/options/istio/istio-authorization-policy.yaml
@@ -8,4 +8,20 @@ spec:
     matchLabels:
       component: model-registry-server
   rules:
-  - {}
+  # Allow all requests from the ingress gateway.
+  # External users are authenticated by oauth2-proxy/authservice at the gateway,
+  # which injects the kubeflow-userid header.
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
+  # Allow internal requests with a valid Kubernetes JWT (authorization header)
+  # but strictly block any request that also carries a kubeflow-userid header,
+  # preventing identity spoofing from within the cluster.
+  - when:
+    - key: request.headers[authorization]
+      values:
+      - "*"
+    - key: request.headers[kubeflow-userid]
+      notValues:
+      - "*"


### PR DESCRIPTION
Port the AuthorizationPolicy rules added in kubeflow/manifests#3318 back to this repo so future manifest syncs don't regress the fix.

Replaces the permissive allow-all rule with proper Kubeflow-aware rules:
- Allow requests from the Istio ingress gateway (authenticated by oauth2-proxy)
- Allow internal requests with a valid K8s JWT but block identity spoofing via kubeflow-userid header

Relates-to: https://github.com/kubeflow/manifests/issues/3457
Relates-to: https://github.com/kubeflow/manifests/pull/3318

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
