### PR TITLE
feat(catalog): add security-metrics to MetricsType enum

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -851,6 +851,7 @@ components:
               enum:
                 - performance-metrics
                 - accuracy-metrics
+                - security-metrics
             customProperties:
               description: User provided custom properties which are not defined by its type.
               type: object

--- a/api/openapi/src/plugins/model.yaml
+++ b/api/openapi/src/plugins/model.yaml
@@ -327,6 +327,7 @@ components:
               enum:
                 - performance-metrics
                 - accuracy-metrics
+                - security-metrics
             customProperties:
               description: User provided custom properties which are not defined by its type.
               type: object

--- a/catalog/internal/catalog/modelcatalog/models/catalog_metrics_artifact.go
+++ b/catalog/internal/catalog/modelcatalog/models/catalog_metrics_artifact.go
@@ -11,6 +11,7 @@ type MetricsType string
 const (
 	MetricsTypePerformance     MetricsType = "performance-metrics"
 	MetricsTypeAccuracy        MetricsType = "accuracy-metrics"
+	MetricsTypeSecurityMetrics MetricsType = "security-metrics"
 	CatalogMetricsArtifactType             = "metrics-artifact"
 )
 

--- a/catalog/internal/catalog/modelcatalog/service/catalog_metrics_artifact.go
+++ b/catalog/internal/catalog/modelcatalog/service/catalog_metrics_artifact.go
@@ -78,7 +78,7 @@ func (r *CatalogMetricsArtifactRepositoryImpl) Save(ma models.CatalogMetricsArti
 	}
 
 	switch attr.MetricsType {
-	case models.MetricsTypeAccuracy, models.MetricsTypePerformance:
+	case models.MetricsTypeAccuracy, models.MetricsTypePerformance, models.MetricsTypeSecurityMetrics:
 		// OK
 	default:
 		return ma, fmt.Errorf("invalid artifact: unknown metrics type: %s", attr.MetricsType)
@@ -112,7 +112,7 @@ func (r *CatalogMetricsArtifactRepositoryImpl) BatchSave(artifacts []models.Cata
 		}
 
 		switch attr.MetricsType {
-		case models.MetricsTypeAccuracy, models.MetricsTypePerformance:
+		case models.MetricsTypeAccuracy, models.MetricsTypePerformance, models.MetricsTypeSecurityMetrics:
 			// OK
 		default:
 			return nil, fmt.Errorf("invalid artifact at index %d: unknown metrics type: %s", i, attr.MetricsType)

--- a/catalog/internal/catalog/modelcatalog/service/catalog_metrics_artifact_test.go
+++ b/catalog/internal/catalog/modelcatalog/service/catalog_metrics_artifact_test.go
@@ -398,7 +398,7 @@ func TestCatalogMetricsArtifactRepository(t *testing.T) {
 
 	t.Run("TestMetricsTypeField", func(t *testing.T) {
 		// Test various metrics types
-		metricsTypes := []models.MetricsType{models.MetricsTypeAccuracy, models.MetricsTypePerformance}
+		metricsTypes := []models.MetricsType{models.MetricsTypeAccuracy, models.MetricsTypePerformance, models.MetricsTypeSecurityMetrics}
 
 		catalogModel := &models.CatalogModelImpl{
 			Attributes: &models.CatalogModelAttributes{
@@ -622,5 +622,64 @@ func TestCatalogMetricsArtifactRepository(t *testing.T) {
 		_, err = repo.Save(catalogMetricsArtifact, savedCatalogModel.GetID())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown metrics type")
+	})
+
+	t.Run("TestBatchSaveWithSecurityMetrics", func(t *testing.T) {
+		catalogModel := &models.CatalogModelImpl{
+			Attributes: &models.CatalogModelAttributes{
+				Name:       new("test-catalog-model-for-batch-security"),
+				ExternalID: new("catalog-model-batch-security-ext"),
+			},
+		}
+		savedCatalogModel, err := catalogModelRepo.Save(catalogModel)
+		require.NoError(t, err)
+
+		artifacts := []models.CatalogMetricsArtifact{
+			&models.CatalogMetricsArtifactImpl{
+				Attributes: &models.CatalogMetricsArtifactAttributes{
+					Name:        new("batch-security-artifact-1"),
+					ExternalID:  new("batch-security-ext-1"),
+					MetricsType: models.MetricsTypeSecurityMetrics,
+				},
+			},
+			&models.CatalogMetricsArtifactImpl{
+				Attributes: &models.CatalogMetricsArtifactAttributes{
+					Name:        new("batch-security-artifact-2"),
+					ExternalID:  new("batch-security-ext-2"),
+					MetricsType: models.MetricsTypeSecurityMetrics,
+				},
+				CustomProperties: &[]dbmodels.Properties{
+					{Name: "attack_success_rate", DoubleValue: new(0.15)},
+					{Name: "pass", BoolValue: new(true)},
+				},
+			},
+		}
+
+		saved, err := repo.BatchSave(artifacts, savedCatalogModel.GetID())
+		require.NoError(t, err)
+		require.Len(t, saved, 2)
+		for _, a := range saved {
+			assert.NotNil(t, a.GetID())
+			assert.Equal(t, models.MetricsTypeSecurityMetrics, a.GetAttributes().MetricsType)
+		}
+
+		// Verify retrieval
+		retrieved1, err := repo.GetByID(*saved[0].GetID())
+		require.NoError(t, err)
+		assert.Equal(t, models.MetricsTypeSecurityMetrics, retrieved1.GetAttributes().MetricsType)
+
+		retrieved2, err := repo.GetByID(*saved[1].GetID())
+		require.NoError(t, err)
+		assert.Equal(t, models.MetricsTypeSecurityMetrics, retrieved2.GetAttributes().MetricsType)
+		require.NotNil(t, retrieved2.GetCustomProperties())
+		props := *retrieved2.GetCustomProperties()
+		var foundRate bool
+		for _, p := range props {
+			if p.Name == "attack_success_rate" {
+				foundRate = true
+				assert.Equal(t, 0.15, *p.DoubleValue)
+			}
+		}
+		assert.True(t, foundRate, "attack_success_rate custom property should be present")
 	})
 }


### PR DESCRIPTION
## Description

Add `security-metrics` as a `metricsType` to the OpenAPI spec. No additional code support; only a spec change.

## How Has This Been Tested?
Unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
