### PR TITLE
fix(ui): replace OuterScrollContainer with InnerScrollContainer for hardware config table

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DashboardEmptyTableView, Table, ManageColumnsModal } from 'mod-arch-shared';
 import { Button, Spinner } from '@patternfly/react-core';
 import { ColumnsIcon } from '@patternfly/react-icons';
-import { OuterScrollContainer } from '@patternfly/react-table';
+import { InnerScrollContainer } from '@patternfly/react-table';
 import { CatalogPerformanceMetricsArtifact, HardwareConfiguration } from '~/app/modelCatalogTypes';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { getActiveLatencyFieldName } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
@@ -106,15 +106,13 @@ const HardwareConfigurationTable: React.FC<HardwareConfigurationTableProps> = ({
 
   return (
     <>
-      <OuterScrollContainer>
+      {toolbarContent}
+      <InnerScrollContainer>
         <Table
           data-testid="hardware-configuration-table"
           variant="compact"
-          isStickyHeader
-          hasStickyColumns
           data={performanceArtifacts}
           columns={columns}
-          toolbarContent={toolbarContent}
           onClearFilters={handleClearFilters}
           {...(hasActiveSort ? { defaultSortColumn: sortIndex } : {})}
           {...controlledSortProps}
@@ -141,7 +139,7 @@ const HardwareConfigurationTable: React.FC<HardwareConfigurationTableProps> = ({
             );
           }}
         />
-      </OuterScrollContainer>
+      </InnerScrollContainer>
       <ManageColumnsModal
         manageColumnsResult={manageColumnsResult}
         description="Manage the columns that appear in the hardware configuration table."


### PR DESCRIPTION
## Summary

- Replaces `OuterScrollContainer` with `InnerScrollContainer` from `@patternfly/react-table` to fix missing table headers
- Removes `isStickyHeader` and `hasStickyColumns` props that were conflicting with the `mod-arch-shared` Table component
- Renders toolbar/filters outside the scroll container so they stay fixed while columns scroll horizontally

## Problem

`OuterScrollContainer` combined with `isStickyHeader`/`hasStickyColumns` was causing the hardware configuration table headers to not render. The PF scroll container was incompatible with the `mod-arch-shared` Table wrapper component.

## How Has This Been Tested?

- Verified locally that table headers now render correctly
- Horizontal scrolling stays within the card boundary
- Toolbar/filters remain fixed while table content scrolls

## Test Impact

No test changes needed — this is a rendering fix only.