### PR TITLE
fix whitespace issue with search and title in model and mcp catalog

### DIFF
--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpCatalogSourceLabelSelector.tsx
@@ -79,6 +79,7 @@ const McpCatalogSourceLabelSelector: React.FC<McpCatalogSourceLabelSelectorProps
     <Stack hasGutter>
       <StackItem>
         <Toolbar
+          className="pf-v6-u-pb-0"
           key={hasFiltersAppliedValue ? 'has-filters' : 'no-filters'}
           {...(toolbarClearAllProps ?? {})}
         >

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalog.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PageSection, Sidebar, SidebarContent, SidebarPanel } from '@patternfly/react-core';
+import { PageSection, Sidebar, SidebarContent, SidebarPanel, Stack } from '@patternfly/react-core';
 import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-shared';
 import { SearchIcon } from '@patternfly/react-icons';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
@@ -85,24 +85,26 @@ const ModelCatalog: React.FC = () => {
               <ModelCatalogFilters />
             </SidebarPanel>
             <SidebarContent>
-              <ModelCatalogSourceLabelSelectorNavigator
-                searchTerm={searchTerm}
-                onSearch={handleSearch}
-                onClearSearch={handleClearSearch}
-                onResetAllFilters={handleFilterReset}
-              />
-              <PageSection isFilled padding={{ default: 'noPadding' }}>
-                {isAllModelsView && !isSingleCategory ? (
-                  <ModelCatalogAllModelsView searchTerm={searchTerm} />
-                ) : (
-                  <ModelCatalogGalleryView
-                    searchTerm={searchTerm}
-                    handleFilterReset={handleFilterReset}
-                    isSingleCategory={isSingleCategory}
-                    singleCategoryLabel={isSingleCategory ? activeCategories[0] : undefined}
-                  />
-                )}
-              </PageSection>
+              <Stack hasGutter>
+                <ModelCatalogSourceLabelSelectorNavigator
+                  searchTerm={searchTerm}
+                  onSearch={handleSearch}
+                  onClearSearch={handleClearSearch}
+                  onResetAllFilters={handleFilterReset}
+                />
+                <PageSection isFilled padding={{ default: 'noPadding' }}>
+                  {isAllModelsView && !isSingleCategory ? (
+                    <ModelCatalogAllModelsView searchTerm={searchTerm} />
+                  ) : (
+                    <ModelCatalogGalleryView
+                      searchTerm={searchTerm}
+                      handleFilterReset={handleFilterReset}
+                      isSingleCategory={isSingleCategory}
+                      singleCategoryLabel={isSingleCategory ? activeCategories[0] : undefined}
+                    />
+                  )}
+                </PageSection>
+              </Stack>
             </SidebarContent>
           </Sidebar>
         )}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelBlocks.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelCatalogSourceLabelBlocks.tsx
@@ -67,7 +67,7 @@ const ModelCatalogSourceLabelBlocks: React.FC = () => {
   };
 
   return (
-    <ToggleGroup aria-label="Source label selection" className="pf-v6-u-pb-md">
+    <ToggleGroup aria-label="Source label selection" className="pf-v6-u-pb-0">
       {blocks.map((block) => (
         <ToggleGroupItem
           buttonId={block.id}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add a small fix for the gap between title and search bar when only one cat is available

- Before PF mode
Model Catalog
<img width="1484" height="273" alt="before-PF-Model-Catalog-one-CAT" src="https://github.com/user-attachments/assets/250e5af1-7ece-4411-804a-ee9d55231cb3" />

MCP Catalog
<img width="1416" height="290" alt="before-PF-MCP-Catalog-one-CAT" src="https://github.com/user-attachments/assets/d37c034a-3109-4344-b1df-702741fb608a" />

- Before non-PF mode
Model Catalog
<img width="1535" height="260" alt="before-non-PF-Model-Catalog-one-cat" src="https://github.com/user-attachments/assets/bb2b261b-5073-49ee-93e9-9fdd8e6d46ad" />

MCP Catalog
<img width="1670" height="296" alt="before-non-PF-MCP-Catalog-one-CAT" src="https://github.com/user-attachments/assets/be32e5ff-071f-46c7-abd1-13f4e0b26430" />

- After PF mode
Model Catalog
<img width="1408" height="302" alt="after-PF-Model-Catalog-one-CAT" src="https://github.com/user-attachments/assets/bbc6ce41-60a1-4864-9b9d-96b852830b1e" />

MCP Catalog
<img width="1338" height="269" alt="after-PF-MCP-Catalog-one-CAT" src="https://github.com/user-attachments/assets/d9943c42-1ce0-4887-957b-af5acf0c730b" />

-After non-PF mode
Model Catalog
<img width="1574" height="278" alt="after-non-PF-Model-Catalog-one-cat" src="https://github.com/user-attachments/assets/836ea1ec-288f-4ef1-b476-dbcfe32a9237" />

MCP Catalog
<img width="1386" height="270" alt="after-non-PF-MCP-Catalog-one-CAT" src="https://github.com/user-attachments/assets/a3f620a5-1f6e-4762-8389-d0e5828032be" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested, the changes are visual.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
