### PR TITLE
Fix the cold start filtering from being passed when the performance toggle is off

### DIFF
--- a/clients/ui/frontend/src/app/api/modelCatalog/service.ts
+++ b/clients/ui/frontend/src/app/api/modelCatalog/service.ts
@@ -40,7 +40,9 @@ export const getCatalogModelsBySource =
   ): Promise<CatalogModelList> => {
     const computedFilterQuery =
       filterQuery ??
-      (filterData && filterOptions ? filtersToFilterQuery(filterData, filterOptions) : '');
+      (filterData && filterOptions
+        ? filtersToFilterQuery(filterData, filterOptions, 'models', !!performanceParams)
+        : '');
 
     const allParams = {
       source: sourceId,

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -491,6 +491,44 @@ describe('filtersToFilterQuery', () => {
       expect(query).toContain('modelcar_image_size.double_value <= 10');
     });
   });
+
+  describe('includeColdStartClause parameter', () => {
+    it('does not append cold-start OR clause when includeColdStartClause is false', () => {
+      const query = filtersToFilterQuery(
+        mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT] }),
+        mockFilterOptions,
+        'models',
+        false,
+      );
+      expect(query).toBe("tasks='text-to-text'");
+      expect(query).not.toContain('performance_sub_type');
+      expect(query).not.toContain('cold-start');
+    });
+
+    it('appends cold-start OR clause when includeColdStartClause is true (default)', () => {
+      const query = filtersToFilterQuery(
+        mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT] }),
+        mockFilterOptions,
+        'models',
+        true,
+      );
+      expect(query).toContain("OR artifacts.performance_sub_type.string_value='cold-start'");
+    });
+
+    it('does not append cold-start OR clause with multiple basic filters when performance is off', () => {
+      const query = filtersToFilterQuery(
+        mockFormData({
+          tasks: [ModelCatalogTask.TEXT_TO_TEXT],
+          provider: [ModelCatalogProvider.GOOGLE],
+        }),
+        mockFilterOptions,
+        'models',
+        false,
+      );
+      expect(query).toBe("tasks='text-to-text' AND provider='Google'");
+      expect(query).not.toContain('performance_sub_type');
+    });
+  });
 });
 
 describe('catalog source filtering utilities', () => {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -429,6 +429,8 @@ const serializeFilterEntry = (
  * @param target - The target endpoint:
  *   - 'models': Include all filters (except RPS), use filter keys directly
  *   - 'artifacts': Only include artifact-prefixed filters, strip the prefix in output
+ * @param includeColdStartClause - Whether to append the cold-start OR clause.
+ *   Should be true only when performance view is enabled.
  *
  * Note: RPS is NOT included in filterQuery for either target - it's passed as targetRPS param.
  */
@@ -436,6 +438,7 @@ export const filtersToFilterQuery = (
   filterData: ModelCatalogFilterStates,
   options: CatalogFilterOptionsList,
   target: FilterQueryTarget = 'models',
+  includeColdStartClause = true,
 ): string => {
   const serializedFilters: string[] = Object.entries(filterData)
     .filter(([filterId]) => shouldIncludeFilter(filterId, target))
@@ -447,6 +450,11 @@ export const filtersToFilterQuery = (
   }
 
   const baseQuery = nonEmptyFilters.join(' AND ');
+
+  if (!includeColdStartClause) {
+    return baseQuery;
+  }
+
   const coldStartClause = buildColdStartOrClause(filterData, options, target);
   return `${baseQuery} OR ${coldStartClause}`;
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to fix the cold start filters being sent to models endpoint when the performance toggle is off

## How Has This Been Tested?
run the application and apply any basic filters and see the cold start filters are not being sent

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
