### PR TITLE
feat(catalog): persist cold_start_matrix as a JSON custom property

### DIFF
--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -782,6 +782,20 @@ func enrichCatalogModelFromMetadata(existingModel dbmodels.CatalogModel, metadat
 		})
 	}
 
+	if len(metadata.ColdStartMatrix) > 0 {
+		csJSON, err := json.Marshal(metadata.ColdStartMatrix)
+		if err != nil {
+			glog.Warningf("Failed to marshal cold_start_matrix for model: %v", err)
+		} else {
+			csStr := string(csJSON)
+			customProperties = append(customProperties, models.Properties{
+				Name:             "cold_start_matrix",
+				StringValue:      &csStr,
+				IsCustomProperty: true,
+			})
+		}
+	}
+
 	if len(customProperties) == 0 {
 		return nil // Nothing to update
 	}

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -1547,6 +1547,68 @@ func TestEnrichCatalogModelFromMetadata_NewFields(t *testing.T) {
 	} else if v != 80.0 {
 		t.Errorf("min_vram_gb = %v, want %v", v, 80.0)
 	}
+
+	// Verify cold_start_matrix is set as a JSON string custom property
+	stringPropMap := make(map[string]string)
+	for _, p := range *props {
+		if p.StringValue != nil {
+			stringPropMap[p.Name] = *p.StringValue
+		}
+	}
+	csJSON, ok := stringPropMap["cold_start_matrix"]
+	if !ok {
+		t.Fatal("expected custom property 'cold_start_matrix' to be set")
+	}
+	var csMatrix []coldStartEntry
+	if err := json.Unmarshal([]byte(csJSON), &csMatrix); err != nil {
+		t.Fatalf("cold_start_matrix is not valid JSON: %v", err)
+	}
+	if len(csMatrix) != 2 {
+		t.Fatalf("cold_start_matrix length = %d, want 2", len(csMatrix))
+	}
+	if csMatrix[0].GPUType != "A100" || csMatrix[0].GPUCount != 2 || csMatrix[0].ColdStartTimeToLoadSeconds != 127.3 {
+		t.Errorf("cold_start_matrix[0] = %+v, want {A100, 2, 127.3}", csMatrix[0])
+	}
+	if csMatrix[1].GPUType != "H100" || csMatrix[1].GPUCount != 1 || csMatrix[1].ColdStartTimeToLoadSeconds != 68.9 {
+		t.Errorf("cold_start_matrix[1] = %+v, want {H100, 1, 68.9}", csMatrix[1])
+	}
+}
+
+func TestEnrichCatalogModelFromMetadata_EmptyColdStartMatrix(t *testing.T) {
+	modelName := "test-vendor/test-model"
+	modelID := int32(2)
+
+	existingModel := &models.CatalogModelImpl{
+		ID: &modelID,
+		Attributes: &models.CatalogModelAttributes{
+			Name: &modelName,
+		},
+	}
+
+	size := "8B params"
+	metadata := metadataJSON{
+		ID:              modelName,
+		Size:            &size,
+		ColdStartMatrix: []coldStartEntry{},
+	}
+
+	mockRepo := &mockPerfModelRepo{}
+
+	err := enrichCatalogModelFromMetadata(existingModel, metadata, mockRepo)
+	if err != nil {
+		t.Fatalf("enrichCatalogModelFromMetadata() error = %v", err)
+	}
+
+	props := existingModel.GetCustomProperties()
+	if props == nil {
+		t.Fatal("expected custom properties to be set, got nil")
+	}
+
+	for _, p := range *props {
+		if p.Name == "cold_start_matrix" {
+			t.Error("cold_start_matrix should not be set when matrix is empty")
+		}
+	}
 }
 
 func TestCreateColdStartArtifact(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Serializes the cold-start matrix entries to a JSON string and stores them as a custom property on the catalog model, following the same pattern used for other structured fields.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
