### PR TITLE
add hardware_tag labels from custom props

### DIFF
--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -297,6 +297,12 @@ func catalogCustomPropertiesWithVariant(variantGroupId string, tensorType string
 				MetadataType: "MetadataStringValue",
 			},
 		},
+		"hardware_tag": {
+			MetadataStringValue: &openapi.MetadataStringValue{
+				StringValue:  "GPU",
+				MetadataType: "MetadataStringValue",
+			},
+		},
 	}
 
 	// Add variant_group_id if provided

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
@@ -88,10 +88,7 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
           tasks={model.tasks ?? []}
           validatedTasks={model.validatedTasks}
           provider={model.provider}
-          labels={[
-            ...allLabels.filter((label) => label !== 'validated'),
-            ...valueLabels,
-          ]}
+          labels={[...allLabels.filter((label) => label !== 'validated'), ...valueLabels]}
           numLabels={isValidated ? 2 : 3}
         />
       </CardFooter>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
@@ -16,9 +16,12 @@ import { CheckCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { CatalogModel, CatalogSource } from '~/app/modelCatalogTypes';
 import { catalogModelDetailsFromModel } from '~/app/routes/modelCatalog/catalogModel';
-import { getLabels } from '~/app/pages/modelRegistry/screens/utils';
+import { getLabels, getValueLabels } from '~/app/pages/modelRegistry/screens/utils';
 import { isModelValidated, getModelName } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
-import { MODEL_CATALOG_POPOVER_MESSAGES } from '~/concepts/modelCatalog/const';
+import {
+  MODEL_CATALOG_POPOVER_MESSAGES,
+  CATALOG_VALUE_LABEL_KEYS,
+} from '~/concepts/modelCatalog/const';
 import ModelCatalogLabels from './ModelCatalogLabels';
 import ModelCatalogCardBody from './ModelCatalogCardBody';
 
@@ -29,6 +32,9 @@ type ModelCatalogCardProps = {
 
 const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) => {
   const allLabels = model.customProperties ? getLabels(model.customProperties) : [];
+  const valueLabels = model.customProperties
+    ? getValueLabels(model.customProperties, CATALOG_VALUE_LABEL_KEYS)
+    : [];
   const isValidated = isModelValidated(model);
 
   return (
@@ -82,7 +88,10 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
           tasks={model.tasks ?? []}
           validatedTasks={model.validatedTasks}
           provider={model.provider}
-          labels={allLabels.filter((label) => label !== 'validated')}
+          labels={[
+            ...allLabels.filter((label) => label !== 'validated'),
+            ...valueLabels,
+          ]}
           numLabels={isValidated ? 2 : 3}
         />
       </CardFooter>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -30,6 +30,7 @@ import text from '@patternfly/react-styles/css/utilities/Text/text';
 import { CatalogArtifactList, CatalogModel } from '~/app/modelCatalogTypes';
 import {
   getLabels,
+  getValueLabels,
   getValidatedOnPlatforms,
   getValidatedDeploymentResources,
   getCustomPropString,
@@ -49,7 +50,7 @@ import {
   getModelSizeFromCustomProperties,
   getMinimumVramFromCustomProperties,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
-import { CatalogModelCustomPropertyKey } from '~/concepts/modelCatalog/const';
+import { CatalogModelCustomPropertyKey, CATALOG_VALUE_LABEL_KEYS } from '~/concepts/modelCatalog/const';
 import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 
 type ModelDetailsViewProps = {
@@ -66,6 +67,9 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
   artifactsLoadError,
 }) => {
   const allLabels = model.customProperties ? getLabels(model.customProperties) : [];
+  const valueLabels = model.customProperties
+    ? getValueLabels(model.customProperties, CATALOG_VALUE_LABEL_KEYS)
+    : [];
   const isValidated = isModelValidated(model);
   const isToolCallingValidated = hasValidatedToolCalling(model);
 
@@ -235,7 +239,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                         <ModelCatalogLabels
                           tasks={model.tasks ?? []}
                           validatedTasks={model.validatedTasks}
-                          labels={allLabels.filter((label) => label !== 'validated')}
+                          labels={[...allLabels.filter((label) => label !== 'validated'), ...valueLabels]}
                           numLabels={isValidated ? 2 : 3}
                         />
                       </DescriptionListDescription>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -50,7 +50,10 @@ import {
   getModelSizeFromCustomProperties,
   getMinimumVramFromCustomProperties,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
-import { CatalogModelCustomPropertyKey, CATALOG_VALUE_LABEL_KEYS } from '~/concepts/modelCatalog/const';
+import {
+  CatalogModelCustomPropertyKey,
+  CATALOG_VALUE_LABEL_KEYS,
+} from '~/concepts/modelCatalog/const';
 import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 
 type ModelDetailsViewProps = {
@@ -239,7 +242,10 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                         <ModelCatalogLabels
                           tasks={model.tasks ?? []}
                           validatedTasks={model.validatedTasks}
-                          labels={[...allLabels.filter((label) => label !== 'validated'), ...valueLabels]}
+                          labels={[
+                            ...allLabels.filter((label) => label !== 'validated'),
+                            ...valueLabels,
+                          ]}
                           numLabels={isValidated ? 2 : 3}
                         />
                       </DescriptionListDescription>

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/__tests__/utils.test.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/__tests__/utils.test.ts
@@ -1,9 +1,86 @@
 /* eslint-disable camelcase */
 import { ModelRegistryMetadataType, ModelRegistryCustomProperties } from '~/app/types';
 import {
+  getValueLabels,
   getValidatedOnPlatforms,
   getValidatedDeploymentResources,
 } from '~/app/pages/modelRegistry/screens/utils';
+
+describe('getValueLabels', () => {
+  it('should return empty array when customProperties is empty', () => {
+    expect(getValueLabels({}, ['foo'])).toEqual([]);
+  });
+
+  it('should return empty array when keys list is empty', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      hardware_tag: {
+        string_value: 'Example Tag',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    expect(getValueLabels(customProperties, [])).toEqual([]);
+  });
+
+  it('should return value when key is present with a valid string value', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      hardware_tag: {
+        string_value: 'Example Tag',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    expect(getValueLabels(customProperties, ['hardware_tag'])).toEqual(['Example Tag']);
+  });
+
+  it('should exclude key whose string_value is empty', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      hardware_tag: {
+        string_value: '',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    expect(getValueLabels(customProperties, ['hardware_tag'])).toEqual([]);
+  });
+
+  it('should exclude key with non-STRING metadata type', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      count: {
+        int_value: '42',
+        metadataType: ModelRegistryMetadataType.INT,
+      },
+    };
+    expect(getValueLabels(customProperties, ['count'])).toEqual([]);
+  });
+
+  it('should skip keys that are missing from customProperties', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      hardware_tag: {
+        string_value: 'Example Tag',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+    };
+    expect(getValueLabels(customProperties, ['missing_key'])).toEqual([]);
+  });
+
+  it('should return values only for matching keys in order', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      hardware_tag: {
+        string_value: 'Example Tag',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+      provider: {
+        string_value: 'Red Hat',
+        metadataType: ModelRegistryMetadataType.STRING,
+      },
+      count: {
+        int_value: '5',
+        metadataType: ModelRegistryMetadataType.INT,
+      },
+    };
+    expect(
+      getValueLabels(customProperties, ['provider', 'missing', 'count', 'hardware_tag']),
+    ).toEqual(['Red Hat', 'Example Tag']);
+  });
+});
 
 describe('getValidatedOnPlatforms', () => {
   it('should return empty array when customProperties is undefined', () => {

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -52,7 +52,7 @@ export const getValueLabels = (
 ): string[] =>
   keys.flatMap((key) => {
     const prop = customProperties[key];
-    if (prop && prop.metadataType === ModelRegistryMetadataType.STRING && prop.string_value) {
+    if (prop.metadataType === ModelRegistryMetadataType.STRING && prop.string_value) {
       return [prop.string_value];
     }
     return [];

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -43,6 +43,25 @@ export const getLabels = <T extends ModelRegistryCustomProperties>(customPropert
     return prop.metadataType === ModelRegistryMetadataType.STRING && prop.string_value === '';
   });
 
+// Extracts display labels from custom properties whose values (not keys) should be shown.
+// For each key in the list, if the property exists and has a non-empty string value,
+// that value is returned as a label.
+export const getValueLabels = (
+  customProperties: ModelRegistryCustomProperties,
+  keys: string[],
+): string[] =>
+  keys.flatMap((key) => {
+    const prop = customProperties[key];
+    if (
+      prop &&
+      prop.metadataType === ModelRegistryMetadataType.STRING &&
+      prop.string_value
+    ) {
+      return [prop.string_value];
+    }
+    return [];
+  });
+
 // Returns the customProperties object with an updated set of labels (non-empty string_value) without affecting other properties.
 export const mergeUpdatedLabels = (
   customProperties: ModelRegistryCustomProperties,

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -52,11 +52,7 @@ export const getValueLabels = (
 ): string[] =>
   keys.flatMap((key) => {
     const prop = customProperties[key];
-    if (
-      prop &&
-      prop.metadataType === ModelRegistryMetadataType.STRING &&
-      prop.string_value
-    ) {
+    if (prop && prop.metadataType === ModelRegistryMetadataType.STRING && prop.string_value) {
       return [prop.string_value];
     }
     return [];

--- a/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/clients/ui/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -50,13 +50,15 @@ export const getValueLabels = (
   customProperties: ModelRegistryCustomProperties,
   keys: string[],
 ): string[] =>
-  keys.flatMap((key) => {
-    const prop = customProperties[key];
-    if (prop.metadataType === ModelRegistryMetadataType.STRING && prop.string_value) {
-      return [prop.string_value];
-    }
-    return [];
-  });
+  keys
+    .filter((key) => key in customProperties)
+    .flatMap((key) => {
+      const prop = customProperties[key];
+      if (prop.metadataType === ModelRegistryMetadataType.STRING && prop.string_value) {
+        return [prop.string_value];
+      }
+      return [];
+    });
 
 // Returns the customProperties object with an updated set of labels (non-empty string_value) without affecting other properties.
 export const mergeUpdatedLabels = (

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -272,7 +272,11 @@ export enum CatalogModelCustomPropertyKey {
   MODEL_SIZE = 'model_size',
   MINIMUM_VRAM = 'min_vram_gb',
   HARDWARE_CONFIGURATIONS = 'cold_start_matrix',
+  HARDWARE_TAG = 'hardware_tag',
 }
+
+// Custom property keys whose values (not keys) should be displayed as card labels.
+export const CATALOG_VALUE_LABEL_KEYS: string[] = [CatalogModelCustomPropertyKey.HARDWARE_TAG];
 
 export enum ModelType {
   GENERATIVE = 'generative',

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -276,7 +276,7 @@ export enum CatalogModelCustomPropertyKey {
 }
 
 // Custom property keys whose values (not keys) should be displayed as card labels.
-export const CATALOG_VALUE_LABEL_KEYS: string[] = [CatalogModelCustomPropertyKey.HARDWARE_TAG];
+export const CATALOG_VALUE_LABEL_KEYS: CatalogModelCustomPropertyKey[] = [CatalogModelCustomPropertyKey.HARDWARE_TAG];
 
 export enum ModelType {
   GENERATIVE = 'generative',

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -276,7 +276,9 @@ export enum CatalogModelCustomPropertyKey {
 }
 
 // Custom property keys whose values (not keys) should be displayed as card labels.
-export const CATALOG_VALUE_LABEL_KEYS: CatalogModelCustomPropertyKey[] = [CatalogModelCustomPropertyKey.HARDWARE_TAG];
+export const CATALOG_VALUE_LABEL_KEYS: CatalogModelCustomPropertyKey[] = [
+  CatalogModelCustomPropertyKey.HARDWARE_TAG,
+];
 
 export enum ModelType {
   GENERATIVE = 'generative',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR surfaces the hardware_tag custom property from model metadata and displays their value as a label on the model card. This allows for multiple keys to be added to the list of properties surfaced in the labels but currently only supports "hardware_tag" (among existing labels).

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Within the demo data yaml file, I updated the certified/production-llm-8b model to include a hardware_tag custom property in the following format:

hardware_tag:
        string_value: "Example Hardware Tag"
        metadataType: MetadataStringValue
        
Here is how it displayed locally when spun up with Tilt:
<img width="328" height="410" alt="Screenshot 2026-05-29 at 1 58 28 PM" src="https://github.com/user-attachments/assets/36179759-64c6-440f-92dd-02874a94088b" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
