### PR TITLE
use performance metrics type instead of cold start

### DIFF
--- a/catalog/internal/catalog/modelcatalog/models/catalog_metrics_artifact.go
+++ b/catalog/internal/catalog/modelcatalog/models/catalog_metrics_artifact.go
@@ -12,7 +12,6 @@ const (
 	MetricsTypePerformance     MetricsType = "performance-metrics"
 	MetricsTypeAccuracy        MetricsType = "accuracy-metrics"
 	MetricsTypeSecurityMetrics MetricsType = "security-metrics"
-	MetricsTypeColdStart       MetricsType = "cold-start-metrics"
 	CatalogMetricsArtifactType             = "metrics-artifact"
 )
 

--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -21,11 +21,11 @@ import (
 // metadataJSON represents the minimal structure needed from metadata.json files
 // Only the ID field is needed to look up existing models
 type metadataJSON struct {
-	ID              string           `json:"id"`                // Maps to model name for lookup
-	OverallAccuracy *float64         `json:"overall_accuracy"`  // Overall accuracy score for the model
-	Size            *string          `json:"size"`              // Model parameter count (e.g., "8B params")
-	TensorType      *string          `json:"tensor_type"`       // Data precision (e.g., "FP16", "INT4")
-	VariantGroupID  *string          `json:"variant_group_id"`  // UUID linking model variants together
+	ID                     string           `json:"id"`                        // Maps to model name for lookup
+	OverallAccuracy        *float64         `json:"overall_accuracy"`          // Overall accuracy score for the model
+	Size                   *string          `json:"size"`                      // Model parameter count (e.g., "8B params")
+	TensorType             *string          `json:"tensor_type"`               // Data precision (e.g., "FP16", "INT4")
+	VariantGroupID         *string          `json:"variant_group_id"`          // UUID linking model variants together
 	MinVRAMGB              *float64         `json:"min_vram_gb"`               // Minimum VRAM required in GB (e.g., 466.0)
 	ModelcarImageSize      *float64         `json:"modelcar_image_size"`       // Modelcar image size in GB (e.g., 405.19)
 	ModelcarImageSizeBytes *int64           `json:"modelcar_image_size_bytes"` // Modelcar image size in bytes (e.g., 405186009411)
@@ -692,7 +692,9 @@ func createColdStartArtifact(entry coldStartEntry, externalID string, modelID in
 	now := time.Now().UnixMilli()
 
 	gpuCount := int32(entry.GPUCount)
+	subType := "cold-start"
 	customProperties := []models.Properties{
+		{Name: "performance_sub_type", StringValue: &subType},
 		{Name: "gpu_type", StringValue: &entry.GPUType},
 		{Name: "gpu_count", IntValue: &gpuCount},
 	}
@@ -721,7 +723,7 @@ func createColdStartArtifact(entry coldStartEntry, externalID string, modelID in
 			ExternalID:               &externalID,
 			CreateTimeSinceEpoch:     &now,
 			LastUpdateTimeSinceEpoch: &now,
-			MetricsType:              dbmodels.MetricsTypeColdStart,
+			MetricsType:              dbmodels.MetricsTypePerformance,
 		},
 		Properties:       &properties,
 		CustomProperties: &customProperties,

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -1700,8 +1700,8 @@ func TestCreateColdStartArtifact(t *testing.T) {
 				t.Errorf("TypeID = %d, want %d", *artifact.TypeID, typeID)
 			}
 			attrs := artifact.GetAttributes()
-			if attrs.MetricsType != models.MetricsTypeColdStart {
-				t.Errorf("MetricsType = %q, want %q", attrs.MetricsType, models.MetricsTypeColdStart)
+			if attrs.MetricsType != models.MetricsTypePerformance {
+				t.Errorf("MetricsType = %q, want %q", attrs.MetricsType, models.MetricsTypePerformance)
 			}
 
 			// Verify naming
@@ -1740,6 +1740,9 @@ func TestCreateColdStartArtifact(t *testing.T) {
 				}
 			}
 
+			if stringPropMap["performance_sub_type"] != "cold-start" {
+				t.Errorf("performance_sub_type = %v, want %q", stringPropMap["performance_sub_type"], "cold-start")
+			}
 			if stringPropMap["gpu_type"] != tt.wantGPUType {
 				t.Errorf("gpu_type = %v, want %q", stringPropMap["gpu_type"], tt.wantGPUType)
 			}
@@ -1801,10 +1804,10 @@ func TestProcessModelArtifactsBatch_ColdStartOnly(t *testing.T) {
 		t.Fatalf("expected 2 saved artifacts, got %d", len(savedArtifacts))
 	}
 
-	// Verify both artifacts have cold-start metrics type
+	// Verify both artifacts have performance metrics type
 	for _, a := range savedArtifacts {
-		if a.GetAttributes().MetricsType != models.MetricsTypeColdStart {
-			t.Errorf("expected MetricsType %q, got %q", models.MetricsTypeColdStart, a.GetAttributes().MetricsType)
+		if a.GetAttributes().MetricsType != models.MetricsTypePerformance {
+			t.Errorf("expected MetricsType %q, got %q", models.MetricsTypePerformance, a.GetAttributes().MetricsType)
 		}
 	}
 }

--- a/catalog/internal/catalog/modelcatalog/service/catalog_metrics_artifact.go
+++ b/catalog/internal/catalog/modelcatalog/service/catalog_metrics_artifact.go
@@ -78,7 +78,7 @@ func (r *CatalogMetricsArtifactRepositoryImpl) Save(ma models.CatalogMetricsArti
 	}
 
 	switch attr.MetricsType {
-	case models.MetricsTypeAccuracy, models.MetricsTypePerformance, models.MetricsTypeSecurityMetrics, models.MetricsTypeColdStart:
+	case models.MetricsTypeAccuracy, models.MetricsTypePerformance, models.MetricsTypeSecurityMetrics:
 		// OK
 	default:
 		return ma, fmt.Errorf("invalid artifact: unknown metrics type: %s", attr.MetricsType)
@@ -112,7 +112,7 @@ func (r *CatalogMetricsArtifactRepositoryImpl) BatchSave(artifacts []models.Cata
 		}
 
 		switch attr.MetricsType {
-		case models.MetricsTypeAccuracy, models.MetricsTypePerformance, models.MetricsTypeSecurityMetrics, models.MetricsTypeColdStart:
+		case models.MetricsTypeAccuracy, models.MetricsTypePerformance, models.MetricsTypeSecurityMetrics:
 			// OK
 		default:
 			return nil, fmt.Errorf("invalid artifact at index %d: unknown metrics type: %s", i, attr.MetricsType)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Change cold start metrics to performance type instead of cold start type.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
