### PR TITLE
feat(catalog): add orderBy=RECOMMENDED to findModels, deprecate recommendations param

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -199,7 +199,9 @@ paths:
       parameters:
         - name: recommendations
           in: query
-          description: Sort models by lowest recommended latency using Pareto filtering
+          deprecated: true
+          description: >-
+            Deprecated: use `orderBy=RECOMMENDED` instead. Sort models by lowest recommended latency using Pareto filtering.
           required: false
           schema:
             type: boolean
@@ -288,10 +290,18 @@ paths:
             - ID
             - NAME
             - ACCURACY
+            - RECOMMENDED
 
             Defaults to `NAME`.
 
             The `ACCURACY` sort will sort by the `overall_average` property in any linked metrics artifact.
+
+            The `RECOMMENDED` sort applies Pareto filtering and ranks models by recommended latency.
+            The Pareto-related parameters (`targetRPS`, `latencyProperty`, `rpsProperty`,
+            `hardwareCountProperty`, `hardwareTypeProperty`) are applied the same way as with the
+            deprecated `recommendations` parameter. With the default `sortOrder=ASC`, the most
+            recommended models (lowest latency) appear first. Use `sortOrder=DESC` to show the least
+            recommended configurations first.
 
             In addition, models can be sorted by properties. For example:
             - `provider.string_value` sorts by provider name
@@ -1863,6 +1873,7 @@ components:
         - LAST_UPDATE_TIME
         - ID
         - NAME
+        - RECOMMENDED
       type: string
     ServingConfig:
       description: >-

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -481,6 +481,7 @@ components:
         - LAST_UPDATE_TIME
         - ID
         - NAME
+        - RECOMMENDED
       type: string
 
   responses:

--- a/api/openapi/src/plugins/model.yaml
+++ b/api/openapi/src/plugins/model.yaml
@@ -9,7 +9,10 @@ paths:
       parameters:
         - name: recommendations
           in: query
-          description: Sort models by lowest recommended latency using Pareto filtering
+          deprecated: true
+          description: >-
+            Deprecated: use `orderBy=RECOMMENDED` instead.
+            Sort models by lowest recommended latency using Pareto filtering.
           required: false
           schema:
             type: boolean
@@ -98,10 +101,18 @@ paths:
             - ID
             - NAME
             - ACCURACY
+            - RECOMMENDED
 
             Defaults to `NAME`.
 
             The `ACCURACY` sort will sort by the `overall_average` property in any linked metrics artifact.
+
+            The `RECOMMENDED` sort applies Pareto filtering and ranks models by recommended latency.
+            The Pareto-related parameters (`targetRPS`, `latencyProperty`, `rpsProperty`,
+            `hardwareCountProperty`, `hardwareTypeProperty`) are applied the same way as with the
+            deprecated `recommendations` parameter. With the default `sortOrder=ASC`, the most
+            recommended models (lowest latency) appear first. Use `sortOrder=DESC` to show the least
+            recommended configurations first.
 
             In addition, models can be sorted by properties. For example:
             - `provider.string_value` sorts by provider name

--- a/catalog/internal/catalog/modelcatalog/api.go
+++ b/catalog/internal/catalog/modelcatalog/api.go
@@ -56,7 +56,8 @@ type APIProvider interface {
 	// Models without computable latency appear at the end of results.
 	// If sourceIDs is provided, filter models by source IDs.
 	// If query is provided, filter models by text search.
-	FindModelsWithRecommendedLatency(ctx context.Context, pagination mrmodels.Pagination, paretoParams ParetoFilteringParams, sourceIDs []string, query string) (*model.CatalogModelList, error)
+	// sortOrder controls direction: "ASC" (default) puts lowest latency first; "DESC" puts highest first.
+	FindModelsWithRecommendedLatency(ctx context.Context, pagination mrmodels.Pagination, paretoParams ParetoFilteringParams, sourceIDs []string, query string, sortOrder string) (*model.CatalogModelList, error)
 
 	// GetArtifacts returns all artifacts for a particular model. If no
 	// model is found with that name, it returns nil. If the model is

--- a/catalog/internal/catalog/modelcatalog/db_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog.go
@@ -606,6 +606,7 @@ func (d *dbCatalogImpl) FindModelsWithRecommendedLatency(
 	paretoParams ParetoFilteringParams,
 	sourceIDs []string,
 	query string,
+	sortOrder string,
 ) (*apimodels.CatalogModelList, error) {
 	// Get all models first (without pagination)
 	var sourceIDsPtr *[]string
@@ -684,20 +685,25 @@ func (d *dbCatalogImpl) FindModelsWithRecommendedLatency(
 		})
 	}
 
-	// Sort: models with latency first (ascending), then models without latency
+	// Sort: models with latency first (ascending), then models without latency.
+	// ASC (default) = lowest latency first (most recommended); DESC = highest latency first.
+	descending := strings.EqualFold(sortOrder, "DESC")
 	sort.Slice(modelsWithLatency, func(i, j int) bool {
 		latencyI, latencyJ := modelsWithLatency[i].Latency, modelsWithLatency[j].Latency
 
 		if latencyI == nil && latencyJ == nil {
-			return false // Maintain original order for models without latency
+			return false
 		}
 		if latencyI == nil {
-			return false // Models without latency go last
+			return false // Models without latency always last
 		}
 		if latencyJ == nil {
-			return true // Models with latency go first
+			return true // Models with latency always first
 		}
-		return *latencyI < *latencyJ // Sort by latency ascending
+		if descending {
+			return *latencyI > *latencyJ
+		}
+		return *latencyI < *latencyJ
 	})
 
 	// Apply pagination to sorted results

--- a/catalog/internal/catalog/modelcatalog/db_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog_test.go
@@ -2123,6 +2123,7 @@ func TestFindModelsWithRecommendedLatency(t *testing.T) {
 		paretoParams,
 		[]string{"latency-test-source"}, // Filter by this test's source ID
 		"",                              // No query filter
+		"",                              // Default sort order (ASC)
 	)
 
 	require.NoError(t, err)
@@ -2140,6 +2141,145 @@ func TestFindModelsWithRecommendedLatency(t *testing.T) {
 		assert.NotEmpty(t, model.Name, "Model %d should have a name", i)
 		// Custom properties may or may not be set depending on performance data availability
 	}
+}
+
+func TestFindModelsWithRecommendedLatencyDescending(t *testing.T) {
+	sharedDB, cleanup := testutils.SetupPostgresWithMigrations(t, testhelpers.MustDatastoreSpec(t))
+	defer cleanup()
+
+	catalogModelTypeID := testhelpers.GetCatalogModelTypeIDForDBTest(t, sharedDB)
+	modelArtifactTypeID := testhelpers.GetCatalogModelArtifactTypeIDForDBTest(t, sharedDB)
+	metricsArtifactTypeID := testhelpers.GetCatalogMetricsArtifactTypeIDForDBTest(t, sharedDB)
+	catalogSourceTypeID := testhelpers.GetCatalogSourceTypeIDForDBTest(t, sharedDB)
+
+	catalogModelRepo := modelservice.NewCatalogModelRepository(sharedDB, catalogModelTypeID)
+	catalogArtifactRepo := service.NewCatalogArtifactRepository(sharedDB, map[string]int32{
+		service.CatalogModelArtifactTypeName:   modelArtifactTypeID,
+		service.CatalogMetricsArtifactTypeName: metricsArtifactTypeID,
+	})
+	modelArtifactRepo := modelservice.NewCatalogModelArtifactRepository(sharedDB, modelArtifactTypeID)
+	metricsArtifactRepo := modelservice.NewCatalogMetricsArtifactRepository(sharedDB, metricsArtifactTypeID)
+	catalogSourceRepo := service.NewCatalogSourceRepository(sharedDB, catalogSourceTypeID)
+
+	svcs := Services{
+		CatalogModelRepository:           catalogModelRepo,
+		CatalogArtifactRepository:        catalogArtifactRepo,
+		CatalogModelArtifactRepository:   modelArtifactRepo,
+		CatalogMetricsArtifactRepository: metricsArtifactRepo,
+		CatalogSourceRepository:          catalogSourceRepo,
+		PropertyOptionsRepository:        service.NewPropertyOptionsRepository(sharedDB),
+	}
+
+	dbCatalog := NewDBCatalog(svcs, nil)
+	ctx := context.Background()
+
+	// modelLow has latency=50 (fastest / most recommended)
+	modelLow := &models.CatalogModelImpl{
+		TypeID: new(int32(catalogModelTypeID)),
+		Attributes: &models.CatalogModelAttributes{
+			Name:       new("desc-test-source:desc-model-low"),
+			ExternalID: new("desc-model-low-ext"),
+		},
+		Properties: &[]mr_models.Properties{
+			{Name: "source_id", StringValue: new("desc-test-source")},
+		},
+	}
+	// modelHigh has latency=200 (slowest / least recommended)
+	modelHigh := &models.CatalogModelImpl{
+		TypeID: new(int32(catalogModelTypeID)),
+		Attributes: &models.CatalogModelAttributes{
+			Name:       new("desc-test-source:desc-model-high"),
+			ExternalID: new("desc-model-high-ext"),
+		},
+		Properties: &[]mr_models.Properties{
+			{Name: "source_id", StringValue: new("desc-test-source")},
+		},
+	}
+	// modelNone has no performance artifacts
+	modelNone := &models.CatalogModelImpl{
+		TypeID: new(int32(catalogModelTypeID)),
+		Attributes: &models.CatalogModelAttributes{
+			Name:       new("desc-test-source:desc-model-none"),
+			ExternalID: new("desc-model-none-ext"),
+		},
+		Properties: &[]mr_models.Properties{
+			{Name: "source_id", StringValue: new("desc-test-source")},
+		},
+	}
+
+	savedModelLow, err := catalogModelRepo.Save(modelLow)
+	require.NoError(t, err)
+	savedModelHigh, err := catalogModelRepo.Save(modelHigh)
+	require.NoError(t, err)
+	_, err = catalogModelRepo.Save(modelNone)
+	require.NoError(t, err)
+
+	perfLow := &models.CatalogMetricsArtifactImpl{
+		TypeID: new(int32(metricsArtifactTypeID)),
+		Attributes: &models.CatalogMetricsArtifactAttributes{
+			Name:        new("desc-perf-low"),
+			ExternalID:  new("desc-perf-low-ext"),
+			MetricsType: models.MetricsTypePerformance,
+		},
+		Properties: &[]mr_models.Properties{},
+		CustomProperties: &[]mr_models.Properties{
+			{Name: "ttft_p90", DoubleValue: new(float64(50.0))},
+			{Name: "requests_per_second", DoubleValue: new(float64(100.0))},
+			{Name: "hardware_count", IntValue: new(int32(1))},
+			{Name: "hardware_type", StringValue: new("gpu")},
+		},
+	}
+	perfHigh := &models.CatalogMetricsArtifactImpl{
+		TypeID: new(int32(metricsArtifactTypeID)),
+		Attributes: &models.CatalogMetricsArtifactAttributes{
+			Name:        new("desc-perf-high"),
+			ExternalID:  new("desc-perf-high-ext"),
+			MetricsType: models.MetricsTypePerformance,
+		},
+		Properties: &[]mr_models.Properties{},
+		CustomProperties: &[]mr_models.Properties{
+			{Name: "ttft_p90", DoubleValue: new(float64(200.0))},
+			{Name: "requests_per_second", DoubleValue: new(float64(30.0))},
+			{Name: "hardware_count", IntValue: new(int32(1))},
+			{Name: "hardware_type", StringValue: new("gpu")},
+		},
+	}
+
+	_, err = metricsArtifactRepo.Save(perfLow, savedModelLow.GetID())
+	require.NoError(t, err)
+	_, err = metricsArtifactRepo.Save(perfHigh, savedModelHigh.GetID())
+	require.NoError(t, err)
+
+	pagination := mr_models.Pagination{PageSize: new(int32(10))}
+	paretoParams := ParetoFilteringParams{
+		LatencyProperty:       "ttft_p90",
+		RpsProperty:           "requests_per_second",
+		HardwareCountProperty: "hardware_count",
+		HardwareTypeProperty:  "hardware_type",
+	}
+
+	// ASC should put lowest latency first
+	ascResult, err := dbCatalog.(*dbCatalogImpl).FindModelsWithRecommendedLatency(
+		ctx, pagination, paretoParams, []string{"desc-test-source"}, "", "ASC",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ascResult)
+	require.Len(t, ascResult.Items, 3)
+	// First two have latency data; last has none. With ASC, low-latency model comes before high-latency.
+	assert.Equal(t, "desc-model-low", ascResult.Items[0].Name)
+	assert.Equal(t, "desc-model-high", ascResult.Items[1].Name)
+	assert.Equal(t, "desc-model-none", ascResult.Items[2].Name)
+
+	// DESC should put highest latency first; models without latency still last
+	descResult, err := dbCatalog.(*dbCatalogImpl).FindModelsWithRecommendedLatency(
+		ctx, pagination, paretoParams, []string{"desc-test-source"}, "", "DESC",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, descResult)
+	require.Len(t, descResult.Items, 3)
+	assert.Equal(t, "desc-model-high", descResult.Items[0].Name)
+	assert.Equal(t, "desc-model-low", descResult.Items[1].Name)
+	assert.Equal(t, "desc-model-none", descResult.Items[2].Name)
 }
 
 // TestGetFilterOptions_NoMCPServerContamination verifies that the model catalog's

--- a/catalog/internal/catalog/modelcatalog/integration_test.go
+++ b/catalog/internal/catalog/modelcatalog/integration_test.go
@@ -151,7 +151,7 @@ func BenchmarkRecommendedLatencySorting(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := provider.FindModelsWithRecommendedLatency(ctx, mr_models.Pagination{
 			PageSize: new(int32(20)),
-		}, paretoParams, []string{"benchmark-source"}, "")
+		}, paretoParams, []string{"benchmark-source"}, "", "")
 
 		require.NoError(b, err)
 	}

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -222,7 +222,7 @@ func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommen
 	// validated inside parsePaginationParams.
 	var pageSizeInt int32
 	var err error
-	if recommended {
+	if recommended || orderBy == model.ORDERBYFIELD_RECOMMENDED {
 		pageSizeInt, err = parsePageSize(pageSize)
 		if err != nil {
 			return ErrorResponse(http.StatusBadRequest, err), err
@@ -264,8 +264,8 @@ func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommen
 		}
 	}
 
-	// Handle recommended latency sorting
-	if recommended {
+	// Handle recommended latency sorting (triggered by recommendations=true or orderBy=RECOMMENDED)
+	if recommended || orderBy == model.ORDERBYFIELD_RECOMMENDED {
 		// Build Pareto filtering parameters with defaults
 		var targetRPSPtr *int32
 		if targetRPS != 0 {
@@ -306,8 +306,8 @@ func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommen
 			FilterQuery:   &filterQuery,
 		}
 
-		// Use recommended latency sorting (ignores orderBy)
-		models, err := m.provider.FindModelsWithRecommendedLatency(ctx, pagination, paretoParams, sourceIDs, q)
+		// Use recommended latency sorting
+		models, err := m.provider.FindModelsWithRecommendedLatency(ctx, pagination, paretoParams, sourceIDs, q, string(sortOrder))
 		if err != nil {
 			return ErrorResponse(api.ErrToStatus(err), fmt.Errorf("failed to find models with recommended latency: %w", err)), err
 		}

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -1224,8 +1224,9 @@ func TestFindLabels(t *testing.T) {
 
 // Define a mock model provider
 type mockModelProvider struct {
-	models    map[string]*model.CatalogModel
-	artifacts map[string][]model.CatalogArtifact
+	models              map[string]*model.CatalogModel
+	artifacts           map[string][]model.CatalogArtifact
+	lastRecommendedSort string // records sortOrder passed to FindModelsWithRecommendedLatency
 }
 
 // Mock provider that fails when recommended is used (for testing implementation)
@@ -1262,7 +1263,7 @@ func (m *mockProviderThatFailsOnRecommended) GetFilterOptions(ctx context.Contex
 	return m.mockModelProvider.GetFilterOptions(ctx)
 }
 
-func (m *mockProviderThatFailsOnRecommended) FindModelsWithRecommendedLatency(ctx context.Context, pagination mrmodels.Pagination, paretoParams modelcatalog.ParetoFilteringParams, sourceIDs []string, query string) (*model.CatalogModelList, error) {
+func (m *mockProviderThatFailsOnRecommended) FindModelsWithRecommendedLatency(ctx context.Context, pagination mrmodels.Pagination, paretoParams modelcatalog.ParetoFilteringParams, sourceIDs []string, query string, sortOrder string) (*model.CatalogModelList, error) {
 	return nil, fmt.Errorf("recommended sorting not implemented")
 }
 
@@ -1352,7 +1353,8 @@ func (m *mockModelProvider) GetFilterOptions(ctx context.Context) (*model.Filter
 	return &model.FilterOptionsList{Filters: &emptyFilters}, nil
 }
 
-func (m *mockModelProvider) FindModelsWithRecommendedLatency(ctx context.Context, pagination mrmodels.Pagination, paretoParams modelcatalog.ParetoFilteringParams, sourceIDs []string, query string) (*model.CatalogModelList, error) {
+func (m *mockModelProvider) FindModelsWithRecommendedLatency(ctx context.Context, pagination mrmodels.Pagination, paretoParams modelcatalog.ParetoFilteringParams, sourceIDs []string, query string, sortOrder string) (*model.CatalogModelList, error) {
+	m.lastRecommendedSort = sortOrder
 	// Basic mock implementation - just return models sorted by name
 	var allModels []*model.CatalogModel
 	for _, mdl := range m.models {
@@ -2265,4 +2267,137 @@ func TestGetAllModelPerformanceArtifactsWithConfigurableProperties(t *testing.T)
 			assert.Equal(t, tc.expectedStatus, resp.Code)
 		})
 	}
+}
+
+func TestFindModelsOrderByRecommended(t *testing.T) {
+	sources := catalog.NewSourceCollection()
+	sources.Merge("",
+		map[string]catalog.ModelSource{
+			"source1": {CatalogSource: model.CatalogSource{Id: "source1", Name: "Test Source 1"}},
+		},
+	)
+
+	provider := &mockModelProvider{
+		models: map[string]*model.CatalogModel{
+			"modelA": {Name: "Model A"},
+			"modelB": {Name: "Model B"},
+		},
+	}
+
+	service := NewModelCatalogServiceAPIService(provider, sources, nil, catalog.NewLabelCollection(), nil)
+
+	// orderBy=RECOMMENDED with recommendations=false should still use the recommendation path
+	resp, err := service.FindModels(
+		context.Background(),
+		false, // recommendations=false
+		0,     // targetRPS
+		"",    // latencyProperty
+		"",    // rpsProperty
+		"",    // hardwareCountProperty
+		"",    // hardwareTypeProperty
+		[]string{"source1"},
+		"",
+		[]string{""},
+		"",
+		"10",
+		model.OrderByField("RECOMMENDED"),
+		model.SORTORDER_ASC,
+		"",
+	)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	require.NoError(t, err)
+
+	require.NotNil(t, resp.Body)
+	response, ok := resp.Body.(model.CatalogModelList)
+	require.True(t, ok)
+	require.True(t, len(response.Items) > 0)
+
+	// Verify the recommendation path was taken (mock records it)
+	assert.Equal(t, "ASC", provider.lastRecommendedSort)
+}
+
+func TestFindModelsOrderByRecommendedDesc(t *testing.T) {
+	sources := catalog.NewSourceCollection()
+	sources.Merge("",
+		map[string]catalog.ModelSource{
+			"source1": {CatalogSource: model.CatalogSource{Id: "source1", Name: "Test Source 1"}},
+		},
+	)
+
+	provider := &mockModelProvider{
+		models: map[string]*model.CatalogModel{
+			"modelA": {Name: "Model A"},
+			"modelB": {Name: "Model B"},
+		},
+	}
+
+	service := NewModelCatalogServiceAPIService(provider, sources, nil, catalog.NewLabelCollection(), nil)
+
+	// orderBy=RECOMMENDED with sortOrder=DESC
+	resp, err := service.FindModels(
+		context.Background(),
+		false, // recommendations=false
+		0,     // targetRPS
+		"",    // latencyProperty
+		"",    // rpsProperty
+		"",    // hardwareCountProperty
+		"",    // hardwareTypeProperty
+		[]string{"source1"},
+		"",
+		[]string{""},
+		"",
+		"10",
+		model.OrderByField("RECOMMENDED"),
+		model.SORTORDER_DESC,
+		"",
+	)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	require.NoError(t, err)
+
+	require.NotNil(t, resp.Body)
+	_, ok := resp.Body.(model.CatalogModelList)
+	require.True(t, ok)
+
+	// Verify DESC was passed to the recommendation path
+	assert.Equal(t, "DESC", provider.lastRecommendedSort)
+}
+
+// TestFindModelsOrderByRecommendedPagination is a regression test for the case where
+// recommendations=false and orderBy=RECOMMENDED: the numeric nextPageToken must not
+// be rejected by the base64-cursor validator used by the non-recommended path.
+func TestFindModelsOrderByRecommendedPagination(t *testing.T) {
+	sources := catalog.NewSourceCollection()
+	sources.Merge("",
+		map[string]catalog.ModelSource{
+			"source1": {CatalogSource: model.CatalogSource{Id: "source1", Name: "Test Source 1"}},
+		},
+	)
+
+	provider := &mockModelProvider{
+		models: map[string]*model.CatalogModel{
+			"modelA": {Name: "Model A"},
+		},
+	}
+
+	service := NewModelCatalogServiceAPIService(provider, sources, nil, catalog.NewLabelCollection(), nil)
+
+	// Pass a numeric nextPageToken (the format produced by the recommended path).
+	// Before the fix, this was rejected with 400 because parsePaginationParams tried
+	// to base64-decode it as a DB cursor.
+	resp, err := service.FindModels(
+		context.Background(),
+		false, // recommendations=false — using orderBy instead
+		0, "", "", "", "",
+		[]string{"source1"},
+		"", []string{""}, "",
+		"10",
+		model.OrderByField("RECOMMENDED"),
+		model.SORTORDER_ASC,
+		"2", // numeric offset token from a prior recommended-path response
+	)
+
+	assert.Equal(t, http.StatusOK, resp.Code, "numeric nextPageToken must be accepted for orderBy=RECOMMENDED")
+	require.NoError(t, err)
 }

--- a/catalog/internal/server/openapi/integration_test.go
+++ b/catalog/internal/server/openapi/integration_test.go
@@ -533,7 +533,7 @@ func (m *mockPerformanceProvider) GetFilterOptions(ctx context.Context) (*model.
 	return &model.FilterOptionsList{}, nil
 }
 
-func (m *mockPerformanceProvider) FindModelsWithRecommendedLatency(ctx context.Context, pagination mrmodels.Pagination, paretoParams modelcatalog.ParetoFilteringParams, sourceIDs []string, query string) (*model.CatalogModelList, error) {
+func (m *mockPerformanceProvider) FindModelsWithRecommendedLatency(ctx context.Context, pagination mrmodels.Pagination, paretoParams modelcatalog.ParetoFilteringParams, sourceIDs []string, query string, sortOrder string) (*model.CatalogModelList, error) {
 	// Basic mock implementation - just return models sorted by name
 	var allModels []*model.CatalogModel
 	for _, mdl := range m.models {

--- a/catalog/pkg/openapi/api_model_catalog_service.go
+++ b/catalog/pkg/openapi/api_model_catalog_service.go
@@ -240,7 +240,8 @@ type ApiFindModelsRequest struct {
 	nextPageToken         *string
 }
 
-// Sort models by lowest recommended latency using Pareto filtering
+// Deprecated: use &#x60;orderBy&#x3D;RECOMMENDED&#x60; instead. Sort models by lowest recommended latency using Pareto filtering.
+// Deprecated
 func (r ApiFindModelsRequest) Recommendations(recommendations bool) ApiFindModelsRequest {
 	r.recommendations = &recommendations
 	return r
@@ -306,7 +307,7 @@ func (r ApiFindModelsRequest) PageSize(pageSize string) ApiFindModelsRequest {
 	return r
 }
 
-// Specifies the order by criteria for listing entities.  Supported values are: - CREATE_TIME - LAST_UPDATE_TIME - ID - NAME - ACCURACY  Defaults to &#x60;NAME&#x60;.  The &#x60;ACCURACY&#x60; sort will sort by the &#x60;overall_average&#x60; property in any linked metrics artifact.  In addition, models can be sorted by properties. For example: - &#x60;provider.string_value&#x60; sorts by provider name - &#x60;artifacts.ifeval.double_value&#x60; sorts by the min/max value a property called ifeval across all associated artifacts
+// Specifies the order by criteria for listing entities.  Supported values are: - CREATE_TIME - LAST_UPDATE_TIME - ID - NAME - ACCURACY - RECOMMENDED  Defaults to &#x60;NAME&#x60;.  The &#x60;ACCURACY&#x60; sort will sort by the &#x60;overall_average&#x60; property in any linked metrics artifact.  The &#x60;RECOMMENDED&#x60; sort applies Pareto filtering and ranks models by recommended latency. The Pareto-related parameters (&#x60;targetRPS&#x60;, &#x60;latencyProperty&#x60;, &#x60;rpsProperty&#x60;, &#x60;hardwareCountProperty&#x60;, &#x60;hardwareTypeProperty&#x60;) are applied the same way as with the deprecated &#x60;recommendations&#x60; parameter. With the default &#x60;sortOrder&#x3D;ASC&#x60;, the most recommended models (lowest latency) appear first. Use &#x60;sortOrder&#x3D;DESC&#x60; to show the least recommended configurations first.  In addition, models can be sorted by properties. For example: - &#x60;provider.string_value&#x60; sorts by provider name - &#x60;artifacts.ifeval.double_value&#x60; sorts by the min/max value a property called ifeval across all associated artifacts
 func (r ApiFindModelsRequest) OrderBy(orderBy OrderByField) ApiFindModelsRequest {
 	r.orderBy = &orderBy
 	return r

--- a/catalog/pkg/openapi/model_order_by_field.go
+++ b/catalog/pkg/openapi/model_order_by_field.go
@@ -24,6 +24,7 @@ const (
 	ORDERBYFIELD_LAST_UPDATE_TIME OrderByField = "LAST_UPDATE_TIME"
 	ORDERBYFIELD_ID               OrderByField = "ID"
 	ORDERBYFIELD_NAME             OrderByField = "NAME"
+	ORDERBYFIELD_RECOMMENDED      OrderByField = "RECOMMENDED"
 )
 
 // All allowed values of OrderByField enum
@@ -32,6 +33,7 @@ var AllowedOrderByFieldEnumValues = []OrderByField{
 	"LAST_UPDATE_TIME",
 	"ID",
 	"NAME",
+	"RECOMMENDED",
 }
 
 func (v *OrderByField) UnmarshalJSON(src []byte) error {


### PR DESCRIPTION
## Description
Passing `recommendations=true` to `GET /api/model_catalog/v1alpha1/models` was confusing because it prevented using `orderBy`. This change makes `orderBy=RECOMMENDED` equivalent: Pareto filtering is applied and models are sorted by recommended latency, with `sortOrder` honored (`ASC` = lowest latency
first, `DESC` = highest latency first).

The recommendations boolean parameter is retained for backward compatibility but marked deprecated in the OpenAPI spec.

## How Has This Been Tested?
Compared the output of `recommendations=true` and `orderBy=RECOMMENDED` and verified there was no difference.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
