### PR TITLE
fix(controller): remove finalizer when ModelRegistry service is deleted before InferenceService

### DIFF
--- a/pkg/inferenceservice-controller/controller.go
+++ b/pkg/inferenceservice-controller/controller.go
@@ -124,6 +124,39 @@ func (r *InferenceServiceController) Reconcile(ctx context.Context, req ctrl.Req
 		mrNamespace = mrNSFromISVC
 	}
 
+	// Check if the InferenceService instance is marked to be deleted, which is
+	// indicated by the deletion timestamp being set.
+	isMarkedToBeDeleted := isvc.GetDeletionTimestamp() != nil
+
+	if isMarkedToBeDeleted {
+		if controllerutil.ContainsFinalizer(isvc, r.modelRegistryFinalizer) {
+			// Best-effort: try to update MR InferenceService state before removing the finalizer.
+			// If the MR service is unavailable (e.g., deleted before the ISVC), we still
+			// must remove the finalizer to avoid blocking deletion indefinitely.
+			mrApi, err := r.initModelRegistryService(ctx, log, mrName, mrNamespace, mrUrl)
+			if err != nil {
+				log.Info("Model Registry service unavailable during deletion, skipping state update", "error", err)
+			} else if mrIsvcId, ok := isvc.Labels[r.inferenceServiceIDLabel]; ok {
+				mrIs, _, getErr := mrApi.ModelRegistryServiceAPI.GetInferenceService(mrApiCtx, mrIsvcId).Execute()
+				if getErr != nil {
+					log.Info("Unable to fetch InferenceService from Model Registry during deletion", "mrIsvcId", mrIsvcId, "error", getErr)
+				} else if err := r.onDeletion(mrApiCtx, mrApi, log, mrIs); err != nil {
+					log.Error(err, "Failed to update DesiredState to UNDEPLOYED, proceeding with finalizer removal")
+				}
+			}
+
+			log.Info("Removing Finalizer for modelRegistry")
+			if ok := controllerutil.RemoveFinalizer(isvc, r.modelRegistryFinalizer); !ok {
+				return ctrl.Result{}, fmt.Errorf("failed to remove modelRegistry finalizer for InferenceService")
+			}
+
+			if err := r.client.Update(ctx, isvc); IgnoreDeletingErrors(err) != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to remove modelRegistry finalizer for InferenceService: %w", err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
 	log.Info("Creating model registry service..")
 	mrApi, err := r.initModelRegistryService(ctx, log, mrName, mrNamespace, mrUrl)
 	if err != nil {
@@ -131,14 +164,10 @@ func (r *InferenceServiceController) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	// Check if the InferenceService instance is marked to be deleted, which is
-	// indicated by the deletion timestamp being set.
-	isMarkedToBeDeleted := isvc.GetDeletionTimestamp() != nil
-
 	// Let's add a finalizer. Then, we can define some operations which should
-	// occurs before the custom resource to be deleted.
+	// occur before the custom resource is deleted.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers
-	if !isMarkedToBeDeleted && !controllerutil.ContainsFinalizer(isvc, r.modelRegistryFinalizer) {
+	if !controllerutil.ContainsFinalizer(isvc, r.modelRegistryFinalizer) {
 		log.Info("Adding Finalizer for ModelRegistry")
 
 		if ok := controllerutil.AddFinalizer(isvc, r.modelRegistryFinalizer); !ok {
@@ -195,25 +224,6 @@ func (r *InferenceServiceController) Reconcile(ctx context.Context, req ctrl.Req
 	if mrIs == nil {
 		// This should NOT happen
 		return ctrl.Result{}, fmt.Errorf("unexpected nil model registry InferenceService")
-	}
-
-	if isMarkedToBeDeleted {
-		err := r.onDeletion(mrApiCtx, mrApi, log, mrIs)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update DesiredState to UNDEPLOYED: %w", err)
-		}
-
-		if controllerutil.ContainsFinalizer(isvc, r.modelRegistryFinalizer) {
-			log.Info("Removing Finalizer for modelRegistry after successfully perform the operations")
-			if ok := controllerutil.RemoveFinalizer(isvc, r.modelRegistryFinalizer); !ok {
-				return ctrl.Result{}, fmt.Errorf("failed to remove modelRegistry finalizer for InferenceService: %w", err)
-			}
-
-			if err = r.client.Update(ctx, isvc); IgnoreDeletingErrors(err) != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to remove modelRegistry finalizer for InferenceService: %w", err)
-			}
-		}
-		return ctrl.Result{}, nil
 	}
 
 	// No need to update the ISVC, the IS id is already set

--- a/pkg/inferenceservice-controller/controller_test.go
+++ b/pkg/inferenceservice-controller/controller_test.go
@@ -649,4 +649,102 @@ var _ = Describe("InferenceService Controller", func() {
 			}, 20*time.Second, 1*time.Second).Should(Succeed())
 		})
 	})
+
+	When("Deleting an InferenceService after the ModelRegistry service has been removed", func() {
+		It("Should remove the finalizer and allow deletion even if the ModelRegistry service no longer exists", func() {
+			const CorrectInferenceServicePath = "./testdata/inferenceservices/inference-service-correct.yaml"
+			const ModelRegistrySVCPath = "./testdata/deploy/model-registry-svc.yaml"
+			const namespace = "mr-deleted-before-isvc"
+
+			ns := &corev1.Namespace{}
+
+			ns.SetName(namespace)
+
+			if err := cli.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			mrSvc := &corev1.Service{}
+			Expect(ConvertFileToStructuredResource(ModelRegistrySVCPath, mrSvc)).To(Succeed())
+
+			mrSvc.SetNamespace(namespace)
+
+			if err := cli.Create(ctx, mrSvc); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			inferenceService := &kservev1beta1.InferenceService{}
+			Expect(ConvertFileToStructuredResource(CorrectInferenceServicePath, inferenceService)).To(Succeed())
+
+			inferenceService.SetNamespace(namespace)
+
+			inferenceService.Labels[namespaceLabel] = namespace
+
+			if err := cli.Create(ctx, inferenceService); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			// Wait for the controller to reconcile: IS ID label should be set and finalizer added
+			Eventually(func() error {
+				isvc := &kservev1beta1.InferenceService{}
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      inferenceService.Name,
+					Namespace: inferenceService.Namespace,
+				}, isvc)
+				if err != nil {
+					return err
+				}
+
+				if isvc.Labels[inferenceServiceIDLabel] == "" {
+					return fmt.Errorf("Label for InferenceServiceID is not set")
+				}
+
+				hasFinalizer := false
+				for _, f := range isvc.Finalizers {
+					if f == finalizerLabel {
+						hasFinalizer = true
+						break
+					}
+				}
+				if !hasFinalizer {
+					return fmt.Errorf("Finalizer %s not added to InferenceService", finalizerLabel)
+				}
+
+				return nil
+			}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+			// Delete the ModelRegistry Service BEFORE deleting the InferenceService
+			Expect(cli.Delete(ctx, mrSvc)).To(Succeed())
+
+			// Verify the MR Service is actually gone
+			Eventually(func() bool {
+				svc := &corev1.Service{}
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      mrSvc.Name,
+					Namespace: mrSvc.Namespace,
+				}, svc)
+				return errors.IsNotFound(err)
+			}, 5*time.Second, 500*time.Millisecond).Should(BeTrue())
+
+			// Now delete the InferenceService
+			err := cli.Get(ctx, types.NamespacedName{
+				Name:      inferenceService.Name,
+				Namespace: inferenceService.Namespace,
+			}, inferenceService)
+			Expect(err).To(BeNil())
+
+			Expect(cli.Delete(ctx, inferenceService)).To(Succeed())
+
+			// The InferenceService should be fully deleted (finalizer removed)
+			// despite the ModelRegistry service being gone
+			Eventually(func() bool {
+				isvc := &kservev1beta1.InferenceService{}
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      inferenceService.Name,
+					Namespace: inferenceService.Namespace,
+				}, isvc)
+				return errors.IsNotFound(err)
+			}, 15*time.Second, 1*time.Second).Should(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

  ### Summary

  - Fix InferenceService finalizer stuck in Terminating when the ModelRegistry service is deleted before the InferenceService
  - Move deletion handling before initModelRegistryService() so the finalizer is always removed, even when the MR Service no longer exists
  - MR state update (DesiredState → UNDEPLOYED) becomes best-effort during deletion — logged and skipped if MR is unavailable
  - Add integration test reproducing the exact scenario (MR Service deleted → ISVC deleted → verify ISVC is fully cleaned up)

 ### Root Cause

  In Reconcile(), initModelRegistryService() was called before checking isvc.GetDeletionTimestamp(). When the ModelRegistry Service was already gone, getMRService() → client.Get() returned a not-found error. This
  error caused an early return, and the finalizer removal code was never reached:

  Reconcile():
```
    mrApi, err := r.initModelRegistryService(...)   // fails: Service not found
    if err != nil { return ctrl.Result{}, err }      // returns here every time
    // ...
    // finalizer removal code below is NEVER reached
    if isMarkedToBeDeleted { ... removeFinalizer ... }
```

  Every reconciliation loop hit the same error → finalizer stayed forever → InferenceService couldn't be deleted → namespace stuck in Terminating.

  ### Fix

  Moved the deletion timestamp check before initModelRegistryService(). When the ISVC is marked for deletion:

  1. Attempt to init MR service and update state (best-effort)
  2. If MR service is unavailable, log and skip
  3. Always remove the finalizer, regardless of MR availability

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

  - [x] New integration test: "Should remove the finalizer and allow deletion even if the ModelRegistry service no longer exists"
    - Creates namespace, MR Service, and InferenceService
    - Waits for controller to add finalizer and IS ID label
    - Deletes the MR Service
    - Deletes the InferenceService
    - Verifies the ISVC is fully deleted (not stuck in Terminating)
  - [x] Test confirmed red before fix, green after
  - [x] All 9 existing tests still pass (no regressions)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.