### PR TITLE
fix(devenv): macOS compatibility issues in Tilt setup - sleep infinity and missing prerequisites

### DIFF
--- a/devenv/configs/tiltfiles/jupyterhub.tiltfile
+++ b/devenv/configs/tiltfiles/jupyterhub.tiltfile
@@ -35,7 +35,7 @@ k8s_resource(
 local_resource(
   "hub-ready",
   resource_deps=["jupyterhub"],
-  serve_cmd="sleep infinity",
+  serve_cmd="tail -f /dev/null",
   readiness_probe=probe(exec=exec_action(command=["curl", "-H", "Authorization: token dummydummy", "-f", "http://localhost:8086/hub/api/users"]), initial_delay_secs=5, timeout_secs=60),
   labels="jupyterhub"
 )
@@ -50,7 +50,7 @@ local_resource(
 local_resource(
     "mr-notebook",
     resource_deps=["mr-notebook-create"],
-    serve_cmd="sleep infinity",
+    serve_cmd="tail -f /dev/null",
     labels="notebooks",
     readiness_probe=probe(exec=exec_action(command=["/bin/bash", "-c", "kubectl get pod -n kubeflow -l app=jupyterhub,component=singleuser-server,hub.jupyter.org/username=mr -o jsonpath={.items[0].status.phase} | grep -q '^Running$' && exit 0 || exit 1"]), initial_delay_secs=5, timeout_secs=60),
     links=[link("http://localhost:8086/user/mr/lab", "Open JupyterLab")]

--- a/docs/dev_kind_environment.md
+++ b/docs/dev_kind_environment.md
@@ -10,6 +10,7 @@ Local Kubernetes development environment for the model-registry UI using Kind an
 - Go >= 1.26
 - Node.js >= 22.0.0
 - Tilt v0.33.22+ (auto-downloaded by `make tilt-up` if not present)
+- `yq` and `kustomize` (required for running the Catalog service)
 
 ## Architecture
 


### PR DESCRIPTION
**Fix:** Replaced `sleep infinity` with `tail -f /dev/null`, which is 
functionally identical (runs forever, does nothing) and works on both 
Linux and macOS.
## Testing
- `make build/compile` 
- `make vet`   
- `make test` 
closes #2795 