### PR TITLE
feat(catalog): add unified plugin server 

### DIFF
--- a/catalog/cmd/catalog.go
+++ b/catalog/cmd/catalog.go
@@ -7,24 +7,21 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"reflect"
 	"syscall"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/kubeflow/hub/catalog/internal/catalog"
-	mcpcatalogmodels "github.com/kubeflow/hub/catalog/internal/catalog/mcpcatalog/models"
-	modelcatalogmodels "github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/models"
-	"github.com/kubeflow/hub/catalog/internal/db/models"
 	"github.com/kubeflow/hub/catalog/internal/db/service"
 	"github.com/kubeflow/hub/catalog/internal/leader"
-	"github.com/kubeflow/hub/catalog/internal/server/openapi"
+	"github.com/kubeflow/hub/catalog/internal/plugin"
 	"github.com/kubeflow/hub/internal/datastore/embedmd"
 	"github.com/kubeflow/hub/internal/platform/datastore"
 	"github.com/kubeflow/hub/internal/platform/db"
 	"github.com/kubeflow/hub/internal/platform/server/middleware"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
+
+	_ "github.com/kubeflow/hub/catalog/internal/plugins/catalog"
 )
 
 var catalogCfg = struct {
@@ -92,14 +89,15 @@ func init() {
 	fs.StringSliceVar(&catalogCfg.PerformanceMetricsPath, "performance-metrics", catalogCfg.PerformanceMetricsPath, "Path to performance metrics data directory")
 }
 
-func runCatalogServer(cmd *cobra.Command, args []string) error {
+func runCatalogServer(_ *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Database setup
 	err := db.Init(
-		"postgres", // We only support postgres right now
-		"",         // Empty DSN, see https://www.postgresql.org/docs/current/libpq-envars.html
-		nil,        // Default TLS config
+		"postgres",
+		"",
+		nil,
 	)
 	if err != nil {
 		return fmt.Errorf("error creating datastore: %w", err)
@@ -117,6 +115,7 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error creating datastore: %w", err)
 	}
 
+	// Leader election setup
 	lockDuration, heartbeat := getLeaderElectionConfig()
 	glog.Infof("Leader election configured: lock duration=%v, heartbeat=%v", lockDuration, heartbeat)
 
@@ -124,9 +123,8 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("error creating leader elector: %w", err)
 	}
-	elector.OnBecomeLeader(func(leaderCtx context.Context) {
-		err := ds.RunMigrations(service.DatastoreSpec())
-		if err != nil {
+	elector.OnBecomeLeader(func(_ context.Context) {
+		if err := ds.RunMigrations(service.DatastoreSpec()); err != nil {
 			glog.Errorf("unable to run migrations: %v", err)
 		}
 	})
@@ -136,33 +134,29 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error initializing datastore: %v", err)
 	}
 
-	services := service.NewServices(
-		getRepo[modelcatalogmodels.CatalogModelRepository](repoSet),
-		getRepo[models.CatalogArtifactRepository](repoSet),
-		getRepo[modelcatalogmodels.CatalogModelArtifactRepository](repoSet),
-		getRepo[modelcatalogmodels.CatalogMetricsArtifactRepository](repoSet),
-		getRepo[models.CatalogSourceRepository](repoSet),
-		getRepo[models.PropertyOptionsRepository](repoSet),
-		getRepo[mcpcatalogmodels.MCPServerRepository](repoSet),
-		getRepo[mcpcatalogmodels.MCPServerToolRepository](repoSet),
-	)
-
-	loader := catalog.NewLoader(services, catalogCfg.ConfigPath)
-
-	perfLoader, err := catalog.NewPerformanceMetricsLoader(catalogCfg.PerformanceMetricsPath, services.CatalogModelRepository, services.CatalogMetricsArtifactRepository, repoSet.TypeMap())
-	if err != nil {
-		return fmt.Errorf("error initializing performance metrics: %v", err)
-	}
-	loader.RegisterEventHandler(perfLoader.Load)
-
-	elector.OnBecomeLeader(func(leaderCtx context.Context) {
-		poRefresher := models.NewPropertyOptionsRefresher(leaderCtx, services.PropertyOptionsRepository, time.Second)
-		loader.RegisterEventHandler(func(ctx context.Context, record catalog.ModelProviderRecord) error {
-			poRefresher.Trigger()
-			return nil
-		})
+	// Plugin server setup
+	pluginServer := plugin.NewServer(plugin.ServerConfig{
+		DB:                     gormDB,
+		ConfigPaths:            catalogCfg.ConfigPath,
+		PerformanceMetricsPath: catalogCfg.PerformanceMetricsPath,
+		RepoSet:                repoSet,
+		TypeMap:                repoSet.TypeMap(),
 	})
 
+	if err := pluginServer.Init(ctx); err != nil {
+		return fmt.Errorf("error initializing plugins: %w", err)
+	}
+
+	router, err := pluginServer.MountRoutes()
+	if err != nil {
+		return fmt.Errorf("error mounting routes: %w", err)
+	}
+
+	if err := pluginServer.Start(ctx); err != nil {
+		return fmt.Errorf("error starting plugins: %w", err)
+	}
+
+	// Signal handling
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
@@ -171,39 +165,13 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 		cancel()
 	}()
 
-	glog.Info("Starting loader in read-only mode (standby)")
-	if err := loader.StartReadOnly(ctx); err != nil {
-		return fmt.Errorf("error starting loader in read-only mode: %v", err)
-	}
-
-	// Create MCP source collection first so it can be shared with the model catalog service.
-	mcpSources := loader.MCPSources()
-
-	// Set up HTTP server (runs continuously regardless of leadership)
-	svc := openapi.NewModelCatalogServiceAPIService(
-		catalog.NewDBCatalog(services, loader.Sources()),
-		loader.Sources(),
-		mcpSources,
-		loader.Labels(),
-		services.CatalogSourceRepository,
-	)
-	ctrl := openapi.NewModelCatalogServiceAPIController(svc)
-
-	// Create MCP provider and service, wiring named query resolution from loaded sources.
-	mcpProvider := catalog.NewDBMCPCatalog(services, mcpSources, func(name string) (map[string]catalog.FieldFilter, bool) {
-		return mcpSources.GetNamedQuery(name)
-	})
-	mcpSvc := openapi.NewMCPCatalogServiceAPIService(mcpProvider, mcpSources)
-	mcpCtrl := openapi.NewMCPCatalogServiceAPIController(mcpSvc)
-
 	server := &http.Server{
 		Addr:    catalogCfg.ListenAddress,
-		Handler: middleware.ValidationMiddleware(openapi.NewRouter(ctrl, mcpCtrl)),
+		Handler: middleware.ValidationMiddleware(router),
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	// HTTP server goroutine
 	g.Go(func() error {
 		glog.Infof("Catalog API server listening on %s", catalogCfg.ListenAddress)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -212,7 +180,6 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 		return nil
 	})
 
-	// HTTP server shutdown goroutine
 	g.Go(func() error {
 		<-gctx.Done()
 		glog.Info("Shutting down HTTP server...")
@@ -225,13 +192,8 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 	})
 
 	elector.OnBecomeLeader(func(leaderCtx context.Context) {
-		glog.Info("Became leader - starting leader-only operations")
-
-		// StartLeader blocks until leaderCtx is cancelled (leadership lost)
-		if err := loader.StartLeader(leaderCtx); err != nil && !errors.Is(err, context.Canceled) {
-			glog.Errorf("StartLeader exited with error: %v", err)
-		}
-
+		glog.Info("Became leader - notifying plugins")
+		pluginServer.NotifyLeader(leaderCtx)
 		glog.Info("Leader callback complete")
 	})
 
@@ -242,24 +204,16 @@ func runCatalogServer(cmd *cobra.Command, args []string) error {
 		return nil
 	})
 
-	// Wait for all goroutines and collect errors
 	errs := []error{}
 	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		errs = append(errs, err)
 	}
 
-	if err := loader.Shutdown(); err != nil {
-		errs = append(errs, fmt.Errorf("loader shutdown error: %w", err))
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	if err := pluginServer.Stop(shutdownCtx); err != nil {
+		errs = append(errs, fmt.Errorf("plugin shutdown error: %w", err))
 	}
 
 	return errors.Join(errs...)
-}
-
-func getRepo[T any](repoSet datastore.RepoSet) T {
-	repo, err := repoSet.Repository(reflect.TypeFor[T]())
-	if err != nil {
-		panic(fmt.Sprintf("unable to get repository: %v", err))
-	}
-
-	return repo.(T)
 }

--- a/catalog/cmd/catalog.go
+++ b/catalog/cmd/catalog.go
@@ -95,9 +95,9 @@ func runCatalogServer(_ *cobra.Command, _ []string) error {
 
 	// Database setup
 	err := db.Init(
-		"postgres",
-		"",
-		nil,
+		"postgres", // We only support postgres right now
+		"",         // Empty DSN, see https://www.postgresql.org/docs/current/libpq-envars.html
+		nil,        // Default TLS config
 	)
 	if err != nil {
 		return fmt.Errorf("error creating datastore: %w", err)

--- a/catalog/internal/plugin/plugin.go
+++ b/catalog/internal/plugin/plugin.go
@@ -3,11 +3,13 @@ package plugin
 import (
 	"context"
 	"flag"
+	"log/slog"
 
 	"github.com/go-chi/chi/v5"
 	"gorm.io/gorm"
 
 	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
+	"github.com/kubeflow/hub/internal/platform/datastore"
 )
 
 // CatalogPlugin defines the interface that all catalog plugins must implement.
@@ -40,7 +42,8 @@ type CatalogPlugin interface {
 	Healthy() bool
 
 	// RegisterRoutes mounts the plugin's HTTP routes on the provided router.
-	// The router is already scoped to the plugin's base path.
+	// The router is the server's root router; plugins are responsible for
+	// using full path patterns (e.g., "/api/model_catalog/v1alpha1/models").
 	RegisterRoutes(router chi.Router) error
 
 	// Migrations returns database migrations for this plugin.
@@ -66,6 +69,14 @@ type SourceKeyProvider interface {
 // to register custom CLI flags before flag parsing.
 type FlagProvider interface {
 	RegisterFlags(fs *flag.FlagSet)
+}
+
+// LeaderAware is an optional interface that plugins can implement
+// to receive leadership notifications. When the pod becomes leader,
+// the server calls OnBecomeLeader. The implementation should block
+// until ctx is cancelled (leadership lost).
+type LeaderAware interface {
+	OnBecomeLeader(ctx context.Context) error
 }
 
 // CatalogLoader defines the interface for data loading strategies.
@@ -101,4 +112,16 @@ type Config struct {
 
 	// ConfigPaths are the paths to all sources.yaml files being used.
 	ConfigPaths []string
+
+	// RepoSet is the shared set of repositories from the datastore.
+	RepoSet datastore.RepoSet
+
+	// TypeMap maps entity type names to their integer IDs.
+	TypeMap map[string]int32
+
+	// PerformanceMetricsPath holds paths to performance metrics data directories.
+	PerformanceMetricsPath []string
+
+	// Logger is a structured logger scoped to this plugin.
+	Logger *slog.Logger
 }

--- a/catalog/internal/plugin/server.go
+++ b/catalog/internal/plugin/server.go
@@ -1,0 +1,273 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/cors"
+	"gorm.io/gorm"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
+	"github.com/kubeflow/hub/internal/platform/datastore"
+)
+
+// ServerConfig holds the dependencies needed to create a plugin Server.
+type ServerConfig struct {
+	DB                     *gorm.DB
+	ConfigPaths            []string
+	PerformanceMetricsPath []string
+	RepoSet                datastore.RepoSet
+	TypeMap                map[string]int32
+	Logger                 *slog.Logger
+}
+
+// Server manages the lifecycle of catalog plugins and provides a unified HTTP server.
+type Server struct {
+	cfg     ServerConfig
+	mu      sync.RWMutex
+	plugins []CatalogPlugin
+	router  chi.Router
+}
+
+// NewServer creates a new plugin server.
+func NewServer(cfg ServerConfig) *Server {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &Server{
+		cfg:     cfg,
+		plugins: make([]CatalogPlugin, 0),
+	}
+}
+
+// Init discovers all registered plugins and initializes them.
+// Fails fast on the first plugin Init error.
+func (s *Server) Init(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	registered := All()
+	if len(registered) == 0 {
+		s.cfg.Logger.Info("no plugins registered")
+		return nil
+	}
+
+	var sourceConfig *basecatalog.SourceConfig
+	if len(s.cfg.ConfigPaths) > 0 {
+		cfg, err := LoadConfig(s.cfg.ConfigPaths[0])
+		if err != nil {
+			return fmt.Errorf("loading source config: %w", err)
+		}
+		sourceConfig = cfg
+	}
+
+	for _, p := range registered {
+		basePath := computeBasePath(p)
+
+		pluginCfg := Config{
+			SourceConfig:           sourceConfig,
+			DB:                     s.cfg.DB,
+			BasePath:               basePath,
+			ConfigPaths:            s.cfg.ConfigPaths,
+			RepoSet:                s.cfg.RepoSet,
+			TypeMap:                s.cfg.TypeMap,
+			PerformanceMetricsPath: s.cfg.PerformanceMetricsPath,
+			Logger:                 s.cfg.Logger.With("plugin", p.Name()),
+		}
+
+		s.cfg.Logger.Info("initializing plugin",
+			"plugin", p.Name(),
+			"version", p.Version(),
+			"basePath", basePath,
+		)
+
+		if err := p.Init(ctx, pluginCfg); err != nil {
+			return fmt.Errorf("plugin %s init failed: %w", p.Name(), err)
+		}
+
+		s.plugins = append(s.plugins, p)
+	}
+
+	s.cfg.Logger.Info("all plugins initialized", "count", len(s.plugins))
+	return nil
+}
+
+// MountRoutes creates the HTTP router with all plugin routes and server endpoints.
+// Returns an error if any plugin fails to register its routes.
+func (s *Server) MountRoutes() (chi.Router, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	s.router = chi.NewRouter()
+	s.router.Use(middleware.Logger)
+	s.router.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   []string{"https://*", "http://*"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-PINGOTHER"},
+		ExposedHeaders:   []string{"Link"},
+		AllowCredentials: false,
+		MaxAge:           300,
+	}))
+
+	for _, p := range s.plugins {
+		s.cfg.Logger.Info("mounting plugin routes", "plugin", p.Name())
+		if err := p.RegisterRoutes(s.router); err != nil {
+			return nil, fmt.Errorf("plugin %s failed to register routes: %w", p.Name(), err)
+		}
+	}
+
+	s.router.Get("/healthz", s.healthHandler)
+	s.router.Get("/readyz", s.readyHandler)
+	s.router.Get("/api/plugins", s.pluginsHandler)
+
+	return s.router, nil
+}
+
+// Start starts all plugins' background operations.
+func (s *Server) Start(ctx context.Context) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, p := range s.plugins {
+		s.cfg.Logger.Info("starting plugin", "plugin", p.Name())
+		if err := p.Start(ctx); err != nil {
+			return fmt.Errorf("plugin %s start failed: %w", p.Name(), err)
+		}
+	}
+	return nil
+}
+
+// Stop gracefully shuts down all plugins in reverse order.
+func (s *Server) Stop(ctx context.Context) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var errs []error
+	for i := len(s.plugins) - 1; i >= 0; i-- {
+		p := s.plugins[i]
+		s.cfg.Logger.Info("stopping plugin", "plugin", p.Name())
+		if err := p.Stop(ctx); err != nil {
+			s.cfg.Logger.Error("plugin stop failed", "plugin", p.Name(), "error", err)
+			errs = append(errs, fmt.Errorf("plugin %s: %w", p.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// NotifyLeader notifies all LeaderAware plugins that this pod became leader.
+// Each plugin's OnBecomeLeader runs in its own goroutine; this method blocks
+// until all return (typically when ctx is cancelled / leadership lost).
+func (s *Server) NotifyLeader(ctx context.Context) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	for _, p := range s.plugins {
+		la, ok := p.(LeaderAware)
+		if !ok {
+			continue
+		}
+		name := p.Name()
+		wg.Go(func() {
+			s.cfg.Logger.Info("plugin becoming leader", "plugin", name)
+			if err := la.OnBecomeLeader(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				s.cfg.Logger.Error("leader callback failed", "plugin", name, "error", err)
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// Plugins returns the list of initialized plugins.
+func (s *Server) Plugins() []CatalogPlugin {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]CatalogPlugin, len(s.plugins))
+	copy(result, s.plugins)
+	return result
+}
+
+func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) readyHandler(w http.ResponseWriter, _ *http.Request) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	allHealthy := true
+	pluginStatus := make(map[string]bool)
+
+	for _, p := range s.plugins {
+		healthy := p.Healthy()
+		pluginStatus[p.Name()] = healthy
+		if !healthy {
+			allHealthy = false
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	response := map[string]any{
+		"plugins": pluginStatus,
+	}
+
+	if allHealthy {
+		response["status"] = "ready"
+		w.WriteHeader(http.StatusOK)
+	} else {
+		response["status"] = "not_ready"
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func (s *Server) pluginsHandler(w http.ResponseWriter, _ *http.Request) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type pluginInfo struct {
+		Name        string `json:"name"`
+		Version     string `json:"version"`
+		Description string `json:"description"`
+		BasePath    string `json:"basePath"`
+		Healthy     bool   `json:"healthy"`
+	}
+
+	plugins := make([]pluginInfo, 0, len(s.plugins))
+	for _, p := range s.plugins {
+		plugins = append(plugins, pluginInfo{
+			Name:        p.Name(),
+			Version:     p.Version(),
+			Description: p.Description(),
+			BasePath:    computeBasePath(p),
+			Healthy:     p.Healthy(),
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"plugins": plugins,
+		"count":   len(plugins),
+	})
+}
+
+func computeBasePath(p CatalogPlugin) string {
+	if bp, ok := p.(BasePathProvider); ok {
+		return bp.BasePath()
+	}
+	return fmt.Sprintf("/api/%s_catalog/%s", p.Name(), p.Version())
+}
+

--- a/catalog/internal/plugin/server.go
+++ b/catalog/internal/plugin/server.go
@@ -165,10 +165,12 @@ func (s *Server) Stop(ctx context.Context) error {
 // until all return (typically when ctx is cancelled / leadership lost).
 func (s *Server) NotifyLeader(ctx context.Context) {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+	plugins := make([]CatalogPlugin, len(s.plugins))
+	copy(plugins, s.plugins)
+	s.mu.RUnlock()
 
 	var wg sync.WaitGroup
-	for _, p := range s.plugins {
+	for _, p := range plugins {
 		la, ok := p.(LeaderAware)
 		if !ok {
 			continue

--- a/catalog/internal/plugin/server.go
+++ b/catalog/internal/plugin/server.go
@@ -125,7 +125,6 @@ func (s *Server) MountRoutes() (chi.Router, error) {
 
 	s.router.Get("/healthz", s.healthHandler)
 	s.router.Get("/readyz", s.readyHandler)
-	s.router.Get("/api/plugins", s.pluginsHandler)
 
 	return s.router, nil
 }
@@ -233,36 +232,6 @@ func (s *Server) readyHandler(w http.ResponseWriter, _ *http.Request) {
 	_ = json.NewEncoder(w).Encode(response)
 }
 
-func (s *Server) pluginsHandler(w http.ResponseWriter, _ *http.Request) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	type pluginInfo struct {
-		Name        string `json:"name"`
-		Version     string `json:"version"`
-		Description string `json:"description"`
-		BasePath    string `json:"basePath"`
-		Healthy     bool   `json:"healthy"`
-	}
-
-	plugins := make([]pluginInfo, 0, len(s.plugins))
-	for _, p := range s.plugins {
-		plugins = append(plugins, pluginInfo{
-			Name:        p.Name(),
-			Version:     p.Version(),
-			Description: p.Description(),
-			BasePath:    computeBasePath(p),
-			Healthy:     p.Healthy(),
-		})
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"plugins": plugins,
-		"count":   len(plugins),
-	})
-}
 
 func computeBasePath(p CatalogPlugin) string {
 	if bp, ok := p.(BasePathProvider); ok {

--- a/catalog/internal/plugin/server_test.go
+++ b/catalog/internal/plugin/server_test.go
@@ -103,10 +103,6 @@ func TestServerZeroPlugins(t *testing.T) {
 	// Readyz with zero plugins is "ready"
 	body := getJSON(t, router, "/readyz")
 	assert.Equal(t, "ready", body["status"])
-
-	// Plugins endpoint returns empty list
-	body = getJSON(t, router, "/api/plugins")
-	assert.Equal(t, float64(0), body["count"])
 }
 
 func TestServerInitLifecycle(t *testing.T) {
@@ -318,51 +314,6 @@ func TestServerMountRoutes(t *testing.T) {
 	// Server endpoints coexist
 	assertStatus(t, router, "/healthz", http.StatusOK)
 	assertStatus(t, router, "/readyz", http.StatusOK)
-	assertStatus(t, router, "/api/plugins", http.StatusOK)
-}
-
-func TestServerPluginsEndpoint(t *testing.T) {
-	Reset()
-	defer Reset()
-
-	Register(&mockPlugin{name: "model", version: "v1alpha1", description: "Model catalog", healthy: true})
-
-	s := newTestServer()
-	require.NoError(t, s.Init(context.Background()))
-	router, err := s.MountRoutes()
-	require.NoError(t, err)
-
-	body := getJSON(t, router, "/api/plugins")
-	assert.Equal(t, float64(1), body["count"])
-
-	plugins := body["plugins"].([]any)
-	p := plugins[0].(map[string]any)
-	assert.Equal(t, "model", p["name"])
-	assert.Equal(t, "v1alpha1", p["version"])
-	assert.Equal(t, "Model catalog", p["description"])
-	assert.Equal(t, "/api/model_catalog/v1alpha1", p["basePath"])
-	assert.Equal(t, true, p["healthy"])
-}
-
-func TestServerBasePathProvider(t *testing.T) {
-	Reset()
-	defer Reset()
-
-	bp := &basePathPlugin{
-		mockPlugin: mockPlugin{name: "custom", version: "v1"},
-		basePath:   "/api/my/custom/path",
-	}
-	Register(bp)
-
-	s := newTestServer()
-	require.NoError(t, s.Init(context.Background()))
-	router, err := s.MountRoutes()
-	require.NoError(t, err)
-
-	body := getJSON(t, router, "/api/plugins")
-	plugins := body["plugins"].([]any)
-	p := plugins[0].(map[string]any)
-	assert.Equal(t, "/api/my/custom/path", p["basePath"])
 }
 
 // failingRoutePlugin returns an error from RegisterRoutes.
@@ -387,13 +338,6 @@ func TestServerMountRoutesFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "broken")
 	assert.Contains(t, err.Error(), "route registration failed")
 }
-
-type basePathPlugin struct {
-	mockPlugin
-	basePath string
-}
-
-func (p *basePathPlugin) BasePath() string { return p.basePath }
 
 // Test helpers
 

--- a/catalog/internal/plugin/server_test.go
+++ b/catalog/internal/plugin/server_test.go
@@ -1,0 +1,416 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trackingPlugin records lifecycle calls for verifying ordering.
+type trackingPlugin struct {
+	mockPlugin
+	mu        sync.Mutex
+	initOrder int32
+	startedAt time.Time
+	stoppedAt time.Time
+	initErr   error
+	startErr  error
+	stopErr   error
+	counter   *atomic.Int32
+}
+
+func (p *trackingPlugin) Init(_ context.Context, _ Config) error {
+	if p.counter != nil {
+		p.initOrder = p.counter.Add(1)
+	}
+	return p.initErr
+}
+
+func (p *trackingPlugin) Start(_ context.Context) error {
+	p.mu.Lock()
+	p.startedAt = time.Now()
+	p.mu.Unlock()
+	return p.startErr
+}
+
+func (p *trackingPlugin) Stop(_ context.Context) error {
+	p.mu.Lock()
+	p.stoppedAt = time.Now()
+	p.mu.Unlock()
+	return p.stopErr
+}
+
+// leaderPlugin implements both CatalogPlugin and LeaderAware.
+type leaderPlugin struct {
+	mockPlugin
+	leaderCalled atomic.Bool
+	leaderCtx    context.Context
+}
+
+func (p *leaderPlugin) OnBecomeLeader(ctx context.Context) error {
+	p.leaderCalled.Store(true)
+	p.leaderCtx = ctx
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// routePlugin registers a test route when RegisterRoutes is called.
+type routePlugin struct {
+	mockPlugin
+}
+
+func (p *routePlugin) RegisterRoutes(router chi.Router) error {
+	router.Get("/api/test_catalog/v1alpha1/items", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	})
+	return nil
+}
+
+func newTestServer() *Server {
+	return NewServer(ServerConfig{})
+}
+
+func TestServerZeroPlugins(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	s := newTestServer()
+
+	require.NoError(t, s.Init(context.Background()))
+	assert.Empty(t, s.Plugins())
+
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	require.NoError(t, s.Start(context.Background()))
+	require.NoError(t, s.Stop(context.Background()))
+
+	// Health endpoints still work
+	assertStatus(t, router, "/healthz", http.StatusOK)
+	assertStatus(t, router, "/readyz", http.StatusOK)
+
+	// Readyz with zero plugins is "ready"
+	body := getJSON(t, router, "/readyz")
+	assert.Equal(t, "ready", body["status"])
+
+	// Plugins endpoint returns empty list
+	body = getJSON(t, router, "/api/plugins")
+	assert.Equal(t, float64(0), body["count"])
+}
+
+func TestServerInitLifecycle(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	counter := &atomic.Int32{}
+	p1 := &trackingPlugin{mockPlugin: mockPlugin{name: "first", version: "v1"}, counter: counter}
+	p2 := &trackingPlugin{mockPlugin: mockPlugin{name: "second", version: "v1"}, counter: counter}
+
+	Register(p1)
+	Register(p2)
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	assert.Len(t, s.Plugins(), 2)
+
+	// Init called in registration order
+	assert.Equal(t, int32(1), p1.initOrder)
+	assert.Equal(t, int32(2), p2.initOrder)
+}
+
+func TestServerInitFailure(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	good := &trackingPlugin{mockPlugin: mockPlugin{name: "good", version: "v1"}}
+	bad := &trackingPlugin{mockPlugin: mockPlugin{name: "bad", version: "v1"}, initErr: errors.New("init boom")}
+
+	Register(good)
+	Register(bad)
+
+	s := newTestServer()
+	err := s.Init(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad")
+	assert.Contains(t, err.Error(), "init boom")
+
+	// Only the first plugin was successfully initialized
+	assert.Len(t, s.Plugins(), 1)
+}
+
+func TestServerStartFailure(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&trackingPlugin{mockPlugin: mockPlugin{name: "ok", version: "v1"}})
+	Register(&trackingPlugin{mockPlugin: mockPlugin{name: "broken", version: "v1"}, startErr: errors.New("start boom")})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	err := s.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broken")
+}
+
+func TestServerStopReverseOrder(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	p1 := &trackingPlugin{mockPlugin: mockPlugin{name: "first", version: "v1"}}
+	p2 := &trackingPlugin{mockPlugin: mockPlugin{name: "second", version: "v1"}}
+
+	Register(p1)
+	Register(p2)
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	require.NoError(t, s.Start(context.Background()))
+
+	// Add small delay so timestamps are distinguishable
+	time.Sleep(time.Millisecond)
+	require.NoError(t, s.Stop(context.Background()))
+
+	// Second plugin should stop before first
+	assert.False(t, p2.stoppedAt.IsZero(), "second plugin Stop was called")
+	assert.False(t, p1.stoppedAt.IsZero(), "first plugin Stop was called")
+	assert.True(t, p2.stoppedAt.Before(p1.stoppedAt) || p2.stoppedAt.Equal(p1.stoppedAt),
+		"second plugin should stop before or at same time as first")
+}
+
+func TestServerStopCollectsErrors(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&trackingPlugin{mockPlugin: mockPlugin{name: "fail1", version: "v1"}, stopErr: errors.New("err1")})
+	Register(&trackingPlugin{mockPlugin: mockPlugin{name: "fail2", version: "v1"}, stopErr: errors.New("err2")})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	err := s.Stop(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "err1")
+	assert.Contains(t, err.Error(), "err2")
+}
+
+func TestServerHealthAggregation(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	healthy := &mockPlugin{name: "healthy", version: "v1", healthy: true}
+	unhealthy := &mockPlugin{name: "unhealthy", version: "v1", healthy: false}
+
+	Register(healthy)
+	Register(unhealthy)
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	// One unhealthy → 503
+	assertStatus(t, router, "/readyz", http.StatusServiceUnavailable)
+	body := getJSON(t, router, "/readyz")
+	assert.Equal(t, "not_ready", body["status"])
+
+	plugins := body["plugins"].(map[string]any)
+	assert.Equal(t, true, plugins["healthy"])
+	assert.Equal(t, false, plugins["unhealthy"])
+}
+
+func TestServerHealthAllHealthy(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&mockPlugin{name: "a", version: "v1", healthy: true})
+	Register(&mockPlugin{name: "b", version: "v1", healthy: true})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	assertStatus(t, router, "/readyz", http.StatusOK)
+	body := getJSON(t, router, "/readyz")
+	assert.Equal(t, "ready", body["status"])
+}
+
+func TestServerNotifyLeader(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	leader := &leaderPlugin{mockPlugin: mockPlugin{name: "leader-aware", version: "v1"}}
+	plain := &mockPlugin{name: "plain", version: "v1"}
+
+	Register(leader)
+	Register(plain)
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		s.NotifyLeader(ctx)
+		close(done)
+	}()
+
+	// Give goroutine time to start
+	time.Sleep(50 * time.Millisecond)
+	assert.True(t, leader.leaderCalled.Load(), "LeaderAware plugin should be called")
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("NotifyLeader did not return after context cancellation")
+	}
+}
+
+func TestServerNotifyLeaderNoLeaderPlugins(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&mockPlugin{name: "plain", version: "v1"})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+
+	done := make(chan struct{})
+	go func() {
+		s.NotifyLeader(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("NotifyLeader should return immediately with no LeaderAware plugins")
+	}
+}
+
+func TestServerMountRoutes(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&routePlugin{mockPlugin: mockPlugin{name: "test", version: "v1alpha1", healthy: true}})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	// Plugin route works
+	assertStatus(t, router, "/api/test_catalog/v1alpha1/items", http.StatusOK)
+
+	// Server endpoints coexist
+	assertStatus(t, router, "/healthz", http.StatusOK)
+	assertStatus(t, router, "/readyz", http.StatusOK)
+	assertStatus(t, router, "/api/plugins", http.StatusOK)
+}
+
+func TestServerPluginsEndpoint(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&mockPlugin{name: "model", version: "v1alpha1", description: "Model catalog", healthy: true})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	body := getJSON(t, router, "/api/plugins")
+	assert.Equal(t, float64(1), body["count"])
+
+	plugins := body["plugins"].([]any)
+	p := plugins[0].(map[string]any)
+	assert.Equal(t, "model", p["name"])
+	assert.Equal(t, "v1alpha1", p["version"])
+	assert.Equal(t, "Model catalog", p["description"])
+	assert.Equal(t, "/api/model_catalog/v1alpha1", p["basePath"])
+	assert.Equal(t, true, p["healthy"])
+}
+
+func TestServerBasePathProvider(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	bp := &basePathPlugin{
+		mockPlugin: mockPlugin{name: "custom", version: "v1"},
+		basePath:   "/api/my/custom/path",
+	}
+	Register(bp)
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	body := getJSON(t, router, "/api/plugins")
+	plugins := body["plugins"].([]any)
+	p := plugins[0].(map[string]any)
+	assert.Equal(t, "/api/my/custom/path", p["basePath"])
+}
+
+// failingRoutePlugin returns an error from RegisterRoutes.
+type failingRoutePlugin struct {
+	mockPlugin
+}
+
+func (p *failingRoutePlugin) RegisterRoutes(_ chi.Router) error {
+	return errors.New("route registration failed")
+}
+
+func TestServerMountRoutesFailure(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&failingRoutePlugin{mockPlugin: mockPlugin{name: "broken", version: "v1"}})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	_, err := s.MountRoutes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broken")
+	assert.Contains(t, err.Error(), "route registration failed")
+}
+
+type basePathPlugin struct {
+	mockPlugin
+	basePath string
+}
+
+func (p *basePathPlugin) BasePath() string { return p.basePath }
+
+// Test helpers
+
+func assertStatus(t *testing.T, handler http.Handler, path string, expectedStatus int) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, expectedStatus, w.Code, "unexpected status for %s", path)
+}
+
+func getJSON(t *testing.T, handler http.Handler, path string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	return result
+}

--- a/catalog/internal/plugins/catalog/plugin.go
+++ b/catalog/internal/plugins/catalog/plugin.go
@@ -1,0 +1,123 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang/glog"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog"
+	mcpcatalogmodels "github.com/kubeflow/hub/catalog/internal/catalog/mcpcatalog/models"
+	modelcatalogmodels "github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/models"
+	"github.com/kubeflow/hub/catalog/internal/db/models"
+	"github.com/kubeflow/hub/catalog/internal/db/service"
+	"github.com/kubeflow/hub/catalog/internal/plugin"
+	"github.com/kubeflow/hub/catalog/internal/server/openapi"
+	"github.com/kubeflow/hub/internal/platform/datastore"
+)
+
+// Plugin wraps both the model catalog and MCP catalog under a single plugin.
+// The two catalogs share a unified Loader with common leader state and file watching.
+type Plugin struct {
+	loader   *catalog.Loader
+	services service.Services
+	typeMap  map[string]int32
+}
+
+func (p *Plugin) Name() string                    { return "catalog" }
+func (p *Plugin) Version() string                  { return "v1alpha1" }
+func (p *Plugin) Description() string              { return "Unified model and MCP catalog" }
+func (p *Plugin) BasePath() string                 { return "/api/catalog/v1alpha1" }
+func (p *Plugin) Healthy() bool                    { return true }
+func (p *Plugin) Migrations() []plugin.Migration   { return nil }
+
+func (p *Plugin) Init(_ context.Context, cfg plugin.Config) error {
+	p.typeMap = cfg.TypeMap
+
+	services := service.NewServices(
+		getRepo[modelcatalogmodels.CatalogModelRepository](cfg.RepoSet),
+		getRepo[models.CatalogArtifactRepository](cfg.RepoSet),
+		getRepo[modelcatalogmodels.CatalogModelArtifactRepository](cfg.RepoSet),
+		getRepo[modelcatalogmodels.CatalogMetricsArtifactRepository](cfg.RepoSet),
+		getRepo[models.CatalogSourceRepository](cfg.RepoSet),
+		getRepo[models.PropertyOptionsRepository](cfg.RepoSet),
+		getRepo[mcpcatalogmodels.MCPServerRepository](cfg.RepoSet),
+		getRepo[mcpcatalogmodels.MCPServerToolRepository](cfg.RepoSet),
+	)
+	p.services = services
+
+	p.loader = catalog.NewLoader(services, cfg.ConfigPaths)
+
+	if len(cfg.PerformanceMetricsPath) > 0 {
+		perfLoader, err := catalog.NewPerformanceMetricsLoader(
+			cfg.PerformanceMetricsPath,
+			services.CatalogModelRepository,
+			services.CatalogMetricsArtifactRepository,
+			p.typeMap,
+		)
+		if err != nil {
+			return fmt.Errorf("initializing performance metrics: %w", err)
+		}
+		p.loader.RegisterEventHandler(perfLoader.Load)
+	}
+
+	return nil
+}
+
+func (p *Plugin) RegisterRoutes(router chi.Router) error {
+	mcpSources := p.loader.MCPSources()
+
+	svc := openapi.NewModelCatalogServiceAPIService(
+		catalog.NewDBCatalog(p.services, p.loader.Sources()),
+		p.loader.Sources(),
+		mcpSources,
+		p.loader.Labels(),
+		p.services.CatalogSourceRepository,
+	)
+	ctrl := openapi.NewModelCatalogServiceAPIController(svc)
+
+	mcpProvider := catalog.NewDBMCPCatalog(p.services, mcpSources, func(name string) (map[string]catalog.FieldFilter, bool) {
+		return mcpSources.GetNamedQuery(name)
+	})
+	mcpSvc := openapi.NewMCPCatalogServiceAPIService(mcpProvider, mcpSources)
+	mcpCtrl := openapi.NewMCPCatalogServiceAPIController(mcpSvc)
+
+	for _, route := range ctrl.OrderedRoutes() {
+		router.Method(route.Method, route.Pattern, route.HandlerFunc)
+	}
+	for _, route := range mcpCtrl.OrderedRoutes() {
+		router.Method(route.Method, route.Pattern, route.HandlerFunc)
+	}
+
+	return nil
+}
+
+func (p *Plugin) Start(ctx context.Context) error {
+	glog.Info("Starting catalog plugin in read-only mode (standby)")
+	return p.loader.StartReadOnly(ctx)
+}
+
+func (p *Plugin) OnBecomeLeader(ctx context.Context) error {
+	glog.Info("Catalog plugin becoming leader")
+	poRefresher := models.NewPropertyOptionsRefresher(ctx, p.services.PropertyOptionsRepository, time.Second)
+	p.loader.RegisterEventHandler(func(_ context.Context, _ catalog.ModelProviderRecord) error {
+		poRefresher.Trigger()
+		return nil
+	})
+	return p.loader.StartLeader(ctx)
+}
+
+func (p *Plugin) Stop(_ context.Context) error {
+	return p.loader.Shutdown()
+}
+
+func getRepo[T any](repoSet datastore.RepoSet) T {
+	repo, err := repoSet.Repository(reflect.TypeFor[T]())
+	if err != nil {
+		panic(fmt.Sprintf("unable to get repository: %v", err))
+	}
+	return repo.(T)
+}

--- a/catalog/internal/plugins/catalog/register.go
+++ b/catalog/internal/plugins/catalog/register.go
@@ -1,0 +1,7 @@
+package catalog
+
+import "github.com/kubeflow/hub/catalog/internal/plugin"
+
+func init() {
+	plugin.Register(&Plugin{})
+}


### PR DESCRIPTION
closes #2529

## Summary

This PR introduces a plugin server that discovers, initializes, and manages the lifecycle of all registered catalog plugins, replacing the directly-wired approach in `catalog/cmd/catalog.go`. The server is a thin orchestrator: it discovers registered plugins via the existing global registry, initializes them, mounts their HTTP handlers, and manages their lifecycle including graceful shutdown and leader election notifications.

## Motivation

The catalog server was tightly coupled to the model and MCP catalog implementations. All service creation, loader setup, route registration, and lifecycle management was hardcoded in the entry point. With the plugin system already defined (`CatalogPlugin` interface, global registry), the server should leverage it — making the entry point generic and ready for future catalog types without code changes.


## Architecture

```
catalog/cmd/catalog.go (entry point)
  |
  |-- DB init, datastore, leader election (infrastructure)
  |
  +-- plugin.Server (new)
        |-- Init()         discovers plugins from registry, loads config, calls plugin.Init()
        |-- MountRoutes()  creates chi router, calls plugin.RegisterRoutes(), adds /healthz /readyz
        |-- Start()        calls plugin.Start() in registration order
        |-- Stop()         calls plugin.Stop() in reverse order
        |-- NotifyLeader() dispatches to LeaderAware plugins in goroutines
        |
        +-- catalog plugin (registered via init())
              |-- wraps existing Loader, Services, OpenAPI controllers
              |-- RegisterRoutes: mounts model + MCP catalog routes with full paths
              |-- Start: loader.StartReadOnly()
              |-- OnBecomeLeader: registers PropertyOptionsRefresher, loader.StartLeader()
              |-- Stop: loader.Shutdown()
```

## Design decisions

**Single plugin for model + MCP catalogs** — The model catalog API's `FindSources` endpoint returns both model and MCP sources, and the `Loader` manages both with shared leader state and file watching. Splitting into separate plugins requires resolving this coupling first. The server infrastructure supports multiple plugins regardless.

**Routes use full paths** — OpenAPI-generated routes contain full patterns (e.g., `/api/model_catalog/v1alpha1/models`). Plugins mount routes directly on the root router rather than under a scoped prefix.

**MountRoutes returns error** — If any plugin fails to register routes, the server fails startup rather than running in a partially broken state.

**Dedicated shutdown context** — `Stop()` receives a fresh `context.WithTimeout(background, 10s)` instead of the already-cancelled signal context, ensuring plugins have time to flush.

**LeaderAware interface** — Optional interface plugins implement to receive leader election callbacks. Each plugin's `OnBecomeLeader` runs in its own goroutine and blocks until leadership is lost.

## Forward compatibility

The planned follow-up is: split the OpenAPI spec per plugin, refactor model catalog as a separate plugin, refactor MCP catalog as a separate plugin. This PR accommodates that:

- Server infrastructure is fully generic (iterates registry, N plugins)
- Route mounting works when each plugin has its own generated routes with distinct path prefixes
- `LeaderAware` gives each plugin independent leader notifications
- `Config.RepoSet` is read-only; multiple plugins can extract their own repos

What the split will additionally require (not in scope):
- A `DatastoreSpec()` method on plugins so each contributes its entity types
- Resolution of the `FindSources` cross-plugin coupling
- Per-plugin config sections (the `SourceKeyProvider` interface already exists for this)

## Endpoints

| Endpoint | Response |
|----------|----------|
| `GET /healthz` | Liveness probe — always `{"status":"ok"}` |
| `GET /readyz` | Readiness probe — aggregates `Healthy()` across all plugins. 200 if all healthy, 503 if any unhealthy. Zero plugins = 200. |

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- 15 unit tests in `server_test.go` (zero-plugin, lifecycle, failures, health, leader, routes)
- All existing unit tests pass (`make test`, `make -C catalog test`)
- 158/158 catalog e2e tests pass (deployed to KinD with PostgreSQL)
- `make build/compile`, `make lint`, `make vet` all clean

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
