### PR TITLE
ci: add mod-arch packages group to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,7 @@ updates:
     directory: "/clients/ui/frontend/"
     schedule:
       interval: "weekly"
+    groups:
+      mod-arch:
+        patterns:
+          - "mod-arch-*"


### PR DESCRIPTION
## Description

Add a `groups` configuration for `mod-arch-*` packages in `.github/dependabot.yml` so that `mod-arch-core`, `mod-arch-shared`, and `mod-arch-kubeflow` are updated together in a single PR.

Currently, dependabot may create separate PRs for each mod-arch package or not pick them up effectively. Grouping them ensures they are bumped in sync since they are released together from [opendatahub-io/mod-arch-library](https://github.com/opendatahub-io/mod-arch-library).

## How Has This Been Tested?

This is a configuration-only change. Verified YAML syntax is correct.

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.