### PR TITLE
fix(ui): replace Popover with Tooltip on disabled Register model button to fix focus trap

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -488,6 +488,10 @@ class ModelCatalog {
     return cy.findByTestId('register-model-button');
   }
 
+  findRegisterCatalogModelTooltip() {
+    return cy.findByTestId('register-catalog-model-tooltip');
+  }
+
   findModelTypeSelect() {
     return cy.findByTestId('register-model-type-select');
   }

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -271,6 +271,24 @@ describe('Model Catalog Details Page - Edge Cases', () => {
     cy.findAllByText('N/A').should('have.length.at.least', 1);
   });
 
+  it('should show disabled register button with tooltip when no model registries exist', () => {
+    cy.intercept('GET', '/model-registry/api/v1/model_registry*', mockModArchResponse([])).as(
+      'getEmptyModelRegistries',
+    );
+
+    setupModelCatalogIntercepts({});
+    interceptArtifactsList();
+
+    modelCatalog.visit();
+    modelCatalog.findLoadingState().should('not.exist');
+    modelCatalog.findModelCatalogDetailLink().first().click();
+    modelCatalog.findBreadcrumb().should('exist');
+
+    modelCatalog.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
+    modelCatalog.findRegisterModelButton().trigger('mouseenter');
+    modelCatalog.findRegisterCatalogModelTooltip().should('be.visible');
+  });
+
   it('should show error alert when artifacts fail to load', () => {
     setupModelCatalogIntercepts({});
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -287,6 +287,7 @@ describe('Model Catalog Details Page - Edge Cases', () => {
     modelCatalog.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
     modelCatalog.findRegisterModelButton().trigger('mouseenter');
     modelCatalog.findRegisterCatalogModelTooltip().should('be.visible');
+    cy.testA11y({ exclude: ['.pf-v6-c-tooltip'] });
   });
 
   it('should show error alert when artifacts fail to load', () => {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -284,6 +284,7 @@ describe('Model Catalog Details Page - Edge Cases', () => {
     modelCatalog.findModelCatalogDetailLink().first().click();
     modelCatalog.findBreadcrumb().should('exist');
 
+    cy.wait('@getEmptyModelRegistries');
     modelCatalog.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
     modelCatalog.findRegisterModelButton().trigger('mouseenter');
     modelCatalog.findRegisterCatalogModelTooltip().should('be.visible');

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -13,6 +13,7 @@ import {
   StackItem,
   Button,
   Popover,
+  Tooltip,
   ActionListGroup,
   Skeleton,
   Label,
@@ -57,17 +58,24 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
     encodeURIComponent(`${decodedParams.modelName}`),
   );
 
-  const registerButtonPopover = (headerContent: string, bodyContent: string) => (
-    <Popover
-      headerContent={headerContent}
-      triggerAction="hover"
-      data-testid="register-catalog-model-popover"
-      bodyContent={<div>{bodyContent}</div>}
+  const registerButtonTooltip = (headerContent: string, bodyContent: string) => (
+    <Tooltip
+      content={
+        headerContent ? (
+          <div>
+            <strong>{headerContent}</strong>
+            <div>{bodyContent}</div>
+          </div>
+        ) : (
+          bodyContent
+        )
+      }
+      data-testid="register-catalog-model-tooltip"
     >
       <Button variant="primary" isAriaDisabled data-testid="register-model-button">
         Register model
       </Button>
-    </Popover>
+    </Tooltip>
   );
 
   const registerModelButton = () => {
@@ -76,7 +84,7 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
     }
 
     if (artifactsLoadError) {
-      return registerButtonPopover(
+      return registerButtonTooltip(
         'Unable to load model artifacts',
         'Model registration is unavailable due to an error loading model artifacts. Please try again later.',
       );
@@ -91,12 +99,12 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
     }
 
     return modelRegistries.length === 0 ? (
-      registerButtonPopover(
+      registerButtonTooltip(
         'Request access to a model registry',
         'To request a new model registry, or to request permission to access an existing model registry, contact your administrator.',
       )
     ) : artifacts.items.length === 0 || !hasModelArtifacts(artifacts.items) ? (
-      registerButtonPopover('', 'Model location is unavailable')
+      registerButtonTooltip('', 'Model location is unavailable')
     ) : (
       <Button
         data-testid="register-model-button"

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -326,22 +326,22 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                     )}
                     <DescriptionListGroup>
                       <DescriptionListTerm>Model location</DescriptionListTerm>
-                      {artifactsLoadError ? (
-                        <Alert variant="danger" isInline title={artifactsLoadError.name}>
-                          {artifactsLoadError.message}
-                        </Alert>
-                      ) : !artifactLoaded ? (
-                        <Spinner size="sm" />
-                      ) : artifacts.items.length > 0 && hasModelArtifacts(artifacts.items) ? (
-                        <DescriptionListDescription>
+                      <DescriptionListDescription>
+                        {artifactsLoadError ? (
+                          <Alert variant="danger" isInline title={artifactsLoadError.name}>
+                            {artifactsLoadError.message}
+                          </Alert>
+                        ) : !artifactLoaded ? (
+                          <Spinner size="sm" />
+                        ) : artifacts.items.length > 0 && hasModelArtifacts(artifacts.items) ? (
                           <InlineTruncatedClipboardCopy
                             testId="source-image-location"
                             textToCopy={getModelArtifactUri(artifacts.items) || ''}
                           />
-                        </DescriptionListDescription>
-                      ) : (
-                        <p className={text.textColorDisabled}>No artifacts available</p>
-                      )}
+                        ) : (
+                          'No artifacts available'
+                        )}
+                      </DescriptionListDescription>
                     </DescriptionListGroup>
                     {architectures.length > 0 && (
                       <DescriptionListGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes an accessibility (a11y) regression on the Model Catalog Details page where keyboard focus (Tab) gets trapped on  the disabled "Register model" button.
**Root cause:** The `Popover` component with `triggerAction="hover"` combined with `isAriaDisabled` on the button causes PatternFly's internal focus management to trap the Tab cycle, preventing users from navigating past the button.
**Fix:** Replace `Popover` with `Tooltip` for the disabled "Register model" button. The `Tooltip` provides the same hover information without interfering with keyboard focus management. The `Popover` used for the "Validated" label is unaffected and remains unchanged.

### Before
<video src="https://github.com/user-attachments/assets/9e84f748-5c4d-44a5-859a-f00ad0ac8efa" controls></video>
### After
<video src="https://github.com/user-attachments/assets/fde3c0fd-3935-48cd-84b0-56a635bf8a81" controls></video>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested as the video sample and added tests in cypress for it

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
