### PR TITLE
fix(catalog): decouple readiness from leadership to prevent rolling update deadlock

### DIFF
--- a/catalog/internal/leader/election.go
+++ b/catalog/internal/leader/election.go
@@ -33,7 +33,7 @@ type pglockAdapter struct {
 }
 
 func (a *pglockAdapter) acquireContext(ctx context.Context, name string) (lockHandle, error) {
-	lock, err := a.client.AcquireContext(ctx, name)
+	lock, err := a.client.AcquireContext(ctx, name, pglock.FailIfLocked())
 	if err != nil {
 		return nil, err
 	}
@@ -102,9 +102,13 @@ type LeaderElector struct {
 	// Dynamic callback tracking
 	activeCallbacks sync.WaitGroup
 
-	// Health tracking: counts consecutive election loop errors (failed
-	// lock acquisition or lost heartbeat). Healthy() returns false after
-	// unhealthyThreshold consecutive failures, resets on successful acquisition.
+	// Health tracking.
+	// dbReachable flips to true on first successful DB contact (acquisition
+	// or ErrNotAcquired). Pods that have never contacted the DB are not ready.
+	// consecutiveFailures counts consecutive infrastructure errors (DB
+	// unreachable, lost heartbeat). Healthy() returns false when the DB has
+	// never been reached OR failures exceed the threshold.
+	dbReachable         atomic.Bool
 	consecutiveFailures atomic.Int32
 	unhealthyThreshold  int32
 
@@ -162,9 +166,8 @@ func NewLeaderElector(
 		done:               make(chan struct{}),
 		unhealthyThreshold: defaultUnhealthyThreshold,
 	}
-	// Start unhealthy: a pod that has never acquired the lock is not ready.
-	// Resets to 0 on first successful acquisition in runOnce().
-	e.consecutiveFailures.Store(e.unhealthyThreshold)
+	// dbReachable starts false (zero value) — pod is not ready until first
+	// successful DB contact. No need to hack the failure counter.
 
 	// Start the background goroutine immediately
 	go e.run()
@@ -217,12 +220,11 @@ func (e *LeaderElector) Wait() error {
 	return e.err
 }
 
-// Healthy returns true if the leader elector has not exceeded its
-// consecutive failure threshold. The counter increments on any
-// runOnce error — failed lock acquisition or lost heartbeat —
-// and resets to zero on successful acquisition.
+// Healthy reports whether this elector can reach the database.
+// Returns false before first DB contact (cold start) and when consecutive
+// infrastructure failures exceed the threshold.
 func (e *LeaderElector) Healthy() bool {
-	return e.consecutiveFailures.Load() < e.unhealthyThreshold
+	return e.dbReachable.Load() && e.consecutiveFailures.Load() < e.unhealthyThreshold
 }
 
 // run starts the leader election process with automatic retry.
@@ -262,9 +264,29 @@ func (e *LeaderElector) run() {
 		}
 
 		if err != nil {
-			failures := e.consecutiveFailures.Add(1)
-			delay := backoff.next()
-			glog.Errorf("Leader election error: %v (consecutive failures: %d, retrying in %v)", err, failures, delay)
+			// pglock returns ErrNotAcquired (not context.Canceled) when the
+			// context is cancelled during acquisition — check context first.
+			if ctx.Err() != nil {
+				glog.Info("Leader election canceled, shutting down")
+				e.err = ctx.Err()
+				return
+			}
+
+			var delay time.Duration
+			if errors.Is(err, pglock.ErrNotAcquired) {
+				// Lock held by another pod — DB is reachable, pod is healthy.
+				// Keep retry interval short so we acquire quickly when the
+				// lease is released (e.g., during rolling updates).
+				e.dbReachable.Store(true)
+				e.consecutiveFailures.Store(0)
+				backoff.reset()
+				delay = backoff.next()
+				glog.Infof("Lock held by another instance, retrying in %v", delay)
+			} else {
+				failures := e.consecutiveFailures.Add(1)
+				delay = backoff.next()
+				glog.Errorf("Leader election error: %v (consecutive failures: %d, retrying in %v)", err, failures, delay)
+			}
 
 			select {
 			case <-time.After(delay):
@@ -290,6 +312,7 @@ func (e *LeaderElector) runOnce(ctx context.Context) error {
 	}
 
 	glog.Infof("Successfully acquired leadership lock: %s", e.lockName)
+	e.dbReachable.Store(true)
 	e.consecutiveFailures.Store(0)
 
 	// Create a context that will be canceled when we lose leadership

--- a/catalog/internal/leader/election_health_internal_test.go
+++ b/catalog/internal/leader/election_health_internal_test.go
@@ -3,10 +3,12 @@ package leader
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"cirello.io/pglock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,7 +79,8 @@ func newTestElector(ctx context.Context, locker lockClient, threshold int32) *Le
 		unhealthyThreshold: threshold,
 		retryBackoff:       &backoff{current: time.Millisecond, max: time.Millisecond},
 	}
-	e.consecutiveFailures.Store(threshold)
+	// dbReachable starts false (zero value) — Healthy() returns false until
+	// first successful DB contact, matching NewLeaderElector behavior.
 	go e.run()
 	return e
 }
@@ -170,6 +173,77 @@ func TestHealthyThresholdBoundary(t *testing.T) {
 	}, 2*time.Second, 5*time.Millisecond, "should have attempted acquisition")
 
 	assert.False(t, e.Healthy(), "should remain unhealthy with sustained failures")
+
+	cancel()
+	_ = e.Wait()
+}
+
+// switchableLocker allows changing the error mid-test.
+type switchableLocker struct {
+	mu  sync.Mutex
+	err error
+}
+
+func (s *switchableLocker) acquireContext(_ context.Context, _ string) (lockHandle, error) {
+	s.mu.Lock()
+	err := s.err
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return &mockHandle{}, nil
+}
+
+func (s *switchableLocker) setErr(err error) {
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+}
+
+func TestHealthyWhenLockHeldByAnother(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	locker := &failingLocker{
+		err:       pglock.ErrNotAcquired,
+		failCount: -1,
+	}
+
+	e := newTestElector(ctx, locker, 3)
+
+	assert.False(t, e.Healthy(), "should start unhealthy")
+
+	// ErrNotAcquired proves DB is reachable → should become healthy
+	require.Eventually(t, func() bool {
+		return e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should become healthy when lock is held by another pod")
+
+	assert.Equal(t, int32(0), e.consecutiveFailures.Load())
+
+	cancel()
+	_ = e.Wait()
+}
+
+func TestHealthyContentionThenInfraFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	locker := &switchableLocker{err: pglock.ErrNotAcquired}
+
+	e := newTestElector(ctx, locker, 3)
+
+	// Contention → healthy
+	require.Eventually(t, func() bool {
+		return e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should become healthy during contention")
+
+	// Switch to infra failure
+	locker.setErr(errors.New("connection refused"))
+
+	// Should become unhealthy after threshold failures
+	require.Eventually(t, func() bool {
+		return !e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should become unhealthy after infra failure")
 
 	cancel()
 	_ = e.Wait()

--- a/catalog/internal/leader/election_test.go
+++ b/catalog/internal/leader/election_test.go
@@ -405,6 +405,82 @@ func TestLeaderElector_WaitReturnsCorrectError(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+// TestRollingUpdateDoesNotDeadlock simulates a rolling update with replicas=1:
+//
+//  1. Old pod holds the leader lease and is healthy.
+//  2. New pod starts and attempts to acquire the lease.
+//  3. New pod cannot become leader (old pod holds the lease).
+//  4. New pod's Healthy() must return true (ErrNotAcquired proves DB is reachable).
+//  5. Kubernetes sees the new pod as ready, terminates the old pod.
+//  6. Old pod releases the lease on shutdown.
+//  7. New pod acquires the lease and becomes leader.
+//
+// Without the ErrNotAcquired fix, step 4 would return false → readiness probe
+// fails → Kubernetes never kills the old pod → deadlock.
+func TestRollingUpdateDoesNotDeadlock(t *testing.T) {
+	db, cleanup := testutils.SetupPostgresWithMigrations(t, testhelpers.MustDatastoreSpec(t))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// --- Step 1: Old pod acquires the lease ---
+	oldCtx, oldCancel := context.WithCancel(ctx)
+	defer oldCancel()
+
+	var oldBecameLeader atomic.Bool
+	oldPod, err := leader.NewLeaderElector(db, oldCtx, "rolling-update-lock", 5*time.Second, 1*time.Second)
+	require.NoError(t, err)
+	oldPod.OnBecomeLeader(func(ctx context.Context) {
+		oldBecameLeader.Store(true)
+		<-ctx.Done()
+	})
+
+	require.Eventually(t, func() bool {
+		return oldBecameLeader.Load()
+	}, 3*time.Second, 100*time.Millisecond, "old pod should acquire leadership")
+	assert.True(t, oldPod.Healthy(), "old pod should be healthy")
+
+	// --- Step 2-3: New pod starts, cannot acquire (old pod holds lease) ---
+	newCtx, newCancel := context.WithCancel(ctx)
+	defer newCancel()
+
+	newPod, err := leader.NewLeaderElector(db, newCtx, "rolling-update-lock", 5*time.Second, 1*time.Second)
+	require.NoError(t, err)
+
+	// New pod starts unhealthy (cold start)
+	assert.False(t, newPod.Healthy(), "new pod should start unhealthy")
+
+	// --- Step 4: New pod gets ErrNotAcquired → becomes healthy ---
+	require.Eventually(t, func() bool {
+		return newPod.Healthy()
+	}, 5*time.Second, 100*time.Millisecond,
+		"new pod should become healthy while waiting for lease (ErrNotAcquired proves DB connectivity)")
+
+	// --- Step 5-6: Kubernetes terminates old pod (simulate with cancel) ---
+	t.Log("Simulating Kubernetes terminating old pod")
+	oldCancel()
+	err = oldPod.Wait()
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// --- Step 7: New pod acquires leadership ---
+	var newBecameLeader atomic.Bool
+	newPod.OnBecomeLeader(func(ctx context.Context) {
+		newBecameLeader.Store(true)
+		<-ctx.Done()
+	})
+
+	require.Eventually(t, func() bool {
+		return newBecameLeader.Load()
+	}, 10*time.Second, 200*time.Millisecond, "new pod should acquire leadership after old pod is terminated")
+
+	assert.True(t, newPod.Healthy(), "new pod should remain healthy as leader")
+
+	newCancel()
+	err = newPod.Wait()
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 // TestLeaderElector_GoroutineStartsImmediately verifies that the background
 // goroutine starts immediately from the constructor.
 func TestLeaderElector_GoroutineStartsImmediately(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
