### PR TITLE
fix(ui): remove _lastModified workaround from timestamp bump utils

### DIFF
--- a/clients/ui/frontend/src/app/api/__tests__/updateTimestamps.test.ts
+++ b/clients/ui/frontend/src/app/api/__tests__/updateTimestamps.test.ts
@@ -1,11 +1,5 @@
 import { mockModelVersion, mockRegisteredModel } from '~/__mocks__';
-import {
-  ModelRegistryAPIs,
-  ModelState,
-  ModelRegistryMetadataType,
-  ModelVersion,
-  RegisteredModel,
-} from '~/app/types';
+import { ModelRegistryAPIs, ModelState, ModelVersion, RegisteredModel } from '~/app/types';
 import {
   bumpModelVersionTimestamp,
   bumpRegisteredModelTimestamp,
@@ -36,10 +30,6 @@ describe('updateTimestamps', () => {
   const fakeModelVersionId = 'test-model-version-id';
   const fakeRegisteredModelId = 'test-registered-model-id';
 
-  beforeEach(() => {
-    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-01-01T00:00:00.000Z');
-  });
-
   describe('bumpModelVersionTimestamp', () => {
     it('should successfully update model version timestamp', async () => {
       await bumpModelVersionTimestamp(mockApi, mockModelVersion({ id: fakeModelVersionId }));
@@ -48,59 +38,6 @@ describe('updateTimestamps', () => {
         {},
         {
           state: ModelState.LIVE,
-          customProperties: {
-            _lastModified: {
-              metadataType: ModelRegistryMetadataType.STRING,
-              // eslint-disable-next-line camelcase
-              string_value: '2024-01-01T00:00:00.000Z',
-            },
-          },
-        },
-        fakeModelVersionId,
-      );
-    });
-
-    it('should successfully update model version timestamp with customProperties of version', async () => {
-      await bumpModelVersionTimestamp(
-        mockApi,
-        mockModelVersion({
-          id: fakeModelVersionId,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-          },
-        }),
-      );
-
-      expect(mockApi.patchModelVersion).toHaveBeenCalledWith(
-        {},
-        {
-          state: ModelState.LIVE,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            _lastModified: {
-              metadataType: ModelRegistryMetadataType.STRING,
-              // eslint-disable-next-line camelcase
-              string_value: '2024-01-01T00:00:00.000Z',
-            },
-          },
         },
         fakeModelVersionId,
       );
@@ -125,52 +62,6 @@ describe('updateTimestamps', () => {
   });
 
   describe('bumpRegisteredModelTimestamp', () => {
-    it('should successfully update registered model timestamp with model customProperties', async () => {
-      await bumpRegisteredModelTimestamp(
-        mockApi,
-        mockRegisteredModel({
-          id: fakeRegisteredModelId,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-          },
-        }),
-      );
-
-      expect(mockApi.patchRegisteredModel).toHaveBeenCalledWith(
-        {},
-        {
-          state: ModelState.LIVE,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            _lastModified: {
-              metadataType: ModelRegistryMetadataType.STRING,
-              // eslint-disable-next-line camelcase
-              string_value: '2024-01-01T00:00:00.000Z',
-            },
-          },
-        },
-        fakeRegisteredModelId,
-      );
-    });
-
     it('should successfully update registered model timestamp', async () => {
       await bumpRegisteredModelTimestamp(
         mockApi,
@@ -183,13 +74,6 @@ describe('updateTimestamps', () => {
         {},
         {
           state: ModelState.LIVE,
-          customProperties: {
-            _lastModified: {
-              metadataType: ModelRegistryMetadataType.STRING,
-              // eslint-disable-next-line camelcase
-              string_value: '2024-01-01T00:00:00.000Z',
-            },
-          },
         },
         fakeRegisteredModelId,
       );
@@ -234,49 +118,6 @@ describe('updateTimestamps', () => {
           id: fakeRegisteredModelId,
         }),
         mockModelVersion({ id: fakeModelVersionId }),
-      );
-
-      expect(mockApi.patchModelVersion).toHaveBeenCalled();
-      expect(mockApi.patchRegisteredModel).toHaveBeenCalled();
-    });
-
-    it('should update both timestamps successfully with both model and version customProperties', async () => {
-      mockApi.patchModelVersion.mockResolvedValue({} as ModelVersion);
-      mockApi.patchRegisteredModel.mockResolvedValue({} as RegisteredModel);
-
-      await bumpBothTimestamps(
-        mockApi,
-
-        mockRegisteredModel({
-          id: fakeRegisteredModelId,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-          },
-        }),
-        mockModelVersion({
-          id: fakeModelVersionId,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test-version',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-          },
-        }),
       );
 
       expect(mockApi.patchModelVersion).toHaveBeenCalled();

--- a/clients/ui/frontend/src/app/api/updateTimestamps.ts
+++ b/clients/ui/frontend/src/app/api/updateTimestamps.ts
@@ -1,10 +1,4 @@
-import {
-  ModelRegistryAPIs,
-  ModelState,
-  ModelRegistryMetadataType,
-  ModelVersion,
-  RegisteredModel,
-} from '~/app/types';
+import { ModelRegistryAPIs, ModelState, ModelVersion, RegisteredModel } from '~/app/types';
 
 type MinimalModelRegistryAPI = Pick<ModelRegistryAPIs, 'patchRegisteredModel'>;
 
@@ -17,21 +11,10 @@ export const bumpModelVersionTimestamp = async (
   }
 
   try {
-    const currentTime = new Date().toISOString();
     await api.patchModelVersion(
       {},
       {
-        // This is a workaround to update the timestamp on the backend. There is a bug opened for model registry team
-        // to fix this issue.
         state: ModelState.LIVE,
-        customProperties: {
-          ...modelVersion.customProperties,
-          _lastModified: {
-            metadataType: ModelRegistryMetadataType.STRING,
-            // eslint-disable-next-line camelcase
-            string_value: currentTime,
-          },
-        },
       },
       modelVersion.id,
     );
@@ -53,21 +36,10 @@ export const bumpRegisteredModelTimestamp = async (
   }
 
   try {
-    const currentTime = new Date().toISOString();
     await api.patchRegisteredModel(
       {},
       {
         state: ModelState.LIVE,
-        customProperties: {
-          ...registeredModel.customProperties,
-          // This is a workaround to update the timestamp on the backend. There is a bug opened for model registry team
-          // to fix this issue.
-          _lastModified: {
-            metadataType: ModelRegistryMetadataType.STRING,
-            // eslint-disable-next-line camelcase
-            string_value: currentTime,
-          },
-        },
       },
       registeredModel.id,
     );

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -88,8 +88,7 @@ export const getProperties = <T extends ModelRegistryCustomProperties>(
 ): ModelRegistryEditableCustomProperties => {
   const initial: ModelRegistryEditableCustomProperties = {};
   return Object.keys(customProperties).reduce((acc, key) => {
-    // _lastModified is a property that is required to update the timestamp on the backend and we have a workaround for it. It should be resolved by
-    // backend team
+    // _lastModified was used by a previous workaround and may still exist on older models; filter it out so users don't see it
     if (
       key === '_lastModified' ||
       key === CatalogModelCustomPropertyKey.MODEL_TYPE ||


### PR DESCRIPTION
## Description

The MR API previously had a bug where PATCH calls didn't always update `lastUpdateTimeSinceEpoch` for RegisteredModels and ModelVersions. A workaround was added in the frontend that injected a `_lastModified` custom property into the PATCH body to force a timestamp update.

Now that the backend correctly updates `lastUpdateTimeSinceEpoch` on every PATCH call (via the generic repository `Save` method), this workaround is no longer needed.

### Changes

- Removed the `customProperties` object (including `_lastModified`) from `bumpModelVersionTimestamp` and `bumpRegisteredModelTimestamp` in `updateTimestamps.ts`. Both now send only `{ state: ModelState.LIVE }`.
- Updated tests to match the simplified behavior and removed tests that specifically verified the workaround's `customProperties` spreading.
- Updated the comment on the `_lastModified` filter in `getProperties` (`utils.ts`) to reflect it's now a legacy filter. The filter is **intentionally kept** so existing models don't suddenly show a confusing `_lastModified` property after upgrade.

## How Has This Been Tested?

- Ran `updateTimestamps.test.ts` — all 8 tests pass
- Ran `utils.spec.ts` — all 66 tests pass (including the `_lastModified` filter test)

To verify end-to-end: edit the details of a ModelVersion (e.g. change its description, labels, or properties) and verify that its associated RegisteredModel has its last modified time updated and appears at the top of the list when sorting by last modified time.

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.