### PR TITLE
add new data types for cold start & vram

### DIFF
--- a/catalog/internal/catalog/modelcatalog/db_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog.go
@@ -57,7 +57,10 @@ func (d *dbCatalogImpl) GetModel(ctx context.Context, modelName string, sourceID
 		return nil, fmt.Errorf("multiple models found for name=%v: %w", modelName, api.ErrNotFound)
 	}
 
-	model := mapDBModelToAPIModel(modelsList.Items[0])
+	model, err := mapDBModelToAPIModel(modelsList.Items[0])
+	if err != nil {
+		glog.Warningf("error mapping custom properties for model %s: %v", modelName, err)
+	}
 
 	return &model, nil
 }
@@ -107,7 +110,11 @@ func (d *dbCatalogImpl) ListModels(ctx context.Context, params ListModelsParams)
 	}
 
 	for _, model := range modelsList.Items {
-		modelList.Items = append(modelList.Items, mapDBModelToAPIModel(model))
+		apiModel, err := mapDBModelToAPIModel(model)
+		if err != nil {
+			glog.Warningf("error mapping custom properties for model: %v", err)
+		}
+		modelList.Items = append(modelList.Items, apiModel)
 	}
 
 	modelList.NextPageToken = modelsList.NextPageToken
@@ -305,7 +312,7 @@ func (d *dbCatalogImpl) GetPerformanceArtifacts(ctx context.Context, modelName s
 	return *artifactList, nil
 }
 
-func mapDBModelToAPIModel(m models.CatalogModel) apimodels.CatalogModel {
+func mapDBModelToAPIModel(m models.CatalogModel) (apimodels.CatalogModel, error) {
 	res := apimodels.CatalogModel{}
 
 	id := strconv.FormatInt(int64(*m.GetID()), 10)
@@ -405,20 +412,14 @@ func mapDBModelToAPIModel(m models.CatalogModel) apimodels.CatalogModel {
 
 	// Map custom properties
 	if m.GetCustomProperties() != nil && len(*m.GetCustomProperties()) > 0 {
-		customProps := make(map[string]apimodels.MetadataValue, len(*m.GetCustomProperties()))
-		for _, prop := range *m.GetCustomProperties() {
-			if prop.StringValue != nil {
-				customProps[prop.Name] = apimodels.MetadataStringValueAsMetadataValue(
-					apimodels.NewMetadataStringValue(*prop.StringValue, "MetadataStringValue"),
-				)
-			}
+		customPropsMap, err := converter.MapEmbedMDCustomProperties(*m.GetCustomProperties())
+		if err != nil {
+			return apimodels.CatalogModel{}, fmt.Errorf("error mapping custom properties: %w", err)
 		}
-		if len(customProps) > 0 {
-			res.CustomProperties = customProps
-		}
+		res.CustomProperties = convertMetadataValueMap(customPropsMap)
 	}
 
-	return res
+	return res, nil
 }
 
 func mapDBArtifactToAPIArtifact(a sharedmodels.CatalogArtifact) (apimodels.CatalogArtifact, error) {
@@ -637,7 +638,11 @@ func (d *dbCatalogImpl) FindModelsWithRecommendedLatency(
 
 	// Get recommended latency for each model
 	for _, model := range allModels.Items {
-		apiModel := mapDBModelToAPIModel(model)
+		apiModel, err := mapDBModelToAPIModel(model)
+		if err != nil {
+			glog.Warningf("error mapping model: %v, skipping", err)
+			continue
+		}
 
 		// Extract source ID from model properties
 		sourceID := ""

--- a/catalog/internal/catalog/modelcatalog/db_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog_test.go
@@ -714,7 +714,8 @@ func TestDBCatalog(t *testing.T) {
 				},
 			}
 
-			result := mapDBModelToAPIModel(catalogModel)
+			result, err := mapDBModelToAPIModel(catalogModel)
+			assert.NoError(t, err)
 
 			assert.Equal(t, "123", *result.Id)
 			assert.Equal(t, "mapping-test-model", result.Name)
@@ -834,7 +835,8 @@ func TestDBCatalog(t *testing.T) {
 				},
 			}
 
-			result := mapDBModelToAPIModel(catalogModel)
+			result, err := mapDBModelToAPIModel(catalogModel)
+			assert.NoError(t, err)
 
 			assert.Equal(t, "malformed-json-model", result.Name)
 			assert.Nil(t, result.ValidatedTasks)

--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -27,15 +26,17 @@ type metadataJSON struct {
 	Size            *string          `json:"size"`              // Model parameter count (e.g., "8B params")
 	TensorType      *string          `json:"tensor_type"`       // Data precision (e.g., "FP16", "INT4")
 	VariantGroupID  *string          `json:"variant_group_id"`  // UUID linking model variants together
-	MinVRAMGB       *string          `json:"min_vram_gb"`       // Minimum VRAM required (e.g., "265 GB")
-	ColdStartMatrix []coldStartEntry `json:"cold_start_matrix"` // Cold start times per GPU configuration
+	MinVRAMGB              *float64         `json:"min_vram_gb"`               // Minimum VRAM required in GB (e.g., 466.0)
+	ModelcarImageSize      *float64         `json:"modelcar_image_size"`       // Modelcar image size in GB (e.g., 405.19)
+	ModelcarImageSizeBytes *int64           `json:"modelcar_image_size_bytes"` // Modelcar image size in bytes (e.g., 405186009411)
+	ColdStartMatrix        []coldStartEntry `json:"cold_start_matrix"`         // Cold start times per GPU configuration
 }
 
 type coldStartEntry struct {
-	GPUType                    string `json:"gpu_type"`
-	GPUCount                   string `json:"gpu_count"`
-	ColdStartTimeToLoadSeconds string `json:"cold_start_time_to_load_seconds"`
-	RuntimeCommand             string `json:"runtime_command"`
+	GPUType                    string  `json:"gpu_type"`
+	GPUCount                   int     `json:"gpu_count"`
+	ColdStartTimeToLoadSeconds float64 `json:"cold_start_time_to_load_seconds"`
+	RuntimeCommand             string  `json:"runtime_command"`
 }
 
 // parseMetadataJSON parses JSON data into metadataJSON struct, extracting only the ID field
@@ -404,7 +405,7 @@ func processModelArtifactsBatch(dirPath string, modelID int32, modelName string,
 
 	// Check cold-start artifacts (one per GPU configuration from metadata.json)
 	for i, csEntry := range coldStartMatrix {
-		if csEntry.GPUType == "" || csEntry.GPUCount == "" {
+		if csEntry.GPUType == "" || csEntry.GPUCount == 0 {
 			glog.Warningf("Skipping cold-start entry %d for model %s: gpu_type and gpu_count are required", i, modelName)
 			continue
 		}
@@ -680,19 +681,20 @@ func createPerformanceArtifact(perfRecord performanceRecord, modelID int32, type
 }
 
 func coldStartExternalID(modelID int32, entry coldStartEntry) string {
-	return fmt.Sprintf("cold-start-%d-%s-%s", modelID, entry.GPUType, entry.GPUCount)
+	return fmt.Sprintf("cold-start-%d-%s-%d", modelID, entry.GPUType, entry.GPUCount)
 }
 
 // createColdStartArtifact creates a metrics artifact from a single cold-start matrix entry.
 // Each GPU configuration becomes its own artifact with discrete, filterable custom properties.
 func createColdStartArtifact(entry coldStartEntry, externalID string, typeID int32) *dbmodels.CatalogMetricsArtifactImpl {
-	artifactName := fmt.Sprintf("cold-start-%s-%s", entry.GPUType, entry.GPUCount)
+	artifactName := fmt.Sprintf("cold-start-%s-%d", entry.GPUType, entry.GPUCount)
 
 	now := time.Now().UnixMilli()
 
+	gpuCount := int32(entry.GPUCount)
 	customProperties := []models.Properties{
 		{Name: "gpu_type", StringValue: &entry.GPUType},
-		{Name: "gpu_count", StringValue: &entry.GPUCount},
+		{Name: "gpu_count", IntValue: &gpuCount},
 	}
 
 	if entry.RuntimeCommand != "" {
@@ -702,14 +704,12 @@ func createColdStartArtifact(entry coldStartEntry, externalID string, typeID int
 		})
 	}
 
-	if seconds, err := strconv.ParseFloat(entry.ColdStartTimeToLoadSeconds, 64); err == nil {
+	if entry.ColdStartTimeToLoadSeconds != 0 {
+		seconds := entry.ColdStartTimeToLoadSeconds
 		customProperties = append(customProperties, models.Properties{
 			Name:        "cold_start_time_to_load_seconds",
 			DoubleValue: &seconds,
 		})
-	} else {
-		glog.Warningf("cold-start artifact %s: invalid cold_start_time_to_load_seconds %q: %v",
-			externalID, entry.ColdStartTimeToLoadSeconds, err)
 	}
 
 	properties := []models.Properties{}
@@ -757,10 +757,27 @@ func enrichCatalogModelFromMetadata(existingModel dbmodels.CatalogModel, metadat
 		})
 	}
 
-	if metadata.MinVRAMGB != nil && *metadata.MinVRAMGB != "" {
+	if metadata.MinVRAMGB != nil {
 		customProperties = append(customProperties, models.Properties{
 			Name:             "min_vram_gb",
-			StringValue:      metadata.MinVRAMGB,
+			DoubleValue:      metadata.MinVRAMGB,
+			IsCustomProperty: true,
+		})
+	}
+
+	if metadata.ModelcarImageSize != nil {
+		customProperties = append(customProperties, models.Properties{
+			Name:             "modelcar_image_size",
+			DoubleValue:      metadata.ModelcarImageSize,
+			IsCustomProperty: true,
+		})
+	}
+
+	if metadata.ModelcarImageSizeBytes != nil {
+		bytesAsDouble := float64(*metadata.ModelcarImageSizeBytes)
+		customProperties = append(customProperties, models.Properties{
+			Name:             "modelcar_image_size_bytes",
+			DoubleValue:      &bytesAsDouble,
 			IsCustomProperty: true,
 		})
 	}

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -962,7 +962,7 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 		wantSize            *string
 		wantTensorType      *string
 		wantVariantID       *string
-		wantMinVRAMGB       *string
+		wantMinVRAMGB       *float64
 		wantColdStartMatrix []coldStartEntry
 		wantErr             bool
 	}{
@@ -1123,17 +1123,17 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 				"size": "405B params",
 				"tensor_type": "FP8",
 				"variant_group_id": "vwx234mn-5678-901v-wx23-456789abcdef",
-				"min_vram_gb": "265 GB",
+				"min_vram_gb": 265.0,
 				"cold_start_matrix": [
 					{
 						"gpu_type": "A100-80",
-						"gpu_count": "4",
-						"cold_start_time_to_load_seconds": "587.3"
+						"gpu_count": 4,
+						"cold_start_time_to_load_seconds": 587.3
 					},
 					{
 						"gpu_type": "B200",
-						"gpu_count": "2",
-						"cold_start_time_to_load_seconds": "559.9"
+						"gpu_count": 2,
+						"cold_start_time_to_load_seconds": 559.9
 					}
 				]
 			}`,
@@ -1141,10 +1141,10 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 			wantSize:       &[]string{"405B params"}[0],
 			wantTensorType: &[]string{"FP8"}[0],
 			wantVariantID:  &[]string{"vwx234mn-5678-901v-wx23-456789abcdef"}[0],
-			wantMinVRAMGB:  &[]string{"265 GB"}[0],
+			wantMinVRAMGB:  &[]float64{265.0}[0],
 			wantColdStartMatrix: []coldStartEntry{
-				{GPUType: "A100-80", GPUCount: "4", ColdStartTimeToLoadSeconds: "587.3"},
-				{GPUType: "B200", GPUCount: "2", ColdStartTimeToLoadSeconds: "559.9"},
+				{GPUType: "A100-80", GPUCount: 4, ColdStartTimeToLoadSeconds: 587.3},
+				{GPUType: "B200", GPUCount: 2, ColdStartTimeToLoadSeconds: 559.9},
 			},
 			wantErr: false,
 		},
@@ -1154,18 +1154,18 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 				"id": "RedHatAI/MiniMax-M2.5",
 				"size": "229B",
 				"tensor_type": "FP8",
-				"min_vram_gb": "265 GB",
+				"min_vram_gb": 265.0,
 				"cold_start_matrix": [
 					{
 						"gpu_type": "A100-80",
-						"gpu_count": "4",
-						"cold_start_time_to_load_seconds": "587.3",
+						"gpu_count": 4,
+						"cold_start_time_to_load_seconds": 587.3,
 						"runtime_command": "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"
 					},
 					{
 						"gpu_type": "H200",
-						"gpu_count": "4",
-						"cold_start_time_to_load_seconds": "806.7",
+						"gpu_count": 4,
+						"cold_start_time_to_load_seconds": 806.7,
 						"runtime_command": "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"
 					}
 				]
@@ -1173,10 +1173,10 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 			wantID:         "RedHatAI/MiniMax-M2.5",
 			wantSize:       &[]string{"229B"}[0],
 			wantTensorType: &[]string{"FP8"}[0],
-			wantMinVRAMGB:  &[]string{"265 GB"}[0],
+			wantMinVRAMGB:  &[]float64{265.0}[0],
 			wantColdStartMatrix: []coldStartEntry{
-				{GPUType: "A100-80", GPUCount: "4", ColdStartTimeToLoadSeconds: "587.3", RuntimeCommand: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"},
-				{GPUType: "H200", GPUCount: "4", ColdStartTimeToLoadSeconds: "806.7", RuntimeCommand: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"},
+				{GPUType: "A100-80", GPUCount: 4, ColdStartTimeToLoadSeconds: 587.3, RuntimeCommand: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"},
+				{GPUType: "H200", GPUCount: 4, ColdStartTimeToLoadSeconds: 806.7, RuntimeCommand: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"},
 			},
 			wantErr: false,
 		},
@@ -1216,8 +1216,10 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 			}
 
 			// Test MinVRAMGB field
-			if (got.MinVRAMGB == nil) != (tt.wantMinVRAMGB == nil) || (got.MinVRAMGB != nil && tt.wantMinVRAMGB != nil && *got.MinVRAMGB != *tt.wantMinVRAMGB) {
-				t.Errorf("parseMetadataJSON() MinVRAMGB = %v, want %v", got.MinVRAMGB, tt.wantMinVRAMGB)
+			if (got.MinVRAMGB == nil) != (tt.wantMinVRAMGB == nil) {
+				t.Errorf("parseMetadataJSON() MinVRAMGB nil mismatch: got %v, want %v", got.MinVRAMGB, tt.wantMinVRAMGB)
+			} else if got.MinVRAMGB != nil && *got.MinVRAMGB != *tt.wantMinVRAMGB {
+				t.Errorf("parseMetadataJSON() MinVRAMGB = %v, want %v", *got.MinVRAMGB, *tt.wantMinVRAMGB)
 			}
 
 			// Test ColdStartMatrix field
@@ -1476,13 +1478,13 @@ func TestEnrichCatalogModelFromMetadata_NewFields(t *testing.T) {
 		},
 	}
 
-	minVRAM := "80GB"
+	minVRAM := 80.0
 	metadata := metadataJSON{
 		ID:        modelName,
 		MinVRAMGB: &minVRAM,
 		ColdStartMatrix: []coldStartEntry{
-			{GPUType: "A100", GPUCount: "2", ColdStartTimeToLoadSeconds: "127.3"},
-			{GPUType: "H100", GPUCount: "1", ColdStartTimeToLoadSeconds: "68.9"},
+			{GPUType: "A100", GPUCount: 2, ColdStartTimeToLoadSeconds: 127.3},
+			{GPUType: "H100", GPUCount: 1, ColdStartTimeToLoadSeconds: 68.9},
 		},
 	}
 
@@ -1498,17 +1500,17 @@ func TestEnrichCatalogModelFromMetadata_NewFields(t *testing.T) {
 		t.Fatal("expected custom properties to be set, got nil")
 	}
 
-	propMap := make(map[string]string)
+	propMap := make(map[string]float64)
 	for _, p := range *props {
-		if p.StringValue != nil {
-			propMap[p.Name] = *p.StringValue
+		if p.DoubleValue != nil {
+			propMap[p.Name] = *p.DoubleValue
 		}
 	}
 
 	if v, ok := propMap["min_vram_gb"]; !ok {
 		t.Error("expected custom property 'min_vram_gb' to be set")
-	} else if v != "80GB" {
-		t.Errorf("min_vram_gb = %q, want %q", v, "80GB")
+	} else if v != 80.0 {
+		t.Errorf("min_vram_gb = %v, want %v", v, 80.0)
 	}
 }
 
@@ -1520,52 +1522,52 @@ func TestCreateColdStartArtifact(t *testing.T) {
 		name           string
 		entry          coldStartEntry
 		wantGPUType    string
-		wantGPUCount   string
+		wantGPUCount   int
 		wantSeconds    *float64
 		wantExtID      string
 		wantArtName    string
 		wantRuntimeCmd string
 	}{
 		{
-			name: "valid entry with numeric seconds",
+			name: "valid entry with float seconds",
 			entry: coldStartEntry{
 				GPUType:                    "A100-80",
-				GPUCount:                   "4",
-				ColdStartTimeToLoadSeconds: "587.3",
+				GPUCount:                   4,
+				ColdStartTimeToLoadSeconds: 587.3,
 				RuntimeCommand:             "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 4 --trust-remote-code",
 			},
 			wantGPUType:    "A100-80",
-			wantGPUCount:   "4",
-			wantSeconds:    new(float64(587.3)),
+			wantGPUCount:   4,
+			wantSeconds:    &[]float64{587.3}[0],
 			wantExtID:      "cold-start-42-A100-80-4",
 			wantArtName:    "cold-start-A100-80-4",
 			wantRuntimeCmd: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 4 --trust-remote-code",
 		},
 		{
-			name: "valid entry with integer seconds",
+			name: "valid entry with integer-like seconds",
 			entry: coldStartEntry{
 				GPUType:                    "H100",
-				GPUCount:                   "1",
-				ColdStartTimeToLoadSeconds: "68",
+				GPUCount:                   1,
+				ColdStartTimeToLoadSeconds: 68.0,
 				RuntimeCommand:             "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 1 --trust-remote-code",
 			},
 			wantGPUType:    "H100",
-			wantGPUCount:   "1",
-			wantSeconds:    new(float64(68)),
+			wantGPUCount:   1,
+			wantSeconds:    &[]float64{68.0}[0],
 			wantExtID:      "cold-start-42-H100-1",
 			wantArtName:    "cold-start-H100-1",
 			wantRuntimeCmd: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 1 --trust-remote-code",
 		},
 		{
-			name: "invalid seconds value omits seconds property",
+			name: "zero seconds value omits seconds property",
 			entry: coldStartEntry{
 				GPUType:                    "B200",
-				GPUCount:                   "2",
-				ColdStartTimeToLoadSeconds: "not-a-number",
+				GPUCount:                   2,
+				ColdStartTimeToLoadSeconds: 0,
 				RuntimeCommand:             "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 2 --trust-remote-code",
 			},
 			wantGPUType:    "B200",
-			wantGPUCount:   "2",
+			wantGPUCount:   2,
 			wantSeconds:    nil,
 			wantExtID:      "cold-start-42-B200-2",
 			wantArtName:    "cold-start-B200-2",
@@ -1575,12 +1577,12 @@ func TestCreateColdStartArtifact(t *testing.T) {
 			name: "empty runtime_command omits property",
 			entry: coldStartEntry{
 				GPUType:                    "H200",
-				GPUCount:                   "4",
-				ColdStartTimeToLoadSeconds: "806.7",
+				GPUCount:                   4,
+				ColdStartTimeToLoadSeconds: 806.7,
 			},
 			wantGPUType:    "H200",
-			wantGPUCount:   "4",
-			wantSeconds:    new(float64(806.7)),
+			wantGPUCount:   4,
+			wantSeconds:    &[]float64{806.7}[0],
 			wantExtID:      "cold-start-42-H200-4",
 			wantArtName:    "cold-start-H200-4",
 			wantRuntimeCmd: "",
@@ -1626,37 +1628,43 @@ func TestCreateColdStartArtifact(t *testing.T) {
 			if customProps == nil {
 				t.Fatal("expected custom properties to be set")
 			}
-			propMap := make(map[string]interface{})
+			stringPropMap := make(map[string]string)
+			doublePropMap := make(map[string]float64)
+			intPropMap := make(map[string]int32)
 			for _, p := range *customProps {
 				if p.StringValue != nil {
-					propMap[p.Name] = *p.StringValue
-				} else if p.DoubleValue != nil {
-					propMap[p.Name] = *p.DoubleValue
+					stringPropMap[p.Name] = *p.StringValue
+				}
+				if p.DoubleValue != nil {
+					doublePropMap[p.Name] = *p.DoubleValue
+				}
+				if p.IntValue != nil {
+					intPropMap[p.Name] = *p.IntValue
 				}
 			}
 
-			if propMap["gpu_type"] != tt.wantGPUType {
-				t.Errorf("gpu_type = %v, want %q", propMap["gpu_type"], tt.wantGPUType)
+			if stringPropMap["gpu_type"] != tt.wantGPUType {
+				t.Errorf("gpu_type = %v, want %q", stringPropMap["gpu_type"], tt.wantGPUType)
 			}
-			if propMap["gpu_count"] != tt.wantGPUCount {
-				t.Errorf("gpu_count = %v, want %q", propMap["gpu_count"], tt.wantGPUCount)
+			if intPropMap["gpu_count"] != int32(tt.wantGPUCount) {
+				t.Errorf("gpu_count = %v, want %d", intPropMap["gpu_count"], tt.wantGPUCount)
 			}
 			if tt.wantRuntimeCmd != "" {
-				if propMap["runtime_command"] != tt.wantRuntimeCmd {
-					t.Errorf("runtime_command = %v, want %q", propMap["runtime_command"], tt.wantRuntimeCmd)
+				if stringPropMap["runtime_command"] != tt.wantRuntimeCmd {
+					t.Errorf("runtime_command = %v, want %q", stringPropMap["runtime_command"], tt.wantRuntimeCmd)
 				}
 			} else {
-				if _, exists := propMap["runtime_command"]; exists {
+				if _, exists := stringPropMap["runtime_command"]; exists {
 					t.Error("expected runtime_command to be absent when not provided")
 				}
 			}
 			if tt.wantSeconds != nil {
-				if propMap["cold_start_time_to_load_seconds"] != *tt.wantSeconds {
-					t.Errorf("cold_start_time_to_load_seconds = %v, want %v", propMap["cold_start_time_to_load_seconds"], *tt.wantSeconds)
+				if doublePropMap["cold_start_time_to_load_seconds"] != *tt.wantSeconds {
+					t.Errorf("cold_start_time_to_load_seconds = %v, want %v", doublePropMap["cold_start_time_to_load_seconds"], *tt.wantSeconds)
 				}
 			} else {
-				if _, exists := propMap["cold_start_time_to_load_seconds"]; exists {
-					t.Error("expected cold_start_time_to_load_seconds to be absent for invalid input")
+				if _, exists := doublePropMap["cold_start_time_to_load_seconds"]; exists {
+					t.Error("expected cold_start_time_to_load_seconds to be absent for zero value")
 				}
 			}
 		})
@@ -1667,8 +1675,8 @@ func TestProcessModelArtifactsBatch_ColdStartOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	coldStartMatrix := []coldStartEntry{
-		{GPUType: "A100", GPUCount: "2", ColdStartTimeToLoadSeconds: "127.3"},
-		{GPUType: "H100", GPUCount: "1", ColdStartTimeToLoadSeconds: "68.9"},
+		{GPUType: "A100", GPUCount: 2, ColdStartTimeToLoadSeconds: 127.3},
+		{GPUType: "H100", GPUCount: 1, ColdStartTimeToLoadSeconds: 68.9},
 	}
 
 	modelID := int32(1)
@@ -1708,7 +1716,7 @@ func TestProcessModelArtifactsBatch_ColdStartDedup(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	coldStartMatrix := []coldStartEntry{
-		{GPUType: "A100", GPUCount: "2", ColdStartTimeToLoadSeconds: "127.3"},
+		{GPUType: "A100", GPUCount: 2, ColdStartTimeToLoadSeconds: 127.3},
 	}
 
 	modelID := int32(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR updates performance metrics to use numerical values rather than strings so that we can add filters and ranges for those metrics in the UI.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
