### PR TITLE
Add validated deployment resource label

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -2347,9 +2347,20 @@ components:
       description: Tool calling configuration for vLLM serving runtime.
       type: object
       properties:
-        args:
+        toolCallParser:
           type: string
-          description: CLI arguments to pass to the serving runtime for tool calling support.
+          description: The tool-call parser identifier for the serving runtime.
+        chatTemplate:
+          type: string
+          description: Path to the chat template file packaged with the model.
+        enableAutoToolChoice:
+          type: boolean
+          description: Whether to enable automatic tool choice in the serving runtime.
+        requiredArgs:
+          type: array
+          items:
+            type: string
+          description: Additional CLI arguments required for tool calling.
     BaseResourceDates:
       description: Common timestamp fields for resources
       type: object

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -265,7 +265,7 @@ func catalogCustomPropertiesWithVariant(variantGroupId string, tensorType string
 		},
 		"validated_on": {
 			MetadataStringValue: &openapi.MetadataStringValue{
-				StringValue:  "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]",
+				StringValue:  "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vllm 0.20.0 - CUDA\"]",
 				MetadataType: "MetadataStringValue",
 			},
 		},
@@ -370,7 +370,9 @@ func GetCatalogModelMocks() []models.CatalogModel {
 		CustomProperties: catalogCustomPropertiesWithVariant(graniteVariantGroupId, "FP16"),
 		ServingConfig: &models.ServingConfig{
 			ToolCalling: &models.ToolCallingConfig{
-				Args: stringToPointer("--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja"),
+				ToolCallParser:       stringToPointer("granite"),
+				ChatTemplate:         stringToPointer("opt/app-root/template/tool_chat_template_granite.jinja"),
+				EnableAutoToolChoice: boolToPointer(true),
 			},
 		},
 		Logo: stringToPointer("data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4="),

--- a/clients/ui/bff/internal/mocks/types_mock.go
+++ b/clients/ui/bff/internal/mocks/types_mock.go
@@ -162,3 +162,7 @@ func stateToPointer[T any](s T) *T {
 func stringToPointer(s string) *string {
 	return &s
 }
+
+func boolToPointer(b bool) *bool {
+	return &b
+}

--- a/clients/ui/bff/internal/models/catalog_model_list.go
+++ b/clients/ui/bff/internal/models/catalog_model_list.go
@@ -5,7 +5,10 @@ import (
 )
 
 type ToolCallingConfig struct {
-	Args *string `json:"args,omitempty"`
+	ToolCallParser       *string  `json:"toolCallParser,omitempty"`
+	ChatTemplate         *string  `json:"chatTemplate,omitempty"`
+	EnableAutoToolChoice *bool    `json:"enableAutoToolChoice,omitempty"`
+	RequiredArgs         []string `json:"requiredArgs,omitempty"`
 }
 
 type ServingConfig struct {

--- a/clients/ui/frontend/src/__mocks__/mockCatalogModelList.ts
+++ b/clients/ui/frontend/src/__mocks__/mockCatalogModelList.ts
@@ -385,10 +385,16 @@ export const mockValidatedModel = mockCatalogModel({
       metadataType: ModelRegistryMetadataType.STRING,
       string_value: '',
     },
+    validated_on: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: '["RHOAI 2.20","RHAIIS 3.0","vLLM v0.8.5 - CUDA"]',
+    },
   },
   servingConfig: {
     toolCalling: {
-      args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
+      toolCallParser: 'granite',
+      chatTemplate: 'opt/app-root/template/tool_chat_template_granite.jinja',
+      enableAutoToolChoice: true,
     },
   },
 });

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -434,6 +434,10 @@ class ModelCatalog {
     return cy.get('#tool-calling-toggle');
   }
 
+  findValidatedDeploymentResourceLabels() {
+    return cy.findAllByTestId('validated-deployment-resource-label');
+  }
+
   // Performance Empty State
   findPerformanceEmptyState() {
     return cy.findByTestId('performance-empty-state');

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
@@ -99,6 +99,10 @@ export const createMockModelsForLabel = (
               metadataType: ModelRegistryMetadataType.STRING,
               string_value: '',
             },
+            validated_on: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: '["rhoai-3.5","vllm 0.20.0 - CUDA"]',
+            },
           } as ModelRegistryCustomProperties)
         : undefined;
       const name = isValidated ? 'validated-model' : `${label.toLowerCase()}-model-${i + 1}`;
@@ -111,7 +115,9 @@ export const createMockModelsForLabel = (
           validatedTasks: [ValidatedConfiguration.TOOL_CALLING],
           servingConfig: {
             toolCalling: {
-              args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
+              toolCallParser: 'granite',
+              chatTemplate: 'opt/app-root/template/tool_chat_template_granite.jinja',
+              enableAutoToolChoice: true,
             },
           },
         }),
@@ -165,6 +171,10 @@ export const interceptAllModels = (modelsPerCategory: number, useValidatedModel:
               metadataType: ModelRegistryMetadataType.STRING,
               string_value: '',
             },
+            validated_on: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: '["rhoai-3.5","vllm 0.20.0 - CUDA"]',
+            },
           } as ModelRegistryCustomProperties)
         : undefined;
       const name = isValidated ? 'validated-model' : `all-models-model-${i + 1}`;
@@ -176,7 +186,9 @@ export const interceptAllModels = (modelsPerCategory: number, useValidatedModel:
           validatedTasks: [ValidatedConfiguration.TOOL_CALLING],
           servingConfig: {
             toolCalling: {
-              args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
+              toolCallParser: 'granite',
+              chatTemplate: 'opt/app-root/template/tool_chat_template_granite.jinja',
+              enableAutoToolChoice: true,
             },
           },
         }),

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -374,7 +374,7 @@ describe('Model Catalog Page', () => {
         .click();
 
       cy.wait('@getFilteredModels').then((interception) => {
-        expect(interception.request.url).to.include('validatedTasks%3D%27tool-calling%27');
+        expect(interception.request.url).to.include('validated_tasks%3D%27tool-calling%27');
       });
     });
 
@@ -396,7 +396,7 @@ describe('Model Catalog Page', () => {
 
       cy.wait('@getFilteredModels').then((interception) => {
         const { url } = interception.request;
-        expect(url).to.include('validatedTasks%3D%27tool-calling%27');
+        expect(url).to.include('validated_tasks%3D%27tool-calling%27');
         expect(url).to.include('provider%3D%27Google%27');
       });
     });
@@ -442,9 +442,9 @@ describe('Model Catalog Page', () => {
 
         cy.wait('@getFilteredModels').then((interception) => {
           const { url } = interception.request;
-          expect(url).to.include('validatedTasks%3D%27tool-calling%27');
+          expect(url).to.include('validated_tasks%3D%27tool-calling%27');
           expect(url).to.include('AND');
-          expect(url).to.include('validatedTasks%3D%27text-generation%27');
+          expect(url).to.include('validated_tasks%3D%27text-generation%27');
           expect(url).to.not.include('IN');
         });
       });

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -350,6 +350,15 @@ describe('Model Catalog Details Page - Validated Configurations Card', () => {
       modelCatalog.findToolCallingCard().should('contain.text', '--enable-auto-tool-choice');
       modelCatalog.findToolCallingCard().should('contain.text', '--tool-call-parser granite');
     });
+
+    it('should display validated deployment resources label when expanded', () => {
+      modelCatalog.findToolCallingToggle().click();
+      modelCatalog.findValidatedDeploymentResourceLabels().should('have.length', 1);
+      modelCatalog
+        .findValidatedDeploymentResourceLabels()
+        .first()
+        .should('contain.text', 'vLLM v0.8.5 - CUDA');
+    });
   });
 
   describe('with feature flag disabled', () => {

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -40,7 +40,10 @@ export type CatalogSource = {
 export type CatalogSourceList = PaginationParams & { items?: CatalogSource[] };
 
 export type ToolCallingConfig = {
-  args?: string;
+  toolCallParser?: string;
+  chatTemplate?: string;
+  enableAutoToolChoice?: boolean;
+  requiredArgs?: string[];
 };
 
 export type ServingConfig = {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -31,6 +31,7 @@ import { CatalogArtifactList, CatalogModel } from '~/app/modelCatalogTypes';
 import {
   getLabels,
   getValidatedOnPlatforms,
+  getValidatedDeploymentResources,
   getCustomPropString,
 } from '~/app/pages/modelRegistry/screens/utils';
 import ModelCatalogLabels from '~/app/pages/modelCatalog/components/ModelCatalogLabels';
@@ -43,6 +44,7 @@ import {
   hasModelArtifacts,
   isModelValidated,
   hasValidatedToolCalling,
+  getToolCallingArgs,
   formatModelTypeDisplay,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { CatalogModelCustomPropertyKey } from '~/concepts/modelCatalog/const';
@@ -68,6 +70,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
   const isToolCallingValidated = isToolCallingEnabled && hasValidatedToolCalling(model);
 
   const validatedOnPlatforms = getValidatedOnPlatforms(model.customProperties);
+  const validatedDeploymentResources = getValidatedDeploymentResources(model.customProperties);
 
   const modelTypeRaw = model.customProperties
     ? getCustomPropString(model.customProperties, CatalogModelCustomPropertyKey.MODEL_TYPE)
@@ -138,7 +141,10 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
           <Stack hasGutter>
             {isToolCallingValidated && (
               <StackItem>
-                <Card data-testid="validated-configurations-card">
+                <Card
+                  data-testid="validated-configurations-card"
+                  style={{ contain: 'inline-size' }}
+                >
                   <CardHeader>
                     <Title headingLevel="h2" size="lg">
                       Validated arguments
@@ -165,7 +171,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                       >
                         <Stack>
                           <StackItem>
-                            <Title headingLevel="h3" size="md">
+                            <Title headingLevel="h4" size="md">
                               Tool calling
                             </Title>
                           </StackItem>
@@ -179,9 +185,32 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                       </CardHeader>
                       <CardExpandableContent>
                         <CardBody>
-                          <CodeBlockComponent>
-                            {model.servingConfig?.toolCalling?.args ?? ''}
-                          </CodeBlockComponent>
+                          <Stack hasGutter>
+                            <StackItem>
+                              <CodeBlockComponent>
+                                {getToolCallingArgs(model.servingConfig?.toolCalling)}
+                              </CodeBlockComponent>
+                            </StackItem>
+                            {validatedDeploymentResources.length > 0 && (
+                              <StackItem>
+                                <div className="pf-v6-u-font-weight-bold">
+                                  Validated deployment resources
+                                </div>
+                                <LabelGroup className="pf-v6-u-mt-sm">
+                                  {validatedDeploymentResources.map((resource) => (
+                                    <Label
+                                      key={resource}
+                                      data-testid="validated-deployment-resource-label"
+                                      color="blue"
+                                      isCompact
+                                    >
+                                      {resource}
+                                    </Label>
+                                  ))}
+                                </LabelGroup>
+                              </StackItem>
+                            )}
+                          </Stack>
                         </CardBody>
                       </CardExpandableContent>
                     </Card>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -39,6 +39,7 @@ import {
   getCatalogModelTypePropertyForRegistration,
   getActiveSourceLabels,
   hasValidatedToolCalling,
+  getToolCallingArgs,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { mockCatalogModelArtifact } from '~/__mocks__/mockCatalogModelArtifactList';
 import { ModelRegistryMetadataType } from '~/app/types';
@@ -363,7 +364,7 @@ describe('filtersToFilterQuery', () => {
     it('handles a single validated configuration value', () => {
       expect(
         filtersToFilterQuery(mockFormData({ validatedTasks: ['tool-calling'] }), mockFilterOptions),
-      ).toBe("validatedTasks='tool-calling'");
+      ).toBe("validated_tasks='tool-calling'");
     });
 
     it('handles multiple validated configuration values with AND logic instead of IN', () => {
@@ -372,7 +373,7 @@ describe('filtersToFilterQuery', () => {
           mockFormData({ validatedTasks: ['tool-calling', 'text-generation'] }),
           mockFilterOptions,
         ),
-      ).toBe("validatedTasks='tool-calling' AND validatedTasks='text-generation'");
+      ).toBe("validated_tasks='tool-calling' AND validated_tasks='text-generation'");
     });
 
     it('handles validated configuration combined with other OR-logic filters', () => {
@@ -386,7 +387,7 @@ describe('filtersToFilterQuery', () => {
           mockFilterOptions,
         ),
       ).toBe(
-        "tasks IN ('text-to-text','image-to-text') AND provider='Google' AND validatedTasks='tool-calling' AND validatedTasks='text-generation'",
+        "tasks IN ('text-to-text','image-to-text') AND provider='Google' AND validated_tasks='tool-calling' AND validated_tasks='text-generation'",
       );
     });
   });
@@ -1705,12 +1706,12 @@ describe('getActiveSourceLabels', () => {
 });
 
 describe('hasValidatedToolCalling', () => {
-  it('should return true when model has tool-calling in validatedTasks and servingConfig.toolCalling', () => {
+  it('should return true when model has tool-calling in validatedTasks and toolCallParser', () => {
     expect(
       hasValidatedToolCalling({
         name: 'test-model',
         validatedTasks: [ModelCatalogTask.TOOL_CALLING],
-        servingConfig: { toolCalling: { args: '--some-args' } },
+        servingConfig: { toolCalling: { toolCallParser: 'granite' } },
       }),
     ).toBe(true);
   });
@@ -1719,7 +1720,7 @@ describe('hasValidatedToolCalling', () => {
     expect(
       hasValidatedToolCalling({
         name: 'test-model',
-        servingConfig: { toolCalling: { args: '--some-args' } },
+        servingConfig: { toolCalling: { toolCallParser: 'granite' } },
       }),
     ).toBe(false);
   });
@@ -1729,7 +1730,7 @@ describe('hasValidatedToolCalling', () => {
       hasValidatedToolCalling({
         name: 'test-model',
         validatedTasks: ['text-generation'],
-        servingConfig: { toolCalling: { args: '--some-args' } },
+        servingConfig: { toolCalling: { toolCallParser: 'granite' } },
       }),
     ).toBe(false);
   });
@@ -1753,7 +1754,64 @@ describe('hasValidatedToolCalling', () => {
     ).toBe(false);
   });
 
+  it('should return false when servingConfig.toolCalling exists but has no toolCallParser', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+        servingConfig: { toolCalling: {} },
+      }),
+    ).toBe(false);
+  });
+
   it('should return false when both validatedTasks and servingConfig are missing', () => {
     expect(hasValidatedToolCalling({ name: 'test-model' })).toBe(false);
+  });
+});
+
+describe('getToolCallingArgs', () => {
+  it('should return empty string when config is undefined', () => {
+    expect(getToolCallingArgs(undefined)).toBe('');
+  });
+
+  it('should return empty string when config has no fields', () => {
+    expect(getToolCallingArgs({})).toBe('');
+  });
+
+  it('should build args from structured fields', () => {
+    const result = getToolCallingArgs({
+      toolCallParser: 'granite',
+      chatTemplate: 'opt/app-root/template/tool_chat_template_granite.jinja',
+      enableAutoToolChoice: true,
+    });
+    expect(result).toContain('--enable-auto-tool-choice');
+    expect(result).toContain('--tool-call-parser granite');
+    expect(result).toContain(
+      '--chat-template opt/app-root/template/tool_chat_template_granite.jinja',
+    );
+  });
+
+  it('should include requiredArgs in output', () => {
+    const result = getToolCallingArgs({
+      toolCallParser: 'granite',
+      enableAutoToolChoice: true,
+      requiredArgs: ['--config_format granite'],
+    });
+    expect(result).toContain('--config_format granite');
+  });
+
+  it('should join parts with backslash-newline separator', () => {
+    const result = getToolCallingArgs({
+      toolCallParser: 'granite',
+      enableAutoToolChoice: true,
+    });
+    expect(result).toBe('--enable-auto-tool-choice \\\n--tool-call-parser granite');
+  });
+
+  it('should handle only toolCallParser without enableAutoToolChoice', () => {
+    const result = getToolCallingArgs({
+      toolCallParser: 'mistral',
+    });
+    expect(result).toBe('--tool-call-parser mistral');
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -15,6 +15,7 @@ import {
   MetricsType,
   ModelCatalogFilterKey,
   SourceLabel,
+  ToolCallingConfig,
 } from '~/app/modelCatalogTypes';
 import { getLabels } from '~/app/pages/modelRegistry/screens/utils';
 import {
@@ -190,7 +191,24 @@ export const shouldShowValidatedInsights = (
 
 export const hasValidatedToolCalling = (model: CatalogModel): boolean =>
   model.validatedTasks?.includes(ModelCatalogTask.TOOL_CALLING) === true &&
-  model.servingConfig?.toolCalling != null;
+  !!model.servingConfig?.toolCalling?.toolCallParser;
+
+export const getToolCallingArgs = (config?: ToolCallingConfig): string => {
+  const parts: string[] = [];
+  if (config?.enableAutoToolChoice) {
+    parts.push('--enable-auto-tool-choice');
+  }
+  if (config?.toolCallParser) {
+    parts.push(`--tool-call-parser ${config.toolCallParser}`);
+  }
+  if (config?.chatTemplate) {
+    parts.push(`--chat-template ${config.chatTemplate}`);
+  }
+  if (config?.requiredArgs) {
+    parts.push(...config.requiredArgs);
+  }
+  return parts.join(' \\\n');
+};
 
 const isArrayOfSelections = (
   filterOption: CatalogFilterOptions[keyof CatalogFilterOptions],

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/__tests__/utils.test.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/__tests__/utils.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable camelcase */
 import { ModelRegistryMetadataType, ModelRegistryCustomProperties } from '~/app/types';
-import { getValidatedOnPlatforms } from '~/app/pages/modelRegistry/screens/utils';
+import {
+  getValidatedOnPlatforms,
+  getValidatedDeploymentResources,
+} from '~/app/pages/modelRegistry/screens/utils';
 
 describe('getValidatedOnPlatforms', () => {
   it('should return empty array when customProperties is undefined', () => {
@@ -162,5 +165,94 @@ describe('getValidatedOnPlatforms', () => {
     };
     const result = getValidatedOnPlatforms(customProperties);
     expect(result).toEqual(['OpenShift', 'Kubernetes']);
+  });
+
+  it('should exclude deployment resource entries starting with vllm', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: '["rhoai-3.5","vllm 0.20.0 - CUDA","RHAIIS 3.0"]',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedOnPlatforms(customProperties);
+    expect(result).toEqual(['rhoai-3.5', 'RHAIIS 3.0']);
+  });
+
+  it('should exclude deployment resources case-insensitively', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: '["RHOAI 2.20","VLLM v0.8.5 - CUDA"]',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedOnPlatforms(customProperties);
+    expect(result).toEqual(['RHOAI 2.20']);
+  });
+});
+
+describe('getValidatedDeploymentResources', () => {
+  it('should return empty array when customProperties is undefined', () => {
+    const result = getValidatedDeploymentResources(undefined);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when customProperties is empty', () => {
+    const result = getValidatedDeploymentResources({});
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when no deployment resources exist', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: '["rhoai-3.5","RHAIIS 3.0"]',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedDeploymentResources(customProperties);
+    expect(result).toEqual([]);
+  });
+
+  it('should return deployment resources starting with vllm', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: '["rhoai-3.5","vllm 0.20.0 - CUDA"]',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedDeploymentResources(customProperties);
+    expect(result).toEqual(['vllm 0.20.0 - CUDA']);
+  });
+
+  it('should handle case-insensitive matching for vllm prefix', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: '["RHOAI 2.20","VLLM v0.8.5 - CUDA","vLLM v0.9.0"]',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedDeploymentResources(customProperties);
+    expect(result).toEqual(['VLLM v0.8.5 - CUDA', 'vLLM v0.9.0']);
+  });
+
+  it('should return multiple deployment resources', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: '["rhoai-3.5","vllm 0.20.0 - CUDA","vllm 0.8.5 - ROCm"]',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedDeploymentResources(customProperties);
+    expect(result).toEqual(['vllm 0.20.0 - CUDA', 'vllm 0.8.5 - ROCm']);
+  });
+
+  it('should return empty array when validated_on contains invalid JSON', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      validated_on: {
+        string_value: 'not valid json',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    const result = getValidatedDeploymentResources(customProperties);
+    expect(result).toEqual([]);
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -16,7 +16,10 @@ import {
   ModelRegistryFilterDataType,
   ModelRegistryVersionsFilterDataType,
 } from '~/app/pages/modelRegistry/screens/const';
-import { CatalogModelCustomPropertyKey } from '~/concepts/modelCatalog/const';
+import {
+  CatalogModelCustomPropertyKey,
+  DEPLOYMENT_RESOURCE_PREFIXES,
+} from '~/concepts/modelCatalog/const';
 
 export type ObjectStorageFields = {
   endpoint: string;
@@ -272,8 +275,6 @@ export const getLatestVersionForRegisteredModel = (
   const latestVersion = getLastCreatedItem(filteredVersions);
   return latestVersion;
 };
-
-const DEPLOYMENT_RESOURCE_PREFIXES = ['vllm'];
 
 const isDeploymentResource = (entry: string): boolean =>
   DEPLOYMENT_RESOURCE_PREFIXES.some((prefix) => entry.toLowerCase().startsWith(prefix));

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -273,7 +273,12 @@ export const getLatestVersionForRegisteredModel = (
   return latestVersion;
 };
 
-export const getValidatedOnPlatforms = <T extends ModelRegistryCustomProperties>(
+const DEPLOYMENT_RESOURCE_PREFIXES = ['vllm'];
+
+const isDeploymentResource = (entry: string): boolean =>
+  DEPLOYMENT_RESOURCE_PREFIXES.some((prefix) => entry.toLowerCase().startsWith(prefix));
+
+const getValidatedOnEntries = <T extends ModelRegistryCustomProperties>(
   customProperties: T | undefined,
 ): string[] => {
   if (!customProperties) {
@@ -302,3 +307,12 @@ export const getValidatedOnPlatforms = <T extends ModelRegistryCustomProperties>
     return [];
   }
 };
+
+export const getValidatedOnPlatforms = <T extends ModelRegistryCustomProperties>(
+  customProperties: T | undefined,
+): string[] =>
+  getValidatedOnEntries(customProperties).filter((entry) => !isDeploymentResource(entry));
+
+export const getValidatedDeploymentResources = <T extends ModelRegistryCustomProperties>(
+  customProperties: T | undefined,
+): string[] => getValidatedOnEntries(customProperties).filter(isDeploymentResource);

--- a/clients/ui/frontend/src/app/shared/components/catalog/__tests__/catalogFilterUtils.spec.ts
+++ b/clients/ui/frontend/src/app/shared/components/catalog/__tests__/catalogFilterUtils.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import {
   wrapInQuotes,
   eqFilter,
@@ -92,19 +93,19 @@ describe('stringFiltersToFilterQuery', () => {
   });
 
   it('uses AND logic for keys in matchAllKeys', () => {
-    const result = stringFiltersToFilterQuery({ validatedTasks: ['chat', 'code'] }, undefined, [
-      'validatedTasks',
+    const result = stringFiltersToFilterQuery({ validated_tasks: ['chat', 'code'] }, undefined, [
+      'validated_tasks',
     ]);
-    expect(result).toBe("validatedTasks='chat' AND validatedTasks='code'");
+    expect(result).toBe("validated_tasks='chat' AND validated_tasks='code'");
   });
 
   it('uses IN for multi-value keys not in matchAllKeys', () => {
     const result = stringFiltersToFilterQuery(
-      { validatedTasks: ['chat', 'code'], provider: ['Red Hat', 'IBM'] },
+      { validated_tasks: ['chat', 'code'], provider: ['Red Hat', 'IBM'] },
       undefined,
-      ['validatedTasks'],
+      ['validated_tasks'],
     );
-    expect(result).toContain("validatedTasks='chat' AND validatedTasks='code'");
+    expect(result).toContain("validated_tasks='chat' AND validated_tasks='code'");
     expect(result).toContain("provider IN ('Red Hat','IBM')");
   });
 

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -469,6 +469,13 @@ export const MATCH_ALL_FILTER_KEYS: ModelCatalogStringFilterKey[] = [
 ];
 
 /**
+ * Prefixes used to identify deployment resource entries within validated_on.
+ * Entries starting with any of these prefixes are categorized as deployment resources
+ * rather than certified platforms.
+ */
+export const DEPLOYMENT_RESOURCE_PREFIXES = ['vllm'];
+
+/**
  * Performance filter keys that are shown when performance view is enabled.
  * These filters should reset to default values (from namedQueries) instead of clearing.
  * Note: HARDWARE_CONFIGURATION is NOT included here because it should clear normally

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -4,7 +4,7 @@ export enum ModelCatalogStringFilterKey {
   LICENSE = 'license',
   LANGUAGE = 'language',
   TENSOR_TYPE = 'tensor_type.string_value',
-  VALIDATED_CONFIGURATION = 'validatedTasks',
+  VALIDATED_CONFIGURATION = 'validated_tasks',
   // Performance filter keys use backend format
   HARDWARE_TYPE = 'artifacts.hardware_type.string_value',
   HARDWARE_CONFIGURATION = 'artifacts.hardware_configuration.string_value',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to add validated deployment resource label to validated configuration and fix few issue with validated configuration card and filter
<img width="408" height="544" alt="Screenshot 2026-05-21 at 2 54 11 p m" src="https://github.com/user-attachments/assets/fab0244e-6bb2-4b93-97d0-575f6df26ccc" />


## How Has This Been Tested?
1. Turn on the feature flag 
2. go to model details page 
3. and expand the validated arguments card and see the vllm version 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
