### PR TITLE
fix(catalog): scope cold-start artifact names to modelID for uniqueness

### DIFF
--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -411,7 +411,7 @@ func processModelArtifactsBatch(dirPath string, modelID int32, modelName string,
 		}
 		externalID := coldStartExternalID(modelID, csEntry)
 		if !existingArtifactsMap[externalID] {
-			artifact := createColdStartArtifact(csEntry, externalID, metricsArtifactTypeID)
+			artifact := createColdStartArtifact(csEntry, externalID, modelID, metricsArtifactTypeID)
 			artifactsToInsert = append(artifactsToInsert, artifact)
 		} else {
 			glog.V(2).Infof("Cold-start artifact %s already exists, skipping", externalID)
@@ -681,13 +681,13 @@ func createPerformanceArtifact(perfRecord performanceRecord, modelID int32, type
 }
 
 func coldStartExternalID(modelID int32, entry coldStartEntry) string {
-	return fmt.Sprintf("cold-start-%d-%s-%d", modelID, entry.GPUType, entry.GPUCount)
+	return fmt.Sprintf("cold-start-model-%d-%s-%d", modelID, entry.GPUType, entry.GPUCount)
 }
 
 // createColdStartArtifact creates a metrics artifact from a single cold-start matrix entry.
 // Each GPU configuration becomes its own artifact with discrete, filterable custom properties.
-func createColdStartArtifact(entry coldStartEntry, externalID string, typeID int32) *dbmodels.CatalogMetricsArtifactImpl {
-	artifactName := fmt.Sprintf("cold-start-%s-%d", entry.GPUType, entry.GPUCount)
+func createColdStartArtifact(entry coldStartEntry, externalID string, modelID int32, typeID int32) *dbmodels.CatalogMetricsArtifactImpl {
+	artifactName := fmt.Sprintf("cold-start-model-%d-%s-%d", modelID, entry.GPUType, entry.GPUCount)
 
 	now := time.Now().UnixMilli()
 

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -2,6 +2,7 @@ package modelcatalog
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1573,8 +1574,8 @@ func TestCreateColdStartArtifact(t *testing.T) {
 			wantGPUType:    "A100-80",
 			wantGPUCount:   4,
 			wantSeconds:    &[]float64{587.3}[0],
-			wantExtID:      "cold-start-42-A100-80-4",
-			wantArtName:    "cold-start-A100-80-4",
+			wantExtID:      "cold-start-model-42-A100-80-4",
+			wantArtName:    "cold-start-model-42-A100-80-4",
 			wantRuntimeCmd: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 4 --trust-remote-code",
 		},
 		{
@@ -1588,8 +1589,8 @@ func TestCreateColdStartArtifact(t *testing.T) {
 			wantGPUType:    "H100",
 			wantGPUCount:   1,
 			wantSeconds:    &[]float64{68.0}[0],
-			wantExtID:      "cold-start-42-H100-1",
-			wantArtName:    "cold-start-H100-1",
+			wantExtID:      "cold-start-model-42-H100-1",
+			wantArtName:    "cold-start-model-42-H100-1",
 			wantRuntimeCmd: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 1 --trust-remote-code",
 		},
 		{
@@ -1603,8 +1604,8 @@ func TestCreateColdStartArtifact(t *testing.T) {
 			wantGPUType:    "B200",
 			wantGPUCount:   2,
 			wantSeconds:    nil,
-			wantExtID:      "cold-start-42-B200-2",
-			wantArtName:    "cold-start-B200-2",
+			wantExtID:      "cold-start-model-42-B200-2",
+			wantArtName:    "cold-start-model-42-B200-2",
 			wantRuntimeCmd: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 2 --trust-remote-code",
 		},
 		{
@@ -1617,8 +1618,8 @@ func TestCreateColdStartArtifact(t *testing.T) {
 			wantGPUType:    "H200",
 			wantGPUCount:   4,
 			wantSeconds:    &[]float64{806.7}[0],
-			wantExtID:      "cold-start-42-H200-4",
-			wantArtName:    "cold-start-H200-4",
+			wantExtID:      "cold-start-model-42-H200-4",
+			wantArtName:    "cold-start-model-42-H200-4",
 			wantRuntimeCmd: "",
 		},
 	}
@@ -1626,7 +1627,7 @@ func TestCreateColdStartArtifact(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			externalID := coldStartExternalID(modelID, tt.entry)
-			artifact := createColdStartArtifact(tt.entry, externalID, typeID)
+			artifact := createColdStartArtifact(tt.entry, externalID, modelID, typeID)
 
 			if artifact == nil {
 				t.Fatal("expected non-nil artifact")
@@ -1755,7 +1756,7 @@ func TestProcessModelArtifactsBatch_ColdStartDedup(t *testing.T) {
 
 	modelID := int32(1)
 	typeID := int32(7)
-	existingExternalID := "cold-start-1-A100-2"
+	existingExternalID := "cold-start-model-1-A100-2"
 
 	mockRepo := &mockMetricsArtifactRepo{
 		listResult: &dbmodels.ListWrapper[models.CatalogMetricsArtifact]{
@@ -1816,9 +1817,48 @@ func TestProcessModelArtifactsBatch_ColdStartInvalidGPUCount(t *testing.T) {
 	}
 
 	attrs := savedArtifacts[0].GetAttributes()
-	wantExtID := "cold-start-1-H200-2"
+	wantExtID := "cold-start-model-1-H200-2"
 	if *attrs.ExternalID != wantExtID {
 		t.Errorf("expected saved artifact ExternalID = %q, got %q", wantExtID, *attrs.ExternalID)
+	}
+}
+
+func TestProcessModelArtifactsBatch_ColdStartNamesUniqueAcrossModels(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	coldStartMatrix := []coldStartEntry{
+		{GPUType: "H100", GPUCount: 4, ColdStartTimeToLoadSeconds: 105.7},
+		{GPUType: "H200", GPUCount: 2, ColdStartTimeToLoadSeconds: 98.5},
+	}
+
+	typeID := int32(7)
+
+	// Collect all artifact names across both models to check uniqueness
+	allNames := map[string]int32{}
+
+	for _, modelID := range []int32{1, 2} {
+		mockRepo := &mockMetricsArtifactRepo{
+			listResult: &dbmodels.ListWrapper[models.CatalogMetricsArtifact]{},
+			batchSaveFunc: func(artifacts []models.CatalogMetricsArtifact, parentID *int32) ([]models.CatalogMetricsArtifact, error) {
+				for _, a := range artifacts {
+					name := *a.GetAttributes().Name
+					if prev, exists := allNames[name]; exists {
+						t.Errorf("artifact name %q from model %d collides with model %d — would violate UNIQUE(type_id, name) constraint", name, modelID, prev)
+					}
+					allNames[name] = modelID
+				}
+				return artifacts, nil
+			},
+		}
+
+		_, err := processModelArtifactsBatch(tmpDir, modelID, fmt.Sprintf("test-model-%d", modelID), nil, coldStartMatrix, mockRepo, typeID)
+		if err != nil {
+			t.Fatalf("processModelArtifactsBatch() model %d error = %v", modelID, err)
+		}
+	}
+
+	if len(allNames) != 4 {
+		t.Errorf("expected 4 unique artifact names (2 GPU configs x 2 models), got %d", len(allNames))
 	}
 }
 


### PR DESCRIPTION
## Description
The createColdStartArtifact function generated artifact names as `cold-start-{gpuType}-{gpuCount}`, which were not scoped to the model. Because the Artifact table has a UNIQUE(type_id, name) constraint, the second model with the same GPU configuration would fail with a "duplicated key not allowed" error.

Include modelID in both the artifact name
(`cold-start-model-{modelID}-{gpuType}-{gpuCount}`) and the externalID, consistent with the `accuracy-metrics-model-{modelID}` naming pattern used elsewhere.

## How Has This Been Tested?

Add regression test
TestProcessModelArtifactsBatch_ColdStartNamesUniqueAcrossModels that processes two models with identical GPU configs and verifies all artifact names are unique.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
