### PR TITLE
Fix the model type selector in model catalog 

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -448,6 +448,14 @@ class ModelCatalog {
       name: /View all models with performance data/i,
     });
   }
+
+  findRegisterModelButton() {
+    return cy.findByTestId('register-model-button');
+  }
+
+  findModelTypeSelect() {
+    return cy.findByTestId('register-model-type-select');
+  }
 }
 
 export const modelCatalog = new ModelCatalog();

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { mockModArchResponse } from 'mod-arch-core';
 import { modelCatalog } from '~/__tests__/cypress/cypress/pages/modelCatalog';
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
 import {
@@ -8,8 +9,12 @@ import {
   interceptPerformanceArtifactsList,
 } from '~/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog';
 import { mockCatalogModelArtifact, mockCatalogModel } from '~/__mocks__';
+import { mockRegisteredModelList } from '~/__mocks__/mockRegisteredModelsList';
 import { ModelRegistryMetadataType } from '~/app/types';
-import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import {
+  MODEL_CATALOG_API_VERSION,
+  MODEL_REGISTRY_API_VERSION,
+} from '~/__tests__/cypress/cypress/support/commands/api';
 import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
 import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
 
@@ -377,5 +382,124 @@ describe('Model Catalog Details Page - Validated Configurations Card', () => {
       modelCatalog.findBreadcrumb().should('exist');
       modelCatalog.findValidatedConfigurationsCard().should('not.exist');
     });
+  });
+});
+
+describe('Model Catalog Registration - Model Type Field', () => {
+  const modelArtifacts = {
+    items: [
+      mockCatalogModelArtifact({ uri: 'oci://quay.io/test-org/test-model:latest' }),
+    ],
+    size: 1,
+    pageSize: 10,
+    nextPageToken: '',
+  };
+
+  const interceptRegisteredModels = () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: new RegExp(
+          `/model-registry/api/${MODEL_REGISTRY_API_VERSION}/model_registry/modelregistry-sample/registered_models`,
+        ),
+      },
+      mockModArchResponse(mockRegisteredModelList({ items: [], size: 0 })),
+    ).as('getRegisteredModels');
+  };
+
+  const navigateToRegisterPage = () => {
+    modelCatalog.visit();
+    modelCatalog.findLoadingState().should('not.exist');
+    modelCatalog.findModelCatalogDetailLink().first().click();
+    modelCatalog.findBreadcrumb().should('exist');
+    modelCatalog.findRegisterModelButton().click();
+    cy.findByTestId('app-page-title').should('contain.text', 'Register');
+  };
+
+  const interceptModelRegistries = () => {
+    cy.interceptApi(
+      'GET /api/:apiVersion/model_registry',
+      { path: { apiVersion: MODEL_REGISTRY_API_VERSION } },
+      [mockModelRegistry({ name: 'modelregistry-sample' })],
+    ).as('getModelRegistries');
+  };
+
+  it('should show "Unknown" and be disabled when model has model_type "unknown"', () => {
+    interceptModelRegistries();
+
+    setupModelCatalogIntercepts({
+      customNonValidatedModel: mockCatalogModel({
+        name: 'unknown-type-model',
+        customProperties: {
+          model_type: {
+            metadataType: ModelRegistryMetadataType.STRING,
+            string_value: 'unknown',
+          },
+        },
+      }),
+    });
+    interceptArtifactsList(modelArtifacts);
+    interceptRegisteredModels();
+
+    navigateToRegisterPage();
+
+    modelCatalog.findModelTypeSelect().should('contain.text', 'Unknown');
+    modelCatalog.findModelTypeSelect().should('be.disabled');
+  });
+
+  it('should default to "Unknown" and be disabled when model has no model_type', () => {
+    interceptModelRegistries();
+
+    setupModelCatalogIntercepts({
+      customNonValidatedModel: mockCatalogModel({
+        name: 'no-type-model',
+        customProperties: {},
+      }),
+    });
+    interceptArtifactsList(modelArtifacts);
+    interceptRegisteredModels();
+
+    navigateToRegisterPage();
+
+    modelCatalog.findModelTypeSelect().should('contain.text', 'Unknown');
+    modelCatalog.findModelTypeSelect().should('be.disabled');
+  });
+
+  it('should show "Generative AI model" and be disabled when model has model_type "generative"', () => {
+    interceptModelRegistries();
+
+    setupModelCatalogIntercepts({});
+    interceptArtifactsList(modelArtifacts);
+    interceptRegisteredModels();
+
+    navigateToRegisterPage();
+
+    modelCatalog
+      .findModelTypeSelect()
+      .should('contain.text', 'Generative AI model (Example, LLM)');
+    modelCatalog.findModelTypeSelect().should('be.disabled');
+  });
+
+  it('should show "Predictive Model" and be disabled when model has model_type "predictive"', () => {
+    interceptModelRegistries();
+
+    setupModelCatalogIntercepts({
+      customNonValidatedModel: mockCatalogModel({
+        name: 'predictive-model',
+        customProperties: {
+          model_type: {
+            metadataType: ModelRegistryMetadataType.STRING,
+            string_value: 'predictive',
+          },
+        },
+      }),
+    });
+    interceptArtifactsList(modelArtifacts);
+    interceptRegisteredModels();
+
+    navigateToRegisterPage();
+
+    modelCatalog.findModelTypeSelect().should('contain.text', 'Predictive Model');
+    modelCatalog.findModelTypeSelect().should('be.disabled');
   });
 });

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -387,9 +387,7 @@ describe('Model Catalog Details Page - Validated Configurations Card', () => {
 
 describe('Model Catalog Registration - Model Type Field', () => {
   const modelArtifacts = {
-    items: [
-      mockCatalogModelArtifact({ uri: 'oci://quay.io/test-org/test-model:latest' }),
-    ],
+    items: [mockCatalogModelArtifact({ uri: 'oci://quay.io/test-org/test-model:latest' })],
     size: 1,
     pageSize: 10,
     nextPageToken: '',
@@ -474,9 +472,7 @@ describe('Model Catalog Registration - Model Type Field', () => {
 
     navigateToRegisterPage();
 
-    modelCatalog
-      .findModelTypeSelect()
-      .should('contain.text', 'Generative AI model (Example, LLM)');
+    modelCatalog.findModelTypeSelect().should('contain.text', 'Generative AI model (Example, LLM)');
     modelCatalog.findModelTypeSelect().should('be.disabled');
   });
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -1466,9 +1466,15 @@ describe('getCatalogModelTypePropertyForRegistration', () => {
     });
   });
 
-  it('returns empty object when model_type is absent or not a recognized value', () => {
-    expect(getCatalogModelTypePropertyForRegistration(undefined)).toEqual({});
-    expect(getCatalogModelTypePropertyForRegistration({})).toEqual({});
+  it('defaults to unknown when model_type is absent or not a recognized value', () => {
+    const expectedUnknown = {
+      [CatalogModelCustomPropertyKey.MODEL_TYPE]: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: ModelType.UNKNOWN,
+      },
+    };
+    expect(getCatalogModelTypePropertyForRegistration(undefined)).toEqual(expectedUnknown);
+    expect(getCatalogModelTypePropertyForRegistration({})).toEqual(expectedUnknown);
   });
 });
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -812,6 +812,6 @@ export const formatModelTypeDisplay = (modelTypeRaw: string | null): string => {
 export const getCatalogModelTypePropertyForRegistration = (
   customProperties?: ModelRegistryCustomProperties,
 ): ModelRegistryCustomProperties => {
-  const stored = getModelTypeStoredValueFromCustomProperties(customProperties);
+  const stored = getModelTypeStoredValueFromCustomProperties(customProperties) ?? ModelType.UNKNOWN;
   return buildCustomPropertiesWithModelType(undefined, stored);
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to Fix the model type selector in model catalog when no model type is present in model's custom properties

## How Has This Been Tested?
update the static_mock_data.go file - remove the model_type from the model's custom properties and see the register flow from model catalog, the selector will have the unknown as preseleceted and disabled.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- x ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
