### PR TITLE
feat(ui): source cold start data from performance artifacts endpoint

### DIFF
--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -358,7 +358,7 @@ func GenerateMockArtifact() openapi.Artifact {
 	return mockData
 }
 
-func withColdStartData(props *map[string]openapi.MetadataValue, modelSize string, minVram string, hwConfigs string) *map[string]openapi.MetadataValue {
+func withColdStartData(props *map[string]openapi.MetadataValue, modelSize string, minVram string, _ string) *map[string]openapi.MetadataValue {
 	if props == nil {
 		return props
 	}
@@ -371,12 +371,6 @@ func withColdStartData(props *map[string]openapi.MetadataValue, modelSize string
 	(*props)["min_vram_gb"] = openapi.MetadataValue{
 		MetadataStringValue: &openapi.MetadataStringValue{
 			StringValue:  minVram,
-			MetadataType: "MetadataStringValue",
-		},
-	}
-	(*props)["cold_start_matrix"] = openapi.MetadataValue{
-		MetadataStringValue: &openapi.MetadataStringValue{
-			StringValue:  hwConfigs,
 			MetadataType: "MetadataStringValue",
 		},
 	}
@@ -1252,6 +1246,12 @@ func performanceMetricsCustomProperties(customProperties map[string]openapi.Meta
 				MetadataType: "MetadataIntValue",
 			},
 		},
+		"hardware_configuration": {
+			MetadataStringValue: &openapi.MetadataStringValue{
+				StringValue:  "2 x H100",
+				MetadataType: "MetadataStringValue",
+			},
+		},
 		"framework": {
 			MetadataStringValue: &openapi.MetadataStringValue{
 				StringValue:  "vllm",
@@ -1375,6 +1375,12 @@ func GetCatalogPerformanceMetricsArtifactMock(itemCount int32) []models.CatalogA
 						MetadataType: "MetadataIntValue",
 					},
 				},
+				"hardware_configuration": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "4 x RTX 4090",
+						MetadataType: "MetadataStringValue",
+					},
+				},
 				"requests_per_second": {
 					MetadataDoubleValue: &openapi.MetadataDoubleValue{
 						DoubleValue:  10,
@@ -1483,6 +1489,12 @@ func GetCatalogPerformanceMetricsArtifactMock(itemCount int32) []models.CatalogA
 					MetadataIntValue: &openapi.MetadataIntValue{
 						IntValue:     "8",
 						MetadataType: "MetadataIntValue",
+					},
+				},
+				"hardware_configuration": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "8 x A100",
+						MetadataType: "MetadataStringValue",
 					},
 				},
 				"requests_per_second": {
@@ -1595,6 +1607,12 @@ func GetCatalogPerformanceMetricsArtifactMock(itemCount int32) []models.CatalogA
 						MetadataType: "MetadataIntValue",
 					},
 				},
+				"hardware_configuration": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "2 x A100-80",
+						MetadataType: "MetadataStringValue",
+					},
+				},
 				"requests_per_second": {
 					MetadataDoubleValue: &openapi.MetadataDoubleValue{
 						DoubleValue:  25,
@@ -1682,7 +1700,165 @@ func GetCatalogPerformanceMetricsArtifactMock(itemCount int32) []models.CatalogA
 			}),
 		},
 	}
+
+	// Add separate cold-start artifacts (matched to throughput artifacts by gpu_type)
+	coldStartArtifacts := []models.CatalogArtifact{
+		{
+			ArtifactType:             *stringToPointer("metrics-artifact"),
+			MetricsType:              stringToPointer("performance-metrics"),
+			CreateTimeSinceEpoch:     stringToPointer("1693526400000"),
+			LastUpdateTimeSinceEpoch: stringToPointer("1704067200000"),
+			CustomProperties: &map[string]openapi.MetadataValue{
+				"performance_sub_type": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "cold-start",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"gpu_type": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "H100",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"gpu_count": {
+					MetadataIntValue: &openapi.MetadataIntValue{
+						IntValue:     "2",
+						MetadataType: "MetadataIntValue",
+					},
+				},
+				"cold_start_time_to_load_seconds": {
+					MetadataDoubleValue: &openapi.MetadataDoubleValue{
+						DoubleValue:  52.1,
+						MetadataType: "MetadataDoubleValue",
+					},
+				},
+				"runtime_command": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "vllm serve model --tensor-parallel-size 2 --dtype float16",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+			},
+		},
+		{
+			ArtifactType:             *stringToPointer("metrics-artifact"),
+			MetricsType:              stringToPointer("performance-metrics"),
+			CreateTimeSinceEpoch:     stringToPointer("1693526400000"),
+			LastUpdateTimeSinceEpoch: stringToPointer("1704067200000"),
+			CustomProperties: &map[string]openapi.MetadataValue{
+				"performance_sub_type": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "cold-start",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"gpu_type": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "RTX 4090",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"gpu_count": {
+					MetadataIntValue: &openapi.MetadataIntValue{
+						IntValue:     "4",
+						MetadataType: "MetadataIntValue",
+					},
+				},
+				"cold_start_time_to_load_seconds": {
+					MetadataDoubleValue: &openapi.MetadataDoubleValue{
+						DoubleValue:  78.4,
+						MetadataType: "MetadataDoubleValue",
+					},
+				},
+				"runtime_command": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "vllm serve model --tensor-parallel-size 4 --dtype float16 --max-model-len 4096",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+			},
+		},
+		{
+			ArtifactType:             *stringToPointer("metrics-artifact"),
+			MetricsType:              stringToPointer("performance-metrics"),
+			CreateTimeSinceEpoch:     stringToPointer("1693526400000"),
+			LastUpdateTimeSinceEpoch: stringToPointer("1704067200000"),
+			CustomProperties: &map[string]openapi.MetadataValue{
+				"performance_sub_type": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "cold-start",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"gpu_type": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "A100",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"gpu_count": {
+					MetadataIntValue: &openapi.MetadataIntValue{
+						IntValue:     "8",
+						MetadataType: "MetadataIntValue",
+					},
+				},
+				"cold_start_time_to_load_seconds": {
+					MetadataDoubleValue: &openapi.MetadataDoubleValue{
+						DoubleValue:  95.3,
+						MetadataType: "MetadataDoubleValue",
+					},
+				},
+				"runtime_command": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "vllm serve model --tensor-parallel-size 8 --dtype auto --gpu-memory-utilization 0.95",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+			},
+		},
+		{
+			ArtifactType:             *stringToPointer("metrics-artifact"),
+			MetricsType:              stringToPointer("performance-metrics"),
+			CreateTimeSinceEpoch:     stringToPointer("1693526400000"),
+			LastUpdateTimeSinceEpoch: stringToPointer("1704067200000"),
+			CustomProperties: &map[string]openapi.MetadataValue{
+				"performance_sub_type": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "cold-start",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"gpu_type": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "A100-80",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"gpu_count": {
+					MetadataIntValue: &openapi.MetadataIntValue{
+						IntValue:     "2",
+						MetadataType: "MetadataIntValue",
+					},
+				},
+				"cold_start_time_to_load_seconds": {
+					MetadataDoubleValue: &openapi.MetadataDoubleValue{
+						DoubleValue:  63.7,
+						MetadataType: "MetadataDoubleValue",
+					},
+				},
+				"runtime_command": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "vllm serve model --tensor-parallel-size 2 --dtype auto --max-model-len 8192",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+			},
+		},
+	}
+
 	artifacts = artifacts[:itemCount]
+	artifacts = append(artifacts, coldStartArtifacts...)
 	return artifacts
 }
 

--- a/clients/ui/frontend/src/__mocks__/mockCatalogModelArtifactList.ts
+++ b/clients/ui/frontend/src/__mocks__/mockCatalogModelArtifactList.ts
@@ -100,6 +100,40 @@ export const mockCatalogPerformanceMetricsArtifact = (
   ...partial,
 });
 
+export const mockColdStartArtifact = (
+  gpuType: string,
+  gpuCount: number,
+  coldStartSeconds: number,
+  runtimeCommand: string,
+): CatalogPerformanceMetricsArtifact => ({
+  artifactType: CatalogArtifactType.metricsArtifact,
+  metricsType: MetricsType.performanceMetrics,
+  createTimeSinceEpoch: '1739210683000',
+  lastUpdateTimeSinceEpoch: '1739210683000',
+  customProperties: {
+    performance_sub_type: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: 'cold-start',
+    },
+    gpu_type: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: gpuType,
+    },
+    gpu_count: {
+      metadataType: ModelRegistryMetadataType.INT,
+      int_value: String(gpuCount),
+    },
+    cold_start_time_to_load_seconds: {
+      metadataType: ModelRegistryMetadataType.DOUBLE,
+      double_value: coldStartSeconds,
+    },
+    runtime_command: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: runtimeCommand,
+    },
+  },
+});
+
 export const mockCatalogModelArtifactList = (
   partial?: Partial<CatalogModelArtifact>,
 ): CatalogArtifactList => ({
@@ -123,6 +157,10 @@ export const mockCatalogPerformanceMetricsArtifactList = (
         },
         hardware_count: { metadataType: ModelRegistryMetadataType.INT, int_value: '2' },
         hardware_type: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'H100-80' },
+        hardware_configuration: {
+          metadataType: ModelRegistryMetadataType.STRING,
+          string_value: '2 x H100-80',
+        },
         requests_per_second: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 7 },
         ttft_mean: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 35.48 },
         ttft_p90: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 51.56 },
@@ -148,6 +186,10 @@ export const mockCatalogPerformanceMetricsArtifactList = (
         },
         hardware_count: { metadataType: ModelRegistryMetadataType.INT, int_value: '4' },
         hardware_type: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'RTX 4090' },
+        hardware_configuration: {
+          metadataType: ModelRegistryMetadataType.STRING,
+          string_value: '4 x RTX 4090',
+        },
         requests_per_second: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 10 },
         ttft_mean: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 67.15 },
         ttft_p90: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 82.34 },
@@ -172,6 +214,10 @@ export const mockCatalogPerformanceMetricsArtifactList = (
         },
         hardware_count: { metadataType: ModelRegistryMetadataType.INT, int_value: '8' },
         hardware_type: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'A100' },
+        hardware_configuration: {
+          metadataType: ModelRegistryMetadataType.STRING,
+          string_value: '8 x A100',
+        },
         requests_per_second: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 15 },
         ttft_mean: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 42.12 },
         ttft_p90: { metadataType: ModelRegistryMetadataType.DOUBLE, double_value: 58.45 },
@@ -187,9 +233,28 @@ export const mockCatalogPerformanceMetricsArtifactList = (
         },
       },
     }),
+    // Cold-start artifacts (separate from throughput, matched by gpu_type)
+    mockColdStartArtifact(
+      'H100-80',
+      2,
+      45.3,
+      'vllm serve model --tensor-parallel-size 2 --dtype float16',
+    ),
+    mockColdStartArtifact(
+      'RTX 4090',
+      4,
+      62.1,
+      'vllm serve model --tensor-parallel-size 4 --dtype float16 --max-model-len 4096',
+    ),
+    mockColdStartArtifact(
+      'A100',
+      8,
+      38.7,
+      'vllm serve model --tensor-parallel-size 8 --dtype auto --gpu-memory-utilization 0.95',
+    ),
   ],
   pageSize: 10,
-  size: 3,
+  size: 6,
   nextPageToken: '',
 });
 

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -34,13 +34,6 @@ import {
   McpToolList,
 } from './mcpServerCatalogTypes';
 
-export type HardwareConfiguration = {
-  gpu_type: string;
-  gpu_count: number;
-  cold_start_time_to_load_seconds: number;
-  runtime_command: string;
-};
-
 export type ToolCallingConfig = {
   toolCallParser?: string;
   chatTemplate?: string;
@@ -82,7 +75,6 @@ export enum CatalogArtifactType {
 export enum MetricsType {
   accuracyMetrics = 'accuracy-metrics',
   performanceMetrics = 'performance-metrics',
-  coldStartMetrics = 'cold-start-metrics',
 }
 
 export enum CategoryName {
@@ -122,6 +114,12 @@ export type PerformanceMetricsCustomProperties = {
   // Framework information
   framework?: ModelRegistryCustomPropertyString;
   framework_version?: ModelRegistryCustomPropertyString;
+  // Cold start (on cold-start sub-type artifacts)
+  cold_start_time_to_load_seconds?: ModelRegistryCustomPropertyDouble;
+  runtime_command?: ModelRegistryCustomPropertyString;
+  gpu_type?: ModelRegistryCustomPropertyString;
+  gpu_count?: ModelRegistryCustomPropertyInt;
+  performance_sub_type?: ModelRegistryCustomPropertyString;
   // Additional fields from ADR (excluded from display per requirements)
   docker_image?: ModelRegistryCustomPropertyString;
   entrypoint?: ModelRegistryCustomPropertyString;
@@ -152,23 +150,9 @@ export type CatalogAccuracyMetricsArtifact = Omit<CatalogArtifactBase, 'customPr
   customProperties?: AccuracyMetricsCustomProperties;
 };
 
-export type ColdStartMetricsCustomProperties = {
-  gpu_type?: ModelRegistryCustomPropertyString;
-  gpu_count?: ModelRegistryCustomPropertyInt;
-  cold_start_time_to_load_seconds?: ModelRegistryCustomPropertyDouble;
-  runtime_command?: ModelRegistryCustomPropertyString;
-};
-
-export type CatalogColdStartMetricsArtifact = Omit<CatalogArtifactBase, 'customProperties'> & {
-  artifactType: CatalogArtifactType.metricsArtifact;
-  metricsType: MetricsType.coldStartMetrics;
-  customProperties?: ColdStartMetricsCustomProperties;
-};
-
 export type CatalogMetricsArtifact =
   | CatalogPerformanceMetricsArtifact
-  | CatalogAccuracyMetricsArtifact
-  | CatalogColdStartMetricsArtifact;
+  | CatalogAccuracyMetricsArtifact;
 
 export type CatalogArtifacts = CatalogModelArtifact | CatalogMetricsArtifact;
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
@@ -3,11 +3,10 @@ import { DashboardEmptyTableView, Table, ManageColumnsModal } from 'mod-arch-sha
 import { Button, Spinner } from '@patternfly/react-core';
 import { ColumnsIcon } from '@patternfly/react-icons';
 import { OuterScrollContainer } from '@patternfly/react-table';
-import { CatalogPerformanceMetricsArtifact, HardwareConfiguration } from '~/app/modelCatalogTypes';
+import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { getActiveLatencyFieldName } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
-import { getStringValue } from '~/app/utils';
-import { SortOrder, PerformancePropertyKey } from '~/concepts/modelCatalog/const';
+import { SortOrder } from '~/concepts/modelCatalog/const';
 import {
   useHardwareConfigColumns,
   ControlledTableSortProps,
@@ -17,14 +16,14 @@ import HardwareConfigurationFilterToolbar from './HardwareConfigurationFilterToo
 
 type HardwareConfigurationTableProps = {
   performanceArtifacts: CatalogPerformanceMetricsArtifact[];
-  hardwareConfigurations?: HardwareConfiguration[];
+  coldStartArtifacts: CatalogPerformanceMetricsArtifact[];
   isLoading?: boolean;
   onSortChange?: (sort: { orderBy?: string; sortOrder?: string }) => void;
 };
 
 const HardwareConfigurationTable: React.FC<HardwareConfigurationTableProps> = ({
   performanceArtifacts,
-  hardwareConfigurations,
+  coldStartArtifacts,
   isLoading = false,
   onSortChange,
 }) => {
@@ -119,27 +118,14 @@ const HardwareConfigurationTable: React.FC<HardwareConfigurationTableProps> = ({
           {...(hasActiveSort ? { defaultSortColumn: sortIndex } : {})}
           {...controlledSortProps}
           emptyTableView={<DashboardEmptyTableView onClearFilters={handleClearFilters} />}
-          rowRenderer={(artifact: CatalogPerformanceMetricsArtifact) => {
-            const hwConfig = getStringValue(
-              artifact.customProperties,
-              PerformancePropertyKey.HARDWARE_CONFIGURATION,
-            );
-            const hwType = getStringValue(
-              artifact.customProperties,
-              PerformancePropertyKey.HARDWARE_TYPE,
-            );
-            const matched = hardwareConfigurations?.find(
-              (c) => hwConfig.startsWith(c.gpu_type) || c.gpu_type === hwType,
-            );
-            return (
-              <HardwareConfigurationTableRow
-                key={artifact.customProperties?.config_id?.string_value}
-                performanceArtifact={artifact}
-                columns={columns}
-                matchedHardwareConfig={matched}
-              />
-            );
-          }}
+          rowRenderer={(artifact: CatalogPerformanceMetricsArtifact) => (
+            <HardwareConfigurationTableRow
+              key={artifact.customProperties?.config_id?.string_value}
+              performanceArtifact={artifact}
+              coldStartArtifacts={coldStartArtifacts}
+              columns={columns}
+            />
+          )}
         />
       </OuterScrollContainer>
       <ManageColumnsModal

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -366,7 +366,12 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
         position: 'left',
       },
     },
-    sortable: false,
+    sortable: (
+      a: CatalogPerformanceMetricsArtifact,
+      b: CatalogPerformanceMetricsArtifact,
+    ): number =>
+      getDoubleValue(a.customProperties, PerformancePropertyKey.COLD_START_TIME_TO_LOAD_SECONDS) -
+      getDoubleValue(b.customProperties, PerformancePropertyKey.COLD_START_TIME_TO_LOAD_SECONDS),
     width: 20,
   },
   {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { Button, Popover } from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
-import { CatalogPerformanceMetricsArtifact, HardwareConfiguration } from '~/app/modelCatalogTypes';
+import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 import {
   formatLatency,
   formatTps,
   formatTokenValue,
   getWorkloadType,
+  findMatchingColdStartArtifact,
 } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
 import { getDoubleValue, getIntValue, getStringValue } from '~/app/utils';
 import { PerformancePropertyKey, EMPTY_CUSTOM_PROPERTY_VALUE } from '~/concepts/modelCatalog/const';
@@ -18,14 +19,14 @@ import {
 
 type HardwareConfigurationTableRowProps = {
   performanceArtifact: CatalogPerformanceMetricsArtifact;
+  coldStartArtifacts: CatalogPerformanceMetricsArtifact[];
   columns: HardwareConfigColumn[];
-  matchedHardwareConfig?: HardwareConfiguration;
 };
 
 const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps> = ({
   performanceArtifact,
+  coldStartArtifacts,
   columns,
-  matchedHardwareConfig,
 }) => {
   const getCellValue = (field: HardwareConfigColumnField): string | number => {
     const { customProperties } = performanceArtifact;
@@ -37,8 +38,8 @@ const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps
         return getStringValue(customProperties, field);
       case PerformancePropertyKey.USE_CASE:
         return getWorkloadType(performanceArtifact);
-      case 'hardware_count':
-        return getIntValue(customProperties, 'hardware_count');
+      case PerformancePropertyKey.HARDWARE_COUNT:
+        return getIntValue(customProperties, PerformancePropertyKey.HARDWARE_COUNT);
       case PerformancePropertyKey.REQUESTS_PER_SECOND:
         return getDoubleValue(customProperties, PerformancePropertyKey.REQUESTS_PER_SECOND);
       case 'replicas': {
@@ -77,18 +78,28 @@ const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps
     }
   };
 
-  const renderModelLevelCell = (field: HardwareConfigColumnField): React.ReactNode => {
+  const matchedColdStart = React.useMemo(
+    () => findMatchingColdStartArtifact(performanceArtifact, coldStartArtifacts),
+    [performanceArtifact, coldStartArtifacts],
+  );
+
+  const renderCell = (field: HardwareConfigColumnField): React.ReactNode => {
     if (field === 'cold_start_load_time') {
-      return matchedHardwareConfig
-        ? `${matchedHardwareConfig.cold_start_time_to_load_seconds.toFixed(2)} s`
-        : EMPTY_CUSTOM_PROPERTY_VALUE;
+      const coldStartValue = matchedColdStart
+        ? getDoubleValue(
+            matchedColdStart.customProperties,
+            PerformancePropertyKey.COLD_START_TIME_TO_LOAD_SECONDS,
+          )
+        : 0;
+      return coldStartValue > 0 ? `${coldStartValue.toFixed(2)} s` : EMPTY_CUSTOM_PROPERTY_VALUE;
     }
     if (field === 'runtime_command') {
-      return matchedHardwareConfig?.runtime_command ? (
+      const command = matchedColdStart
+        ? getStringValue(matchedColdStart.customProperties, PerformancePropertyKey.RUNTIME_COMMAND)
+        : '';
+      return command ? (
         <Popover
-          bodyContent={
-            <CodeBlockComponent>{matchedHardwareConfig.runtime_command}</CodeBlockComponent>
-          }
+          bodyContent={<CodeBlockComponent>{command}</CodeBlockComponent>}
           position="left"
           maxWidth="450px"
         >
@@ -115,7 +126,7 @@ const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps
           hasRightBorder={column.hasRightBorder}
           modifier="fitContent"
         >
-          {renderModelLevelCell(column.field)}
+          {renderCell(column.field)}
         </Td>
       ))}
     </Tr>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -13,7 +13,7 @@ import { Link } from 'react-router-dom';
 import { HelpIcon, AngleLeftIcon, AngleRightIcon, ArrowRightIcon } from '@patternfly/react-icons';
 import { TruncatedText } from 'mod-arch-shared';
 import type { CatalogSource } from '~/app/shared/types/catalogTypes';
-import type { CatalogModel, HardwareConfiguration } from '~/app/modelCatalogTypes';
+import type { CatalogModel } from '~/app/modelCatalogTypes';
 import {
   extractValidatedModelMetrics,
   getLatencyValue,
@@ -27,28 +27,21 @@ import {
   latencyMetricDescriptions,
   parseLatencyFilterKey,
   SortOrder,
+  PerformancePropertyKey,
 } from '~/concepts/modelCatalog/const';
 import { useCatalogPerformanceArtifacts } from '~/app/hooks/modelCatalog/useCatalogPerformanceArtifacts';
 import {
   getActiveLatencyFieldName,
   stripArtifactsPrefix,
-  getHardwareConfigurationsFromCustomProperties,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
-import { formatLatency } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
+import {
+  formatLatency,
+  separatePerformanceArtifacts,
+  findMatchingColdStartArtifact,
+} from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { useNotification } from '~/app/hooks/useNotification';
-
-const findMatchedColdStart = (
-  customProperties: CatalogModel['customProperties'],
-  hwConfig: string,
-  hwType: string,
-): number | undefined => {
-  const configs = getHardwareConfigurationsFromCustomProperties(customProperties);
-  const match = configs.find(
-    (c: HardwareConfiguration) => hwConfig.startsWith(c.gpu_type) || c.gpu_type === hwType,
-  );
-  return match?.cold_start_time_to_load_seconds;
-};
+import { getDoubleValue } from '~/app/utils';
 
 type ModelCatalogCardBodyProps = {
   model: CatalogModel;
@@ -109,8 +102,13 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
       isValidated, // Only fetch if validated
     );
 
-  // Performance artifacts are already filtered by the server endpoint
-  const performanceMetrics = performanceArtifactsList.items;
+  // Separate throughput artifacts from cold-start artifacts
+  const { throughputArtifacts, coldStartArtifacts } = React.useMemo(
+    () => separatePerformanceArtifacts(performanceArtifactsList.items),
+    [performanceArtifactsList.items],
+  );
+
+  const performanceMetrics = throughputArtifacts;
 
   // NOTE: Accuracy metrics are not currently returned by the /performance_artifacts endpoint.
   // This is kept as a placeholder for when accuracy metrics support is restored.
@@ -215,11 +213,15 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
       ? parseLatencyFilterKey(activeLatencyField).metric
       : LatencyMetric.TTFT;
 
-    const matchedColdStart = findMatchedColdStart(
-      model.customProperties,
-      metrics.hardwareConfiguration,
-      metrics.hardwareType,
-    );
+    const currentArtifact = performanceMetrics[currentPerformanceIndex];
+    const matchingColdStart = findMatchingColdStartArtifact(currentArtifact, coldStartArtifacts);
+    const coldStartValue = matchingColdStart
+      ? getDoubleValue(
+          matchingColdStart.customProperties,
+          PerformancePropertyKey.COLD_START_TIME_TO_LOAD_SECONDS,
+        )
+      : 0;
+    const matchedColdStart = coldStartValue > 0 ? coldStartValue : undefined;
 
     return (
       <Stack hasGutter>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
@@ -29,8 +29,8 @@ import {
 import {
   decodeParams,
   getActiveLatencyFieldName,
-  getHardwareConfigurationsFromCustomProperties,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import { separatePerformanceArtifacts } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
 import { getDefaultFiltersFromNamedQuery } from '~/app/pages/modelCatalog/utils/performanceFilterUtils';
 import TensorTypeComparisonCard from './TensorTypeComparisonCard';
 
@@ -130,9 +130,9 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
     model.name,
   ]);
 
-  const hardwareConfigurations = React.useMemo(
-    () => getHardwareConfigurationsFromCustomProperties(model.customProperties),
-    [model.customProperties],
+  const { throughputArtifacts, coldStartArtifacts } = React.useMemo(
+    () => separatePerformanceArtifacts(performanceArtifacts.items),
+    [performanceArtifacts.items],
   );
 
   if (performanceArtifactsError) {
@@ -168,8 +168,8 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
               </FlexItem>
               <FlexItem>
                 <HardwareConfigurationTable
-                  performanceArtifacts={performanceArtifacts.items}
-                  hardwareConfigurations={hardwareConfigurations}
+                  performanceArtifacts={throughputArtifacts}
+                  coldStartArtifacts={coldStartArtifacts}
                   isLoading={!performanceArtifactsLoaded && performanceArtifacts.items.length === 0}
                   onSortChange={setTableSort}
                 />

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -460,7 +460,7 @@ describe('filtersToFilterQuery', () => {
   //   });
 
   describe('numeric filter target behavior', () => {
-    it('includes cold-start and model-level filters for models target, excludes cold-start for artifacts target', () => {
+    it('includes cold-start and model-level filters for models target, includes cold-start but excludes model-level filters for artifacts target', () => {
       const data = mockFormData({ cold_start_latency: 50, min_vram: 24, image_size: 15 });
 
       const modelsQuery = filtersToFilterQuery(data, mockFilterOptions, 'models');
@@ -469,7 +469,7 @@ describe('filtersToFilterQuery', () => {
       expect(modelsQuery).toContain('modelcar_image_size.double_value');
 
       const artifactsQuery = filtersToFilterQuery(data, mockFilterOptions, 'artifacts');
-      expect(artifactsQuery).not.toContain('cold_start_time_to_load_seconds');
+      expect(artifactsQuery).toContain('cold_start_time_to_load_seconds');
       expect(artifactsQuery).not.toContain('min_vram_gb');
       expect(artifactsQuery).not.toContain('modelcar_image_size');
     });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -8,7 +8,6 @@ import {
   CatalogModel,
   CatalogModelArtifact,
   CatalogModelDetailsParams,
-  HardwareConfiguration,
   MetricsType,
   ModelCatalogFilterStates,
   ToolCallingConfig,
@@ -345,12 +344,6 @@ const shouldIncludeFilter = (filterId: string, target: FilterQueryTarget): boole
     return false;
   }
 
-  // Cold-start filter is excluded from the performance artifacts endpoint
-  // (performance-metrics artifacts don't have this field — it's on cold-start-metrics artifacts).
-  if (filterId === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME && target === 'artifacts') {
-    return false;
-  }
-
   if (target === 'models') {
     // For models, include all filters (except RPS and cold-start which are already excluded)
     return true;
@@ -602,25 +595,4 @@ export const getMinimumVramFromCustomProperties = (
     return `${doubleVal.toFixed(2)} GB`;
   }
   return getCustomPropString(customProperties, CatalogModelCustomPropertyKey.MINIMUM_VRAM);
-};
-
-export const getHardwareConfigurationsFromCustomProperties = (
-  customProperties?: ModelRegistryCustomProperties,
-): HardwareConfiguration[] => {
-  if (!customProperties) {
-    return [];
-  }
-  const hwConfigStr = getCustomPropString(
-    customProperties,
-    CatalogModelCustomPropertyKey.HARDWARE_CONFIGURATIONS,
-  );
-  if (!hwConfigStr) {
-    return [];
-  }
-  try {
-    const parsed = JSON.parse(hwConfigStr);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
 };

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
@@ -1,10 +1,11 @@
 import { asEnumMember } from 'mod-arch-core';
 import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
-import { getStringValue } from '~/app/utils';
+import { getStringValue, getIntValue } from '~/app/utils';
 import {
   UseCaseOptionValue,
   PerformancePropertyKey,
   EMPTY_CUSTOM_PROPERTY_VALUE,
+  COLD_START_SUB_TYPE,
 } from '~/concepts/modelCatalog/const';
 import { getUseCaseOption } from './workloadTypeUtils';
 
@@ -63,6 +64,60 @@ export const getWorkloadType = (artifact: CatalogPerformanceMetricsArtifact): st
     return EMPTY_CUSTOM_PROPERTY_VALUE;
   }
   return getUseCaseOption(useCaseEnum)?.label || EMPTY_CUSTOM_PROPERTY_VALUE;
+};
+
+export const isColdStartArtifact = (artifact: CatalogPerformanceMetricsArtifact): boolean =>
+  getStringValue(artifact.customProperties, PerformancePropertyKey.PERFORMANCE_SUB_TYPE) ===
+  COLD_START_SUB_TYPE;
+
+export const separatePerformanceArtifacts = (
+  artifacts: CatalogPerformanceMetricsArtifact[],
+): {
+  throughputArtifacts: CatalogPerformanceMetricsArtifact[];
+  coldStartArtifacts: CatalogPerformanceMetricsArtifact[];
+} => {
+  const throughputArtifacts: CatalogPerformanceMetricsArtifact[] = [];
+  const coldStartArtifacts: CatalogPerformanceMetricsArtifact[] = [];
+  artifacts.forEach((artifact) => {
+    if (isColdStartArtifact(artifact)) {
+      coldStartArtifacts.push(artifact);
+    } else {
+      throughputArtifacts.push(artifact);
+    }
+  });
+  return { throughputArtifacts, coldStartArtifacts };
+};
+
+/**
+ * Finds a matching cold-start artifact for a throughput artifact by GPU type.
+ * Matches on gpu_type from cold-start artifact against hardware_type or hardware_configuration
+ * from the throughput artifact.
+ */
+export const findMatchingColdStartArtifact = (
+  throughputArtifact: CatalogPerformanceMetricsArtifact,
+  coldStartArtifacts: CatalogPerformanceMetricsArtifact[],
+): CatalogPerformanceMetricsArtifact | undefined => {
+  const hwConfig = getStringValue(
+    throughputArtifact.customProperties,
+    PerformancePropertyKey.HARDWARE_CONFIGURATION,
+  );
+  const hwType = getStringValue(
+    throughputArtifact.customProperties,
+    PerformancePropertyKey.HARDWARE_TYPE,
+  );
+  const hwCount = getIntValue(
+    throughputArtifact.customProperties,
+    PerformancePropertyKey.HARDWARE_COUNT,
+  );
+
+  return coldStartArtifacts.find((cs) => {
+    const csGpuType = getStringValue(cs.customProperties, PerformancePropertyKey.GPU_TYPE);
+    const csGpuCount = getIntValue(cs.customProperties, PerformancePropertyKey.GPU_COUNT);
+
+    const typeMatches = hwConfig.includes(csGpuType) || csGpuType === hwType;
+    const countMatches = csGpuCount === 0 || hwCount === 0 || csGpuCount === hwCount;
+    return typeMatches && countMatches;
+  });
 };
 
 export const getSliderRange = ({

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -26,9 +26,17 @@ export enum ModelCatalogNumberFilterKey {
 export const PerformancePropertyKey = {
   HARDWARE_TYPE: 'hardware_type',
   HARDWARE_CONFIGURATION: 'hardware_configuration',
+  HARDWARE_COUNT: 'hardware_count',
   USE_CASE: 'use_case',
   REQUESTS_PER_SECOND: 'requests_per_second',
+  COLD_START_TIME_TO_LOAD_SECONDS: 'cold_start_time_to_load_seconds',
+  RUNTIME_COMMAND: 'runtime_command',
+  PERFORMANCE_SUB_TYPE: 'performance_sub_type',
+  GPU_TYPE: 'gpu_type',
+  GPU_COUNT: 'gpu_count',
 } as const;
+
+export const COLD_START_SUB_TYPE = 'cold-start';
 
 export type PerformancePropertyKeyType =
   (typeof PerformancePropertyKey)[keyof typeof PerformancePropertyKey];
@@ -273,7 +281,6 @@ export enum CatalogModelCustomPropertyKey {
   MODEL_TYPE = 'model_type',
   MODEL_SIZE = 'model_size',
   MINIMUM_VRAM = 'min_vram_gb',
-  HARDWARE_CONFIGURATIONS = 'cold_start_matrix',
   HARDWARE_TAG = 'hardware_tag',
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Cold start load time and runtime command are now read from separate cold-start performance artifacts (performance_sub_type: "cold-start") returned by the /performance_artifacts endpoint, instead of from the model-level cold_start_matrix custom property.
- Add separatePerformanceArtifacts/findMatchingColdStartArtifact utils
- Match cold-start artifacts to throughput rows by gpu_type/gpu_count
- Remove model-level HardwareConfiguration type and cold_start_matrix
- Centralize field names as PerformancePropertyKey constants
- Update BFF and frontend mock data to match backend response shape
<img width="853" height="267" alt="Screenshot 2026-06-15 at 8 13 20 PM" src="https://github.com/user-attachments/assets/cc0bd409-2c34-445e-a7d7-3dec0b428cbd" />
<img width="1055" height="185" alt="Screenshot 2026-06-15 at 8 43 15 PM" src="https://github.com/user-attachments/assets/b0a91801-78bc-45b1-901d-94b4591c4c7b" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
