### PR TITLE
Add catalog hardware tags

### DIFF
--- a/catalog/internal/catalog/modelcatalog/loader.go
+++ b/catalog/internal/catalog/modelcatalog/loader.go
@@ -329,11 +329,11 @@ func (l *ModelLoader) updateDatabase(ctx context.Context) error {
 					}
 				}
 
-			for _, handler := range l.handlers {
-				if err := handler(ctx, record); err != nil {
-					glog.Errorf("%s: event handler error: %v", *attr.Name, err)
+				for _, handler := range l.handlers {
+					if err := handler(ctx, record); err != nil {
+						glog.Errorf("%s: event handler error: %v", *attr.Name, err)
+					}
 				}
-			}
 			}()
 		}
 	}()

--- a/catalog/internal/catalog/modelcatalog/yaml_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog.go
@@ -51,7 +51,8 @@ func convertMetadataValueToProperty(key string, value apimodels.MetadataValue) m
 	}
 }
 
-// convertCustomProperties converts a map of custom properties to a slice of Properties
+// convertCustomProperties converts a map of custom properties to a slice of Properties.
+// hardware_tag entries with empty values are skipped.
 func convertCustomProperties(customProps *map[string]apimodels.MetadataValue) []models.Properties {
 	if customProps == nil {
 		return nil
@@ -59,42 +60,14 @@ func convertCustomProperties(customProps *map[string]apimodels.MetadataValue) []
 
 	var properties []models.Properties
 	for key, value := range *customProps {
+		if key == "hardware_tag" && value.MetadataStringValue != nil && value.MetadataStringValue.StringValue == "" {
+			continue
+		}
 		properties = append(properties, convertMetadataValueToProperty(key, value))
 	}
 	return properties
 }
 
-const hardwareTagKey = "hardware_tag"
-
-// extractHardwareTagsFromYAML reads a YAML catalog file and returns unique
-// hardware_tag values found in model customProperties.
-func extractHardwareTagsFromYAML(path string) ([]string, error) {
-	buf, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var catalog yamlCatalog
-	if err = yaml.UnmarshalStrict(buf, &catalog); err != nil {
-		return nil, err
-	}
-
-	seen := make(map[string]struct{})
-	var tags []string
-	for _, model := range catalog.Models {
-		if val, ok := model.CustomProperties[hardwareTagKey]; ok && val.MetadataStringValue != nil {
-			tag := val.MetadataStringValue.StringValue
-			if tag != "" {
-				if _, exists := seen[tag]; !exists {
-					seen[tag] = struct{}{}
-					tags = append(tags, tag)
-				}
-			}
-		}
-	}
-
-	return tags, nil
-}
 
 func init() {
 	if err := RegisterModelProvider("yaml", newYamlModelProvider); err != nil {

--- a/catalog/internal/catalog/modelcatalog/yaml_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog.go
@@ -68,7 +68,6 @@ func convertCustomProperties(customProps *map[string]apimodels.MetadataValue) []
 	return properties
 }
 
-
 func init() {
 	if err := RegisterModelProvider("yaml", newYamlModelProvider); err != nil {
 		panic(err)

--- a/catalog/internal/catalog/modelcatalog/yaml_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog.go
@@ -51,8 +51,7 @@ func convertMetadataValueToProperty(key string, value apimodels.MetadataValue) m
 	}
 }
 
-// convertCustomProperties converts a map of custom properties to a slice of Properties.
-// hardware_tag entries with empty values are skipped.
+// convertCustomProperties converts a map of custom properties to a slice of Properties
 func convertCustomProperties(customProps *map[string]apimodels.MetadataValue) []models.Properties {
 	if customProps == nil {
 		return nil
@@ -60,9 +59,6 @@ func convertCustomProperties(customProps *map[string]apimodels.MetadataValue) []
 
 	var properties []models.Properties
 	for key, value := range *customProps {
-		if key == "hardware_tag" && value.MetadataStringValue != nil && value.MetadataStringValue.StringValue == "" {
-			continue
-		}
 		properties = append(properties, convertMetadataValueToProperty(key, value))
 	}
 	return properties
@@ -166,6 +162,12 @@ func (ym *yamlModel) convertModelProperties() ([]models.Properties, []models.Pro
 		if servingConfigJSON, err := json.Marshal(ym.ServingConfig); err == nil {
 			properties = append(properties, models.NewStringProperty("serving_config", string(servingConfigJSON), false))
 		}
+	}
+
+	// Drop hardware_tag if its value is empty
+	if val, ok := ym.CustomProperties["hardware_tag"]; ok &&
+		val.MetadataStringValue != nil && val.MetadataStringValue.StringValue == "" {
+		delete(ym.CustomProperties, "hardware_tag")
 	}
 
 	// Convert custom properties from the YAML model

--- a/catalog/internal/catalog/modelcatalog/yaml_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog.go
@@ -64,6 +64,38 @@ func convertCustomProperties(customProps *map[string]apimodels.MetadataValue) []
 	return properties
 }
 
+const hardwareTagKey = "hardware_tag"
+
+// extractHardwareTagsFromYAML reads a YAML catalog file and returns unique
+// hardware_tag values found in model customProperties.
+func extractHardwareTagsFromYAML(path string) ([]string, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var catalog yamlCatalog
+	if err = yaml.UnmarshalStrict(buf, &catalog); err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	var tags []string
+	for _, model := range catalog.Models {
+		if val, ok := model.CustomProperties[hardwareTagKey]; ok && val.MetadataStringValue != nil {
+			tag := val.MetadataStringValue.StringValue
+			if tag != "" {
+				if _, exists := seen[tag]; !exists {
+					seen[tag] = struct{}{}
+					tags = append(tags, tag)
+				}
+			}
+		}
+	}
+
+	return tags, nil
+}
+
 func init() {
 	if err := RegisterModelProvider("yaml", newYamlModelProvider); err != nil {
 		panic(err)

--- a/catalog/internal/catalog/modelcatalog/yaml_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog_test.go
@@ -31,18 +31,18 @@ func TestYamlModelToModelProviderRecord(t *testing.T) {
 			name: "complete model with all properties",
 			yamlModel: yamlModel{
 				CatalogModel: model.CatalogModel{
-					Name:                     "test-model",
-					Description:              apiutils.Of("Test model description"),
-					Readme:                   apiutils.Of("# Test Model\nThis is a test model."),
-					Maturity:                 apiutils.Of("Generally Available"),
-					Language:                 []string{"en", "fr"},
-					Tasks:                    []string{"text-generation", "nlp"},
-					ValidatedTasks:           []string{"text-generation", "tool-calling"},
-					Provider:                 apiutils.Of("IBM"),
-					Logo:                     apiutils.Of("https://example.com/logo.png"),
-					License:                  apiutils.Of("apache-2.0"),
-					LicenseLink:              apiutils.Of("https://www.apache.org/licenses/LICENSE-2.0"),
-					LibraryName:              apiutils.Of("transformers"),
+					Name:           "test-model",
+					Description:    apiutils.Of("Test model description"),
+					Readme:         apiutils.Of("# Test Model\nThis is a test model."),
+					Maturity:       apiutils.Of("Generally Available"),
+					Language:       []string{"en", "fr"},
+					Tasks:          []string{"text-generation", "nlp"},
+					ValidatedTasks: []string{"text-generation", "tool-calling"},
+					Provider:       apiutils.Of("IBM"),
+					Logo:           apiutils.Of("https://example.com/logo.png"),
+					License:        apiutils.Of("apache-2.0"),
+					LicenseLink:    apiutils.Of("https://www.apache.org/licenses/LICENSE-2.0"),
+					LibraryName:    apiutils.Of("transformers"),
 					ServingConfig: &model.ServingConfig{
 						ToolCalling: &model.ToolCallingConfig{
 							ToolCallParser:       apiutils.Of("granite"),
@@ -905,4 +905,110 @@ func modelNameFromRecord(t *testing.T, record ModelProviderRecord) string {
 	require.NotNil(t, attrs)
 	require.NotNil(t, attrs.Name)
 	return *attrs.Name
+}
+
+func TestExtractHardwareTagsFromYAML(t *testing.T) {
+	t.Run("extracts unique hardware_tag values from validated models", func(t *testing.T) {
+		path := filepath.Join("testdata", "dev-validated-models.yaml")
+		tags, err := extractHardwareTagsFromYAML(path)
+		require.NoError(t, err)
+		assert.Contains(t, tags, "Intel Xeon")
+	})
+
+	t.Run("returns empty for catalog without hardware_tag", func(t *testing.T) {
+		dir := t.TempDir()
+		catalogPath := filepath.Join(dir, "no-tags.yaml")
+		content := `source: test
+models:
+  - name: TestModel/no-tags
+    description: A model without hardware tags
+    tasks:
+      - text-generation
+    customProperties:
+      model_type:
+        metadataType: MetadataStringValue
+        string_value: "generative"
+    artifacts:
+      - uri: oci://registry.example.com/test:latest
+`
+		require.NoError(t, os.WriteFile(catalogPath, []byte(content), 0o644))
+
+		tags, err := extractHardwareTagsFromYAML(catalogPath)
+		require.NoError(t, err)
+		assert.Empty(t, tags)
+	})
+
+	t.Run("deduplicates identical hardware_tag values", func(t *testing.T) {
+		dir := t.TempDir()
+		catalogPath := filepath.Join(dir, "dup-tags.yaml")
+		content := `source: test
+models:
+  - name: TestModel/model-a
+    description: First model
+    tasks:
+      - text-generation
+    customProperties:
+      hardware_tag:
+        metadataType: MetadataStringValue
+        string_value: "HRDWR X3000"
+    artifacts:
+      - uri: oci://registry.example.com/a:latest
+  - name: TestModel/model-b
+    description: Second model
+    tasks:
+      - text-generation
+    customProperties:
+      hardware_tag:
+        metadataType: MetadataStringValue
+        string_value: "HRDWR X3000"
+    artifacts:
+      - uri: oci://registry.example.com/b:latest
+  - name: TestModel/model-c
+    description: Third model
+    tasks:
+      - text-generation
+    customProperties:
+      hardware_tag:
+        metadataType: MetadataStringValue
+        string_value: "HRDWR X2000"
+    artifacts:
+      - uri: oci://registry.example.com/c:latest
+`
+		require.NoError(t, os.WriteFile(catalogPath, []byte(content), 0o644))
+
+		tags, err := extractHardwareTagsFromYAML(catalogPath)
+		require.NoError(t, err)
+		assert.Len(t, tags, 2)
+		assert.Contains(t, tags, "HRDWR X3000")
+		assert.Contains(t, tags, "HRDWR X2000")
+	})
+
+	t.Run("skips empty hardware_tag values", func(t *testing.T) {
+		dir := t.TempDir()
+		catalogPath := filepath.Join(dir, "empty-tag.yaml")
+		content := `source: test
+models:
+  - name: TestModel/empty-tag
+    description: Model with empty tag
+    tasks:
+      - text-generation
+    customProperties:
+      hardware_tag:
+        metadataType: MetadataStringValue
+        string_value: ""
+    artifacts:
+      - uri: oci://registry.example.com/empty:latest
+`
+		require.NoError(t, os.WriteFile(catalogPath, []byte(content), 0o644))
+
+		tags, err := extractHardwareTagsFromYAML(catalogPath)
+		require.NoError(t, err)
+		assert.Empty(t, tags)
+	})
+
+	t.Run("returns error for nonexistent file", func(t *testing.T) {
+		tags, err := extractHardwareTagsFromYAML("/nonexistent/path.yaml")
+		assert.Error(t, err)
+		assert.Nil(t, tags)
+	})
 }

--- a/catalog/internal/catalog/modelcatalog/yaml_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog_test.go
@@ -820,6 +820,163 @@ func TestYamlModelProviderInvalidPattern(t *testing.T) {
 	assert.Contains(t, err.Error(), "pattern cannot be empty")
 }
 
+func TestYamlModelHardwareTagAsCustomProperty(t *testing.T) {
+	t.Run("single hardware_tag value", func(t *testing.T) {
+		ym := yamlModel{
+			CatalogModel: model.CatalogModel{
+				Name:  "test-vendor/single-hw",
+				Tasks: []string{"text-generation"},
+				CustomProperties: map[string]model.MetadataValue{
+					"hardware_tag": {
+						MetadataStringValue: &model.MetadataStringValue{
+							StringValue:  "Hardware Tag 1",
+							MetadataType: "MetadataStringValue",
+						},
+					},
+				},
+			},
+			Artifacts: []*yamlArtifact{
+				{CatalogArtifact: model.CatalogArtifact{
+					CatalogModelArtifact: &model.CatalogModelArtifact{
+						ArtifactType: "model-artifact",
+						Uri:          "oci://registry.example.com/test:latest",
+					},
+				}},
+			},
+		}
+
+		record := ym.ToModelProviderRecord()
+		require.NotNil(t, record.Model)
+		require.Nil(t, record.Error)
+
+		customPropMap := customPropsToMap(t, record)
+		assert.Contains(t, customPropMap, "hardware_tag")
+		assert.Equal(t, "Hardware Tag 1", *customPropMap["hardware_tag"].StringValue)
+		assert.True(t, customPropMap["hardware_tag"].IsCustomProperty)
+	})
+
+	t.Run("multiple hardware_tag values comma-separated", func(t *testing.T) {
+		ym := yamlModel{
+			CatalogModel: model.CatalogModel{
+				Name:  "test-vendor/multi-hw",
+				Tasks: []string{"text-generation"},
+				CustomProperties: map[string]model.MetadataValue{
+					"hardware_tag": {
+						MetadataStringValue: &model.MetadataStringValue{
+							StringValue:  "Hardware Tag 1,Hardware Tag 2",
+							MetadataType: "MetadataStringValue",
+						},
+					},
+				},
+			},
+			Artifacts: []*yamlArtifact{
+				{CatalogArtifact: model.CatalogArtifact{
+					CatalogModelArtifact: &model.CatalogModelArtifact{
+						ArtifactType: "model-artifact",
+						Uri:          "oci://registry.example.com/test:latest",
+					},
+				}},
+			},
+		}
+
+		record := ym.ToModelProviderRecord()
+		require.NotNil(t, record.Model)
+		require.Nil(t, record.Error)
+
+		customPropMap := customPropsToMap(t, record)
+		assert.Contains(t, customPropMap, "hardware_tag")
+		assert.Equal(t, "Hardware Tag 1,Hardware Tag 2", *customPropMap["hardware_tag"].StringValue)
+		assert.True(t, customPropMap["hardware_tag"].IsCustomProperty)
+	})
+
+	t.Run("empty hardware_tag produces no custom property", func(t *testing.T) {
+		ym := yamlModel{
+			CatalogModel: model.CatalogModel{
+				Name:  "test-vendor/empty-hw",
+				Tasks: []string{"text-generation"},
+				CustomProperties: map[string]model.MetadataValue{
+					"hardware_tag": {
+						MetadataStringValue: &model.MetadataStringValue{
+							StringValue:  "",
+							MetadataType: "MetadataStringValue",
+						},
+					},
+					"model_type": {
+						MetadataStringValue: &model.MetadataStringValue{
+							StringValue:  "predictive",
+							MetadataType: "MetadataStringValue",
+						},
+					},
+				},
+			},
+			Artifacts: []*yamlArtifact{
+				{CatalogArtifact: model.CatalogArtifact{
+					CatalogModelArtifact: &model.CatalogModelArtifact{
+						ArtifactType: "model-artifact",
+						Uri:          "oci://registry.example.com/test:latest",
+					},
+				}},
+			},
+		}
+
+		record := ym.ToModelProviderRecord()
+		require.NotNil(t, record.Model)
+		require.Nil(t, record.Error)
+
+		customPropMap := customPropsToMap(t, record)
+		assert.NotContains(t, customPropMap, "hardware_tag")
+		assert.Contains(t, customPropMap, "model_type")
+		assert.Equal(t, "predictive", *customPropMap["model_type"].StringValue)
+	})
+
+	t.Run("missing hardware_tag produces no custom property", func(t *testing.T) {
+		ym := yamlModel{
+			CatalogModel: model.CatalogModel{
+				Name:  "test-vendor/no-hw",
+				Tasks: []string{"text-generation"},
+				CustomProperties: map[string]model.MetadataValue{
+					"model_type": {
+						MetadataStringValue: &model.MetadataStringValue{
+							StringValue:  "generative",
+							MetadataType: "MetadataStringValue",
+						},
+					},
+				},
+			},
+			Artifacts: []*yamlArtifact{
+				{CatalogArtifact: model.CatalogArtifact{
+					CatalogModelArtifact: &model.CatalogModelArtifact{
+						ArtifactType: "model-artifact",
+						Uri:          "oci://registry.example.com/test:latest",
+					},
+				}},
+			},
+		}
+
+		record := ym.ToModelProviderRecord()
+		require.NotNil(t, record.Model)
+		require.Nil(t, record.Error)
+
+		customPropMap := customPropsToMap(t, record)
+		assert.NotContains(t, customPropMap, "hardware_tag")
+		assert.Contains(t, customPropMap, "model_type")
+		assert.Equal(t, "generative", *customPropMap["model_type"].StringValue)
+	})
+}
+
+func customPropsToMap(t *testing.T, record ModelProviderRecord) map[string]models.Properties {
+	t.Helper()
+	customProps := record.Model.GetCustomProperties()
+	m := make(map[string]models.Properties)
+	if customProps == nil {
+		return m
+	}
+	for _, prop := range *customProps {
+		m[prop.Name] = prop
+	}
+	return m
+}
+
 func writeMiniCatalog(t *testing.T, modelNames []string) string {
 	t.Helper()
 
@@ -905,110 +1062,4 @@ func modelNameFromRecord(t *testing.T, record ModelProviderRecord) string {
 	require.NotNil(t, attrs)
 	require.NotNil(t, attrs.Name)
 	return *attrs.Name
-}
-
-func TestExtractHardwareTagsFromYAML(t *testing.T) {
-	t.Run("extracts unique hardware_tag values from validated models", func(t *testing.T) {
-		path := filepath.Join("testdata", "dev-validated-models.yaml")
-		tags, err := extractHardwareTagsFromYAML(path)
-		require.NoError(t, err)
-		assert.Contains(t, tags, "Intel Xeon")
-	})
-
-	t.Run("returns empty for catalog without hardware_tag", func(t *testing.T) {
-		dir := t.TempDir()
-		catalogPath := filepath.Join(dir, "no-tags.yaml")
-		content := `source: test
-models:
-  - name: TestModel/no-tags
-    description: A model without hardware tags
-    tasks:
-      - text-generation
-    customProperties:
-      model_type:
-        metadataType: MetadataStringValue
-        string_value: "generative"
-    artifacts:
-      - uri: oci://registry.example.com/test:latest
-`
-		require.NoError(t, os.WriteFile(catalogPath, []byte(content), 0o644))
-
-		tags, err := extractHardwareTagsFromYAML(catalogPath)
-		require.NoError(t, err)
-		assert.Empty(t, tags)
-	})
-
-	t.Run("deduplicates identical hardware_tag values", func(t *testing.T) {
-		dir := t.TempDir()
-		catalogPath := filepath.Join(dir, "dup-tags.yaml")
-		content := `source: test
-models:
-  - name: TestModel/model-a
-    description: First model
-    tasks:
-      - text-generation
-    customProperties:
-      hardware_tag:
-        metadataType: MetadataStringValue
-        string_value: "HRDWR X3000"
-    artifacts:
-      - uri: oci://registry.example.com/a:latest
-  - name: TestModel/model-b
-    description: Second model
-    tasks:
-      - text-generation
-    customProperties:
-      hardware_tag:
-        metadataType: MetadataStringValue
-        string_value: "HRDWR X3000"
-    artifacts:
-      - uri: oci://registry.example.com/b:latest
-  - name: TestModel/model-c
-    description: Third model
-    tasks:
-      - text-generation
-    customProperties:
-      hardware_tag:
-        metadataType: MetadataStringValue
-        string_value: "HRDWR X2000"
-    artifacts:
-      - uri: oci://registry.example.com/c:latest
-`
-		require.NoError(t, os.WriteFile(catalogPath, []byte(content), 0o644))
-
-		tags, err := extractHardwareTagsFromYAML(catalogPath)
-		require.NoError(t, err)
-		assert.Len(t, tags, 2)
-		assert.Contains(t, tags, "HRDWR X3000")
-		assert.Contains(t, tags, "HRDWR X2000")
-	})
-
-	t.Run("skips empty hardware_tag values", func(t *testing.T) {
-		dir := t.TempDir()
-		catalogPath := filepath.Join(dir, "empty-tag.yaml")
-		content := `source: test
-models:
-  - name: TestModel/empty-tag
-    description: Model with empty tag
-    tasks:
-      - text-generation
-    customProperties:
-      hardware_tag:
-        metadataType: MetadataStringValue
-        string_value: ""
-    artifacts:
-      - uri: oci://registry.example.com/empty:latest
-`
-		require.NoError(t, os.WriteFile(catalogPath, []byte(content), 0o644))
-
-		tags, err := extractHardwareTagsFromYAML(catalogPath)
-		require.NoError(t, err)
-		assert.Empty(t, tags)
-	})
-
-	t.Run("returns error for nonexistent file", func(t *testing.T) {
-		tags, err := extractHardwareTagsFromYAML("/nonexistent/path.yaml")
-		assert.Error(t, err)
-		assert.Nil(t, tags)
-	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds testing for the addition of "hardware_tags" expected to be retrieved as part of a catalog model's custom properties. The yaml contents are expected to display as:

```customProperties:
      hardware_tag:
          metadataType: MetadataStringValue
          string_value: "Hardware Tag Name"
```
          
          
Any hardware_tags that are present in the yaml but have no string value will be skipped. 

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

This was tested by adding 
```customProperties:
      hardware_tag:
          metadataType: MetadataStringValue
          string_value: "Hardware Tag Name"
```
          
to a demo model's custom properties and then making an API call to /api/model_catalog/v1alpha1/models for that specific model to ensure that the hardware_tag returns in the appropriately as a custom property. Unit testing has been added to ensure that different edge cases are handled appropriately as well. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
