### PR TITLE
fix(catalog): add health state tracking to PluginBase and negative readyz tests

### DIFF
--- a/catalog/internal/catalog/mcpcatalog/loader.go
+++ b/catalog/internal/catalog/mcpcatalog/loader.go
@@ -118,12 +118,14 @@ func (ml *MCPLoader) PerformLeaderOperations(ctx context.Context, allKnownSource
 
 // ReloadParsing re-parses all config files into in-memory collections.
 // Called by the unified loader before computing combined source IDs for leader writes.
-func (ml *MCPLoader) ReloadParsing() {
+func (ml *MCPLoader) ReloadParsing() error {
+	var errs []error
 	for _, path := range ml.state.Paths() {
 		if err := ml.parseAndMerge(path); err != nil {
-			glog.Errorf("unable to reload MCP sources from %s: %v", path, err)
+			errs = append(errs, fmt.Errorf("unable to reload MCP sources from %s: %w", path, err))
 		}
 	}
+	return errors.Join(errs...)
 }
 
 // parseAndMerge parses a config file and merges its MCP sources into the collection.

--- a/catalog/internal/catalog/modelcatalog/loader.go
+++ b/catalog/internal/catalog/modelcatalog/loader.go
@@ -133,12 +133,14 @@ func (l *ModelLoader) PerformLeaderOperations(ctx context.Context, allKnownSourc
 
 // ReloadParsing re-parses all config files into in-memory collections.
 // Called by the unified loader before computing combined source IDs for leader writes.
-func (l *ModelLoader) ReloadParsing() {
+func (l *ModelLoader) ReloadParsing() error {
+	var errs []error
 	for _, path := range l.state.Paths() {
 		if err := l.parseAndMerge(path); err != nil {
-			glog.Errorf("unable to reload model sources from %s: %v", path, err)
+			errs = append(errs, fmt.Errorf("unable to reload model sources from %s: %w", path, err))
 		}
 	}
+	return errors.Join(errs...)
 }
 
 // performLeaderWrites executes database write operations: removing orphaned

--- a/catalog/internal/plugin/base.go
+++ b/catalog/internal/plugin/base.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -33,14 +34,22 @@ type PluginBaseConfig struct {
 
 // PluginBase provides the shared lifecycle implementation for catalog plugins.
 // Embed this in concrete plugin structs to get Start, Stop, OnBecomeLeader,
-// and KnownSourceIDs for free.
+// Healthy, and KnownSourceIDs for free.
 type PluginBase struct {
-	cfg PluginBaseConfig
+	cfg     PluginBaseConfig
+	healthy atomic.Bool
 }
 
 // NewPluginBase creates a PluginBase with the given configuration.
-func NewPluginBase(cfg PluginBaseConfig) PluginBase {
-	return PluginBase{cfg: cfg}
+func NewPluginBase(cfg PluginBaseConfig) *PluginBase {
+	pb := &PluginBase{cfg: cfg}
+	pb.healthy.Store(true)
+	return pb
+}
+
+// Healthy returns true if the plugin has not encountered any runtime errors.
+func (pb *PluginBase) Healthy() bool {
+	return pb.healthy.Load()
 }
 
 // Start sets up file watchers, parses all configs, and launches
@@ -68,6 +77,7 @@ func (pb *PluginBase) Start(ctx context.Context) error {
 func (pb *PluginBase) watchFile(ctx context.Context, path string) {
 	changes, err := pb.cfg.FileWatcher.Path(ctx, path)
 	if err != nil {
+		pb.healthy.Store(false)
 		glog.Errorf("unable to watch file (%s): %v", path, err)
 		return
 	}
@@ -79,6 +89,7 @@ func (pb *PluginBase) watchFile(ctx context.Context, path string) {
 		if pb.cfg.State.ShouldWriteDatabase() {
 			allKnownSourceIDs := CollectAllSourceIDs()
 			if err := pb.cfg.Loader.PerformLeaderOperations(ctx, allKnownSourceIDs); err != nil {
+				pb.healthy.Store(false)
 				glog.Errorf("unable to perform %s leader writes on reload: %v", pb.cfg.Name, err)
 			}
 		}
@@ -98,12 +109,14 @@ func (pb *PluginBase) OnBecomeLeader(ctx context.Context) error {
 
 	allKnownSourceIDs := CollectAllSourceIDs()
 	if err := pb.cfg.Loader.PerformLeaderOperations(ctx, allKnownSourceIDs); err != nil {
+		pb.healthy.Store(false)
 		pb.cfg.State.SetLeader(false)
 		return fmt.Errorf("%s leader operations: %w", pb.cfg.Name, err)
 	}
 
 	if pb.cfg.OnLeaderReady != nil {
 		if err := pb.cfg.OnLeaderReady(ctx); err != nil {
+			pb.healthy.Store(false)
 			pb.cfg.State.SetLeader(false)
 			return fmt.Errorf("%s post-leader setup: %w", pb.cfg.Name, err)
 		}

--- a/catalog/internal/plugin/base.go
+++ b/catalog/internal/plugin/base.go
@@ -84,13 +84,19 @@ func (pb *PluginBase) watchFile(ctx context.Context, path string) {
 
 	for range changes {
 		glog.Infof("Config file changed, reloading %s sources: %s", pb.cfg.Name, path)
-		pb.cfg.Loader.ReloadParsing()
+		if err := pb.cfg.Loader.ReloadParsing(); err != nil {
+			pb.healthy.Store(false)
+			glog.Errorf("unable to reload %s config: %v", pb.cfg.Name, err)
+			continue
+		}
 
 		if pb.cfg.State.ShouldWriteDatabase() {
 			allKnownSourceIDs := CollectAllSourceIDs()
 			if err := pb.cfg.Loader.PerformLeaderOperations(ctx, allKnownSourceIDs); err != nil {
 				pb.healthy.Store(false)
 				glog.Errorf("unable to perform %s leader writes on reload: %v", pb.cfg.Name, err)
+			} else {
+				pb.healthy.Store(true)
 			}
 		}
 	}
@@ -122,6 +128,7 @@ func (pb *PluginBase) OnBecomeLeader(ctx context.Context) error {
 		}
 	}
 
+	pb.healthy.Store(true)
 	glog.Infof("%s plugin leader mode active", pb.cfg.Name)
 	<-ctx.Done()
 

--- a/catalog/internal/plugin/base.go
+++ b/catalog/internal/plugin/base.go
@@ -89,6 +89,7 @@ func (pb *PluginBase) watchFile(ctx context.Context, path string) {
 			glog.Errorf("unable to reload %s config: %v", pb.cfg.Name, err)
 			continue
 		}
+		pb.healthy.Store(true)
 
 		if pb.cfg.State.ShouldWriteDatabase() {
 			allKnownSourceIDs := CollectAllSourceIDs()

--- a/catalog/internal/plugin/base_test.go
+++ b/catalog/internal/plugin/base_test.go
@@ -180,9 +180,7 @@ func TestPluginBaseWatchFileErrorMarksUnhealthy(t *testing.T) {
 
 	require.NoError(t, pb.Start(context.Background()))
 
-	// Wait for the goroutine to hit the error.
-	time.Sleep(50 * time.Millisecond)
-	assert.False(t, pb.Healthy())
+	assert.Eventually(t, func() bool { return !pb.Healthy() }, time.Second, 5*time.Millisecond)
 }
 
 func TestPluginBaseWatchFileLeaderOpsFailureMarksUnhealthy(t *testing.T) {
@@ -201,7 +199,8 @@ func TestPluginBaseWatchFileLeaderOpsFailureMarksUnhealthy(t *testing.T) {
 	assert.True(t, pb.Healthy(), "should be healthy before reload failure")
 
 	watcher.send("a.yaml")
-	assert.False(t, pb.Healthy(), "should be unhealthy after leader ops failure on reload")
+	assert.Eventually(t, func() bool { return !pb.Healthy() }, time.Second, 5*time.Millisecond,
+		"should be unhealthy after leader ops failure on reload")
 
 	watcher.closeAll()
 }

--- a/catalog/internal/plugin/base_test.go
+++ b/catalog/internal/plugin/base_test.go
@@ -151,14 +151,59 @@ func (w *mockFileWatcher) closeAll() {
 }
 
 func newTestPluginBase(state *mockState, loader *mockReloader, watcher *mockFileWatcher) *PluginBase {
-	pb := NewPluginBase(PluginBaseConfig{
+	return NewPluginBase(PluginBaseConfig{
 		Name:        "test",
 		State:       state,
 		Loader:      loader,
 		FileWatcher: watcher,
 		SourceIDs:   func() mapset.Set[string] { return mapset.NewSet("src-1", "src-2") },
 	})
-	return &pb
+}
+
+// --- Healthy tests ---
+
+func TestPluginBaseHealthyByDefault(t *testing.T) {
+	state := newMockState()
+	loader := &mockReloader{}
+	watcher := newMockFileWatcher()
+	pb := newTestPluginBase(state, loader, watcher)
+
+	assert.True(t, pb.Healthy())
+}
+
+func TestPluginBaseWatchFileErrorMarksUnhealthy(t *testing.T) {
+	state := newMockState("a.yaml")
+	loader := &mockReloader{}
+	watcher := newMockFileWatcher()
+	watcher.pathErr = errors.New("watch error")
+	pb := newTestPluginBase(state, loader, watcher)
+
+	require.NoError(t, pb.Start(context.Background()))
+
+	// Wait for the goroutine to hit the error.
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, pb.Healthy())
+}
+
+func TestPluginBaseWatchFileLeaderOpsFailureMarksUnhealthy(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	state := newMockState("a.yaml")
+	loader := &mockReloader{leaderOpsErr: errors.New("db write failed")}
+	watcher := newMockFileWatcher()
+	pb := newTestPluginBase(state, loader, watcher)
+
+	state.SetLeader(true)
+	require.NoError(t, pb.Start(context.Background()))
+	require.True(t, watcher.waitForPath("a.yaml", time.Second))
+
+	assert.True(t, pb.Healthy(), "should be healthy before reload failure")
+
+	watcher.send("a.yaml")
+	assert.False(t, pb.Healthy(), "should be unhealthy after leader ops failure on reload")
+
+	watcher.closeAll()
 }
 
 // --- Start tests ---
@@ -304,6 +349,7 @@ func TestPluginBaseOnBecomeLeaderOpsFail(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "db down")
 	assert.False(t, state.IsLeader(), "leader state should revert on failure")
+	assert.False(t, pb.Healthy(), "should be unhealthy after leader ops failure")
 }
 
 func TestPluginBaseOnBecomeLeaderHookCalled(t *testing.T) {
@@ -361,6 +407,7 @@ func TestPluginBaseOnBecomeLeaderHookFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "hook failed")
 	assert.False(t, state.IsLeader(), "leader state should revert on hook failure")
+	assert.False(t, pb.Healthy(), "should be unhealthy after hook failure")
 }
 
 func TestPluginBaseOnBecomeLeaderNilHook(t *testing.T) {

--- a/catalog/internal/plugin/base_test.go
+++ b/catalog/internal/plugin/base_test.go
@@ -21,6 +21,7 @@ type mockReloader struct {
 	leaderOpsCalled        atomic.Int32
 	lastLeaderSourceIDs    mapset.Set[string]
 	parseAllErr            error
+	reloadParsingErr       error
 	leaderOpsErr           error
 }
 
@@ -29,8 +30,11 @@ func (m *mockReloader) ParseAllConfigs() error {
 	return m.parseAllErr
 }
 
-func (m *mockReloader) ReloadParsing() {
+func (m *mockReloader) ReloadParsing() error {
 	m.reloadParsingCalled.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.reloadParsingErr
 }
 
 func (m *mockReloader) PerformLeaderOperations(_ context.Context, allKnownSourceIDs mapset.Set[string]) error {
@@ -201,6 +205,36 @@ func TestPluginBaseWatchFileLeaderOpsFailureMarksUnhealthy(t *testing.T) {
 	watcher.send("a.yaml")
 	assert.Eventually(t, func() bool { return !pb.Healthy() }, time.Second, 5*time.Millisecond,
 		"should be unhealthy after leader ops failure on reload")
+
+	// Clear the error — next reload should recover health.
+	loader.mu.Lock()
+	loader.leaderOpsErr = nil
+	loader.mu.Unlock()
+
+	watcher.send("a.yaml")
+	assert.Eventually(t, func() bool { return pb.Healthy() }, time.Second, 5*time.Millisecond,
+		"should recover health after successful reload")
+
+	watcher.closeAll()
+}
+
+func TestPluginBaseWatchFileParseFailureMarksUnhealthy(t *testing.T) {
+	state := newMockState("a.yaml")
+	loader := &mockReloader{reloadParsingErr: errors.New("malformed yaml")}
+	watcher := newMockFileWatcher()
+	pb := newTestPluginBase(state, loader, watcher)
+
+	require.NoError(t, pb.Start(context.Background()))
+	require.True(t, watcher.waitForPath("a.yaml", time.Second))
+
+	assert.True(t, pb.Healthy(), "should be healthy before parse failure")
+
+	watcher.send("a.yaml")
+	assert.Eventually(t, func() bool { return !pb.Healthy() }, time.Second, 5*time.Millisecond,
+		"should be unhealthy after parse failure")
+
+	// Leader ops should not be attempted after a parse failure.
+	assert.Equal(t, int32(0), loader.leaderOpsCalled.Load())
 
 	watcher.closeAll()
 }

--- a/catalog/internal/plugin/lifecycle.go
+++ b/catalog/internal/plugin/lifecycle.go
@@ -12,7 +12,7 @@ import (
 // Both modelcatalog.ModelLoader and mcpcatalog.MCPLoader satisfy this.
 type Reloader interface {
 	ParseAllConfigs() error
-	ReloadParsing()
+	ReloadParsing() error
 	PerformLeaderOperations(ctx context.Context, allKnownSourceIDs mapset.Set[string]) error
 }
 

--- a/catalog/internal/plugin/server_test.go
+++ b/catalog/internal/plugin/server_test.go
@@ -241,6 +241,48 @@ func TestServerHealthAllHealthy(t *testing.T) {
 	assert.Equal(t, "ready", body["status"])
 }
 
+func TestReadyzBothPluginsUnhealthy(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&mockPlugin{name: "model", version: "v1", healthy: false})
+	Register(&mockPlugin{name: "mcp", version: "v1", healthy: false})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	assertStatus(t, router, "/readyz", http.StatusServiceUnavailable)
+	body := getJSON(t, router, "/readyz")
+	assert.Equal(t, "not_ready", body["status"])
+
+	plugins := body["plugins"].(map[string]any)
+	assert.Equal(t, false, plugins["model"])
+	assert.Equal(t, false, plugins["mcp"])
+}
+
+func TestReadyzSinglePluginUnhealthy(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&mockPlugin{name: "model", version: "v1", healthy: true})
+	Register(&mockPlugin{name: "mcp", version: "v1", healthy: false})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	assertStatus(t, router, "/readyz", http.StatusServiceUnavailable)
+	body := getJSON(t, router, "/readyz")
+	assert.Equal(t, "not_ready", body["status"])
+
+	plugins := body["plugins"].(map[string]any)
+	assert.Equal(t, true, plugins["model"])
+	assert.Equal(t, false, plugins["mcp"])
+}
+
 func TestServerNotifyLeader(t *testing.T) {
 	Reset()
 	defer Reset()

--- a/catalog/internal/plugins/mcp/plugin.go
+++ b/catalog/internal/plugins/mcp/plugin.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Plugin struct {
-	plugin.PluginBase
+	*plugin.PluginBase
 	loader   *mcpcatalog.MCPLoader
 	services mcpcatalog.Services
 }
@@ -27,7 +27,6 @@ func (p *Plugin) Name() string                   { return "mcp" }
 func (p *Plugin) Version() string                { return "v1alpha1" }
 func (p *Plugin) Description() string            { return "MCP server catalog" }
 func (p *Plugin) BasePath() string               { return "/api/mcp_catalog/v1alpha1" }
-func (p *Plugin) Healthy() bool                  { return true }
 func (p *Plugin) Migrations() []plugin.Migration { return nil }
 
 // MCPSources returns the MCP source collection for cross-plugin access.

--- a/catalog/internal/plugins/model/plugin.go
+++ b/catalog/internal/plugins/model/plugin.go
@@ -28,7 +28,7 @@ type mcpSourceProvider interface {
 }
 
 type Plugin struct {
-	plugin.PluginBase
+	*plugin.PluginBase
 	loader   *modelcatalog.ModelLoader
 	services modelcatalog.Services
 }
@@ -37,7 +37,6 @@ func (p *Plugin) Name() string                   { return "model" }
 func (p *Plugin) Version() string                { return "v1alpha1" }
 func (p *Plugin) Description() string            { return "Model catalog" }
 func (p *Plugin) BasePath() string               { return "/api/model_catalog/v1alpha1" }
-func (p *Plugin) Healthy() bool                  { return true }
 func (p *Plugin) Migrations() []plugin.Migration { return nil }
 
 func (p *Plugin) DatastoreEntries() []plugin.DatastoreEntry {


### PR DESCRIPTION

Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
