### PR TITLE
change the labels from microcopy

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
@@ -300,7 +300,7 @@ describe('Model Catalog Performance Filters API Behavior', () => {
     });
   });
 
-  describe('Cold start latency filter API behavior', () => {
+  describe('Cold start load time filter API behavior', () => {
     it('should include cold_start_load_time_seconds in filterQuery when applied with toggle ON', () => {
       visitWithPerformanceToggle(true);
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
@@ -179,7 +179,7 @@ const HardwareConfigurationFilterToolbar: React.FC<HardwareConfigurationFilterTo
             >
               <Button
                 variant="plain"
-                aria-label="More info for cold start latency"
+                aria-label="More info for cold start load time"
                 className="pf-v6-u-p-xs"
                 icon={<HelpIcon />}
               />

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
@@ -173,7 +173,7 @@ const HardwareConfigurationFilterToolbar: React.FC<HardwareConfigurationFilterTo
           <ToolbarItem>
             <ColdStartLatencyFilter />
             <Popover
-              bodyContent="The estimated time required to provision hardware resources and initialize the container before the model can accept traffic."
+              bodyContent="Set the maximum acceptable time that it can take for vLLM to load the model. This does not include the time it takes to download the model."
               appendTo={() => document.body}
               position="top"
             >

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -361,7 +361,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
     label: `Cold start\nlatency`,
     info: {
       popover:
-        'The estimated time required to provision hardware resources and initialize the container before the model can accept traffic.',
+        'The time it takes for vLLM to load the model. This does not include the time it takes to download the model.',
       popoverProps: {
         position: 'left',
       },
@@ -374,7 +374,8 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
     field: 'runtime_command',
     label: 'Runtime Command',
     info: {
-      popover: 'Runtime configuration used to validate this model.',
+      popover:
+        'The vLLM runtime command used to validate the model with the selected hardware configuration.',
       popoverProps: {
         position: 'left',
       },

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -358,7 +358,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
   },
   {
     field: 'cold_start_load_time',
-    label: `Cold start\nlatency`,
+    label: `Cold start load time`,
     info: {
       popover:
         'The time it takes for vLLM to load the model. This does not include the time it takes to download the model.',
@@ -368,7 +368,6 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
     },
     sortable: false,
     width: 20,
-    modifier: 'wrap',
   },
   {
     field: 'runtime_command',

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -272,9 +272,8 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
                     bodyContent={
                       <div>
                         <p>
-                          <strong>Cold start latency:</strong> The estimated time required to
-                          provision hardware resources and initialize the container before the model
-                          can accept traffic.
+                          <strong>Cold start latency:</strong> The time it takes for vLLM to load
+                          the model. This does not include the time it takes to download the model.
                         </p>
                       </div>
                     }

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -267,13 +267,13 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
                   {formatLatency(matchedColdStart * 1000)}
                 </span>
                 <Flex alignItems={{ default: 'alignItemsBaseline' }} gap={{ default: 'gapXs' }}>
-                  <Content component={ContentVariants.small}>Cold start latency</Content>
+                  <Content component={ContentVariants.small}>Cold start load time</Content>
                   <Popover
                     bodyContent={
                       <div>
                         <p>
-                          <strong>Cold start latency:</strong> The time it takes for vLLM to load
-                          the model. This does not include the time it takes to download the model.
+                          This is the initial delay that occurs when a model is triggered after a
+                          period of inactivity.
                         </p>
                       </div>
                     }
@@ -281,7 +281,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
                     <Button
                       icon={<HelpIcon />}
                       hasNoPadding
-                      aria-label="More info for cold start latency"
+                      aria-label="More info for cold start load time"
                       variant="plain"
                     />
                   </Popover>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogSortDropdown.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogSortDropdown.tsx
@@ -52,7 +52,7 @@ const ModelCatalogSortDropdown: React.FC<ModelCatalogSortDropdownProps> = ({
       return 'Latency (Lowest → Highest)';
     }
     if (sortBy === ModelCatalogSortOption.LOWEST_COLD_START) {
-      return 'Cold start latency (Lowest → Highest)';
+      return 'Cold start load time (Lowest → Highest)';
     }
     return 'Publish date (Newest → Oldest)';
   };
@@ -97,7 +97,7 @@ const ModelCatalogSortDropdown: React.FC<ModelCatalogSortDropdownProps> = ({
             value={ModelCatalogSortOption.LOWEST_COLD_START}
             data-testid="sort-option-lowest-cold-start"
           >
-            Cold start latency (Lowest → Highest)
+            Cold start load time (Lowest → Highest)
           </SelectOption>
         </SelectList>
       </Select>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
@@ -39,7 +39,7 @@ const ColdStartLatencyFilter: React.FC = () => {
     if (hasActiveFilter) {
       return (
         <>
-          <strong>Cold start load time:</strong> {filterValue} ms
+          <strong>Cold start load time:</strong> ≤ {filterValue} ms
         </>
       );
     }

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
@@ -39,11 +39,11 @@ const ColdStartLatencyFilter: React.FC = () => {
     if (hasActiveFilter) {
       return (
         <>
-          <strong>Cold start latency:</strong> {filterValue} ms
+          <strong>Cold start load time:</strong> {filterValue} ms
         </>
       );
     }
-    return 'Cold start latency';
+    return 'Cold start load time';
   };
 
   const handleApplyFilter = () => {
@@ -75,7 +75,7 @@ const ColdStartLatencyFilter: React.FC = () => {
       flexWrap={{ default: 'wrap' }}
       style={{ minWidth: '400px', padding: '16px' }}
     >
-      <FlexItem>Cold start latency (ms)</FlexItem>
+      <FlexItem>Cold start load time (ms)</FlexItem>
       <FlexItem>
         <SliderWithInput
           value={clampedValue}
@@ -83,7 +83,7 @@ const ColdStartLatencyFilter: React.FC = () => {
           max={maxValue}
           isDisabled={isSliderDisabled}
           onChange={setLocalValue}
-          ariaLabel="Cold start latency value input"
+          ariaLabel="Cold start load time value input"
         />
       </FlexItem>
       <FlexItem>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -261,7 +261,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                       <DescriptionListDescription>{tensorType || 'N/A'}</DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
-                      <DescriptionListTerm>Size</DescriptionListTerm>
+                      <DescriptionListTerm>Parameter size</DescriptionListTerm>
                       <DescriptionListDescription>{size || 'N/A'}</DescriptionListDescription>
                     </DescriptionListGroup>
                     {minimumVram && (
@@ -318,7 +318,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                     )}
                     {modelSize && (
                       <DescriptionListGroup>
-                        <DescriptionListTerm>Image size</DescriptionListTerm>
+                        <DescriptionListTerm>Container size</DescriptionListTerm>
                         <DescriptionListDescription data-testid="image-size">
                           {modelSize}
                         </DescriptionListDescription>

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -594,7 +594,7 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
   [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: 'Validated arguments',
   // Number filter keys
   [ModelCatalogNumberFilterKey.MAX_RPS]: 'Max RPS',
-  [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: 'Cold start latency',
+  [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: 'Cold start load time',
   // Latency field names - all use "Latency" as category name
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   ...(Object.fromEntries(ALL_LATENCY_FILTER_KEYS.map((field) => [field, 'Latency'])) as Record<
@@ -606,7 +606,7 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
 export const MODEL_CATALOG_FILTER_CHIP_PREFIXES = {
   WORKLOAD_TYPE: 'Workload type:',
   MAX_RPS: 'Max RPS:',
-  COLD_START_LATENCY: 'Cold start latency:',
+  COLD_START_LATENCY: 'Cold start load time:',
   LATENCY_METRIC: 'Metric:',
   LATENCY_PERCENTILE: 'Percentile:',
   LATENCY_THRESHOLD: 'Under',

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -606,7 +606,7 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
 export const MODEL_CATALOG_FILTER_CHIP_PREFIXES = {
   WORKLOAD_TYPE: 'Workload type:',
   MAX_RPS: 'Max RPS:',
-  COLD_START_LATENCY: 'Cold start load time:',
+  COLD_START_LATENCY: 'Cold start load time: ≤',
   LATENCY_METRIC: 'Metric:',
   LATENCY_PERCENTILE: 'Percentile:',
   LATENCY_THRESHOLD: 'Under',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Change the labels text from the following places:
**Cold Start Latency filter popover (toolbar):**
Before:
<img width="519" height="195" alt="before-cold-start-filter-bar" src="https://github.com/user-attachments/assets/eed8b829-2ea9-46a3-b26d-1b12afa11fba" />
After:
<img width="468" height="213" alt="Screenshot 2026-06-10 at 10 26 16" src="https://github.com/user-attachments/assets/1bfdbde2-2f89-4501-98f0-ec0706107ef0" />

**"Cold start latency" column popover (hardware config table)**
Before:
<img width="388" height="242" alt="before-cold-start-hardware-table-column" src="https://github.com/user-attachments/assets/b8df8260-45d1-449a-86e1-67636882d5dc" />
After:
<img width="478" height="261" alt="after-cold-start-hardware-table-column" src="https://github.com/user-attachments/assets/5641cfc1-cd54-47da-a904-8e6ba09769d5" />

**"Cold start latency" popover (model card overview)**
Before:
<img width="585" height="304" alt="before-cold-start-model-card" src="https://github.com/user-attachments/assets/8550a45c-1ba3-4f47-8b69-48f6249c4834" />
After:
<img width="312" height="112" alt="Screenshot 2026-06-09 at 09 40 50" src="https://github.com/user-attachments/assets/21ea5ab6-1650-414e-9cde-094137ed2fdf" />

**"Runtime Command" column popover (hardware config table)**
Before:
<img width="389" height="237" alt="before-runtime-hardware-table-column" src="https://github.com/user-attachments/assets/528eb3dc-6102-462f-8bab-9139c9509ad0" />
After:
<img width="375" height="120" alt="after-runtime-hardware-table-column" src="https://github.com/user-attachments/assets/df5bf5d3-d78f-48bb-8fb2-d7e5df8039c7" />

**"Size and Image size" label in model details**
Before:
<img width="516" height="511" alt="Screenshot 2026-06-10 at 10 26 52" src="https://github.com/user-attachments/assets/13436d82-d6f4-4869-959e-3acdb62a9e65" />
After:
<img width="487" height="483" alt="Screenshot 2026-06-10 at 10 25 19" src="https://github.com/user-attachments/assets/ba3c226a-0b61-43a4-8a43-65400632f468" />

This PR was to change all the text from "Cold start latency" to "Cold start load time"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested, no new tests added, only text changes

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
