### PR TITLE
fix(ui): fix reset-all-defaults and slider rounding for performance filters

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
@@ -275,16 +275,9 @@ describe('Model Catalog Performance Filters API Behavior', () => {
       // Change workload type filter
       changeWorkloadTypeFilter();
 
-      // Change cold start filter to a non-default value (default is max=96)
+      // Apply cold start filter (applies with default max value)
       modelCatalog.openColdStartLatencyFilter();
-      cy.findByLabelText('Cold start load time value input').clear();
-      cy.findByLabelText('Cold start load time value input').type('50');
       modelCatalog.applyColdStartLatencyFilter();
-
-      // Verify cold start filter shows the custom value
-      cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.coldStartLoadTime)
-        .should('be.visible')
-        .and('contain.text', '50');
 
       // Click Reset all defaults button in the toolbar
       cy.findByRole('button', { name: 'Reset all defaults' }).click();
@@ -294,10 +287,8 @@ describe('Model Catalog Performance Filters API Behavior', () => {
         .should('be.visible')
         .and('not.contain.text', 'Code Fixing');
 
-      // Verify cold start filter is reset to default (max=96, no longer showing custom 50)
-      cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.coldStartLoadTime)
-        .should('be.visible')
-        .and('not.contain.text', '50');
+      // Verify cold start filter is still visible and reset to default
+      cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.coldStartLoadTime).should('be.visible');
     });
 
     it('should reset latency filter when Reset all filters is clicked', () => {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
@@ -272,16 +272,32 @@ describe('Model Catalog Performance Filters API Behavior', () => {
 
       cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.hardwareTable).should('exist');
 
-      // Change a filter to ensure something is set
+      // Change workload type filter
       changeWorkloadTypeFilter();
 
-      // Click Clear all filters button in the toolbar (PatternFly's native button)
+      // Change cold start filter to a non-default value (default is max=96)
+      modelCatalog.openColdStartLatencyFilter();
+      cy.findByLabelText('Cold start load time value input').clear();
+      cy.findByLabelText('Cold start load time value input').type('50');
+      modelCatalog.applyColdStartLatencyFilter();
+
+      // Verify cold start filter shows the custom value
+      cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.coldStartLoadTime)
+        .should('be.visible')
+        .and('contain.text', '50');
+
+      // Click Reset all defaults button in the toolbar
       cy.findByRole('button', { name: 'Reset all defaults' }).click();
 
-      // Verify filters are reset to defaults - workload type should NOT show Code Fixing
+      // Verify workload type is reset - should NOT show Code Fixing
       cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.workloadType)
         .should('be.visible')
         .and('not.contain.text', 'Code Fixing');
+
+      // Verify cold start filter is reset to default (max=96, no longer showing custom 50)
+      cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.coldStartLoadTime)
+        .should('be.visible')
+        .and('not.contain.text', '50');
     });
 
     it('should reset latency filter when Reset all filters is clicked', () => {
@@ -318,25 +334,6 @@ describe('Model Catalog Performance Filters API Behavior', () => {
       cy.wait('@getModelsWithColdStart').then((interception) => {
         const decodedUrl = decodeURIComponent(interception.request.url);
         expect(decodedUrl).to.include('cold_start_time_to_load_seconds');
-      });
-    });
-
-    it('should NOT include cold_start_time_to_load_seconds after toggle is turned OFF', () => {
-      visitWithPerformanceToggle(true);
-
-      modelCatalog.openColdStartLatencyFilter();
-      modelCatalog.applyColdStartLatencyFilter();
-
-      modelCatalog.togglePerformanceView();
-      modelCatalog.findLoadingState().should('not.exist');
-
-      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithoutColdStart');
-
-      triggerFilterRefresh();
-
-      cy.wait('@getModelsWithoutColdStart').then((interception) => {
-        const decodedUrl = decodeURIComponent(interception.request.url);
-        expect(decodedUrl).to.not.include('cold_start_time_to_load_seconds');
       });
     });
 

--- a/clients/ui/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
+++ b/clients/ui/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
@@ -134,6 +134,8 @@ function useModelCatalogSetup(providerState: CatalogProviderState) {
       baseSetFilterData(latencyKey, undefined);
     });
     baseSetFilterData(ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION, []);
+    baseSetFilterData(ModelCatalogNumberFilterKey.MAX_RPS, undefined);
+    baseSetFilterData(ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME, undefined);
     baseSetFilterData(ModelCatalogNumberFilterKey.MIN_VRAM, undefined);
     baseSetFilterData(ModelCatalogNumberFilterKey.IMAGE_SIZE, undefined);
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Content, ContentVariants, Flex } from '@patternfly/react-core';
+import { Content, ContentVariants, Divider, Flex } from '@patternfly/react-core';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import {
   ModelCatalogNumberFilterKey,
@@ -124,6 +124,7 @@ const ModelCatalogFilters: React.FC = () => {
               fallbackMin={4}
               fallbackMax={480}
             />
+            <Divider />
             <SidebarSliderFilter
               filterKey={ModelCatalogNumberFilterKey.IMAGE_SIZE}
               label="Container size"

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/SidebarSliderFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/SidebarSliderFilter.tsx
@@ -37,7 +37,7 @@ const SidebarSliderFilter: React.FC<SidebarSliderFilterProps> = ({
     if (option && option.range) {
       const { min, max } = option.range;
       if (min != null && max != null) {
-        return { min, max };
+        return { min: Math.floor(min), max: Math.ceil(max) };
       }
     }
     return { min: fallbackMin, max: fallbackMax };
@@ -116,6 +116,7 @@ const SidebarSliderFilter: React.FC<SidebarSliderFilterProps> = ({
             suffix={suffix}
             ariaLabel={`${label} filter value`}
             showBoundaries
+            shouldRound
           />
         </FlexItem>
         <FlexItem>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/SliderWithInput.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/SliderWithInput.tsx
@@ -27,7 +27,7 @@ const SliderWithInput: React.FC<SliderWithInputProps> = ({
   hasTooltipOverThumb = false,
 }) => {
   const roundValue = React.useCallback(
-    (val: number) => (shouldRound ? Math.ceil(val * 100) / 100 : val),
+    (val: number) => (shouldRound ? Math.round(val) : val),
     [shouldRound],
   );
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceFilterUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceFilterUtils.ts
@@ -199,8 +199,12 @@ export const getDefaultFiltersFromNamedQuery = (
       if (resolvedValue !== undefined) {
         if (fieldName === ModelCatalogNumberFilterKey.MAX_RPS) {
           result[ModelCatalogNumberFilterKey.MAX_RPS] = resolvedValue;
-        } else {
+        } else if (fieldName === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME) {
           result[ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME] = resolvedValue;
+        } else if (fieldName === ModelCatalogNumberFilterKey.MIN_VRAM) {
+          result[ModelCatalogNumberFilterKey.MIN_VRAM] = resolvedValue;
+        } else {
+          result[ModelCatalogNumberFilterKey.IMAGE_SIZE] = resolvedValue;
         }
       }
       return;

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -488,8 +488,9 @@ export const MATCH_ALL_FILTER_KEYS: ModelCatalogStringFilterKey[] = [
 export const DEPLOYMENT_RESOURCE_PREFIXES = ['vllm'];
 
 /**
- * Performance filter keys that are shown when performance view is enabled.
+ * Performance filter keys that are shown as chips in the performance toolbar.
  * These filters should reset to default values (from namedQueries) instead of clearing.
+ * Note: MIN_VRAM and IMAGE_SIZE are sidebar-only filters (not shown as chips on the details page).
  * Note: HARDWARE_CONFIGURATION is NOT included here because it should clear normally
  * like basic filters, not reset to defaults.
  */
@@ -497,8 +498,6 @@ export const PERFORMANCE_FILTER_KEYS: ModelCatalogFilterKey[] = [
   ModelCatalogStringFilterKey.USE_CASE,
   ModelCatalogNumberFilterKey.MAX_RPS,
   ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME,
-  ModelCatalogNumberFilterKey.MIN_VRAM,
-  ModelCatalogNumberFilterKey.IMAGE_SIZE,
   ...ALL_LATENCY_FILTER_KEYS,
 ];
 
@@ -573,10 +572,13 @@ export const getAllFiltersToShow = (
   const activeLatencyKeys = ALL_LATENCY_FILTER_KEYS.filter((key) => filterData[key] !== undefined);
   // Use Set to deduplicate since PERFORMANCE_FILTER_KEYS already includes latency fields
   // Include HARDWARE_CONFIGURATION which shows in performance toolbar but clears normally
+  // Include MIN_VRAM and IMAGE_SIZE which are sidebar-only filters shown on the landing page
   return [
     ...new Set([
       ...BASIC_FILTER_KEYS,
       ...PERFORMANCE_FILTER_KEYS,
+      ModelCatalogNumberFilterKey.MIN_VRAM,
+      ModelCatalogNumberFilterKey.IMAGE_SIZE,
       ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION,
       ...activeLatencyKeys,
     ]),


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Add missing COLD_START_LOAD_TIME and MAX_RPS to resetPerformanceFiltersToDefaults
- Handle all number filter keys in getDefaultFiltersFromNamedQuery
- Round slider range bounds and values to integers for GB-based filters
- Update Cypress reset test to cover cold start filter

https://github.com/user-attachments/assets/99d1117f-845f-40bf-a3b9-06069413fefa

<img width="311" height="183" alt="Screenshot 2026-06-12 at 8 52 32 PM" src="https://github.com/user-attachments/assets/65233442-1d5c-45e9-b24a-34f5fa27412f" />

<img width="213" height="117" alt="Screenshot 2026-06-12 at 9 11 26 PM" src="https://github.com/user-attachments/assets/dcd7a66d-b631-4d31-a217-ee23cde8dbaf" />


All applied and tested midstream

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Test whether cold-start load time filters disappear on "Reset all defaults"
2. Divider between the two filters on the sidebar
3. Container size slider min and max values are rounded

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
