### PR TITLE
Defer nextPageToken validation for recommended pagination path

### DIFF
--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -217,12 +217,24 @@ func (m *ModelCatalogServiceAPIService) FindLabels(ctx context.Context, assetTyp
 }
 
 func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommended bool, targetRPS int32, latencyProperty string, rpsProperty string, hardwareCountProperty string, hardwareTypeProperty string, sourceIDs []string, q string, sourceLabels []string, filterQuery string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	// Parse pageSize first, valid for both recommended and non-recommended paths.
-	// nextPageToken validation is deferred because the recommended path uses numeric
-	// offset tokens while the non-recommended path uses base64-encoded cursors.
-	pageSizeInt, err := parsePageSize(pageSize)
-	if err != nil {
-		return ErrorResponse(http.StatusBadRequest, err), err
+	// Validate pageSize and nextPageToken up-front. The recommended path uses numeric
+	// offset tokens; the non-recommended path uses base64-encoded DB cursors
+	// validated inside parsePaginationParams.
+	var pageSizeInt int32
+	var err error
+	if recommended {
+		pageSizeInt, err = parsePageSize(pageSize)
+		if err != nil {
+			return ErrorResponse(http.StatusBadRequest, err), err
+		}
+		if tokenErr := validateRecommendedNextPageToken(nextPageToken); tokenErr != nil {
+			return ErrorResponse(http.StatusBadRequest, tokenErr), tokenErr
+		}
+	} else {
+		pageSizeInt, err = parsePaginationParams(pageSize, nextPageToken)
+		if err != nil {
+			return ErrorResponse(http.StatusBadRequest, err), err
+		}
 	}
 
 	if len(sourceIDs) == 1 && sourceIDs[0] == "" {
@@ -301,13 +313,6 @@ func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommen
 		}
 
 		return Response(http.StatusOK, *models), nil
-	}
-
-	// Non-recommended path: validate nextPageToken as a base64-encoded cursor
-	if nextPageToken != "" {
-		if _, err := parsePaginationParams(pageSize, nextPageToken); err != nil {
-			return ErrorResponse(http.StatusBadRequest, err), err
-		}
 	}
 
 	// Existing logic for non-recommended sorting

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -217,8 +217,10 @@ func (m *ModelCatalogServiceAPIService) FindLabels(ctx context.Context, assetTyp
 }
 
 func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommended bool, targetRPS int32, latencyProperty string, rpsProperty string, hardwareCountProperty string, hardwareTypeProperty string, sourceIDs []string, q string, sourceLabels []string, filterQuery string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	// Validate pagination parameters
-	pageSizeInt, err := parsePaginationParams(pageSize, nextPageToken)
+	// Parse pageSize first, valid for both recommended and non-recommended paths.
+	// nextPageToken validation is deferred because the recommended path uses numeric
+	// offset tokens while the non-recommended path uses base64-encoded cursors.
+	pageSizeInt, err := parsePageSize(pageSize)
 	if err != nil {
 		return ErrorResponse(http.StatusBadRequest, err), err
 	}
@@ -299,6 +301,13 @@ func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommen
 		}
 
 		return Response(http.StatusOK, *models), nil
+	}
+
+	// Non-recommended path: validate nextPageToken as a base64-encoded cursor
+	if nextPageToken != "" {
+		if _, err := parsePaginationParams(pageSize, nextPageToken); err != nil {
+			return ErrorResponse(http.StatusBadRequest, err), err
+		}
 	}
 
 	// Existing logic for non-recommended sorting

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -2034,6 +2034,91 @@ func TestFindModelsRecommendedIgnoresOrderBy(t *testing.T) {
 	require.True(t, len(response.Items) > 0)
 }
 
+func TestFindModelsRecommendedWithNumericNextPageToken(t *testing.T) {
+	// Regression test: when recommended=true, FindModelsWithRecommendedLatency uses
+	// numeric offset tokens (e.g. "10") for pagination. The service must NOT validate
+	// these tokens as base64 cursors, which is the format used by DB-backed pagination.
+	sources := catalog.NewSourceCollection()
+	sources.Merge("",
+		map[string]catalog.ModelSource{
+			"source1": {CatalogSource: model.CatalogSource{Id: "source1", Name: "Test Source 1"}},
+		},
+	)
+
+	sourceLabels := catalog.NewLabelCollection()
+
+	provider := &mockModelProvider{
+		models: map[string]*model.CatalogModel{
+			"modelA": {Name: "Model A"},
+			"modelB": {Name: "Model B"},
+		},
+	}
+
+	service := NewModelCatalogServiceAPIService(provider, sources, nil, sourceLabels, nil)
+
+	resp, err := service.FindModels(
+		context.Background(),
+		true, // recommended
+		1,    // targetRPS
+		"ttft_p90",
+		"",
+		"",
+		"",
+		[]string{"source1"},
+		"",
+		[]string{""},
+		"",
+		"10",
+		model.ORDERBYFIELD_NAME,
+		model.SORTORDER_ASC,
+		"10", // numeric nextPageToken from FindModelsWithRecommendedLatency
+	)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	require.NoError(t, err)
+}
+
+func TestFindModelsNonRecommendedRejectsInvalidToken(t *testing.T) {
+	// When recommended=false, invalid nextPageToken should be rejected
+	sources := catalog.NewSourceCollection()
+	sources.Merge("",
+		map[string]catalog.ModelSource{
+			"source1": {CatalogSource: model.CatalogSource{Id: "source1", Name: "Test Source 1"}},
+		},
+	)
+
+	sourceLabels := catalog.NewLabelCollection()
+
+	provider := &mockModelProvider{
+		models: map[string]*model.CatalogModel{
+			"modelA": {Name: "Model A"},
+		},
+	}
+
+	service := NewModelCatalogServiceAPIService(provider, sources, nil, sourceLabels, nil)
+
+	resp, err := service.FindModels(
+		context.Background(),
+		false, // NOT recommended
+		0,
+		"",
+		"",
+		"",
+		"",
+		[]string{"source1"},
+		"",
+		[]string{""},
+		"",
+		"10",
+		model.ORDERBYFIELD_NAME,
+		model.SORTORDER_ASC,
+		"10", // invalid non-base64 token, it should be rejected
+	)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Error(t, err)
+}
+
 func TestGetAllModelPerformanceArtifactsWithConfigurableProperties(t *testing.T) {
 	artifact1Name := "performance-artifact-1"
 	artifact1 := model.CatalogArtifact{

--- a/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service_test.go
@@ -2034,10 +2034,7 @@ func TestFindModelsRecommendedIgnoresOrderBy(t *testing.T) {
 	require.True(t, len(response.Items) > 0)
 }
 
-func TestFindModelsRecommendedWithNumericNextPageToken(t *testing.T) {
-	// Regression test: when recommended=true, FindModelsWithRecommendedLatency uses
-	// numeric offset tokens (e.g. "10") for pagination. The service must NOT validate
-	// these tokens as base64 cursors, which is the format used by DB-backed pagination.
+func newTestServiceWithSources(models map[string]*model.CatalogModel) ModelCatalogServiceAPIServicer {
 	sources := catalog.NewSourceCollection()
 	sources.Merge("",
 		map[string]catalog.ModelSource{
@@ -2048,13 +2045,20 @@ func TestFindModelsRecommendedWithNumericNextPageToken(t *testing.T) {
 	sourceLabels := catalog.NewLabelCollection()
 
 	provider := &mockModelProvider{
-		models: map[string]*model.CatalogModel{
-			"modelA": {Name: "Model A"},
-			"modelB": {Name: "Model B"},
-		},
+		models: models,
 	}
 
-	service := NewModelCatalogServiceAPIService(provider, sources, nil, sourceLabels, nil)
+	return NewModelCatalogServiceAPIService(provider, sources, nil, sourceLabels, nil)
+}
+
+func TestFindModelsRecommendedWithNumericNextPageToken(t *testing.T) {
+	// Regression test: when recommended=true, FindModelsWithRecommendedLatency uses
+	// numeric offset tokens (e.g. "10") for pagination. The service must NOT validate
+	// these tokens as base64 cursors, which is the format used by DB-backed pagination.
+	service := newTestServiceWithSources(map[string]*model.CatalogModel{
+		"modelA": {Name: "Model A"},
+		"modelB": {Name: "Model B"},
+	})
 
 	resp, err := service.FindModels(
 		context.Background(),
@@ -2074,28 +2078,15 @@ func TestFindModelsRecommendedWithNumericNextPageToken(t *testing.T) {
 		"10", // numeric nextPageToken from FindModelsWithRecommendedLatency
 	)
 
-	assert.Equal(t, http.StatusOK, resp.Code)
 	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.Code)
 }
 
 func TestFindModelsNonRecommendedRejectsInvalidToken(t *testing.T) {
 	// When recommended=false, invalid nextPageToken should be rejected
-	sources := catalog.NewSourceCollection()
-	sources.Merge("",
-		map[string]catalog.ModelSource{
-			"source1": {CatalogSource: model.CatalogSource{Id: "source1", Name: "Test Source 1"}},
-		},
-	)
-
-	sourceLabels := catalog.NewLabelCollection()
-
-	provider := &mockModelProvider{
-		models: map[string]*model.CatalogModel{
-			"modelA": {Name: "Model A"},
-		},
-	}
-
-	service := NewModelCatalogServiceAPIService(provider, sources, nil, sourceLabels, nil)
+	service := newTestServiceWithSources(map[string]*model.CatalogModel{
+		"modelA": {Name: "Model A"},
+	})
 
 	resp, err := service.FindModels(
 		context.Background(),
@@ -2112,11 +2103,68 @@ func TestFindModelsNonRecommendedRejectsInvalidToken(t *testing.T) {
 		"10",
 		model.ORDERBYFIELD_NAME,
 		model.SORTORDER_ASC,
-		"10", // invalid non-base64 token, it should be rejected
+		"!!!not-base64", // definitively invalid base64 token
 	)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid nextPageToken")
+}
+
+func TestFindModelsRecommendedRejectsNonNumericToken(t *testing.T) {
+	service := newTestServiceWithSources(map[string]*model.CatalogModel{
+		"modelA": {Name: "Model A"},
+	})
+
+	resp, err := service.FindModels(
+		context.Background(),
+		true, // recommended
+		1,
+		"ttft_p90",
+		"",
+		"",
+		"",
+		[]string{"source1"},
+		"",
+		[]string{""},
+		"",
+		"10",
+		model.ORDERBYFIELD_NAME,
+		model.SORTORDER_ASC,
+		"abc", // non-numeric token must be rejected
+	)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid nextPageToken")
+}
+
+func TestFindModelsRecommendedRejectsOverflowToken(t *testing.T) {
+	service := newTestServiceWithSources(map[string]*model.CatalogModel{
+		"modelA": {Name: "Model A"},
+	})
+
+	resp, err := service.FindModels(
+		context.Background(),
+		true, // recommended
+		1,
+		"ttft_p90",
+		"",
+		"",
+		"",
+		[]string{"source1"},
+		"",
+		[]string{""},
+		"",
+		"10",
+		model.ORDERBYFIELD_NAME,
+		model.SORTORDER_ASC,
+		"9999999999999", // exceeds MaxInt32, must be rejected
+	)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid nextPageToken")
 }
 
 func TestGetAllModelPerformanceArtifactsWithConfigurableProperties(t *testing.T) {

--- a/catalog/internal/server/openapi/pagination.go
+++ b/catalog/internal/server/openapi/pagination.go
@@ -11,13 +11,15 @@ import (
 	"github.com/kubeflow/hub/internal/platform/db/scopes"
 )
 
+const defaultPageSize int32 = 10
+
 // parsePageSize validates and parses the pageSize parameter, returning the
-// page size as int32 (defaulting to 10 when empty). This is the single source
+// page size as int32 (defaulting to defaultPageSize when empty). This is the single source
 // of truth for pageSize validation, used by both parsePaginationParams and the
 // recommended path in FindModels.
 func parsePageSize(pageSize string) (int32, error) {
 	if pageSize == "" {
-		return 10, nil
+		return defaultPageSize, nil
 	}
 	parsed, err := strconv.ParseInt(pageSize, 10, 32)
 	if err != nil {
@@ -48,16 +50,15 @@ func parsePaginationParams(pageSize string, nextPageToken string) (int32, error)
 // path is a non-negative integer within the int32 range (0..2147483647).
 // The recommended path uses numeric offset tokens, unlike the non-recommended path
 // which uses base64-encoded DB cursors.
+// Using bitSize 31 in ParseUint ensures values >= 2^31 (i.e. > MaxInt32) are
+// rejected during parsing, eliminating the need for a separate range check.
 func validateRecommendedNextPageToken(nextPageToken string) error {
 	if nextPageToken == "" {
 		return nil
 	}
-	n, err := strconv.ParseUint(nextPageToken, 10, 32)
+	_, err := strconv.ParseUint(nextPageToken, 10, 31)
 	if err != nil {
 		return fmt.Errorf("invalid nextPageToken: must be a non-negative integer (0..%d), got %q: %w", math.MaxInt32, nextPageToken, err)
-	}
-	if n > math.MaxInt32 {
-		return fmt.Errorf("invalid nextPageToken: must be a non-negative integer (0..%d), got %q", math.MaxInt32, nextPageToken)
 	}
 	return nil
 }
@@ -78,7 +79,7 @@ func newPaginator[T model.Sortable](pageSize string, orderBy model.OrderByField,
 	}
 
 	p := &paginator[T]{
-		PageSize:  10, // Default page size
+		PageSize:  defaultPageSize,
 		OrderBy:   orderBy,
 		SortOrder: sortOrder,
 	}

--- a/catalog/internal/server/openapi/pagination.go
+++ b/catalog/internal/server/openapi/pagination.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -10,19 +11,30 @@ import (
 	"github.com/kubeflow/hub/internal/platform/db/scopes"
 )
 
+// parsePageSize validates and parses the pageSize parameter, returning the
+// page size as int32 (defaulting to 10 when empty). This is the single source
+// of truth for pageSize validation, used by both parsePaginationParams and the
+// recommended path in FindModels.
+func parsePageSize(pageSize string) (int32, error) {
+	if pageSize == "" {
+		return 10, nil
+	}
+	parsed, err := strconv.ParseInt(pageSize, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid pageSize: %w", err)
+	}
+	if parsed < 1 {
+		return 0, fmt.Errorf("pageSize must be at least 1, got %d", parsed)
+	}
+	return int32(parsed), nil
+}
+
 // parsePaginationParams validates and parses pageSize and nextPageToken for DB-backed endpoints.
 // It returns the page size as int32, or an error if either parameter is invalid.
 func parsePaginationParams(pageSize string, nextPageToken string) (int32, error) {
-	pageSizeInt := int32(10)
-	if pageSize != "" {
-		parsed, err := strconv.ParseInt(pageSize, 10, 32)
-		if err != nil {
-			return 0, fmt.Errorf("invalid pageSize: %w", err)
-		}
-		if parsed < 1 {
-			return 0, fmt.Errorf("pageSize must be at least 1, got %d", parsed)
-		}
-		pageSizeInt = int32(parsed)
+	pageSizeInt, err := parsePageSize(pageSize)
+	if err != nil {
+		return 0, err
 	}
 	if nextPageToken != "" {
 		if _, err := scopes.DecodeCursor(nextPageToken); err != nil {
@@ -32,21 +44,22 @@ func parsePaginationParams(pageSize string, nextPageToken string) (int32, error)
 	return pageSizeInt, nil
 }
 
-// parsePageSize validates and parses only the pageSize parameter, without validating nextPageToken.
-// Used by endpoints that handle their own pagination token format (e.g., in-memory offset-based pagination).
-func parsePageSize(pageSize string) (int32, error) {
-	pageSizeInt := int32(10)
-	if pageSize != "" {
-		parsed, err := strconv.ParseInt(pageSize, 10, 32)
-		if err != nil {
-			return 0, fmt.Errorf("invalid pageSize: %w", err)
-		}
-		if parsed < 1 {
-			return 0, fmt.Errorf("pageSize must be at least 1, got %d", parsed)
-		}
-		pageSizeInt = int32(parsed)
+// validateRecommendedNextPageToken validates that a nextPageToken for the recommended
+// path is a non-negative integer within the int32 range (0..2147483647).
+// The recommended path uses numeric offset tokens, unlike the non-recommended path
+// which uses base64-encoded DB cursors.
+func validateRecommendedNextPageToken(nextPageToken string) error {
+	if nextPageToken == "" {
+		return nil
 	}
-	return pageSizeInt, nil
+	n, err := strconv.ParseUint(nextPageToken, 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid nextPageToken: must be a non-negative integer (0..%d), got %q: %w", math.MaxInt32, nextPageToken, err)
+	}
+	if n > math.MaxInt32 {
+		return fmt.Errorf("invalid nextPageToken: must be a non-negative integer (0..%d), got %q", math.MaxInt32, nextPageToken)
+	}
+	return nil
 }
 
 type paginator[T model.Sortable] struct {

--- a/catalog/internal/server/openapi/pagination.go
+++ b/catalog/internal/server/openapi/pagination.go
@@ -32,6 +32,23 @@ func parsePaginationParams(pageSize string, nextPageToken string) (int32, error)
 	return pageSizeInt, nil
 }
 
+// parsePageSize validates and parses only the pageSize parameter, without validating nextPageToken.
+// Used by endpoints that handle their own pagination token format (e.g., in-memory offset-based pagination).
+func parsePageSize(pageSize string) (int32, error) {
+	pageSizeInt := int32(10)
+	if pageSize != "" {
+		parsed, err := strconv.ParseInt(pageSize, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("invalid pageSize: %w", err)
+		}
+		if parsed < 1 {
+			return 0, fmt.Errorf("pageSize must be at least 1, got %d", parsed)
+		}
+		pageSizeInt = int32(parsed)
+	}
+	return pageSizeInt, nil
+}
+
 type paginator[T model.Sortable] struct {
 	PageSize  int32
 	OrderBy   model.OrderByField

--- a/catalog/internal/server/openapi/pagination_test.go
+++ b/catalog/internal/server/openapi/pagination_test.go
@@ -1,11 +1,14 @@
 package openapi
 
 import (
+	"fmt"
+	"math"
 	"strconv"
 	"testing"
 
 	model "github.com/kubeflow/hub/catalog/pkg/openapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createCatalogSource(id int) model.CatalogSource {
@@ -262,6 +265,84 @@ func TestParsePaginationParams(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedSize, size)
+			}
+		})
+	}
+}
+
+func TestValidateRecommendedNextPageToken(t *testing.T) {
+	testCases := []struct {
+		name        string
+		token       string
+		expectError bool
+		errContains string
+	}{
+		{
+			name:        "empty token is valid",
+			token:       "",
+			expectError: false,
+		},
+		{
+			name:        "zero is valid",
+			token:       "0",
+			expectError: false,
+		},
+		{
+			name:        "positive integer is valid",
+			token:       "42",
+			expectError: false,
+		},
+		{
+			name:        "MaxInt32 is valid",
+			token:       strconv.Itoa(math.MaxInt32),
+			expectError: false,
+		},
+		{
+			name:        "non-numeric token is rejected",
+			token:       "abc",
+			expectError: true,
+			errContains: "invalid nextPageToken",
+		},
+		{
+			name:        "overflow token is rejected",
+			token:       "9999999999999",
+			expectError: true,
+			errContains: "invalid nextPageToken",
+		},
+		{
+			name:        "MaxInt32+1 is rejected",
+			token:       strconv.FormatInt(math.MaxInt32+1, 10),
+			expectError: true,
+			errContains: "invalid nextPageToken",
+		},
+		{
+			name:        "negative number is rejected",
+			token:       "-1",
+			expectError: true,
+			errContains: "invalid nextPageToken",
+		},
+		{
+			name:        "special characters are rejected",
+			token:       "!!!not-numeric",
+			expectError: true,
+			errContains: "invalid nextPageToken",
+		},
+		{
+			name:        "error message includes allowed range",
+			token:       "abc",
+			expectError: true,
+			errContains: fmt.Sprintf("0..%d", math.MaxInt32),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRecommendedNextPageToken(tc.token)
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix "Load more models" returning HTTP 500 when the Model Performance View is active (`recommended=true`).
**Root cause:** `FindModels` calls `parsePaginationParams()` , which validates `nextPageToken` as a base64-encoded cursor, **before** checking if `recommended=true`. However, `FindModelsWithRecommendedLatency` uses numeric offset tokens (e.g. `"10"`, `"20"`) for its in-memory pagination, not base64 cursors. When the frontend sends `nextPageToken=10` on the second page request, `base64.StdEncoding.DecodeString("10")` fails with `illegal base64 data`, returning 400 which the BFF converts to 500.

**Fix:** Introduce `parsePageSize()` that validates only `pageSize` without touching the token. `FindModels` now calls `parsePageSize()` upfront (valid for both paths), and defers `nextPageToken` base64 validation to the non-recommended path only. The recommended path passes the numeric token directly to `FindModelsWithRecommendedLatency`, which already handles it correctly via `strconv.Atoi()`.

This is related to the recent cold_start/min_vram work the new performance filters activate the `recommendations=true` path, which triggers this incompatible token validation on pagination.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added `TestFindModelsRecommendedWithNumericNextPageToken`: regression test verifying that `recommended=true` with a numeric `nextPageToken="10"` returns 200 (not 400/500)
- Added `TestFindModelsNonRecommendedRejectsInvalidToken`: verifies that `recommended=false` still correctly rejects invalid (non-base64) tokens with 400
- All existing catalog tests pass

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
