### PR TITLE
chore: loosen rh-model-signing pin from exact to ^1.0.2

### DIFF
--- a/clients/python/poetry.lock
+++ b/clients/python/poetry.lock
@@ -4390,4 +4390,4 @@ signing = ["platformdirs", "rh-model-signing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.10, < 4.0"
-content-hash = "30b1371aedcc56ac29819a5c73c54dbd78862500cae39e8ba114d2919f83d929"
+content-hash = "6e7f0f487781cbce0da72dafc08ecba2db3919e14d9eef3cc5a437fc6efbc8e2"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -27,7 +27,7 @@ nest-asyncio2 = "^1.7.1"
 huggingface-hub = { version = ">=0.20.1,<1.18.0", optional = true }
 olot = { version = "^0.1.17", optional = true }
 boto3 = { version = "^1.37.34", optional = true }
-rh-model-signing = { version = "1.0.2", optional = true }
+rh-model-signing = { version = "^1.0.2", optional = true }
 platformdirs = { version = "^4.0.0", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
This allows us to use minor version upgrades of this package.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
