### PR TITLE
add modelcar image size & byte size

### DIFF
--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -22,13 +22,15 @@ import (
 // metadataJSON represents the minimal structure needed from metadata.json files
 // Only the ID field is needed to look up existing models
 type metadataJSON struct {
-	ID              string           `json:"id"`                // Maps to model name for lookup
-	OverallAccuracy *float64         `json:"overall_accuracy"`  // Overall accuracy score for the model
-	Size            *string          `json:"size"`              // Model parameter count (e.g., "8B params")
-	TensorType      *string          `json:"tensor_type"`       // Data precision (e.g., "FP16", "INT4")
-	VariantGroupID  *string          `json:"variant_group_id"`  // UUID linking model variants together
-	MinVRAMGB       *string          `json:"min_vram_gb"`       // Minimum VRAM required (e.g., "265 GB")
-	ColdStartMatrix []coldStartEntry `json:"cold_start_matrix"` // Cold start times per GPU configuration
+	ID                    string           `json:"id"`                       // Maps to model name for lookup
+	OverallAccuracy       *float64         `json:"overall_accuracy"`         // Overall accuracy score for the model
+	Size                  *string          `json:"size"`                     // Model parameter count (e.g., "8B params")
+	TensorType            *string          `json:"tensor_type"`              // Data precision (e.g., "FP16", "INT4")
+	VariantGroupID        *string          `json:"variant_group_id"`         // UUID linking model variants together
+	MinVRAMGB             *string          `json:"min_vram_gb"`              // Minimum VRAM required (e.g., "265 GB")
+	ModelcarImageSize     *string          `json:"modelcar_image_size"`      // Human-readable modelcar image size (e.g., "230.17 GB")
+	ModelcarImageSizeBytes *int64          `json:"modelcar_image_size_bytes"` // Modelcar image size in bytes
+	ColdStartMatrix       []coldStartEntry `json:"cold_start_matrix"`        // Cold start times per GPU configuration
 }
 
 type coldStartEntry struct {
@@ -761,6 +763,23 @@ func enrichCatalogModelFromMetadata(existingModel dbmodels.CatalogModel, metadat
 		customProperties = append(customProperties, models.Properties{
 			Name:             "min_vram_gb",
 			StringValue:      metadata.MinVRAMGB,
+			IsCustomProperty: true,
+		})
+	}
+
+	if metadata.ModelcarImageSize != nil && *metadata.ModelcarImageSize != "" {
+		customProperties = append(customProperties, models.Properties{
+			Name:             "modelcar_image_size",
+			StringValue:      metadata.ModelcarImageSize,
+			IsCustomProperty: true,
+		})
+	}
+
+	if metadata.ModelcarImageSizeBytes != nil {
+		bytesStr := strconv.FormatInt(*metadata.ModelcarImageSizeBytes, 10)
+		customProperties = append(customProperties, models.Properties{
+			Name:             "modelcar_image_size_bytes",
+			StringValue:      &bytesStr,
 			IsCustomProperty: true,
 		})
 	}

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -956,15 +956,17 @@ func TestUnmarshalJSON_EdgeCases(t *testing.T) {
 
 func TestParseMetadataJSON_NewFields(t *testing.T) {
 	tests := []struct {
-		name                string
-		jsonData            string
-		wantID              string
-		wantSize            *string
-		wantTensorType      *string
-		wantVariantID       *string
-		wantMinVRAMGB       *string
-		wantColdStartMatrix []coldStartEntry
-		wantErr             bool
+		name                       string
+		jsonData                   string
+		wantID                     string
+		wantSize                   *string
+		wantTensorType             *string
+		wantVariantID              *string
+		wantMinVRAMGB              *string
+		wantModelcarImageSize      *string
+		wantModelcarImageSizeBytes *int64
+		wantColdStartMatrix        []coldStartEntry
+		wantErr                    bool
 	}{
 		{
 			name: "complete metadata with all new fields",
@@ -1124,6 +1126,8 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 				"tensor_type": "FP8",
 				"variant_group_id": "vwx234mn-5678-901v-wx23-456789abcdef",
 				"min_vram_gb": "265 GB",
+				"modelcar_image_size": "230.17 GB",
+				"modelcar_image_size_bytes": 230171650363,
 				"cold_start_matrix": [
 					{
 						"gpu_type": "A100-80",
@@ -1137,11 +1141,13 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 					}
 				]
 			}`,
-			wantID:         "sample-model/test-405b-instruct",
-			wantSize:       &[]string{"405B params"}[0],
-			wantTensorType: &[]string{"FP8"}[0],
-			wantVariantID:  &[]string{"vwx234mn-5678-901v-wx23-456789abcdef"}[0],
-			wantMinVRAMGB:  &[]string{"265 GB"}[0],
+			wantID:                     "sample-model/test-405b-instruct",
+			wantSize:                   &[]string{"405B params"}[0],
+			wantTensorType:             &[]string{"FP8"}[0],
+			wantVariantID:              &[]string{"vwx234mn-5678-901v-wx23-456789abcdef"}[0],
+			wantMinVRAMGB:              &[]string{"265 GB"}[0],
+			wantModelcarImageSize:      &[]string{"230.17 GB"}[0],
+			wantModelcarImageSizeBytes: &[]int64{230171650363}[0],
 			wantColdStartMatrix: []coldStartEntry{
 				{GPUType: "A100-80", GPUCount: "4", ColdStartTimeToLoadSeconds: "587.3"},
 				{GPUType: "B200", GPUCount: "2", ColdStartTimeToLoadSeconds: "559.9"},
@@ -1218,6 +1224,16 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 			// Test MinVRAMGB field
 			if (got.MinVRAMGB == nil) != (tt.wantMinVRAMGB == nil) || (got.MinVRAMGB != nil && tt.wantMinVRAMGB != nil && *got.MinVRAMGB != *tt.wantMinVRAMGB) {
 				t.Errorf("parseMetadataJSON() MinVRAMGB = %v, want %v", got.MinVRAMGB, tt.wantMinVRAMGB)
+			}
+
+			// Test ModelcarImageSize field
+			if (got.ModelcarImageSize == nil) != (tt.wantModelcarImageSize == nil) || (got.ModelcarImageSize != nil && tt.wantModelcarImageSize != nil && *got.ModelcarImageSize != *tt.wantModelcarImageSize) {
+				t.Errorf("parseMetadataJSON() ModelcarImageSize = %v, want %v", got.ModelcarImageSize, tt.wantModelcarImageSize)
+			}
+
+			// Test ModelcarImageSizeBytes field
+			if (got.ModelcarImageSizeBytes == nil) != (tt.wantModelcarImageSizeBytes == nil) || (got.ModelcarImageSizeBytes != nil && tt.wantModelcarImageSizeBytes != nil && *got.ModelcarImageSizeBytes != *tt.wantModelcarImageSizeBytes) {
+				t.Errorf("parseMetadataJSON() ModelcarImageSizeBytes = %v, want %v", got.ModelcarImageSizeBytes, tt.wantModelcarImageSizeBytes)
 			}
 
 			// Test ColdStartMatrix field
@@ -1477,9 +1493,13 @@ func TestEnrichCatalogModelFromMetadata_NewFields(t *testing.T) {
 	}
 
 	minVRAM := "80GB"
+	modelcarSize := "230.17 GB"
+	modelcarSizeBytes := int64(230171650363)
 	metadata := metadataJSON{
-		ID:        modelName,
-		MinVRAMGB: &minVRAM,
+		ID:                     modelName,
+		MinVRAMGB:              &minVRAM,
+		ModelcarImageSize:      &modelcarSize,
+		ModelcarImageSizeBytes: &modelcarSizeBytes,
 		ColdStartMatrix: []coldStartEntry{
 			{GPUType: "A100", GPUCount: "2", ColdStartTimeToLoadSeconds: "127.3"},
 			{GPUType: "H100", GPUCount: "1", ColdStartTimeToLoadSeconds: "68.9"},
@@ -1509,6 +1529,18 @@ func TestEnrichCatalogModelFromMetadata_NewFields(t *testing.T) {
 		t.Error("expected custom property 'min_vram_gb' to be set")
 	} else if v != "80GB" {
 		t.Errorf("min_vram_gb = %q, want %q", v, "80GB")
+	}
+
+	if v, ok := propMap["modelcar_image_size"]; !ok {
+		t.Error("expected custom property 'modelcar_image_size' to be set")
+	} else if v != "230.17 GB" {
+		t.Errorf("modelcar_image_size = %q, want %q", v, "230.17 GB")
+	}
+
+	if v, ok := propMap["modelcar_image_size_bytes"]; !ok {
+		t.Error("expected custom property 'modelcar_image_size_bytes' to be set")
+	} else if v != "230171650363" {
+		t.Errorf("modelcar_image_size_bytes = %q, want %q", v, "230171650363")
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR surfaces modelcar image size and modelcar image size bytes to the catalog model's custom properties. 

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
