### PR TITLE
fix(catalog): report /readyz unhealthy when leader election fails

### DIFF
--- a/catalog/cmd/catalog.go
+++ b/catalog/cmd/catalog.go
@@ -148,6 +148,8 @@ func runCatalogServer(_ *cobra.Command, _ []string) error {
 		RepoSet:                repoSet,
 	})
 
+	pluginServer.AddReadinessCheck("leader_election", elector.Healthy)
+
 	if err := pluginServer.Init(ctx); err != nil {
 		return fmt.Errorf("error initializing plugins: %w", err)
 	}

--- a/catalog/internal/leader/election.go
+++ b/catalog/internal/leader/election.go
@@ -6,12 +6,53 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"cirello.io/pglock"
 	"github.com/golang/glog"
 	"gorm.io/gorm"
 )
+
+const defaultUnhealthyThreshold int32 = 3
+
+// lockHandle represents a held distributed lock.
+type lockHandle interface {
+	sendHeartbeat(ctx context.Context) error
+	release() error
+}
+
+// lockClient abstracts distributed lock acquisition for testability.
+type lockClient interface {
+	acquireContext(ctx context.Context, name string) (lockHandle, error)
+}
+
+// pglockAdapter wraps *pglock.Client to satisfy lockClient.
+type pglockAdapter struct {
+	client *pglock.Client
+}
+
+func (a *pglockAdapter) acquireContext(ctx context.Context, name string) (lockHandle, error) {
+	lock, err := a.client.AcquireContext(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &pglockHandle{client: a.client, lock: lock}, nil
+}
+
+// pglockHandle wraps a held *pglock.Lock to satisfy lockHandle.
+type pglockHandle struct {
+	client *pglock.Client
+	lock   *pglock.Lock
+}
+
+func (h *pglockHandle) sendHeartbeat(ctx context.Context) error {
+	return h.client.SendHeartbeat(ctx, h.lock)
+}
+
+func (h *pglockHandle) release() error {
+	return h.client.Release(h.lock)
+}
 
 // backoff provides exponential backoff for retry logic.
 type backoff struct {
@@ -46,7 +87,7 @@ type LeaderElector struct {
 	lockDuration   time.Duration
 	heartbeatFreq  time.Duration
 	onBecomeLeader []func(context.Context)
-	client         *pglock.Client
+	locker         lockClient
 	mu             sync.Mutex
 
 	// Leadership state (protected by mu)
@@ -60,6 +101,15 @@ type LeaderElector struct {
 
 	// Dynamic callback tracking
 	activeCallbacks sync.WaitGroup
+
+	// Health tracking: counts consecutive election loop errors (failed
+	// lock acquisition or lost heartbeat). Healthy() returns false after
+	// unhealthyThreshold consecutive failures, resets on successful acquisition.
+	consecutiveFailures atomic.Int32
+	unhealthyThreshold  int32
+
+	// retryBackoff overrides the default backoff for testing. nil = use defaults.
+	retryBackoff *backoff
 }
 
 // NewLeaderElector creates a new LeaderElector instance.
@@ -104,13 +154,17 @@ func NewLeaderElector(
 	}
 
 	e := &LeaderElector{
-		ctx:           ctx,
-		lockName:      lockName,
-		lockDuration:  lockDuration,
-		heartbeatFreq: heartbeatFreq,
-		client:        client,
-		done:          make(chan struct{}),
+		ctx:                ctx,
+		lockName:           lockName,
+		lockDuration:       lockDuration,
+		heartbeatFreq:      heartbeatFreq,
+		locker:             &pglockAdapter{client: client},
+		done:               make(chan struct{}),
+		unhealthyThreshold: defaultUnhealthyThreshold,
 	}
+	// Start unhealthy: a pod that has never acquired the lock is not ready.
+	// Resets to 0 on first successful acquisition in runOnce().
+	e.consecutiveFailures.Store(e.unhealthyThreshold)
 
 	// Start the background goroutine immediately
 	go e.run()
@@ -163,6 +217,14 @@ func (e *LeaderElector) Wait() error {
 	return e.err
 }
 
+// Healthy returns true if the leader elector has not exceeded its
+// consecutive failure threshold. The counter increments on any
+// runOnce error — failed lock acquisition or lost heartbeat —
+// and resets to zero on successful acquisition.
+func (e *LeaderElector) Healthy() bool {
+	return e.consecutiveFailures.Load() < e.unhealthyThreshold
+}
+
 // run starts the leader election process with automatic retry.
 // This runs in a background goroutine started by NewLeaderElector.
 //
@@ -179,7 +241,10 @@ func (e *LeaderElector) run() {
 	defer close(e.done)
 
 	ctx := e.ctx
-	backoff := newBackoff()
+	backoff := e.retryBackoff
+	if backoff == nil {
+		backoff = newBackoff()
+	}
 
 	for {
 		if ctx.Err() != nil {
@@ -197,8 +262,9 @@ func (e *LeaderElector) run() {
 		}
 
 		if err != nil {
+			failures := e.consecutiveFailures.Add(1)
 			delay := backoff.next()
-			glog.Errorf("Leader election error: %v (retrying in %v)", err, delay)
+			glog.Errorf("Leader election error: %v (consecutive failures: %d, retrying in %v)", err, failures, delay)
 
 			select {
 			case <-time.After(delay):
@@ -218,12 +284,13 @@ func (e *LeaderElector) run() {
 // Returns when context is canceled or lock is lost.
 // Per the plan, callbacks exiting early no longer causes lock release.
 func (e *LeaderElector) runOnce(ctx context.Context) error {
-	lock, err := e.client.AcquireContext(ctx, e.lockName)
+	handle, err := e.locker.acquireContext(ctx, e.lockName)
 	if err != nil {
 		return fmt.Errorf("failed to acquire lock %q: %w", e.lockName, err)
 	}
 
 	glog.Infof("Successfully acquired leadership lock: %s", e.lockName)
+	e.consecutiveFailures.Store(0)
 
 	// Create a context that will be canceled when we lose leadership
 	leaderCtx, cancelLeader := context.WithCancel(e.ctx)
@@ -263,14 +330,14 @@ func (e *LeaderElector) runOnce(ctx context.Context) error {
 			e.cancelLeader = nil
 			e.mu.Unlock()
 
-			if err := e.client.Release(lock); err != nil {
+			if err := handle.release(); err != nil {
 				glog.Errorf("Error releasing lock: %v", err)
 			}
 			return ctx.Err()
 
 		case <-ticker.C:
 			// Verify we still own the lock
-			if err := e.client.SendHeartbeat(ctx, lock); err != nil {
+			if err := handle.sendHeartbeat(ctx); err != nil {
 				glog.Errorf("Lost leadership lock: %v", err)
 				cancelLeader()           // Signal ALL callbacks to stop
 				e.activeCallbacks.Wait() // Wait for ALL callbacks to finish

--- a/catalog/internal/leader/election_health_internal_test.go
+++ b/catalog/internal/leader/election_health_internal_test.go
@@ -1,0 +1,203 @@
+package leader
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockHandle satisfies lockHandle for testing.
+type mockHandle struct{}
+
+func (h *mockHandle) sendHeartbeat(_ context.Context) error { return nil }
+func (h *mockHandle) release() error                        { return nil }
+
+// failingHandle succeeds for failAfter heartbeats, then returns err.
+type failingHandle struct {
+	err       error
+	failAfter int32
+	beats     atomic.Int32
+}
+
+func (h *failingHandle) sendHeartbeat(_ context.Context) error {
+	if h.beats.Add(1) > h.failAfter {
+		return h.err
+	}
+	return nil
+}
+
+func (h *failingHandle) release() error { return nil }
+
+// heartbeatFailLocker acquires successfully but returns a handle that
+// fails after a configured number of heartbeats.
+type heartbeatFailLocker struct {
+	handleErr      error
+	failAfter      int32
+	acquireCount   atomic.Int32
+	reacquireErr   error
+	reacquireAfter int32 // fail reacquisition after this many acquires (0 = always succeed)
+}
+
+func (l *heartbeatFailLocker) acquireContext(_ context.Context, _ string) (lockHandle, error) {
+	n := l.acquireCount.Add(1)
+	if l.reacquireAfter > 0 && n > l.reacquireAfter {
+		return nil, l.reacquireErr
+	}
+	return &failingHandle{err: l.handleErr, failAfter: l.failAfter}, nil
+}
+
+// failingLocker is a lockClient that fails a configurable number of times
+// before succeeding. Set failCount to -1 to always fail.
+type failingLocker struct {
+	err       error
+	failCount int32
+	calls     atomic.Int32
+}
+
+func (f *failingLocker) acquireContext(_ context.Context, _ string) (lockHandle, error) {
+	n := f.calls.Add(1)
+	if f.failCount < 0 || n <= f.failCount {
+		return nil, f.err
+	}
+	return &mockHandle{}, nil
+}
+
+func newTestElector(ctx context.Context, locker lockClient, threshold int32) *LeaderElector {
+	e := &LeaderElector{
+		ctx:                ctx,
+		lockName:           "test-health",
+		heartbeatFreq:      50 * time.Millisecond,
+		locker:             locker,
+		done:               make(chan struct{}),
+		unhealthyThreshold: threshold,
+		retryBackoff:       &backoff{current: time.Millisecond, max: time.Millisecond},
+	}
+	e.consecutiveFailures.Store(threshold)
+	go e.run()
+	return e
+}
+
+func TestHealthyStartsUnhealthy(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	locker := &failingLocker{
+		err:       errors.New("connection refused"),
+		failCount: -1,
+	}
+
+	e := newTestElector(ctx, locker, 3)
+
+	assert.False(t, e.Healthy(), "should start unhealthy before first acquisition")
+
+	require.Eventually(t, func() bool {
+		return locker.calls.Load() >= 3
+	}, 2*time.Second, 5*time.Millisecond, "should have attempted acquisition at least 3 times")
+
+	assert.False(t, e.Healthy(), "should remain unhealthy with sustained failures")
+
+	cancel()
+	_ = e.Wait()
+}
+
+func TestHealthyRecoveryAfterAcquisitionSucceeds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	locker := &failingLocker{
+		err:       errors.New("connection refused"),
+		failCount: 4,
+	}
+
+	e := newTestElector(ctx, locker, 3)
+
+	assert.False(t, e.Healthy(), "should start unhealthy")
+
+	require.Eventually(t, func() bool {
+		return e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should recover to healthy after successful acquisition")
+
+	assert.Equal(t, int32(0), e.consecutiveFailures.Load(), "consecutive failures should be reset")
+
+	cancel()
+	_ = e.Wait()
+}
+
+func TestHealthyBecomesHealthyOnFirstSuccess(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	locker := &failingLocker{
+		err:       errors.New("connection refused"),
+		failCount: 0, // succeeds on first call
+	}
+
+	e := newTestElector(ctx, locker, 3)
+
+	assert.False(t, e.Healthy(), "should start unhealthy")
+
+	require.Eventually(t, func() bool {
+		return e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should become healthy after first successful acquisition")
+
+	assert.Equal(t, int32(0), e.consecutiveFailures.Load())
+
+	cancel()
+	_ = e.Wait()
+}
+
+func TestHealthyThresholdBoundary(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	locker := &failingLocker{
+		err:       errors.New("db unavailable"),
+		failCount: -1,
+	}
+
+	e := newTestElector(ctx, locker, 2)
+
+	assert.False(t, e.Healthy(), "should start unhealthy (threshold=2)")
+
+	// Continued failures keep it unhealthy
+	require.Eventually(t, func() bool {
+		return locker.calls.Load() >= 2
+	}, 2*time.Second, 5*time.Millisecond, "should have attempted acquisition")
+
+	assert.False(t, e.Healthy(), "should remain unhealthy with sustained failures")
+
+	cancel()
+	_ = e.Wait()
+}
+
+func TestHealthyLoseLockBecomesUnhealthy(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	locker := &heartbeatFailLocker{
+		handleErr:      errors.New("heartbeat lost"),
+		failAfter:      2,              // heartbeat fails after 2 successful beats
+		reacquireErr:   errors.New("db down"),
+		reacquireAfter: 1,              // first acquire succeeds, reacquisitions fail
+	}
+
+	e := newTestElector(ctx, locker, 3)
+
+	// Should become healthy after first successful acquisition
+	require.Eventually(t, func() bool {
+		return e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should become healthy after lock acquisition")
+
+	// After heartbeat loss + 3 failed reacquisitions → unhealthy
+	require.Eventually(t, func() bool {
+		return !e.Healthy()
+	}, 5*time.Second, 10*time.Millisecond, "should become unhealthy after losing lock and failing reacquisition")
+
+	cancel()
+	_ = e.Wait()
+}

--- a/catalog/internal/plugin/server.go
+++ b/catalog/internal/plugin/server.go
@@ -26,12 +26,20 @@ type ServerConfig struct {
 	Logger                 *slog.Logger
 }
 
+// readinessCheck is a named readiness check evaluated by the /readyz handler.
+type readinessCheck struct {
+	name string
+	fn   func() bool
+}
+
 // Server manages the lifecycle of catalog plugins and provides a unified HTTP server.
 type Server struct {
-	cfg     ServerConfig
-	mu      sync.RWMutex
-	plugins []CatalogPlugin
-	router  chi.Router
+	cfg             ServerConfig
+	mu              sync.RWMutex
+	plugins         []CatalogPlugin
+	router          chi.Router
+	readinessChecks []readinessCheck
+	lastReady       map[string]bool
 }
 
 // NewServer creates a new plugin server.
@@ -40,8 +48,9 @@ func NewServer(cfg ServerConfig) *Server {
 		cfg.Logger = slog.Default()
 	}
 	return &Server{
-		cfg:     cfg,
-		plugins: make([]CatalogPlugin, 0),
+		cfg:       cfg,
+		plugins:   make([]CatalogPlugin, 0),
+		lastReady: make(map[string]bool),
 	}
 }
 
@@ -183,6 +192,14 @@ func (s *Server) Plugins() []CatalogPlugin {
 	return result
 }
 
+// AddReadinessCheck registers a readiness check evaluated by the /readyz
+// handler alongside plugin health. Must be called before serving traffic.
+func (s *Server) AddReadinessCheck(name string, fn func() bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.readinessChecks = append(s.readinessChecks, readinessCheck{name: name, fn: fn})
+}
+
 func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -190,8 +207,9 @@ func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) readyHandler(w http.ResponseWriter, _ *http.Request) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	// Write lock: readiness check transition tracking updates lastReady.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	allHealthy := true
 	pluginStatus := make(map[string]bool)
@@ -202,6 +220,22 @@ func (s *Server) readyHandler(w http.ResponseWriter, _ *http.Request) {
 		if !healthy {
 			allHealthy = false
 		}
+	}
+
+	for _, rc := range s.readinessChecks {
+		ready := rc.fn()
+		if !ready {
+			allHealthy = false
+		}
+		prev, seen := s.lastReady[rc.name]
+		if seen && prev != ready {
+			if ready {
+				s.cfg.Logger.Info("readiness check recovered", "check", rc.name)
+			} else {
+				s.cfg.Logger.Warn("readiness check failed", "check", rc.name)
+			}
+		}
+		s.lastReady[rc.name] = ready
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -221,11 +255,9 @@ func (s *Server) readyHandler(w http.ResponseWriter, _ *http.Request) {
 	_ = json.NewEncoder(w).Encode(response)
 }
 
-
 func computeBasePath(p CatalogPlugin) string {
 	if bp, ok := p.(BasePathProvider); ok {
 		return bp.BasePath()
 	}
 	return fmt.Sprintf("/api/%s_catalog/%s", p.Name(), p.Version())
 }
-

--- a/catalog/internal/plugin/server_test.go
+++ b/catalog/internal/plugin/server_test.go
@@ -381,6 +381,79 @@ func TestServerMountRoutesFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "route registration failed")
 }
 
+func TestReadyzNoReadinessChecks(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&mockPlugin{name: "model", version: "v1", healthy: true})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	assertStatus(t, router, "/readyz", http.StatusOK)
+	body := getJSON(t, router, "/readyz")
+	assert.Equal(t, "ready", body["status"])
+}
+
+func TestReadyzWithReadinessCheck(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&mockPlugin{name: "model", version: "v1", healthy: true})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+
+	healthy := true
+	s.AddReadinessCheck("leader_election", func() bool { return healthy })
+
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	// All healthy → 200
+	assertStatus(t, router, "/readyz", http.StatusOK)
+	body := getJSON(t, router, "/readyz")
+	assert.Equal(t, "ready", body["status"])
+
+	// Health check fails → 503
+	healthy = false
+	assertStatus(t, router, "/readyz", http.StatusServiceUnavailable)
+	body = getJSON(t, router, "/readyz")
+	assert.Equal(t, "not_ready", body["status"])
+
+	// Plugin still healthy
+	plugins := body["plugins"].(map[string]any)
+	assert.Equal(t, true, plugins["model"])
+}
+
+func TestReadyzReadinessCheckRecovery(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register(&mockPlugin{name: "model", version: "v1", healthy: true})
+
+	s := newTestServer()
+	require.NoError(t, s.Init(context.Background()))
+
+	healthy := false
+	s.AddReadinessCheck("leader_election", func() bool { return healthy })
+
+	router, err := s.MountRoutes()
+	require.NoError(t, err)
+
+	// Starts unhealthy
+	assertStatus(t, router, "/readyz", http.StatusServiceUnavailable)
+
+	// Recovers
+	healthy = true
+	assertStatus(t, router, "/readyz", http.StatusOK)
+	body := getJSON(t, router, "/readyz")
+	assert.Equal(t, "ready", body["status"])
+}
+
 // Test helpers
 
 func assertStatus(t *testing.T, handler http.Handler, path string, expectedStatus int) {


### PR DESCRIPTION
Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
`/readyz` returns 200 and reports all plugins as healthy even when leader election was failing due to postgres being down.  
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Other than unit tests, manual verification with catalog running, stop Postgres or drop the leader lock table, then curl /readyz → expect 503 with "status": "not_ready".
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
