### PR TITLE
add cypress coverage for manage columns behaviour in hardware conf table

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -491,6 +491,40 @@ class ModelCatalog {
   findModelTypeSelect() {
     return cy.findByTestId('register-model-type-select');
   }
+
+  findManageColumnsButton() {
+    return cy.findByTestId('manage-columns-button');
+  }
+
+  findManageColumnsModal() {
+    return cy.findByTestId('hardware-config-manage-columns');
+  }
+
+  findManageColumnsUpdateButton() {
+    return cy.findByTestId('hardware-config-manage-columns-update-button');
+  }
+
+  findManageColumnsCancelButton() {
+    return cy.findByTestId('hardware-config-manage-columns-cancel-button');
+  }
+
+  findManageColumnsRestoreDefaults() {
+    return cy.findByTestId('hardware-config-manage-columns-restore-defaults');
+  }
+
+  findManageColumnsSearch() {
+    return cy.findByTestId('hardware-config-manage-columns-search');
+  }
+
+  findManageColumnCheckbox(columnLabel: string) {
+    return this.findManageColumnsModal().find(`[aria-label="${columnLabel}"]`).scrollIntoView();
+  }
+
+  openManageColumnsModal() {
+    this.findManageColumnsButton().click();
+    this.findManageColumnsModal().should('be.visible');
+    return this;
+  }
 }
 
 export const modelCatalog = new ModelCatalog();

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/manageColumns.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/manageColumns.cy.ts
@@ -8,8 +8,10 @@ import {
   type ModelCatalogInterceptOptions,
 } from '~/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog';
 import { NBSP } from '~/__tests__/cypress/cypress/support/constants';
-
-const STORAGE_KEY = 'hardware-config-table-columns';
+import {
+  DEFAULT_VISIBLE_COLUMN_FIELDS,
+  HARDWARE_CONFIG_COLUMNS_STORAGE_KEY as STORAGE_KEY,
+} from '~/app/pages/modelCatalog/components/HardwareConfigurationTableColumns';
 
 const initIntercepts = (options: Partial<ModelCatalogInterceptOptions> = {}) => {
   const resolvedOptions = {
@@ -33,6 +35,14 @@ const navigateToPerformanceInsights = () => {
   modelCatalog.clickPerformanceInsightsTab();
 };
 
+const navigateWithPerformanceView = () => {
+  modelCatalog.visit();
+  modelCatalog.findLoadingState().should('not.exist');
+  modelCatalog.togglePerformanceView();
+  modelCatalog.findModelCatalogDetailLink().first().click();
+  modelCatalog.clickPerformanceInsightsTab();
+};
+
 describe('Manage Columns Modal', () => {
   beforeEach(() => {
     cy.intercept('GET', '/model-registry/api/v1/model_registry*', [
@@ -40,7 +50,7 @@ describe('Manage Columns Modal', () => {
     ]).as('getModelRegistries');
 
     cy.clearLocalStorage(STORAGE_KEY);
-    initIntercepts({ useValidatedModel: true, includePerformanceArtifacts: true });
+    initIntercepts();
   });
 
   describe('Opening the Modal', () => {
@@ -49,7 +59,6 @@ describe('Manage Columns Modal', () => {
 
       modelCatalog.findManageColumnsButton().should('be.visible');
       modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnsModal().should('be.visible');
     });
 
     it('should display search input and column list in the modal', () => {
@@ -64,17 +73,11 @@ describe('Manage Columns Modal', () => {
   });
 
   describe('Sticky Columns Exclusion', () => {
-    it('should not show Hardware configuration column in the modal', () => {
+    it('should not show sticky columns in the modal', () => {
       navigateToPerformanceInsights();
       modelCatalog.openManageColumnsModal();
 
       modelCatalog.findManageColumnsModal().should('not.contain.text', 'Hardware configuration');
-    });
-
-    it('should not show Workload type column in the modal', () => {
-      navigateToPerformanceInsights();
-      modelCatalog.openManageColumnsModal();
-
       modelCatalog.findManageColumnsModal().should('not.contain.text', 'Workload type');
     });
 
@@ -102,11 +105,14 @@ describe('Manage Columns Modal', () => {
     });
 
     it('should add a column back when re-checked and Update is clicked', () => {
-      navigateToPerformanceInsights();
+      const columnsWithoutReplicas = DEFAULT_VISIBLE_COLUMN_FIELDS.filter(
+        (col) => col !== 'replicas',
+      );
+      cy.window().then((win) => {
+        win.localStorage.setItem(STORAGE_KEY, JSON.stringify(columnsWithoutReplicas));
+      });
 
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
-      modelCatalog.findManageColumnsUpdateButton().click();
+      navigateToPerformanceInsights();
 
       modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
 
@@ -201,17 +207,8 @@ describe('Manage Columns Modal', () => {
   });
 
   describe('Latency Filter Interaction with Column Visibility', () => {
-    beforeEach(() => {
-      cy.clearLocalStorage(STORAGE_KEY);
-      initIntercepts({ useValidatedModel: true, includePerformanceArtifacts: true });
-    });
-
     it('should update visible columns when latency filter is applied', () => {
-      modelCatalog.visit();
-      modelCatalog.findLoadingState().should('not.exist');
-      modelCatalog.togglePerformanceView();
-      modelCatalog.findModelCatalogDetailLink().first().click();
-      modelCatalog.clickPerformanceInsightsTab();
+      navigateWithPerformanceView();
 
       modelCatalog.openLatencyFilter();
       modelCatalog.selectLatencyMetric('E2E');
@@ -228,11 +225,7 @@ describe('Manage Columns Modal', () => {
     });
 
     it('should reflect latency filter changes in the manage columns modal state', () => {
-      modelCatalog.visit();
-      modelCatalog.findLoadingState().should('not.exist');
-      modelCatalog.togglePerformanceView();
-      modelCatalog.findModelCatalogDetailLink().first().click();
-      modelCatalog.clickPerformanceInsightsTab();
+      navigateWithPerformanceView();
 
       modelCatalog.openLatencyFilter();
       modelCatalog.selectLatencyMetric('ITL');
@@ -251,11 +244,7 @@ describe('Manage Columns Modal', () => {
     });
 
     it('should keep non-latency columns unchanged when latency filter updates column visibility', () => {
-      modelCatalog.visit();
-      modelCatalog.findLoadingState().should('not.exist');
-      modelCatalog.togglePerformanceView();
-      modelCatalog.findModelCatalogDetailLink().first().click();
-      modelCatalog.clickPerformanceInsightsTab();
+      navigateWithPerformanceView();
 
       modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/manageColumns.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/manageColumns.cy.ts
@@ -8,10 +8,7 @@ import {
   type ModelCatalogInterceptOptions,
 } from '~/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog';
 import { NBSP } from '~/__tests__/cypress/cypress/support/constants';
-import {
-  DEFAULT_VISIBLE_COLUMN_FIELDS,
-  HARDWARE_CONFIG_COLUMNS_STORAGE_KEY as STORAGE_KEY,
-} from '~/app/pages/modelCatalog/components/HardwareConfigurationTableColumns';
+import { HARDWARE_CONFIG_COLUMNS_STORAGE_KEY as STORAGE_KEY } from '~/app/pages/modelCatalog/components/HardwareConfigurationTableColumns';
 
 const initIntercepts = (options: Partial<ModelCatalogInterceptOptions> = {}) => {
   const resolvedOptions = {
@@ -53,16 +50,11 @@ describe('Manage Columns Modal', () => {
     initIntercepts();
   });
 
-  describe('Opening the Modal', () => {
-    it('should open the modal when clicking the Customize columns button', () => {
+  describe('Smoke Test', () => {
+    it('should open the manage columns modal and display its controls', () => {
       navigateToPerformanceInsights();
 
       modelCatalog.findManageColumnsButton().should('be.visible');
-      modelCatalog.openManageColumnsModal();
-    });
-
-    it('should display search input and column list in the modal', () => {
-      navigateToPerformanceInsights();
       modelCatalog.openManageColumnsModal();
 
       modelCatalog.findManageColumnsSearch().should('be.visible');
@@ -81,128 +73,23 @@ describe('Manage Columns Modal', () => {
       modelCatalog.findManageColumnsModal().should('not.contain.text', 'Workload type');
     });
 
-    it('should always show sticky columns in the table regardless of manage columns settings', () => {
+    it('should always show sticky columns in the table after toggling other columns off', () => {
       navigateToPerformanceInsights();
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
+      modelCatalog.findManageColumnCheckbox('vLLM Version').uncheck();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
+      modelCatalog
+        .findHardwareConfigurationTableHeaders()
+        .should('not.contain.text', 'vLLM Version');
 
       modelCatalog
         .findHardwareConfigurationTableHeaders()
         .should('contain.text', 'Hardware configuration');
       modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Workload type');
-    });
-  });
-
-  describe('Toggling Columns Off/On', () => {
-    it('should remove a column from the table when unchecked and Update is clicked', () => {
-      navigateToPerformanceInsights();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
-
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
-      modelCatalog.findManageColumnsUpdateButton().click();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
-    });
-
-    it('should add a column back when re-checked and Update is clicked', () => {
-      const columnsWithoutReplicas = DEFAULT_VISIBLE_COLUMN_FIELDS.filter(
-        (col) => col !== 'replicas',
-      );
-      cy.window().then((win) => {
-        win.localStorage.setItem(STORAGE_KEY, JSON.stringify(columnsWithoutReplicas));
-      });
-
-      navigateToPerformanceInsights();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
-
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnCheckbox('Replicas').check();
-      modelCatalog.findManageColumnsUpdateButton().click();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
-    });
-
-    it('should not apply changes when Cancel is clicked', () => {
-      navigateToPerformanceInsights();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
-
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
-      modelCatalog.findManageColumnsCancelButton().click();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
-    });
-
-    it('should toggle multiple columns at once', () => {
-      navigateToPerformanceInsights();
-
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
-      modelCatalog.findManageColumnCheckbox('vLLM Version').uncheck();
-      modelCatalog.findManageColumnsUpdateButton().click();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
-      modelCatalog
-        .findHardwareConfigurationTableHeaders()
-        .should('not.contain.text', 'vLLM Version');
-    });
-  });
-
-  describe('Column Visibility Persistence', () => {
-    it('should persist column visibility to localStorage', () => {
-      navigateToPerformanceInsights();
-
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
-      modelCatalog.findManageColumnsUpdateButton().click();
-
-      cy.window().then((win) => {
-        const stored = win.localStorage.getItem(STORAGE_KEY);
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        expect(stored).to.not.be.null;
-        const parsed = JSON.parse(stored!);
-        expect(parsed).to.be.an('array');
-        expect(parsed).to.not.include('replicas');
-      });
-    });
-
-    it('should restore column visibility from localStorage on reload', () => {
-      navigateToPerformanceInsights();
-
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
-      modelCatalog.findManageColumnsUpdateButton().click();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
-
-      navigateToPerformanceInsights();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
-    });
-  });
-
-  describe('Restore Defaults', () => {
-    it('should restore default column visibility when Restore default columns is clicked', () => {
-      navigateToPerformanceInsights();
-
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
-      modelCatalog.findManageColumnCheckbox('vLLM Version').uncheck();
-      modelCatalog.findManageColumnsUpdateButton().click();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
-      modelCatalog
-        .findHardwareConfigurationTableHeaders()
-        .should('not.contain.text', 'vLLM Version');
-
-      modelCatalog.openManageColumnsModal();
-      modelCatalog.findManageColumnsRestoreDefaults().click();
-      modelCatalog.findManageColumnsUpdateButton().click();
-
-      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
-      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'vLLM Version');
     });
   });
 
@@ -258,20 +145,6 @@ describe('Manage Columns Modal', () => {
         .findHardwareConfigurationTableHeaders()
         .should('contain.text', 'Hardware configuration');
       modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Workload type');
-    });
-  });
-
-  describe('Search', () => {
-    it('should filter columns when typing in the search input', () => {
-      navigateToPerformanceInsights();
-      modelCatalog.openManageColumnsModal();
-
-      modelCatalog.findManageColumnsSearch().type('TTFT');
-
-      modelCatalog.findManageColumnsModal().should('contain.text', `TTFT${NBSP}Latency Mean`);
-      modelCatalog.findManageColumnsModal().should('contain.text', `TTFT${NBSP}Latency P90`);
-      modelCatalog.findManageColumnsModal().should('not.contain.text', 'Replicas');
-      modelCatalog.findManageColumnsModal().should('not.contain.text', 'vLLM Version');
     });
   });
 });

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/manageColumns.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/manageColumns.cy.ts
@@ -1,0 +1,288 @@
+/* eslint-disable camelcase */
+import { modelCatalog } from '~/__tests__/cypress/cypress/pages/modelCatalog';
+import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
+import {
+  setupModelCatalogIntercepts,
+  interceptPerformanceArtifactsList,
+  interceptArtifactsList,
+  type ModelCatalogInterceptOptions,
+} from '~/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog';
+import { NBSP } from '~/__tests__/cypress/cypress/support/constants';
+
+const STORAGE_KEY = 'hardware-config-table-columns';
+
+const initIntercepts = (options: Partial<ModelCatalogInterceptOptions> = {}) => {
+  const resolvedOptions = {
+    useValidatedModel: true,
+    includePerformanceArtifacts: true,
+    ...options,
+  };
+
+  setupModelCatalogIntercepts(resolvedOptions);
+
+  if (resolvedOptions.includePerformanceArtifacts) {
+    interceptArtifactsList();
+    interceptPerformanceArtifactsList();
+  }
+};
+
+const navigateToPerformanceInsights = () => {
+  modelCatalog.visit();
+  modelCatalog.findLoadingState().should('not.exist');
+  modelCatalog.findModelCatalogDetailLink().first().click();
+  modelCatalog.clickPerformanceInsightsTab();
+};
+
+describe('Manage Columns Modal', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/model-registry/api/v1/model_registry*', [
+      mockModelRegistry({ name: 'modelregistry-sample' }),
+    ]).as('getModelRegistries');
+
+    cy.clearLocalStorage(STORAGE_KEY);
+    initIntercepts({ useValidatedModel: true, includePerformanceArtifacts: true });
+  });
+
+  describe('Opening the Modal', () => {
+    it('should open the modal when clicking the Customize columns button', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog.findManageColumnsButton().should('be.visible');
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnsModal().should('be.visible');
+    });
+
+    it('should display search input and column list in the modal', () => {
+      navigateToPerformanceInsights();
+      modelCatalog.openManageColumnsModal();
+
+      modelCatalog.findManageColumnsSearch().should('be.visible');
+      modelCatalog.findManageColumnsUpdateButton().should('be.visible');
+      modelCatalog.findManageColumnsCancelButton().should('be.visible');
+      modelCatalog.findManageColumnsRestoreDefaults().should('be.visible');
+    });
+  });
+
+  describe('Sticky Columns Exclusion', () => {
+    it('should not show Hardware configuration column in the modal', () => {
+      navigateToPerformanceInsights();
+      modelCatalog.openManageColumnsModal();
+
+      modelCatalog.findManageColumnsModal().should('not.contain.text', 'Hardware configuration');
+    });
+
+    it('should not show Workload type column in the modal', () => {
+      navigateToPerformanceInsights();
+      modelCatalog.openManageColumnsModal();
+
+      modelCatalog.findManageColumnsModal().should('not.contain.text', 'Workload type');
+    });
+
+    it('should always show sticky columns in the table regardless of manage columns settings', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog
+        .findHardwareConfigurationTableHeaders()
+        .should('contain.text', 'Hardware configuration');
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Workload type');
+    });
+  });
+
+  describe('Toggling Columns Off/On', () => {
+    it('should remove a column from the table when unchecked and Update is clicked', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
+    });
+
+    it('should add a column back when re-checked and Update is clicked', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').check();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
+    });
+
+    it('should not apply changes when Cancel is clicked', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
+      modelCatalog.findManageColumnsCancelButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
+    });
+
+    it('should toggle multiple columns at once', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
+      modelCatalog.findManageColumnCheckbox('vLLM Version').uncheck();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
+      modelCatalog
+        .findHardwareConfigurationTableHeaders()
+        .should('not.contain.text', 'vLLM Version');
+    });
+  });
+
+  describe('Column Visibility Persistence', () => {
+    it('should persist column visibility to localStorage', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      cy.window().then((win) => {
+        const stored = win.localStorage.getItem(STORAGE_KEY);
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        expect(stored).to.not.be.null;
+        const parsed = JSON.parse(stored!);
+        expect(parsed).to.be.an('array');
+        expect(parsed).to.not.include('replicas');
+      });
+    });
+
+    it('should restore column visibility from localStorage on reload', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
+
+      navigateToPerformanceInsights();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
+    });
+  });
+
+  describe('Restore Defaults', () => {
+    it('should restore default column visibility when Restore default columns is clicked', () => {
+      navigateToPerformanceInsights();
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnCheckbox('Replicas').uncheck();
+      modelCatalog.findManageColumnCheckbox('vLLM Version').uncheck();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'Replicas');
+      modelCatalog
+        .findHardwareConfigurationTableHeaders()
+        .should('not.contain.text', 'vLLM Version');
+
+      modelCatalog.openManageColumnsModal();
+      modelCatalog.findManageColumnsRestoreDefaults().click();
+      modelCatalog.findManageColumnsUpdateButton().click();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'vLLM Version');
+    });
+  });
+
+  describe('Latency Filter Interaction with Column Visibility', () => {
+    beforeEach(() => {
+      cy.clearLocalStorage(STORAGE_KEY);
+      initIntercepts({ useValidatedModel: true, includePerformanceArtifacts: true });
+    });
+
+    it('should update visible columns when latency filter is applied', () => {
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.clickPerformanceInsightsTab();
+
+      modelCatalog.openLatencyFilter();
+      modelCatalog.selectLatencyMetric('E2E');
+      modelCatalog.selectLatencyPercentile('Mean');
+      modelCatalog.clickApplyFilter();
+
+      modelCatalog
+        .findHardwareConfigurationTableHeaders()
+        .should('contain.text', `E2E${NBSP}Latency Mean`);
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', `TPS${NBSP}Mean`);
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'TTFT');
+      modelCatalog.findHardwareConfigurationTableHeaders().should('not.contain.text', 'ITL');
+    });
+
+    it('should reflect latency filter changes in the manage columns modal state', () => {
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.clickPerformanceInsightsTab();
+
+      modelCatalog.openLatencyFilter();
+      modelCatalog.selectLatencyMetric('ITL');
+      modelCatalog.selectLatencyPercentile('P95');
+      modelCatalog.clickApplyFilter();
+
+      modelCatalog
+        .findHardwareConfigurationTableHeaders()
+        .should('contain.text', `ITL${NBSP}Latency P95`);
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', `TPS${NBSP}P95`);
+
+      modelCatalog.openManageColumnsModal();
+
+      modelCatalog.findManageColumnCheckbox(`ITL${NBSP}Latency P95`).should('be.checked');
+      modelCatalog.findManageColumnCheckbox(`TPS${NBSP}P95`).should('be.checked');
+    });
+
+    it('should keep non-latency columns unchanged when latency filter updates column visibility', () => {
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.clickPerformanceInsightsTab();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
+
+      modelCatalog.openLatencyFilter();
+      modelCatalog.selectLatencyMetric('E2E');
+      modelCatalog.selectLatencyPercentile('P99');
+      modelCatalog.clickApplyFilter();
+
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Replicas');
+      modelCatalog
+        .findHardwareConfigurationTableHeaders()
+        .should('contain.text', 'Hardware configuration');
+      modelCatalog.findHardwareConfigurationTableHeaders().should('contain.text', 'Workload type');
+    });
+  });
+
+  describe('Search', () => {
+    it('should filter columns when typing in the search input', () => {
+      navigateToPerformanceInsights();
+      modelCatalog.openManageColumnsModal();
+
+      modelCatalog.findManageColumnsSearch().type('TTFT');
+
+      modelCatalog.findManageColumnsModal().should('contain.text', `TTFT${NBSP}Latency Mean`);
+      modelCatalog.findManageColumnsModal().should('contain.text', `TTFT${NBSP}Latency P90`);
+      modelCatalog.findManageColumnsModal().should('not.contain.text', 'Replicas');
+      modelCatalog.findManageColumnsModal().should('not.contain.text', 'vLLM Version');
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added cypress coverage to Manage Columns in Hardware Configuration Table

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
