### PR TITLE
fix(ui): use repo root as Docker build context in CI workflows

### DIFF
--- a/.github/workflows/build-and-push-ui-images-standalone.yml
+++ b/.github/workflows/build-and-push-ui-images-standalone.yml
@@ -76,7 +76,7 @@ jobs:
       id: build-push
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
       with:
-        context: ./clients/ui
+        context: .
         file: ./clients/ui/Dockerfile.standalone
         target: release
         platforms: ${{ env.PLATFORMS }}
@@ -84,6 +84,8 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
+          UI_SOURCE_CODE=clients/ui/frontend
+          BFF_SOURCE_CODE=clients/ui/bff
           DEPLOYMENT_MODE=standalone
           STYLE_THEME=mui-theme
         cache-from: type=gha

--- a/.github/workflows/build-and-push-ui-images.yml
+++ b/.github/workflows/build-and-push-ui-images.yml
@@ -76,12 +76,15 @@ jobs:
       id: build-push
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
       with:
-        context: ./clients/ui
+        context: .
+        file: ./clients/ui/Dockerfile
         platforms: ${{ env.PLATFORMS }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
+          UI_SOURCE_CODE=clients/ui/frontend
+          BFF_SOURCE_CODE=clients/ui/bff
           DEPLOYMENT_MODE=kubeflow
           STYLE_THEME=mui-theme
         cache-from: type=gha

--- a/clients/ui/Dockerfile
+++ b/clients/ui/Dockerfile
@@ -32,7 +32,7 @@ ARG BFF_SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY ../../pkg/openapi /usr/src/app/pkg/openapi
+COPY pkg/openapi /usr/src/app/pkg/openapi
 
 WORKDIR /usr/src/app/clients/ui/bff
 

--- a/clients/ui/Dockerfile.standalone
+++ b/clients/ui/Dockerfile.standalone
@@ -32,7 +32,7 @@ ARG BFF_SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY ../../pkg/openapi /usr/src/app/pkg/openapi
+COPY pkg/openapi /usr/src/app/pkg/openapi
 
 WORKDIR /usr/src/app/clients/ui/bff
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

  ### Problem

  Both UI image CI workflows (`build-and-push-ui-images.yml` and `build-and-push-ui-images-standalone.yml`) have been failing on every main push since May 28 (commit f07ab21d).

  The error:
  COPY ../../pkg/openapi /usr/src/app/pkg/openapi
  ERROR: "/pkg/openapi": not found

  PR #2634 updated the Dockerfiles to `COPY ../../pkg/openapi` (requiring repo-root context) but didn't update the CI workflows, which still use `context: ./clients/ui`. Docker can't escape the build context, so the path resolves to nothing.

  The local Makefile already works correctly — it uses `../..` (repo root) as context with explicit `--build-arg` overrides.

  ### Fix

  - **Dockerfiles**: `COPY ../../pkg/openapi` → `COPY pkg/openapi` (relative to repo root context)
  - **CI workflows**: `context: ./clients/ui` → `context: .`, added `file:` directive, added `UI_SOURCE_CODE` and `BFF_SOURCE_CODE` build args

  This aligns CI with the existing Makefile build pattern.

  ### Files changed

  - `clients/ui/Dockerfile`
  - `clients/ui/Dockerfile.standalone`
  - `.github/workflows/build-and-push-ui-images.yml`
  - `.github/workflows/build-and-push-ui-images-standalone.yml`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Both `make docker-build` and `make docker-build-standalone-release` pass locally.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

