### PR TITLE
feat(ui): resolve hardware configs from cold-start artifacts and filter query OR clause

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
@@ -380,7 +380,7 @@ describe('Model Catalog Performance Filters API Behavior', () => {
       });
     });
 
-    it('should NOT include min_vram_gb after toggle is turned OFF', () => {
+    it('should still include min_vram_gb after toggle is turned OFF (basic filter)', () => {
       visitWithPerformanceToggle(true);
 
       cy.findByTestId('minimum-vram-filter').scrollIntoView();
@@ -390,17 +390,17 @@ describe('Model Catalog Performance Filters API Behavior', () => {
       modelCatalog.togglePerformanceView();
       modelCatalog.findLoadingState().should('not.exist');
 
-      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithoutVram');
+      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithVram');
 
       triggerFilterRefresh();
 
-      cy.wait('@getModelsWithoutVram').then((interception) => {
+      cy.wait('@getModelsWithVram').then((interception) => {
         const decodedUrl = decodeURIComponent(interception.request.url);
-        expect(decodedUrl).to.not.include('min_vram_gb');
+        expect(decodedUrl).to.include('min_vram_gb');
       });
     });
 
-    it('should NOT include modelcar_image_size after toggle is turned OFF', () => {
+    it('should still include modelcar_image_size after toggle is turned OFF (basic filter)', () => {
       visitWithPerformanceToggle(true);
 
       cy.findByTestId('container-size-filter').scrollIntoView();
@@ -410,13 +410,13 @@ describe('Model Catalog Performance Filters API Behavior', () => {
       modelCatalog.togglePerformanceView();
       modelCatalog.findLoadingState().should('not.exist');
 
-      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithoutContainerSize');
+      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithContainerSize');
 
       triggerFilterRefresh();
 
-      cy.wait('@getModelsWithoutContainerSize').then((interception) => {
+      cy.wait('@getModelsWithContainerSize').then((interception) => {
         const decodedUrl = decodeURIComponent(interception.request.url);
-        expect(decodedUrl).to.not.include('modelcar_image_size');
+        expect(decodedUrl).to.include('modelcar_image_size');
       });
     });
   });

--- a/clients/ui/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
+++ b/clients/ui/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
@@ -136,8 +136,6 @@ function useModelCatalogSetup(providerState: CatalogProviderState) {
     baseSetFilterData(ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION, []);
     baseSetFilterData(ModelCatalogNumberFilterKey.MAX_RPS, undefined);
     baseSetFilterData(ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME, undefined);
-    baseSetFilterData(ModelCatalogNumberFilterKey.MIN_VRAM, undefined);
-    baseSetFilterData(ModelCatalogNumberFilterKey.IMAGE_SIZE, undefined);
 
     // Then apply all defaults from namedQueries
     const defaultQuery = filterOptions?.namedQueries?.[DEFAULT_PERFORMANCE_FILTERS_QUERY_NAME];
@@ -161,6 +159,8 @@ function useModelCatalogSetup(providerState: CatalogProviderState) {
     baseSetFilterData(ModelCatalogStringFilterKey.LANGUAGE, []);
     baseSetFilterData(ModelCatalogStringFilterKey.TENSOR_TYPE, []);
     baseSetFilterData(ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION, []);
+    baseSetFilterData(ModelCatalogNumberFilterKey.MIN_VRAM, undefined);
+    baseSetFilterData(ModelCatalogNumberFilterKey.IMAGE_SIZE, undefined);
   }, [baseSetFilterData]);
 
   /**

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -133,6 +133,12 @@ export type PerformanceMetricsCustomProperties = {
   // Computed properties when targetRPS is provided
   replicas?: ModelRegistryCustomPropertyInt;
   total_requests_per_second?: ModelRegistryCustomPropertyDouble;
+  // Cold-start sub-type fields (returned by API with metricsType "performance-metrics")
+  performance_sub_type?: ModelRegistryCustomPropertyString;
+  gpu_type?: ModelRegistryCustomPropertyString;
+  gpu_count?: ModelRegistryCustomPropertyInt;
+  cold_start_time_to_load_seconds?: ModelRegistryCustomPropertyDouble;
+  runtime_command?: ModelRegistryCustomPropertyString;
 } & Partial<Record<LatencyPropertyKey, ModelRegistryCustomPropertyDouble>>;
 
 export type AccuracyMetricsCustomProperties = {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
@@ -5,7 +5,10 @@ import { ColumnsIcon } from '@patternfly/react-icons';
 import { OuterScrollContainer } from '@patternfly/react-table';
 import { CatalogPerformanceMetricsArtifact, HardwareConfiguration } from '~/app/modelCatalogTypes';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
-import { getActiveLatencyFieldName } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import {
+  getActiveLatencyFieldName,
+  findMatchingHardwareConfig,
+} from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { getStringValue } from '~/app/utils';
 import { SortOrder, PerformancePropertyKey } from '~/concepts/modelCatalog/const';
 import {
@@ -128,15 +131,20 @@ const HardwareConfigurationTable: React.FC<HardwareConfigurationTableProps> = ({
               artifact.customProperties,
               PerformancePropertyKey.HARDWARE_TYPE,
             );
-            const matched = hardwareConfigurations?.find(
-              (c) => hwConfig.startsWith(c.gpu_type) || c.gpu_type === hwType,
-            );
+            const hwCount = artifact.customProperties?.hardware_count?.int_value
+              ? parseInt(artifact.customProperties.hardware_count.int_value, 10)
+              : 1;
             return (
               <HardwareConfigurationTableRow
                 key={artifact.customProperties?.config_id?.string_value}
                 performanceArtifact={artifact}
                 columns={columns}
-                matchedHardwareConfig={matched}
+                matchedHardwareConfig={findMatchingHardwareConfig(
+                  hardwareConfigurations ?? [],
+                  hwConfig,
+                  hwType,
+                  hwCount,
+                )}
               />
             );
           }}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -13,7 +13,7 @@ import { Link } from 'react-router-dom';
 import { HelpIcon, AngleLeftIcon, AngleRightIcon, ArrowRightIcon } from '@patternfly/react-icons';
 import { TruncatedText } from 'mod-arch-shared';
 import type { CatalogSource } from '~/app/shared/types/catalogTypes';
-import type { CatalogModel, HardwareConfiguration } from '~/app/modelCatalogTypes';
+import type { CatalogModel } from '~/app/modelCatalogTypes';
 import {
   extractValidatedModelMetrics,
   getLatencyValue,
@@ -32,23 +32,13 @@ import { useCatalogPerformanceArtifacts } from '~/app/hooks/modelCatalog/useCata
 import {
   getActiveLatencyFieldName,
   stripArtifactsPrefix,
-  getHardwareConfigurationsFromCustomProperties,
+  filterRegularPerformanceArtifacts,
+  findMatchingHardwareConfig,
+  resolveHardwareConfigurations,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { formatLatency } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { useNotification } from '~/app/hooks/useNotification';
-
-const findMatchedColdStart = (
-  customProperties: CatalogModel['customProperties'],
-  hwConfig: string,
-  hwType: string,
-): number | undefined => {
-  const configs = getHardwareConfigurationsFromCustomProperties(customProperties);
-  const match = configs.find(
-    (c: HardwareConfiguration) => hwConfig.startsWith(c.gpu_type) || c.gpu_type === hwType,
-  );
-  return match?.cold_start_time_to_load_seconds;
-};
 
 type ModelCatalogCardBodyProps = {
   model: CatalogModel;
@@ -109,8 +99,16 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
       isValidated, // Only fetch if validated
     );
 
-  // Performance artifacts are already filtered by the server endpoint
-  const performanceMetrics = performanceArtifactsList.items;
+  // Separate cold-start artifacts from regular performance artifacts
+  const performanceMetrics = React.useMemo(
+    () => filterRegularPerformanceArtifacts(performanceArtifactsList.items),
+    [performanceArtifactsList.items],
+  );
+
+  const hardwareConfigurations = React.useMemo(
+    () => resolveHardwareConfigurations(performanceArtifactsList.items, model.customProperties),
+    [performanceArtifactsList.items, model.customProperties],
+  );
 
   // NOTE: Accuracy metrics are not currently returned by the /performance_artifacts endpoint.
   // This is kept as a placeholder for when accuracy metrics support is restored.
@@ -215,11 +213,13 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
       ? parseLatencyFilterKey(activeLatencyField).metric
       : LatencyMetric.TTFT;
 
-    const matchedColdStart = findMatchedColdStart(
-      model.customProperties,
+    const matchedConfig = findMatchingHardwareConfig(
+      hardwareConfigurations,
       metrics.hardwareConfiguration,
       metrics.hardwareType,
+      parseInt(metrics.hardwareCount, 10) || 1,
     );
+    const matchedColdStart = matchedConfig?.cold_start_time_to_load_seconds;
 
     return (
       <Stack hasGutter>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
@@ -29,7 +29,8 @@ import {
 import {
   decodeParams,
   getActiveLatencyFieldName,
-  getHardwareConfigurationsFromCustomProperties,
+  filterRegularPerformanceArtifacts,
+  resolveHardwareConfigurations,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { getDefaultFiltersFromNamedQuery } from '~/app/pages/modelCatalog/utils/performanceFilterUtils';
 import TensorTypeComparisonCard from './TensorTypeComparisonCard';
@@ -130,9 +131,14 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
     model.name,
   ]);
 
+  const regularPerformanceArtifacts = React.useMemo(
+    () => filterRegularPerformanceArtifacts(performanceArtifacts.items),
+    [performanceArtifacts.items],
+  );
+
   const hardwareConfigurations = React.useMemo(
-    () => getHardwareConfigurationsFromCustomProperties(model.customProperties),
-    [model.customProperties],
+    () => resolveHardwareConfigurations(performanceArtifacts.items, model.customProperties),
+    [performanceArtifacts.items, model.customProperties],
   );
 
   if (performanceArtifactsError) {
@@ -168,7 +174,7 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
               </FlexItem>
               <FlexItem>
                 <HardwareConfigurationTable
-                  performanceArtifacts={performanceArtifacts.items}
+                  performanceArtifacts={regularPerformanceArtifacts}
                   hardwareConfigurations={hardwareConfigurations}
                   isLoading={!performanceArtifactsLoaded && performanceArtifacts.items.length === 0}
                   onSortChange={setTableSort}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -257,39 +257,41 @@ describe('filtersToFilterQuery', () => {
     });
 
     it('handles a single array of a single data point', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT] }),
           mockFilterOptions,
         ),
-      ).toBe("tasks='text-to-text'");
+      ).toBe(`tasks='text-to-text'${orSuffix}`);
       expect(
         filtersToFilterQuery(
           mockFormData({ provider: [ModelCatalogProvider.GOOGLE] }),
           mockFilterOptions,
         ),
-      ).toBe("provider='Google'");
+      ).toBe(`provider='Google'${orSuffix}`);
       expect(
         filtersToFilterQuery(mockFormData({ license: ['Apache 2.0'] }), mockFilterOptions),
-      ).toBe("license='Apache 2.0'");
+      ).toBe(`license='Apache 2.0'${orSuffix}`);
       expect(
         filtersToFilterQuery(mockFormData({ language: [AllLanguageCode.CA] }), mockFilterOptions),
-      ).toBe("language='ca'");
+      ).toBe(`language='ca'${orSuffix}`);
       expect(
         filtersToFilterQuery(
           mockFormData({ use_case: [UseCaseOptionValue.CHATBOT] }),
           mockFilterOptions,
         ),
-      ).toBe("artifacts.use_case.string_value='chatbot'");
+      ).toBe(`artifacts.use_case.string_value='chatbot'${orSuffix}`);
       expect(
         filtersToFilterQuery(
           mockFormData({ tensor_type: [ModelCatalogTensorType.FP16] }),
           mockFilterOptions,
         ),
-      ).toBe("tensor_type.string_value='FP16'");
+      ).toBe(`tensor_type.string_value='FP16'${orSuffix}`);
     });
 
     it('handles multiple arrays of a single data point', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -298,47 +300,48 @@ describe('filtersToFilterQuery', () => {
           }),
           mockFilterOptions,
         ),
-      ).toBe("tasks='text-to-text' AND license='Apache 2.0'");
+      ).toBe(`tasks='text-to-text' AND license='Apache 2.0'${orSuffix}`);
       expect(
         filtersToFilterQuery(
           mockFormData({ provider: [ModelCatalogProvider.GOOGLE], language: [AllLanguageCode.CA] }),
           mockFilterOptions,
         ),
-      ).toBe("provider='Google' AND language='ca'");
+      ).toBe(`provider='Google' AND language='ca'${orSuffix}`);
     });
 
     it('handles a single array with multiple data points', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT, ModelCatalogTask.IMAGE_TO_TEXT] }),
           mockFilterOptions,
         ),
-      ).toBe("tasks IN ('text-to-text','image-to-text')");
+      ).toBe(`tasks IN ('text-to-text','image-to-text')${orSuffix}`);
       expect(
         filtersToFilterQuery(
           mockFormData({ provider: [ModelCatalogProvider.GOOGLE, ModelCatalogProvider.DEEPSEEK] }),
           mockFilterOptions,
         ),
-      ).toBe("provider IN ('Google','DeepSeek')");
+      ).toBe(`provider IN ('Google','DeepSeek')${orSuffix}`);
       expect(
         filtersToFilterQuery(mockFormData({ license: ['Apache 2.0', 'MIT'] }), mockFilterOptions),
-      ).toBe("license IN ('Apache 2.0','MIT')");
+      ).toBe(`license IN ('Apache 2.0','MIT')${orSuffix}`);
       expect(
         filtersToFilterQuery(
           mockFormData({ language: [AllLanguageCode.CA, AllLanguageCode.PT] }),
           mockFilterOptions,
         ),
-      ).toBe("language IN ('ca','pt')");
+      ).toBe(`language IN ('ca','pt')${orSuffix}`);
       expect(
         filtersToFilterQuery(
           mockFormData({ tensor_type: [ModelCatalogTensorType.FP16, ModelCatalogTensorType.FP8] }),
           mockFilterOptions,
         ),
-      ).toBe("tensor_type.string_value IN ('FP16','FP8')");
-      // Note: use_case is now single-select, so multi-select test is not applicable
+      ).toBe(`tensor_type.string_value IN ('FP16','FP8')${orSuffix}`);
     });
 
     it('handles all tensor type enum values', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -352,10 +355,11 @@ describe('filtersToFilterQuery', () => {
           }),
           mockFilterOptions,
         ),
-      ).toBe("tensor_type.string_value IN ('FP16','FP8','INT4','INT8','MXFP4')");
+      ).toBe(`tensor_type.string_value IN ('FP16','FP8','INT4','INT8','MXFP4')${orSuffix}`);
     });
 
     it('handles multiple arrays with mixed count of data points', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -372,11 +376,12 @@ describe('filtersToFilterQuery', () => {
           mockFilterOptions,
         ),
       ).toBe(
-        "tasks IN ('text-to-text','image-to-text') AND provider='Google' AND license='MIT' AND language IN ('ca','pt','vi','zsm')",
+        `tasks IN ('text-to-text','image-to-text') AND provider='Google' AND license='MIT' AND language IN ('ca','pt','vi','zsm')${orSuffix}`,
       );
     });
 
     it('handles tensor type combined with other basic filters', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -387,28 +392,31 @@ describe('filtersToFilterQuery', () => {
           mockFilterOptions,
         ),
       ).toBe(
-        "tasks='text-to-text' AND provider='Google' AND tensor_type.string_value IN ('FP16','INT8')",
+        `tasks='text-to-text' AND provider='Google' AND tensor_type.string_value IN ('FP16','INT8')${orSuffix}`,
       );
     });
   });
 
   describe('match-all (AND logic) filters', () => {
     it('handles a single validated configuration value', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(mockFormData({ validatedTasks: ['tool-calling'] }), mockFilterOptions),
-      ).toBe("validated_tasks='tool-calling'");
+      ).toBe(`validated_tasks='tool-calling'${orSuffix}`);
     });
 
     it('handles multiple validated configuration values with AND logic instead of IN', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({ validatedTasks: ['tool-calling', 'text-generation'] }),
           mockFilterOptions,
         ),
-      ).toBe("validated_tasks='tool-calling' AND validated_tasks='text-generation'");
+      ).toBe(`validated_tasks='tool-calling' AND validated_tasks='text-generation'${orSuffix}`);
     });
 
     it('handles validated configuration combined with other OR-logic filters', () => {
+      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -419,7 +427,7 @@ describe('filtersToFilterQuery', () => {
           mockFilterOptions,
         ),
       ).toBe(
-        "tasks IN ('text-to-text','image-to-text') AND provider='Google' AND validated_tasks='tool-calling' AND validated_tasks='text-generation'",
+        `tasks IN ('text-to-text','image-to-text') AND provider='Google' AND validated_tasks='tool-calling' AND validated_tasks='text-generation'${orSuffix}`,
       );
     });
   });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -8,6 +8,7 @@ import {
   CatalogModel,
   CatalogModelArtifact,
   CatalogModelDetailsParams,
+  CatalogPerformanceMetricsArtifact,
   HardwareConfiguration,
   MetricsType,
   ModelCatalogFilterStates,
@@ -338,6 +339,8 @@ export type FilterQueryTarget = 'models' | 'artifacts';
  * Determines if a filter should be included based on the target endpoint.
  * - For models: Include all filters except RPS (which is passed as a separate param)
  * - For artifacts: Only include filters that have the artifacts.* prefix
+ * Cold-start load time is excluded from the main AND clause for both targets;
+ * it is placed in the OR clause via buildColdStartOrClause.
  */
 const shouldIncludeFilter = (filterId: string, target: FilterQueryTarget): boolean => {
   // RPS is always passed as a separate param, not in filterQuery
@@ -345,14 +348,13 @@ const shouldIncludeFilter = (filterId: string, target: FilterQueryTarget): boole
     return false;
   }
 
-  // Cold-start filter is excluded from the performance artifacts endpoint
-  // (performance-metrics artifacts don't have this field — it's on cold-start-metrics artifacts).
-  if (filterId === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME && target === 'artifacts') {
+  // Cold-start filter is excluded from the main AND clause for both targets.
+  // It is placed in the OR clause via buildColdStartOrClause.
+  if (filterId === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME) {
     return false;
   }
 
   if (target === 'models') {
-    // For models, include all filters (except RPS and cold-start which are already excluded)
     return true;
   }
 
@@ -440,7 +442,43 @@ export const filtersToFilterQuery = (
     .map(([filterId, data]) => serializeFilterEntry(filterId, data, options, target));
 
   const nonEmptyFilters = serializedFilters.filter((v) => !!v);
-  return nonEmptyFilters.length === 0 ? '' : nonEmptyFilters.join(' AND ');
+  if (nonEmptyFilters.length === 0) {
+    return '';
+  }
+
+  const baseQuery = nonEmptyFilters.join(' AND ');
+  const coldStartClause = buildColdStartOrClause(filterData, options, target);
+  return `${baseQuery} OR ${coldStartClause}`;
+};
+
+/**
+ * Builds the OR clause for cold-start artifacts in the filter query.
+ * Always includes `performance_sub_type.string_value='cold-start'`.
+ * If a cold start load time filter is active, appends it as an AND condition.
+ * Uses the appropriate key format based on target (with artifacts.* prefix for models, stripped for artifacts).
+ */
+const buildColdStartOrClause = (
+  filterData: ModelCatalogFilterStates,
+  options: CatalogFilterOptionsList,
+  target: FilterQueryTarget,
+): string => {
+  const subTypePrefix = target === 'models' ? 'artifacts.' : '';
+  const subTypeFilter = `${subTypePrefix}performance_sub_type.string_value='cold-start'`;
+  const coldStartValue = filterData[ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME];
+
+  if (coldStartValue === undefined || typeof coldStartValue !== 'number') {
+    return subTypeFilter;
+  }
+
+  const operator = getNumericFilterOperator(
+    options,
+    ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME,
+  );
+  const coldStartKey =
+    target === 'models'
+      ? ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME
+      : stripArtifactsPrefix(ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME);
+  return `${subTypeFilter} AND ${coldStartKey} ${operator} ${coldStartValue}`;
 };
 
 /**
@@ -623,4 +661,73 @@ export const getHardwareConfigurationsFromCustomProperties = (
   } catch {
     return [];
   }
+};
+
+/**
+ * Identifies whether a performance artifact is a cold-start sub-type.
+ */
+export const isColdStartArtifact = (artifact: CatalogPerformanceMetricsArtifact): boolean => {
+  const subType = artifact.customProperties?.performance_sub_type;
+  return (
+    subType?.metadataType === ModelRegistryMetadataType.STRING &&
+    subType.string_value === 'cold-start'
+  );
+};
+
+/**
+ * Extracts HardwareConfiguration[] from cold-start performance artifacts.
+ * Cold-start artifacts are identified by `performance_sub_type === "cold-start"` in customProperties
+ * and contain gpu_type, gpu_count, cold_start_time_to_load_seconds, and runtime_command.
+ */
+export const getHardwareConfigurationsFromArtifacts = (
+  artifacts: CatalogPerformanceMetricsArtifact[],
+): HardwareConfiguration[] =>
+  artifacts.filter(isColdStartArtifact).map((artifact) => {
+    const props = artifact.customProperties;
+    return {
+      // eslint-disable-next-line camelcase
+      gpu_type: props?.gpu_type?.string_value ?? '',
+      // eslint-disable-next-line camelcase
+      gpu_count: props?.gpu_count?.int_value ? parseInt(props.gpu_count.int_value, 10) : 0,
+      // eslint-disable-next-line camelcase
+      cold_start_time_to_load_seconds: props?.cold_start_time_to_load_seconds?.double_value ?? 0,
+      // eslint-disable-next-line camelcase
+      runtime_command: props?.runtime_command?.string_value ?? '',
+    };
+  });
+
+/**
+ * Filters out cold-start artifacts, returning only regular performance artifacts.
+ */
+export const filterRegularPerformanceArtifacts = (
+  artifacts: CatalogPerformanceMetricsArtifact[],
+): CatalogPerformanceMetricsArtifact[] => artifacts.filter((a) => !isColdStartArtifact(a));
+
+/**
+ * Finds the matching HardwareConfiguration for a given hardware description.
+ * Requires an exact match on both gpu_type and gpu_count; returns undefined otherwise.
+ */
+export const findMatchingHardwareConfig = (
+  configs: HardwareConfiguration[],
+  hwConfig: string,
+  hwType: string,
+  hwCount: number,
+): HardwareConfiguration | undefined =>
+  configs.find(
+    (c) => (hwConfig.startsWith(c.gpu_type) || c.gpu_type === hwType) && c.gpu_count === hwCount,
+  );
+
+/**
+ * Resolves hardware configurations from performance artifacts (cold-start sub-type),
+ * falling back to the model's customProperties when no artifact-based configs exist.
+ */
+export const resolveHardwareConfigurations = (
+  artifacts: CatalogPerformanceMetricsArtifact[],
+  customProperties?: ModelRegistryCustomProperties,
+): HardwareConfiguration[] => {
+  const fromArtifacts = getHardwareConfigurationsFromArtifacts(artifacts);
+  if (fromArtifacts.length > 0) {
+    return fromArtifacts;
+  }
+  return getHardwareConfigurationsFromCustomProperties(customProperties);
 };


### PR DESCRIPTION
## Summary

- Adds cold-start sub-type fields (`performance_sub_type`, `gpu_type`, `gpu_count`, `cold_start_time_to_load_seconds`, `runtime_command`) to `PerformanceMetricsCustomProperties` type
- Builds an OR clause in `filtersToFilterQuery` so the backend always returns cold-start artifacts alongside regular performance artifacts
- Introduces `resolveHardwareConfigurations` to extract hardware configs from cold-start artifacts, falling back to model `customProperties`
- Introduces `findMatchingHardwareConfig` to correlate performance rows to hardware configs by exact `gpu_type` + `gpu_count` match (returns `-` when no match)
- Filters cold-start entries out of the regular performance table via `filterRegularPerformanceArtifacts`
- Removes unused `HardwareConfiguration` import from `ModelCatalogCardBody`

## How Has This Been Tested?

- Updated unit tests for `filtersToFilterQuery` to verify the OR clause is appended
- Manual verification against dev environment with cold-start artifacts present

## Test Impact

Unit tests updated in `modelCatalogUtils.spec.ts`.

Made with [Cursor](https://cursor.com)