### PR TITLE
fix(manifests): add namespace: kubeflow to kustomization overlays and add namespace regression check

### DIFF
--- a/manifests/kustomize/check-namespace.sh
+++ b/manifests/kustomize/check-namespace.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Verify that kustomize build output for all overlays sets namespace: kubeflow
+# and does not produce resources in the default namespace.
+#
+# Usage: ./check-namespace.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KUSTOMIZE_DIR="${SCRIPT_DIR}"
+
+OVERLAYS=(
+  "overlays/postgres"
+  "options/istio"
+  "options/ui/overlays/istio"
+  "options/catalog/overlays/demo"
+)
+
+EXIT_CODE=0
+
+for overlay in "${OVERLAYS[@]}"; do
+  overlay_path="${KUSTOMIZE_DIR}/${overlay}"
+
+  if [ ! -d "${overlay_path}" ]; then
+    echo "SKIP: ${overlay} (directory not found)"
+    continue
+  fi
+
+  echo "Checking ${overlay}..."
+
+  output=$(kustomize build "${overlay_path}" 2>&1) || {
+    echo "FAIL: kustomize build failed for ${overlay}"
+    EXIT_CODE=1
+    continue
+  }
+
+  # Check for resources landing in the default namespace
+  default_ns_resources=$(echo "${output}" | grep -c '^\s*namespace: default$' || true)
+  if [ "${default_ns_resources}" -gt 0 ]; then
+    echo "FAIL: ${overlay} produces ${default_ns_resources} resource(s) with namespace: default"
+    EXIT_CODE=1
+  fi
+
+  # Verify namespace: kubeflow is present in the kustomization
+  if ! grep -q 'namespace: kubeflow' "${overlay_path}/kustomization.yaml"; then
+    echo "FAIL: ${overlay}/kustomization.yaml is missing 'namespace: kubeflow'"
+    EXIT_CODE=1
+  else
+    echo "PASS: ${overlay}"
+  fi
+done
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo ""
+  echo "All overlays correctly set namespace: kubeflow"
+else
+  echo ""
+  echo "ERROR: namespace check failed — see above"
+fi
+
+exit "${EXIT_CODE}"

--- a/manifests/kustomize/options/catalog/overlays/demo/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/kustomization.yaml
@@ -70,3 +70,5 @@ patches:
             capabilities:
               drop:
                 - ALL
+
+namespace: kubeflow

--- a/manifests/kustomize/options/istio/kustomization.yaml
+++ b/manifests/kustomize/options/istio/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 - istio-authorization-policy.yaml
 - destination-rule.yaml
 - virtual-service.yaml
+
+namespace: kubeflow

--- a/manifests/kustomize/overlays/postgres/kustomization.yaml
+++ b/manifests/kustomize/overlays/postgres/kustomization.yaml
@@ -41,3 +41,5 @@ replacements:
       kind: Deployment
       name: model-registry-deployment
       version: v1
+
+namespace: kubeflow


### PR DESCRIPTION
## Summary

Three of the four kustomization overlays consumed by `kubeflow/manifests` `example/kustomization.yaml` were missing the `namespace: kubeflow` directive. This causes all model-registry, istio networking, and catalog resources to deploy into the `default` namespace instead of `kubeflow` when using `kustomize build`.

This pull request adds `namespace: kubeflow` to the three affected overlays and introduces a namespace regression check script to prevent recurrence.

Fixes https://github.com/kubeflow/manifests/issues/3457  
Supersedes https://github.com/kubeflow/manifests/pull/3458 (closed per maintainer direction to fix upstream)

## Root Cause

The CI install script (`model_registry_install.sh`) passes `-n kubeflow` to `kubectl apply`, which overrides the namespace at apply-time. This masked the fact that the kustomization overlays themselves had no `namespace` directive. When users follow the documented deployment path (`kustomize build example/ | kubectl apply -f -`), there is no namespace override — all resources land in the `default` namespace.

This was confirmed by `istioctl analyze` output showing VirtualService and DestinationRule reference errors in the `default` namespace.

## Changes

| File | Change |
|---|---|
| `manifests/kustomize/overlays/postgres/kustomization.yaml` | Add `namespace: kubeflow` |
| `manifests/kustomize/options/istio/kustomization.yaml` | Add `namespace: kubeflow` |
| `manifests/kustomize/options/catalog/overlays/demo/kustomization.yaml` | Add `namespace: kubeflow` |
| `manifests/kustomize/check-namespace.sh` | New — namespace regression check script |

No change needed for `options/ui/overlays/istio/kustomization.yaml` — it already has `namespace: kubeflow`.

## Design Decisions

- **Placement:** The `namespace: kubeflow` directive is placed at the bottom of each file, consistent with the existing pattern in `options/ui/overlays/istio/kustomization.yaml`.
- **Regression check:** `check-namespace.sh` iterates over all four overlays, verifies each `kustomization.yaml` contains `namespace: kubeflow`, and checks that `kustomize build` output does not produce resources with `namespace: default`. This was explicitly requested by @jonburdo and @juliusvonkohout in https://github.com/kubeflow/manifests/pull/3458.
- **Upstream-first:** This fix is raised here in `kubeflow/hub` (the source of truth) rather than in `kubeflow/manifests`, where the `upstream/` folder is overwritten on every sync. Precedent: https://github.com/kubeflow/hub/pull/2706.

## Dependencies and Related Issues

- https://github.com/kubeflow/manifests/issues/3457 — original issue report
- https://github.com/kubeflow/manifests/pull/3458 — closed downstream pull request (maintainers directed upstream fix)
- https://github.com/kubeflow/manifests/pull/3450 — renamed `applications/model-registry` to `applications/hub` and synced v0.3.9
- https://github.com/kubeflow/hub/pull/2706 — precedent for upstream-first fix pattern

## Contributor Checklist

- [x] DCO sign-off included
- [x] AI assistance disclosed (`Assisted-by: Antigravity AI` in commit message)
- [x] Matches existing codebase pattern (`options/ui/overlays/istio/kustomization.yaml`)
- [x] Minimal scope — only the 3 files that need the fix plus 1 regression check
- [x] Root cause identified and stated in one sentence
- [x] Namespace regression check added per maintainer request

cc @tarilabs @pboyd
