### PR TITLE
feat(tools): add csv-exporter for Model Catalog metadata

### DIFF
--- a/tools/csv-exporter/Makefile
+++ b/tools/csv-exporter/Makefile
@@ -1,0 +1,14 @@
+.PHONY: install test lint clean
+
+install:
+	pip install pytest ruff mypy
+
+test:
+	python -m pytest -s -x -rA tests/
+
+lint:
+	ruff check model_catalog_export.py tests/
+	mypy model_catalog_export.py
+
+clean:
+	rm -rf __pycache__ tests/__pycache__ .mypy_cache .pytest_cache

--- a/tools/csv-exporter/README.md
+++ b/tools/csv-exporter/README.md
@@ -172,18 +172,15 @@ spec:
 
 The output is RFC 4180-compliant CSV with UTF-8 BOM (for Excel compatibility).
 
-### Fixed Columns
+### Model Columns
 
-Always present in this order:
+All top-level model fields are included automatically, in a stable default order.
+New fields added to the API will appear in the CSV without code changes.
 
-`id`, `name`, `description`, `provider`, `maturity`, `license`, `licenseLink`,
-`libraryName`, `source_id`, `externalId`, `createTimeSinceEpoch`,
-`lastUpdateTimeSinceEpoch`, `language`, `tasks`, `validatedTasks`
-
-### Dynamic Columns
+### Custom Property Columns
 
 Each custom property key found across all exported models becomes its own column,
-appended after the fixed columns in alphabetical order. Models that lack a particular
+appended after the model columns in alphabetical order. Models that lack a particular
 custom property have an empty cell for that column.
 
 ### Value Handling
@@ -196,9 +193,13 @@ custom property have an empty cell for that column.
 
 ### Excluded Fields
 
-- `readme` — can exceed 32K characters, not useful in tabular form
-- `logo` — can contain large data URLs, not useful in tabular form
-- `servingConfig` — internal serving configuration
+The following fields are excluded because they are too large or not useful in
+tabular form:
+
+- `readme` — can exceed 32K characters
+- `logo` — can contain large data URLs
+- `servingConfig` — nested serving configuration object
+- `customProperties` — handled separately as dynamic columns (see above)
 
 ## Troubleshooting
 

--- a/tools/csv-exporter/README.md
+++ b/tools/csv-exporter/README.md
@@ -1,0 +1,250 @@
+# Model Catalog CSV Export
+
+A standalone Python CLI script that exports Model Catalog metadata to a CSV file.
+
+## Prerequisites
+
+- Python 3.10 or later
+- Network access to the Model Catalog API
+
+No third-party Python packages required — the script uses only the Python standard library.
+
+## Usage
+
+```bash
+python model_catalog_export.py --url <catalog-api-url> --output <file.csv>
+```
+
+### Arguments
+
+| Argument       | Required | Description                                              |
+|----------------|----------|----------------------------------------------------------|
+| `--url`          | Yes      | Catalog API base URL (e.g., `http://localhost:8080`)     |
+| `--output`       | Yes      | Output CSV file path (not required with `--list-sources`)|
+| `--source`       | No       | Filter by source ID (repeatable for multiple sources)    |
+| `--limit`        | No       | Maximum number of models to export                       |
+| `--page-size`    | No       | Models per API page (default: 100)                       |
+| `--header`       | No       | HTTP header as `"Name: Value"` (repeatable)              |
+| `--list-sources` | No       | List available sources and exit                          |
+
+### Examples
+
+Export all models:
+
+```bash
+python model_catalog_export.py \
+  --url http://localhost:8080 \
+  --output models.csv
+```
+
+List available sources:
+
+```bash
+python model_catalog_export.py \
+  --url http://localhost:8080 \
+  --list-sources
+```
+
+```
+ID                NAME              STATUS
+community         Community         available
+validated_models   Validated Models  available
+```
+
+Export models from a specific source (use the ID from `--list-sources`):
+
+```bash
+python model_catalog_export.py \
+  --url http://localhost:8080 \
+  --output filtered.csv \
+  --source community
+```
+
+Export with authentication:
+
+```bash
+python model_catalog_export.py \
+  --url https://catalog-api.example.com \
+  --output models.csv \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+Limit output to 50 models:
+
+```bash
+python model_catalog_export.py \
+  --url http://localhost:8080 \
+  --output top50.csv \
+  --limit 50
+```
+
+## Accessing the Model Catalog API
+
+The Model Catalog API is a cluster-internal service. There are several ways to access it
+depending on your environment.
+
+### Ingress / Route
+
+If an ingress or route has been created for the catalog service, use the external URL directly:
+
+```bash
+python model_catalog_export.py --url "https://catalog.example.com" --output models.csv
+```
+
+### Port Forward
+
+Forward the catalog service port to your local machine:
+
+```bash
+kubectl port-forward svc/model-catalog -n <namespace> 8080:8080 &
+python model_catalog_export.py --url http://localhost:8080 --output models.csv
+```
+
+## Authentication
+
+The script does not implement its own authentication flow. Use `--header` to pass
+credentials when the API requires authentication:
+
+```bash
+# Bearer token
+python model_catalog_export.py \
+  --url https://catalog-api.example.com \
+  --output models.csv \
+  --header "Authorization: Bearer $(cat /var/run/secrets/token)"
+
+# Multiple headers
+python model_catalog_export.py \
+  --url https://catalog-api.example.com \
+  --output models.csv \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "X-Custom-Header: value"
+```
+
+When using `kubectl port-forward`, authentication is typically not required since the
+connection is already authenticated through your kubeconfig.
+
+## Scheduled Export (Kubernetes CronJob)
+
+The script's CLI interface makes it suitable for use as a Kubernetes CronJob:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: catalog-export
+spec:
+  schedule: "0 6 * * 1"  # Every Monday at 6am
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: export
+            image: python:3.12-slim
+            command:
+            - python
+            - /scripts/model_catalog_export.py
+            - --url
+            - http://model-catalog:8080
+            - --output
+            - /exports/models.csv
+            - --header
+            - "Authorization: Bearer $(cat /var/run/secrets/token)"
+            volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            - name: exports
+              mountPath: /exports
+            - name: token
+              mountPath: /var/run/secrets
+          restartPolicy: OnFailure
+          volumes:
+          - name: scripts
+            configMap:
+              name: catalog-export-script
+          - name: exports
+            persistentVolumeClaim:
+              claimName: catalog-exports
+          - name: token
+            secret:
+              secretName: catalog-api-token
+```
+
+## CSV Format
+
+The output is RFC 4180-compliant CSV with UTF-8 BOM (for Excel compatibility).
+
+### Fixed Columns
+
+Always present in this order:
+
+`id`, `name`, `description`, `provider`, `maturity`, `license`, `licenseLink`,
+`libraryName`, `source_id`, `externalId`, `createTimeSinceEpoch`,
+`lastUpdateTimeSinceEpoch`, `language`, `tasks`, `validatedTasks`
+
+### Dynamic Columns
+
+Each custom property key found across all exported models becomes its own column,
+appended after the fixed columns in alphabetical order. Models that lack a particular
+custom property have an empty cell for that column.
+
+### Value Handling
+
+- **Strings, numbers, booleans**: written directly
+- **Lists** (language, tasks, validatedTasks): JSON-encoded (e.g., `["en", "es"]`)
+- **Custom properties**: scalar values extracted from the metadata wrapper; complex types
+  (proto, struct) are JSON-stringified
+- **Null or missing fields**: empty cell
+
+### Excluded Fields
+
+- `readme` — can exceed 32K characters, not useful in tabular form
+- `logo` — can contain large data URLs, not useful in tabular form
+- `servingConfig` — internal serving configuration
+
+## Troubleshooting
+
+### Connection refused
+
+```
+Error: cannot connect to http://localhost:8080/...: Connection refused
+```
+
+The catalog service is not reachable. Check that:
+- `kubectl port-forward` is running (if using port-forward)
+- The correct namespace and service name are used
+- The catalog service pod is running: `kubectl get pods -n <namespace>`
+
+### HTTP 401 Unauthorized
+
+```
+Error: HTTP 401 from http://...
+```
+
+Authentication is required. Pass a valid bearer token via `--header`:
+
+```bash
+--header "Authorization: Bearer $TOKEN"
+```
+
+### HTTP 403 Forbidden
+
+The authenticated user does not have permission to access the catalog API.
+Check RBAC policies in the target namespace.
+
+### Empty CSV (header only)
+
+The catalog contains no models matching your filters. Verify by checking
+the API directly:
+
+```bash
+curl -s http://localhost:8080/api/model_catalog/v1alpha1/models | python -m json.tool
+```
+
+If using `--source`, confirm the source name is correct.
+
+### Excel shows garbled characters
+
+The CSV includes a UTF-8 BOM for Excel compatibility. If characters still
+display incorrectly, open the file via Excel's Data > From Text/CSV import
+and select UTF-8 encoding.

--- a/tools/csv-exporter/README.md
+++ b/tools/csv-exporter/README.md
@@ -141,15 +141,13 @@ spec:
           containers:
           - name: export
             image: python:3.12-slim
-            command:
-            - python
-            - /scripts/model_catalog_export.py
-            - --url
-            - http://model-catalog:8080
-            - --output
-            - /exports/models.csv
-            - --header
-            - "Authorization: Bearer $(cat /var/run/secrets/token)"
+            command: ["sh", "-c"]
+            args:
+            - |
+              python /scripts/model_catalog_export.py \
+                --url http://model-catalog:8080 \
+                --output /exports/models.csv \
+                --header "Authorization: Bearer $(cat /var/run/secrets/token)"
             volumeMounts:
             - name: scripts
               mountPath: /scripts

--- a/tools/csv-exporter/model_catalog_export.py
+++ b/tools/csv-exporter/model_catalog_export.py
@@ -16,7 +16,9 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-FIXED_COLUMNS = [
+EXCLUDED_FIELDS = {"readme", "logo", "servingConfig", "customProperties"}
+
+COLUMN_ORDER = [
     "id",
     "name",
     "description",
@@ -113,6 +115,17 @@ def format_field(value):
     return str(value)
 
 
+def discover_columns(models):
+    if not models:
+        return list(COLUMN_ORDER)
+    seen: set[str] = set()
+    for model in models:
+        seen.update(k for k in model if k not in EXCLUDED_FIELDS)
+    ordered = [k for k in COLUMN_ORDER if k in seen]
+    ordered += sorted(seen - set(COLUMN_ORDER))
+    return ordered
+
+
 def collect_models_and_keys(base_url, page_size, sources, limit, headers):
     models = []
     custom_keys: set[str] = set()
@@ -120,12 +133,12 @@ def collect_models_and_keys(base_url, page_size, sources, limit, headers):
         models.append(model)
         props = model.get("customProperties") or {}
         custom_keys.update(props.keys())
-    return models, sorted(custom_keys)
+    return models, discover_columns(models), sorted(custom_keys)
 
 
-def model_to_row(model, custom_keys):
+def model_to_row(model, columns, custom_keys):
     row = []
-    for col in FIXED_COLUMNS:
+    for col in columns:
         row.append(format_field(model.get(col)))
     props = model.get("customProperties") or {}
     for key in custom_keys:
@@ -136,7 +149,7 @@ def model_to_row(model, custom_keys):
     return row
 
 
-def write_csv(models, custom_keys, output_path):
+def write_csv(models, columns, custom_keys, output_path):
     output_dir = os.path.dirname(os.path.abspath(output_path))
     os.makedirs(output_dir, exist_ok=True)
     tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv", dir=output_dir)
@@ -144,10 +157,10 @@ def write_csv(models, custom_keys, output_path):
         with os.fdopen(tmp_fd, "w", newline="", encoding="utf-8") as f:
             f.write(UTF8_BOM)
             writer = csv.writer(f)
-            header = list(FIXED_COLUMNS) + custom_keys
+            header = list(columns) + custom_keys
             writer.writerow(header)
             for model in models:
-                writer.writerow(model_to_row(model, custom_keys))
+                writer.writerow(model_to_row(model, columns, custom_keys))
         os.replace(tmp_path, os.path.abspath(output_path))
     except BaseException:
         with contextlib.suppress(OSError):
@@ -283,14 +296,14 @@ def main(argv=None):
         raise SystemExit(2)
 
     try:
-        models, custom_keys = collect_models_and_keys(
+        models, columns, custom_keys = collect_models_and_keys(
             base_url=args.url,
             page_size=args.page_size,
             sources=args.source,
             limit=args.limit,
             headers=headers,
         )
-        write_csv(models, custom_keys, args.output)
+        write_csv(models, columns, custom_keys, args.output)
     except SystemExit:
         raise
     except Exception as e:
@@ -299,7 +312,7 @@ def main(argv=None):
 
     print(
         f"Exported {len(models)} models "
-        f"({len(FIXED_COLUMNS) + len(custom_keys)} columns) "
+        f"({len(columns) + len(custom_keys)} columns) "
         f"to {args.output}",
         file=sys.stderr,
     )

--- a/tools/csv-exporter/model_catalog_export.py
+++ b/tools/csv-exporter/model_catalog_export.py
@@ -34,8 +34,6 @@ FIXED_COLUMNS = [
     "validatedTasks",
 ]
 
-EXCLUDED_FIELDS = {"readme", "logo", "servingConfig", "customProperties"}
-
 API_PATH = "/api/model_catalog/v1alpha1/models"
 SOURCES_API_PATH = "/api/model_catalog/v1alpha1/sources"
 
@@ -60,9 +58,6 @@ def fetch_page(base_url, page_size, next_page_token=None, sources=None, headers=
         req.add_header(key, value)
     try:
         with urllib.request.urlopen(req) as resp:
-            if resp.status != 200:
-                msg = f"Error: API returned HTTP {resp.status} for {url}"
-                raise SystemExit(msg)
             return json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         body = ""
@@ -173,9 +168,11 @@ def fetch_sources(base_url, headers=None):
         body = ""
         with contextlib.suppress(Exception):
             body = e.read().decode("utf-8", errors="replace")[:500]
-        raise SystemExit(f"Error: HTTP {e.code} from {url}\n{body}") from None
+        msg = f"Error: HTTP {e.code} from {url}\n{body}"
+        raise SystemExit(msg) from None
     except urllib.error.URLError as e:
-        raise SystemExit(f"Error: cannot connect to {url}: {e.reason}") from None
+        msg = f"Error: cannot connect to {url}: {e.reason}"
+        raise SystemExit(msg) from None
     return data.get("items") or []
 
 
@@ -183,8 +180,8 @@ def print_sources(sources):
     if not sources:
         print("No sources found.", file=sys.stderr)
         return
-    id_width = max(len(s.get("id", "")) for s in sources)
-    name_width = max(len(s.get("name", "")) for s in sources)
+    id_width = max(len("ID"), max(len(s.get("id", "")) for s in sources))
+    name_width = max(len("NAME"), max(len(s.get("name", "")) for s in sources))
     print(f"{'ID':<{id_width}}  {'NAME':<{name_width}}  STATUS", file=sys.stderr)
     for s in sources:
         print(
@@ -222,19 +219,19 @@ def parse_args(argv=None):
         "--source",
         action="append",
         default=None,
-        help="Filter by source name (repeatable)",
+        help="Filter by source ID (repeatable)",
     )
     parser.add_argument(
         "--limit",
         type=int,
         default=None,
-        help="Maximum number of models to export",
+        help="Maximum number of models to export (must be >= 1)",
     )
     parser.add_argument(
         "--page-size",
         type=int,
         default=100,
-        help="Number of models per API page (default: 100)",
+        help="Number of models per API page (default: 100, must be >= 1)",
     )
     parser.add_argument(
         "--header",
@@ -253,8 +250,21 @@ def parse_args(argv=None):
     return parser.parse_args(argv)
 
 
+def validate_url_scheme(url):
+    if not url.startswith(("http://", "https://")):
+        msg = "Error: --url must use http:// or https:// scheme"
+        raise SystemExit(msg)
+
+
 def main(argv=None):
     args = parse_args(argv)
+    validate_url_scheme(args.url)
+    if args.limit is not None and args.limit < 1:
+        msg = "Error: --limit must be >= 1"
+        raise SystemExit(msg)
+    if args.page_size < 1:
+        msg = "Error: --page-size must be >= 1"
+        raise SystemExit(msg)
     headers = dict(args.headers) if args.headers else None
 
     if args.list_sources:

--- a/tools/csv-exporter/model_catalog_export.py
+++ b/tools/csv-exporter/model_catalog_export.py
@@ -39,7 +39,7 @@ COLUMN_ORDER = [
 API_PATH = "/api/model_catalog/v1alpha1/models"
 SOURCES_API_PATH = "/api/model_catalog/v1alpha1/sources"
 
-UTF8_BOM = "﻿"
+UTF8_BOM = "\ufeff"
 
 
 def build_url(base_url, page_size, next_page_token=None, sources=None):

--- a/tools/csv-exporter/model_catalog_export.py
+++ b/tools/csv-exporter/model_catalog_export.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Export Model Catalog metadata to CSV.
+
+Standalone script — requires only Python 3.10+ standard library.
+Run: python model_catalog_export.py --url <base-url> --output models.csv
+"""
+
+import argparse
+import contextlib
+import csv
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+
+FIXED_COLUMNS = [
+    "id",
+    "name",
+    "description",
+    "provider",
+    "maturity",
+    "license",
+    "licenseLink",
+    "libraryName",
+    "source_id",
+    "externalId",
+    "createTimeSinceEpoch",
+    "lastUpdateTimeSinceEpoch",
+    "language",
+    "tasks",
+    "validatedTasks",
+]
+
+EXCLUDED_FIELDS = {"readme", "logo", "servingConfig", "customProperties"}
+
+API_PATH = "/api/model_catalog/v1alpha1/models"
+SOURCES_API_PATH = "/api/model_catalog/v1alpha1/sources"
+
+UTF8_BOM = "﻿"
+
+
+def build_url(base_url, page_size, next_page_token=None, sources=None):
+    url = base_url.rstrip("/") + API_PATH
+    params = {"pageSize": str(page_size)}
+    if next_page_token:
+        params["nextPageToken"] = next_page_token
+    if sources:
+        params["source"] = sources
+    return f"{url}?{urllib.parse.urlencode(params, doseq=True)}"
+
+
+def fetch_page(base_url, page_size, next_page_token=None, sources=None, headers=None):
+    url = build_url(base_url, page_size, next_page_token, sources)
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/json")
+    for key, value in (headers or {}).items():
+        req.add_header(key, value)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status != 200:
+                msg = f"Error: API returned HTTP {resp.status} for {url}"
+                raise SystemExit(msg)
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = ""
+        with contextlib.suppress(Exception):
+            body = e.read().decode("utf-8", errors="replace")[:500]
+        msg = f"Error: HTTP {e.code} from {url}\n{body}"
+        raise SystemExit(msg) from None
+    except urllib.error.URLError as e:
+        msg = f"Error: cannot connect to {url}: {e.reason}"
+        raise SystemExit(msg) from None
+
+
+def paginate_models(base_url, page_size, sources=None, limit=None, headers=None):
+    next_page_token = None
+    count = 0
+    while True:
+        data = fetch_page(base_url, page_size, next_page_token, sources, headers)
+        items = data.get("items") or []
+        for model in items:
+            yield model
+            count += 1
+            if limit and count >= limit:
+                return
+        next_page_token = data.get("nextPageToken", "")
+        if not next_page_token:
+            return
+
+
+def extract_custom_property_value(metadata_value):
+    if not isinstance(metadata_value, dict):
+        return str(metadata_value)
+    meta_type = metadata_value.get("metadataType", "")
+    if meta_type == "MetadataStringValue":
+        return metadata_value.get("string_value", "")
+    if meta_type == "MetadataDoubleValue":
+        return metadata_value.get("double_value", "")
+    if meta_type == "MetadataIntValue":
+        return metadata_value.get("int_value", "")
+    if meta_type == "MetadataBoolValue":
+        return metadata_value.get("bool_value", "")
+    return json.dumps(metadata_value, ensure_ascii=False)
+
+
+def format_field(value):
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def collect_models_and_keys(base_url, page_size, sources, limit, headers):
+    models = []
+    custom_keys: set[str] = set()
+    for model in paginate_models(base_url, page_size, sources, limit, headers):
+        models.append(model)
+        props = model.get("customProperties") or {}
+        custom_keys.update(props.keys())
+    return models, sorted(custom_keys)
+
+
+def model_to_row(model, custom_keys):
+    row = []
+    for col in FIXED_COLUMNS:
+        row.append(format_field(model.get(col)))
+    props = model.get("customProperties") or {}
+    for key in custom_keys:
+        if key in props:
+            row.append(format_field(extract_custom_property_value(props[key])))
+        else:
+            row.append("")
+    return row
+
+
+def write_csv(models, custom_keys, output_path):
+    output_dir = os.path.dirname(os.path.abspath(output_path))
+    os.makedirs(output_dir, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv", dir=output_dir)
+    try:
+        with os.fdopen(tmp_fd, "w", newline="", encoding="utf-8") as f:
+            f.write(UTF8_BOM)
+            writer = csv.writer(f)
+            header = list(FIXED_COLUMNS) + custom_keys
+            writer.writerow(header)
+            for model in models:
+                writer.writerow(model_to_row(model, custom_keys))
+        os.replace(tmp_path, os.path.abspath(output_path))
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def fetch_sources(base_url, headers=None):
+    url = base_url.rstrip("/") + SOURCES_API_PATH
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/json")
+    for key, value in (headers or {}).items():
+        req.add_header(key, value)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = ""
+        with contextlib.suppress(Exception):
+            body = e.read().decode("utf-8", errors="replace")[:500]
+        raise SystemExit(f"Error: HTTP {e.code} from {url}\n{body}") from None
+    except urllib.error.URLError as e:
+        raise SystemExit(f"Error: cannot connect to {url}: {e.reason}") from None
+    return data.get("items") or []
+
+
+def print_sources(sources):
+    if not sources:
+        print("No sources found.", file=sys.stderr)
+        return
+    id_width = max(len(s.get("id", "")) for s in sources)
+    name_width = max(len(s.get("name", "")) for s in sources)
+    print(f"{'ID':<{id_width}}  {'NAME':<{name_width}}  STATUS", file=sys.stderr)
+    for s in sources:
+        print(
+            f"{s.get('id', ''):<{id_width}}  "
+            f"{s.get('name', ''):<{name_width}}  "
+            f"{s.get('status', '')}",
+            file=sys.stderr,
+        )
+
+
+def parse_header(value):
+    if ":" not in value:
+        msg = f"Invalid header format: '{value}'. Expected 'Name: Value'."
+        raise argparse.ArgumentTypeError(msg)
+    key, _, val = value.partition(":")
+    return key.strip(), val.strip()
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="model-catalog-export",
+        description="Export Model Catalog metadata to CSV.",
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="Catalog API base URL (e.g., http://localhost:8080)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output CSV file path",
+    )
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=None,
+        help="Filter by source name (repeatable)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of models to export",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=100,
+        help="Number of models per API page (default: 100)",
+    )
+    parser.add_argument(
+        "--header",
+        action="append",
+        type=parse_header,
+        default=None,
+        dest="headers",
+        help='HTTP header as "Name: Value" (repeatable)',
+    )
+    parser.add_argument(
+        "--list-sources",
+        action="store_true",
+        default=False,
+        help="List available sources and exit",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    headers = dict(args.headers) if args.headers else None
+
+    if args.list_sources:
+        try:
+            sources = fetch_sources(args.url, headers)
+        except SystemExit:
+            raise
+        except Exception as e:
+            print(f"Error: {e}", file=sys.stderr)
+            raise SystemExit(1) from None
+        print_sources(sources)
+        return
+
+    if not args.output:
+        print("Error: --output is required (unless using --list-sources)", file=sys.stderr)
+        raise SystemExit(2)
+
+    try:
+        models, custom_keys = collect_models_and_keys(
+            base_url=args.url,
+            page_size=args.page_size,
+            sources=args.source,
+            limit=args.limit,
+            headers=headers,
+        )
+        write_csv(models, custom_keys, args.output)
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        raise SystemExit(1) from None
+
+    print(
+        f"Exported {len(models)} models "
+        f"({len(FIXED_COLUMNS) + len(custom_keys)} columns) "
+        f"to {args.output}",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/csv-exporter/pyproject.toml
+++ b/tools/csv-exporter/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "model-catalog-export"
+version = "0.1.0"
+description = "Export Model Catalog metadata to CSV"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 119
+
+[tool.ruff.lint]
+select = ["F", "W", "E", "C90", "B", "S", "C4", "EM", "I", "PT", "Q", "RET", "SIM", "UP"]
+ignore = ["S310"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S", "EM"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = false
+check_untyped_defs = true

--- a/tools/csv-exporter/tests/test_csv_compliance.py
+++ b/tools/csv-exporter/tests/test_csv_compliance.py
@@ -1,0 +1,186 @@
+import csv
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from model_catalog_export import FIXED_COLUMNS, write_csv
+
+
+def make_model(name, description="", custom_props=None, **overrides):
+    model = {
+        "id": f"id-{name}",
+        "name": name,
+        "description": description,
+        "provider": "TestProvider",
+        "maturity": "Generally Available",
+        "license": "apache-2.0",
+        "licenseLink": "",
+        "libraryName": "transformers",
+        "source_id": "test-source",
+        "externalId": "",
+        "createTimeSinceEpoch": "1609459200000",
+        "lastUpdateTimeSinceEpoch": "1609459200000",
+        "language": ["en"],
+        "tasks": ["text-generation"],
+        "validatedTasks": [],
+    }
+    if custom_props:
+        model["customProperties"] = custom_props
+    model.update(overrides)
+    return model
+
+
+def read_csv(path):
+    with open(path, encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        return list(reader), reader.fieldnames
+
+
+class TestRFC4180Compliance:
+    def test_commas_in_description(self):
+        model = make_model("m1", description="Has commas, lots of them, really")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            rows, _ = read_csv(path)
+            assert rows[0]["description"] == "Has commas, lots of them, really"
+
+    def test_double_quotes_in_name(self):
+        model = make_model('model "quoted"')
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            rows, _ = read_csv(path)
+            assert rows[0]["name"] == 'model "quoted"'
+
+    def test_newlines_in_description(self):
+        model = make_model("m1", description="Line 1\nLine 2\nLine 3")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            rows, _ = read_csv(path)
+            assert rows[0]["description"] == "Line 1\nLine 2\nLine 3"
+
+    def test_unicode_characters(self):
+        model = make_model("modèle-français", description="日本語テスト données")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            rows, _ = read_csv(path)
+            assert rows[0]["name"] == "modèle-français"
+            assert "日本語テスト" in rows[0]["description"]
+
+    def test_emoji_in_fields(self):
+        model = make_model("model-1", description="Great model! 🚀🔥💯")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            rows, _ = read_csv(path)
+            assert "🚀" in rows[0]["description"]
+
+    def test_combined_hostile_characters(self):
+        model = make_model(
+            'model "A", v2',
+            description='Line 1\nHas "quotes" and, commas\nAnd Unicode: café ☕',
+        )
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            rows, _ = read_csv(path)
+            assert rows[0]["name"] == 'model "A", v2'
+            assert "café ☕" in rows[0]["description"]
+
+    def test_empty_fields(self):
+        model = make_model("m1", description="")
+        model["provider"] = None
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            rows, _ = read_csv(path)
+            assert rows[0]["description"] == ""
+            assert rows[0]["provider"] == ""
+
+
+class TestBOM:
+    def test_utf8_bom_present(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([], [], path)
+            with open(path, "rb") as f:
+                bom = f.read(3)
+            assert bom == b"\xef\xbb\xbf"
+
+    def test_readable_with_utf8_sig(self):
+        model = make_model("m1")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            with open(path, encoding="utf-8-sig") as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+            assert rows[0]["name"] == "m1"
+            assert reader.fieldnames[0] == "id"
+
+
+class TestCustomPropertyColumns:
+    def test_custom_keys_appear_as_columns(self):
+        props = {
+            "framework": {"metadataType": "MetadataStringValue", "string_value": "pytorch"},
+            "accuracy": {"metadataType": "MetadataDoubleValue", "double_value": 0.95},
+        }
+        model = make_model("m1", custom_props=props)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], sorted(props.keys()), path)
+            rows, fieldnames = read_csv(path)
+            assert "accuracy" in fieldnames
+            assert "framework" in fieldnames
+            assert rows[0]["accuracy"] == "0.95"
+            assert rows[0]["framework"] == "pytorch"
+
+    def test_custom_keys_sorted_alphabetically(self):
+        keys = ["zebra", "alpha", "middle"]
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([], keys, path)
+            _, fieldnames = read_csv(path)
+            custom_cols = fieldnames[len(FIXED_COLUMNS):]
+            assert custom_cols == ["zebra", "alpha", "middle"]  # order as passed
+
+    def test_sparse_custom_properties(self):
+        m1 = make_model("m1", custom_props={
+            "a": {"metadataType": "MetadataStringValue", "string_value": "x"},
+        })
+        m2 = make_model("m2", custom_props={
+            "b": {"metadataType": "MetadataStringValue", "string_value": "y"},
+        })
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([m1, m2], ["a", "b"], path)
+            rows, _ = read_csv(path)
+            assert rows[0]["a"] == "x"
+            assert rows[0]["b"] == ""
+            assert rows[1]["a"] == ""
+            assert rows[1]["b"] == "y"
+
+
+class TestExcludedFields:
+    def test_readme_excluded(self):
+        model = make_model("m1")
+        model["readme"] = "x" * 50000
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            _, fieldnames = read_csv(path)
+            assert "readme" not in fieldnames
+
+    def test_logo_excluded(self):
+        model = make_model("m1")
+        model["logo"] = "data:image/png;base64,iVBOR..."
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([model], [], path)
+            _, fieldnames = read_csv(path)
+            assert "logo" not in fieldnames

--- a/tools/csv-exporter/tests/test_csv_compliance.py
+++ b/tools/csv-exporter/tests/test_csv_compliance.py
@@ -5,7 +5,7 @@ import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from model_catalog_export import FIXED_COLUMNS, write_csv
+from model_catalog_export import COLUMN_ORDER, EXCLUDED_FIELDS, discover_columns, write_csv
 
 
 def make_model(name, description="", custom_props=None, **overrides):
@@ -41,53 +41,59 @@ def read_csv(path):
 class TestRFC4180Compliance:
     def test_commas_in_description(self):
         model = make_model("m1", description="Has commas, lots of them, really")
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
+            write_csv([model], columns, [], path)
             rows, _ = read_csv(path)
             assert rows[0]["description"] == "Has commas, lots of them, really"
 
     def test_double_quotes_in_name(self):
         model = make_model('model "quoted"')
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
+            write_csv([model], columns, [], path)
             rows, _ = read_csv(path)
             assert rows[0]["name"] == 'model "quoted"'
 
     def test_newlines_in_description(self):
         model = make_model("m1", description="Line 1\nLine 2\nLine 3")
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
+            write_csv([model], columns, [], path)
             rows, _ = read_csv(path)
             assert rows[0]["description"] == "Line 1\nLine 2\nLine 3"
 
     def test_unicode_characters(self):
         model = make_model("modèle-français", description="日本語テスト données")
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
+            write_csv([model], columns, [], path)
             rows, _ = read_csv(path)
             assert rows[0]["name"] == "modèle-français"
             assert "日本語テスト" in rows[0]["description"]
 
     def test_emoji_in_fields(self):
-        model = make_model("model-1", description="Great model! 🚀🔥💯")
+        model = make_model("model-1", description="Great model! \U0001f680\U0001f525\U0001f4af")
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
+            write_csv([model], columns, [], path)
             rows, _ = read_csv(path)
-            assert "🚀" in rows[0]["description"]
+            assert "\U0001f680" in rows[0]["description"]
 
     def test_combined_hostile_characters(self):
         model = make_model(
             'model "A", v2',
             description='Line 1\nHas "quotes" and, commas\nAnd Unicode: café ☕',
         )
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
+            write_csv([model], columns, [], path)
             rows, _ = read_csv(path)
             assert rows[0]["name"] == 'model "A", v2'
             assert "café ☕" in rows[0]["description"]
@@ -95,9 +101,10 @@ class TestRFC4180Compliance:
     def test_empty_fields(self):
         model = make_model("m1", description="")
         model["provider"] = None
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
+            write_csv([model], columns, [], path)
             rows, _ = read_csv(path)
             assert rows[0]["description"] == ""
             assert rows[0]["provider"] == ""
@@ -107,16 +114,17 @@ class TestBOM:
     def test_utf8_bom_present(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([], [], path)
+            write_csv([], COLUMN_ORDER, [], path)
             with open(path, "rb") as f:
                 bom = f.read(3)
             assert bom == b"\xef\xbb\xbf"
 
     def test_readable_with_utf8_sig(self):
         model = make_model("m1")
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
+            write_csv([model], columns, [], path)
             with open(path, encoding="utf-8-sig") as f:
                 reader = csv.DictReader(f)
                 rows = list(reader)
@@ -131,9 +139,10 @@ class TestCustomPropertyColumns:
             "accuracy": {"metadataType": "MetadataDoubleValue", "double_value": 0.95},
         }
         model = make_model("m1", custom_props=props)
+        columns = discover_columns([model])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([model], sorted(props.keys()), path)
+            write_csv([model], columns, sorted(props.keys()), path)
             rows, fieldnames = read_csv(path)
             assert "accuracy" in fieldnames
             assert "framework" in fieldnames
@@ -144,9 +153,9 @@ class TestCustomPropertyColumns:
         keys = ["zebra", "alpha", "middle"]
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([], keys, path)
+            write_csv([], COLUMN_ORDER, keys, path)
             _, fieldnames = read_csv(path)
-            custom_cols = fieldnames[len(FIXED_COLUMNS):]
+            custom_cols = fieldnames[len(COLUMN_ORDER):]
             assert custom_cols == ["zebra", "alpha", "middle"]  # order as passed
 
     def test_sparse_custom_properties(self):
@@ -156,9 +165,10 @@ class TestCustomPropertyColumns:
         m2 = make_model("m2", custom_props={
             "b": {"metadataType": "MetadataStringValue", "string_value": "y"},
         })
+        columns = discover_columns([m1, m2])
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([m1, m2], ["a", "b"], path)
+            write_csv([m1, m2], columns, ["a", "b"], path)
             rows, _ = read_csv(path)
             assert rows[0]["a"] == "x"
             assert rows[0]["b"] == ""
@@ -166,21 +176,52 @@ class TestCustomPropertyColumns:
             assert rows[1]["b"] == "y"
 
 
-class TestExcludedFields:
-    def test_readme_excluded(self):
+class TestDiscoverColumns:
+    def test_empty_models_returns_column_order(self):
+        assert discover_columns([]) == list(COLUMN_ORDER)
+
+    def test_excludes_readme(self):
         model = make_model("m1")
         model["readme"] = "x" * 50000
-        with tempfile.TemporaryDirectory() as d:
-            path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
-            _, fieldnames = read_csv(path)
-            assert "readme" not in fieldnames
+        columns = discover_columns([model])
+        assert "readme" not in columns
 
-    def test_logo_excluded(self):
+    def test_excludes_logo(self):
         model = make_model("m1")
         model["logo"] = "data:image/png;base64,iVBOR..."
-        with tempfile.TemporaryDirectory() as d:
-            path = os.path.join(d, "out.csv")
-            write_csv([model], [], path)
-            _, fieldnames = read_csv(path)
-            assert "logo" not in fieldnames
+        columns = discover_columns([model])
+        assert "logo" not in columns
+
+    def test_excludes_serving_config(self):
+        model = make_model("m1")
+        model["servingConfig"] = {"toolCalling": {}}
+        columns = discover_columns([model])
+        assert "servingConfig" not in columns
+
+    def test_excludes_custom_properties(self):
+        model = make_model("m1", custom_props={"k": {"metadataType": "MetadataStringValue", "string_value": "v"}})
+        columns = discover_columns([model])
+        assert "customProperties" not in columns
+
+    def test_preserves_column_order(self):
+        model = make_model("m1")
+        columns = discover_columns([model])
+        order_indices = [columns.index(c) for c in COLUMN_ORDER if c in columns]
+        assert order_indices == sorted(order_indices)
+
+    def test_new_api_fields_appended_alphabetically(self):
+        model = make_model("m1")
+        model["newFieldB"] = "val"
+        model["newFieldA"] = "val"
+        columns = discover_columns([model])
+        known_end = len([c for c in COLUMN_ORDER if c in columns])
+        new_cols = columns[known_end:]
+        assert new_cols == ["newFieldA", "newFieldB"]
+
+    def test_all_excluded_fields_filtered(self):
+        model = make_model("m1")
+        for field in EXCLUDED_FIELDS:
+            model[field] = "value"
+        columns = discover_columns([model])
+        for field in EXCLUDED_FIELDS:
+            assert field not in columns

--- a/tools/csv-exporter/tests/test_export.py
+++ b/tools/csv-exporter/tests/test_export.py
@@ -14,7 +14,6 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from model_catalog_export import (
     COLUMN_ORDER,
-    EXCLUDED_FIELDS,
     build_url,
     collect_models_and_keys,
     discover_columns,

--- a/tools/csv-exporter/tests/test_export.py
+++ b/tools/csv-exporter/tests/test_export.py
@@ -1,3 +1,4 @@
+import argparse
 import csv
 import io
 import json
@@ -16,11 +17,15 @@ from model_catalog_export import (
     build_url,
     collect_models_and_keys,
     extract_custom_property_value,
+    fetch_sources,
     format_field,
     main,
     model_to_row,
     paginate_models,
     parse_args,
+    parse_header,
+    print_sources,
+    validate_url_scheme,
     write_csv,
 )
 
@@ -377,3 +382,156 @@ class TestMainIntegration:
             ])
             req = mock_open.call_args[0][0]
             assert req.get_header("Authorization") == "Bearer mytoken"
+
+
+class TestParseHeader:
+    def test_valid_header(self):
+        key, val = parse_header("Authorization: Bearer tok123")
+        assert key == "Authorization"
+        assert val == "Bearer tok123"
+
+    def test_header_with_multiple_colons(self):
+        key, val = parse_header("X-Custom: value:with:colons")
+        assert key == "X-Custom"
+        assert val == "value:with:colons"
+
+    def test_invalid_header_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid header"):
+            parse_header("no-colon-here")
+
+
+class TestValidateUrlScheme:
+    def test_http_allowed(self):
+        validate_url_scheme("http://localhost:8080")
+
+    def test_https_allowed(self):
+        validate_url_scheme("https://catalog.example.com")
+
+    def test_file_rejected(self):
+        with pytest.raises(SystemExit, match="http:// or https://"):
+            validate_url_scheme("file:///etc/passwd")
+
+    def test_ftp_rejected(self):
+        with pytest.raises(SystemExit, match="http:// or https://"):
+            validate_url_scheme("ftp://server/file")
+
+    def test_no_scheme_rejected(self):
+        with pytest.raises(SystemExit, match="http:// or https://"):
+            validate_url_scheme("localhost:8080")
+
+
+class TestFetchSources:
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_returns_items(self, mock_open):
+        sources_resp = {
+            "items": [
+                {"id": "src1", "name": "Source One", "status": "available"},
+                {"id": "src2", "name": "Source Two", "status": "available"},
+            ],
+            "nextPageToken": "",
+            "pageSize": 10,
+            "size": 2,
+        }
+        mock_open.side_effect = mock_urlopen([sources_resp])
+        result = fetch_sources("http://localhost:8080")
+        assert len(result) == 2
+        assert result[0]["id"] == "src1"
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_empty_sources(self, mock_open):
+        mock_open.side_effect = mock_urlopen([{"items": [], "nextPageToken": "", "pageSize": 10, "size": 0}])
+        result = fetch_sources("http://localhost:8080")
+        assert result == []
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_http_error(self, mock_open):
+        mock_open.side_effect = urllib.error.HTTPError(
+            "http://localhost:8080", 403, "Forbidden", {}, io.BytesIO(b"")
+        )
+        with pytest.raises(SystemExit, match="403"):
+            fetch_sources("http://localhost:8080")
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_connection_error(self, mock_open):
+        mock_open.side_effect = urllib.error.URLError("Connection refused")
+        with pytest.raises(SystemExit, match="cannot connect"):
+            fetch_sources("http://localhost:8080")
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_passes_headers(self, mock_open):
+        mock_open.side_effect = mock_urlopen([{"items": [], "nextPageToken": "", "pageSize": 10, "size": 0}])
+        fetch_sources("http://localhost:8080", headers={"Authorization": "Bearer tok"})
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer tok"
+
+
+class TestPrintSources:
+    def test_formats_table(self, capsys):
+        sources = [
+            {"id": "src1", "name": "Source One", "status": "available"},
+            {"id": "long_source_id", "name": "S", "status": "disabled"},
+        ]
+        print_sources(sources)
+        captured = capsys.readouterr().err
+        assert "ID" in captured
+        assert "NAME" in captured
+        assert "STATUS" in captured
+        assert "src1" in captured
+        assert "long_source_id" in captured
+
+    def test_empty_sources(self, capsys):
+        print_sources([])
+        captured = capsys.readouterr().err
+        assert "No sources found" in captured
+
+    def test_min_column_width(self, capsys):
+        sources = [{"id": "x", "name": "y", "status": "ok"}]
+        print_sources(sources)
+        captured = capsys.readouterr().err
+        lines = captured.strip().split("\n")
+        header = lines[0]
+        assert "ID" in header
+        assert "NAME" in header
+
+
+class TestListSourcesIntegration:
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_list_sources_flag(self, mock_open, capsys):
+        sources_resp = {
+            "items": [{"id": "s1", "name": "Source", "status": "available"}],
+            "nextPageToken": "",
+            "pageSize": 10,
+            "size": 1,
+        }
+        mock_open.side_effect = mock_urlopen([sources_resp])
+        main(["--url", "http://localhost:8080", "--list-sources"])
+        captured = capsys.readouterr().err
+        assert "s1" in captured
+        assert "Source" in captured
+
+    def test_missing_output_without_list_sources(self):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--url", "http://localhost:8080"])
+        assert exc_info.value.code == 2
+
+
+class TestInputValidation:
+    def test_limit_zero_rejected(self):
+        with pytest.raises(SystemExit, match="--limit must be >= 1"):
+            main(["--url", "http://localhost:8080", "--output", "out.csv", "--limit", "0"])
+
+    def test_limit_negative_rejected(self):
+        with pytest.raises(SystemExit, match="--limit must be >= 1"):
+            main(["--url", "http://localhost:8080", "--output", "out.csv", "--limit", "-1"])
+
+    def test_page_size_zero_rejected(self):
+        with pytest.raises(SystemExit, match="--page-size must be >= 1"):
+            main(["--url", "http://localhost:8080", "--output", "out.csv", "--page-size", "0"])
+
+    def test_page_size_negative_rejected(self):
+        with pytest.raises(SystemExit, match="--page-size must be >= 1"):
+            main(["--url", "http://localhost:8080", "--output", "out.csv", "--page-size", "-1"])
+
+    def test_file_url_rejected(self):
+        with pytest.raises(SystemExit, match="http:// or https://"):
+            main(["--url", "file:///etc/passwd", "--output", "out.csv"])

--- a/tools/csv-exporter/tests/test_export.py
+++ b/tools/csv-exporter/tests/test_export.py
@@ -13,9 +13,11 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from model_catalog_export import (
-    FIXED_COLUMNS,
+    COLUMN_ORDER,
+    EXCLUDED_FIELDS,
     build_url,
     collect_models_and_keys,
+    discover_columns,
     extract_custom_property_value,
     fetch_sources,
     format_field,
@@ -210,16 +212,18 @@ class TestCollectModelsAndKeys:
         m1 = make_model("m1", {"framework": {"metadataType": "MetadataStringValue", "string_value": "pt"}})
         m2 = make_model("m2", {"accuracy": {"metadataType": "MetadataDoubleValue", "double_value": 0.9}})
         mock_open.side_effect = mock_urlopen([make_api_response([m1, m2])])
-        models, keys = collect_models_and_keys("http://localhost:8080", 100, None, None, None)
+        models, columns, keys = collect_models_and_keys("http://localhost:8080", 100, None, None, None)
         assert len(models) == 2
         assert keys == ["accuracy", "framework"]
+        assert columns == list(COLUMN_ORDER)
 
 
 class TestModelToRow:
     def test_fixed_columns(self):
         model = make_model("test")
-        row = model_to_row(model, [])
-        assert len(row) == len(FIXED_COLUMNS)
+        columns = discover_columns([model])
+        row = model_to_row(model, columns, [])
+        assert len(row) == len(columns)
         assert row[0] == "id-test"
         assert row[1] == "test"
 
@@ -229,28 +233,31 @@ class TestModelToRow:
             "accuracy": {"metadataType": "MetadataDoubleValue", "double_value": 0.95},
         }
         model = make_model("test", custom_props=props)
-        row = model_to_row(model, ["accuracy", "framework"])
-        assert row[len(FIXED_COLUMNS)] == "0.95"
-        assert row[len(FIXED_COLUMNS) + 1] == "pytorch"
+        columns = discover_columns([model])
+        row = model_to_row(model, columns, ["accuracy", "framework"])
+        assert row[len(columns)] == "0.95"
+        assert row[len(columns) + 1] == "pytorch"
 
     def test_missing_custom_key(self):
         model = make_model("test", {"a": {"metadataType": "MetadataStringValue", "string_value": "x"}})
-        row = model_to_row(model, ["a", "b"])
-        assert row[len(FIXED_COLUMNS)] == "x"
-        assert row[len(FIXED_COLUMNS) + 1] == ""
+        columns = discover_columns([model])
+        row = model_to_row(model, columns, ["a", "b"])
+        assert row[len(columns)] == "x"
+        assert row[len(columns) + 1] == ""
 
 
 class TestWriteCsv:
     def test_creates_file(self):
+        models = [make_model("m1")]
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([make_model("m1")], [], path)
+            write_csv(models, discover_columns(models), [], path)
             assert os.path.exists(path)
 
     def test_header_only_for_empty(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([], [], path)
+            write_csv([], COLUMN_ORDER, [], path)
             with open(path, encoding="utf-8-sig") as f:
                 lines = f.readlines()
             assert len(lines) == 1
@@ -258,7 +265,7 @@ class TestWriteCsv:
     def test_bom_present(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv([], [], path)
+            write_csv([], COLUMN_ORDER, [], path)
             with open(path, "rb") as f:
                 assert f.read(3) == b"\xef\xbb\xbf"
 
@@ -266,7 +273,7 @@ class TestWriteCsv:
         models = [make_model(f"m{i}") for i in range(5)]
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "out.csv")
-            write_csv(models, [], path)
+            write_csv(models, discover_columns(models), [], path)
             with open(path, encoding="utf-8-sig") as f:
                 reader = csv.reader(f)
                 rows = list(reader)
@@ -281,13 +288,14 @@ class TestWriteCsv:
                     raise RuntimeError("disk full")
 
             with pytest.raises(RuntimeError):
-                write_csv([BrokenModel()], [], path)
+                write_csv([BrokenModel()], COLUMN_ORDER, [], path)
             assert not os.path.exists(path)
 
     def test_creates_output_directory(self):
+        models = [make_model("m1")]
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "subdir", "nested", "out.csv")
-            write_csv([make_model("m1")], [], path)
+            write_csv(models, discover_columns(models), [], path)
             assert os.path.exists(path)
 
 

--- a/tools/csv-exporter/tests/test_export.py
+++ b/tools/csv-exporter/tests/test_export.py
@@ -1,0 +1,379 @@
+import csv
+import io
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from model_catalog_export import (
+    FIXED_COLUMNS,
+    build_url,
+    collect_models_and_keys,
+    extract_custom_property_value,
+    format_field,
+    main,
+    model_to_row,
+    paginate_models,
+    parse_args,
+    write_csv,
+)
+
+
+def make_api_response(items, next_page_token=""):
+    return {
+        "items": items,
+        "size": len(items),
+        "pageSize": 100,
+        "nextPageToken": next_page_token,
+    }
+
+
+def make_model(name, custom_props=None, **overrides):
+    model = {
+        "id": f"id-{name}",
+        "name": name,
+        "description": f"Description of {name}",
+        "provider": "TestProvider",
+        "maturity": "Generally Available",
+        "license": "apache-2.0",
+        "licenseLink": "https://www.apache.org/licenses/LICENSE-2.0",
+        "libraryName": "transformers",
+        "source_id": "test-source",
+        "externalId": f"ext-{name}",
+        "createTimeSinceEpoch": "1609459200000",
+        "lastUpdateTimeSinceEpoch": "1609459200000",
+        "language": ["en"],
+        "tasks": ["text-generation"],
+        "validatedTasks": ["text-generation"],
+    }
+    if custom_props:
+        model["customProperties"] = custom_props
+    model.update(overrides)
+    return model
+
+
+def mock_urlopen(responses):
+    call_count = {"n": 0}
+
+    def _urlopen(req):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        data = json.dumps(responses[idx]).encode("utf-8")
+        resp = mock.MagicMock()
+        resp.status = 200
+        resp.read.return_value = data
+        resp.__enter__ = mock.MagicMock(return_value=resp)
+        resp.__exit__ = mock.MagicMock(return_value=False)
+        return resp
+
+    return _urlopen
+
+
+class TestBuildUrl:
+    def test_basic(self):
+        url = build_url("http://localhost:8080", 50)
+        assert url == "http://localhost:8080/api/model_catalog/v1alpha1/models?pageSize=50"
+
+    def test_with_trailing_slash(self):
+        url = build_url("http://localhost:8080/", 50)
+        assert url == "http://localhost:8080/api/model_catalog/v1alpha1/models?pageSize=50"
+
+    def test_with_next_page_token(self):
+        url = build_url("http://localhost:8080", 50, next_page_token="abc123")
+        assert "pageSize=50" in url
+        assert "nextPageToken=abc123" in url
+
+    def test_with_sources(self):
+        url = build_url("http://localhost:8080", 50, sources=["src1", "src2"])
+        assert "source=src1" in url
+        assert "source=src2" in url
+
+
+class TestExtractCustomPropertyValue:
+    def test_string_value(self):
+        val = {"metadataType": "MetadataStringValue", "string_value": "pytorch"}
+        assert extract_custom_property_value(val) == "pytorch"
+
+    def test_double_value(self):
+        val = {"metadataType": "MetadataDoubleValue", "double_value": 0.95}
+        assert extract_custom_property_value(val) == 0.95
+
+    def test_int_value(self):
+        val = {"metadataType": "MetadataIntValue", "int_value": "42"}
+        assert extract_custom_property_value(val) == "42"
+
+    def test_bool_value(self):
+        val = {"metadataType": "MetadataBoolValue", "bool_value": True}
+        assert extract_custom_property_value(val) is True
+
+    def test_proto_value(self):
+        val = {"metadataType": "MetadataProtoValue", "type": "some.type", "proto_value": "abc"}
+        result = extract_custom_property_value(val)
+        parsed = json.loads(result)
+        assert parsed["metadataType"] == "MetadataProtoValue"
+
+    def test_struct_value(self):
+        val = {"metadataType": "MetadataStructValue", "struct_value": "encoded"}
+        result = extract_custom_property_value(val)
+        parsed = json.loads(result)
+        assert parsed["metadataType"] == "MetadataStructValue"
+
+    def test_plain_string_fallback(self):
+        assert extract_custom_property_value("raw") == "raw"
+
+
+class TestFormatField:
+    def test_none(self):
+        assert format_field(None) == ""
+
+    def test_string(self):
+        assert format_field("hello") == "hello"
+
+    def test_number(self):
+        assert format_field(42) == "42"
+
+    def test_bool(self):
+        assert format_field(True) == "true"
+        assert format_field(False) == "false"
+
+    def test_list(self):
+        result = format_field(["en", "es"])
+        assert json.loads(result) == ["en", "es"]
+
+    def test_dict(self):
+        result = format_field({"key": "val"})
+        assert json.loads(result) == {"key": "val"}
+
+
+class TestPagination:
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_single_page(self, mock_open):
+        models = [make_model("m1"), make_model("m2")]
+        mock_open.side_effect = mock_urlopen([make_api_response(models)])
+        result = list(paginate_models("http://localhost:8080", 100))
+        assert len(result) == 2
+        assert result[0]["name"] == "m1"
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_multi_page(self, mock_open):
+        page1 = make_api_response([make_model("m1")], next_page_token="page2")
+        page2 = make_api_response([make_model("m2")], next_page_token="page3")
+        page3 = make_api_response([make_model("m3")])
+        mock_open.side_effect = mock_urlopen([page1, page2, page3])
+        result = list(paginate_models("http://localhost:8080", 100))
+        assert len(result) == 3
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_empty_catalog(self, mock_open):
+        mock_open.side_effect = mock_urlopen([make_api_response([])])
+        result = list(paginate_models("http://localhost:8080", 100))
+        assert len(result) == 0
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_limit(self, mock_open):
+        page1 = make_api_response([make_model("m1"), make_model("m2")], next_page_token="p2")
+        page2 = make_api_response([make_model("m3")])
+        mock_open.side_effect = mock_urlopen([page1, page2])
+        result = list(paginate_models("http://localhost:8080", 100, limit=2))
+        assert len(result) == 2
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_limit_across_pages(self, mock_open):
+        page1 = make_api_response([make_model("m1")], next_page_token="p2")
+        page2 = make_api_response([make_model("m2"), make_model("m3")])
+        mock_open.side_effect = mock_urlopen([page1, page2])
+        result = list(paginate_models("http://localhost:8080", 100, limit=2))
+        assert len(result) == 2
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_source_filter(self, mock_open):
+        mock_open.side_effect = mock_urlopen([make_api_response([])])
+        list(paginate_models("http://localhost:8080", 100, sources=["my-source"]))
+        req = mock_open.call_args[0][0]
+        assert "source=my-source" in req.full_url
+
+
+class TestCollectModelsAndKeys:
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_discovers_custom_keys(self, mock_open):
+        m1 = make_model("m1", {"framework": {"metadataType": "MetadataStringValue", "string_value": "pt"}})
+        m2 = make_model("m2", {"accuracy": {"metadataType": "MetadataDoubleValue", "double_value": 0.9}})
+        mock_open.side_effect = mock_urlopen([make_api_response([m1, m2])])
+        models, keys = collect_models_and_keys("http://localhost:8080", 100, None, None, None)
+        assert len(models) == 2
+        assert keys == ["accuracy", "framework"]
+
+
+class TestModelToRow:
+    def test_fixed_columns(self):
+        model = make_model("test")
+        row = model_to_row(model, [])
+        assert len(row) == len(FIXED_COLUMNS)
+        assert row[0] == "id-test"
+        assert row[1] == "test"
+
+    def test_custom_columns(self):
+        props = {
+            "framework": {"metadataType": "MetadataStringValue", "string_value": "pytorch"},
+            "accuracy": {"metadataType": "MetadataDoubleValue", "double_value": 0.95},
+        }
+        model = make_model("test", custom_props=props)
+        row = model_to_row(model, ["accuracy", "framework"])
+        assert row[len(FIXED_COLUMNS)] == "0.95"
+        assert row[len(FIXED_COLUMNS) + 1] == "pytorch"
+
+    def test_missing_custom_key(self):
+        model = make_model("test", {"a": {"metadataType": "MetadataStringValue", "string_value": "x"}})
+        row = model_to_row(model, ["a", "b"])
+        assert row[len(FIXED_COLUMNS)] == "x"
+        assert row[len(FIXED_COLUMNS) + 1] == ""
+
+
+class TestWriteCsv:
+    def test_creates_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([make_model("m1")], [], path)
+            assert os.path.exists(path)
+
+    def test_header_only_for_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([], [], path)
+            with open(path, encoding="utf-8-sig") as f:
+                lines = f.readlines()
+            assert len(lines) == 1
+
+    def test_bom_present(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv([], [], path)
+            with open(path, "rb") as f:
+                assert f.read(3) == b"\xef\xbb\xbf"
+
+    def test_row_count(self):
+        models = [make_model(f"m{i}") for i in range(5)]
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            write_csv(models, [], path)
+            with open(path, encoding="utf-8-sig") as f:
+                reader = csv.reader(f)
+                rows = list(reader)
+            assert len(rows) == 6  # header + 5 models
+
+    def test_no_partial_on_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+
+            class BrokenModel:
+                def get(self, _key, _default=None):
+                    raise RuntimeError("disk full")
+
+            with pytest.raises(RuntimeError):
+                write_csv([BrokenModel()], [], path)
+            assert not os.path.exists(path)
+
+    def test_creates_output_directory(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "subdir", "nested", "out.csv")
+            write_csv([make_model("m1")], [], path)
+            assert os.path.exists(path)
+
+
+class TestErrorHandling:
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_http_error_exits_nonzero(self, mock_open):
+        error_body = b'{"error": "unauthorized"}'
+        mock_open.side_effect = urllib.error.HTTPError(
+            "http://localhost:8080", 401, "Unauthorized", {}, io.BytesIO(error_body)
+        )
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            with pytest.raises(SystemExit) as exc_info:
+                main(["--url", "http://localhost:8080", "--output", path])
+            assert exc_info.value.code != 0
+            assert not os.path.exists(path)
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_connection_error_exits_nonzero(self, mock_open):
+        mock_open.side_effect = urllib.error.URLError("Connection refused")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            with pytest.raises(SystemExit) as exc_info:
+                main(["--url", "http://localhost:8080", "--output", path])
+            assert exc_info.value.code != 0
+            assert not os.path.exists(path)
+
+
+class TestParseArgs:
+    def test_required_args(self):
+        args = parse_args(["--url", "http://localhost", "--output", "out.csv"])
+        assert args.url == "http://localhost"
+        assert args.output == "out.csv"
+
+    def test_optional_args(self):
+        args = parse_args([
+            "--url", "http://localhost", "--output", "out.csv",
+            "--source", "s1", "--source", "s2",
+            "--limit", "10",
+            "--page-size", "50",
+            "--header", "Authorization: Bearer tok123",
+        ])
+        assert args.source == ["s1", "s2"]
+        assert args.limit == 10
+        assert args.page_size == 50
+        assert args.headers == [("Authorization", "Bearer tok123")]
+
+    def test_defaults(self):
+        args = parse_args(["--url", "http://localhost", "--output", "out.csv"])
+        assert args.source is None
+        assert args.limit is None
+        assert args.page_size == 100
+        assert args.headers is None
+
+
+class TestMainIntegration:
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_full_export(self, mock_open):
+        props = {"framework": {"metadataType": "MetadataStringValue", "string_value": "pytorch"}}
+        models = [make_model("m1", props), make_model("m2")]
+        mock_open.side_effect = mock_urlopen([make_api_response(models)])
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            main(["--url", "http://localhost:8080", "--output", path])
+            with open(path, encoding="utf-8-sig") as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+            assert len(rows) == 2
+            assert "framework" in reader.fieldnames
+            assert rows[0]["framework"] == "pytorch"
+            assert rows[1]["framework"] == ""
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_empty_catalog_produces_header_only(self, mock_open):
+        mock_open.side_effect = mock_urlopen([make_api_response([])])
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            main(["--url", "http://localhost:8080", "--output", path])
+            with open(path, encoding="utf-8-sig") as f:
+                lines = f.readlines()
+            assert len(lines) == 1
+
+    @mock.patch("model_catalog_export.urllib.request.urlopen")
+    def test_with_headers(self, mock_open):
+        mock_open.side_effect = mock_urlopen([make_api_response([])])
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.csv")
+            main([
+                "--url", "http://localhost:8080",
+                "--output", path,
+                "--header", "Authorization: Bearer mytoken",
+            ])
+            req = mock_open.call_args[0][0]
+            assert req.get_header("Authorization") == "Bearer mytoken"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

  - Add a standalone Python CLI tool (`tools/csv-exporter/`) that exports Model Catalog metadata to RFC 4180-compliant CSV
  - Supports pagination, source filtering (`--source`), authentication via custom headers (`--header`), and output limits (`--limit`)
  - Add `--list-sources` flag to discover available catalog sources before exporting
  - No third-party dependencies — uses only Python 3.10+ standard library
  - Includes 55 tests covering export logic, pagination, custom property extraction, RFC 4180 compliance, and Unicode handling

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

  - [x] Unit tests pass: `cd tools/csv-exporter && python -m pytest tests/ -v` (55 tests)
  - [x] Verified end-to-end export against a live cluster (91 models, 120 columns)
  - [x] Verified `--list-sources` returns correct source IDs from live cluster
  - [x] Verified `--source` filtering produces correct subset

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
