### PR TITLE
feat: set NextProtos (ALPN) on HTTP TLS configs

### DIFF
--- a/clients/ui/bff/cmd/main.go
+++ b/clients/ui/bff/cmd/main.go
@@ -101,6 +101,7 @@ func main() {
 			// Configure TLS if both cert and key files are provided
 			tlsConfig := &tls.Config{
 				MinVersion: tls.VersionTLS13,
+				NextProtos: []string{"h2", "http/1.1"},
 			}
 			srv.TLSConfig = tlsConfig
 			err = srv.ListenAndServeTLS(certFile, keyFile)

--- a/clients/ui/bff/internal/integrations/httpclient/http.go
+++ b/clients/ui/bff/internal/integrations/httpclient/http.go
@@ -43,13 +43,18 @@ func (e *HTTPError) Error() string {
 }
 
 func NewHTTPClient(logger *slog.Logger, baseURL string, headers http.Header, insecureSkipVerify bool, rootCAs *x509.CertPool) (HTTPClientInterface, error) {
-	tlsCfg := &tls.Config{InsecureSkipVerify: insecureSkipVerify}
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify,
+		MinVersion:         tls.VersionTLS12,
+		NextProtos:         []string{"h2", "http/1.1"},
+	}
 	if rootCAs != nil {
 		tlsCfg.RootCAs = rootCAs
 	}
 	return &HTTPClient{
 		client: &http.Client{Transport: &http.Transport{
-			TLSClientConfig: tlsCfg,
+			ForceAttemptHTTP2: true,
+			TLSClientConfig:   tlsCfg,
 		}},
 		baseURL: baseURL,
 		logger:  logger,

--- a/pkg/inferenceservice-controller/controller.go
+++ b/pkg/inferenceservice-controller/controller.go
@@ -48,13 +48,15 @@ func NewInferenceServiceController(
 	serviceURLAnnotation,
 	defaultMRNamespace string,
 ) *InferenceServiceController {
-	httpClient := http.DefaultClient
-
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if skipTLSVerify {
-		httpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			NextProtos:         []string{"h2", "http/1.1"},
 		}
 	}
+	httpClient := &http.Client{Transport: transport}
 
 	return &InferenceServiceController{
 		client:                        client,


### PR DESCRIPTION
## Summary
- Add explicit ALPN negotiation (`h2`, `http/1.1`) to all HTTP-facing TLS configurations
- BFF server TLS, BFF outbound HTTP client, InferenceService controller HTTP client
- Ensures proper HTTP/2 negotiation on OpenShift clusters where ALPN is required by the serving infrastructure

The generic `BuildTLSConfig()` in `internal/platform/tls/config.go` is intentionally NOT modified since it is shared with database connectors (MySQL, PostgreSQL) that do not use HTTP ALPN negotiation.

## Files changed
- `clients/ui/bff/cmd/main.go`: BFF server TLS config
- `clients/ui/bff/internal/integrations/httpclient/http.go`: BFF outbound HTTP client
- `pkg/inferenceservice-controller/controller.go`: InferenceService controller HTTP client

## Test plan
- [ ] Verify BFF server negotiates HTTP/2 via ALPN when TLS is enabled
- [ ] Verify BFF outbound HTTP client includes ALPN in TLS handshake
- [ ] Verify InferenceService controller HTTP client includes ALPN in TLS handshake
- [ ] Confirm database connections (MySQL, PostgreSQL) are not affected