### PR TITLE
fix(catalog): prevent SSRF and env-var oracle in HuggingFace catalog loader

### DIFF
--- a/catalog/README.md
+++ b/catalog/README.md
@@ -343,8 +343,8 @@ kubectl create secret generic model-catalog-hf-api-key \
 kubectl rollout restart deployment model-catalog-server -n kubeflow
 ```
 
-**Custom Environment Variable Name:**
-You can configure a custom environment variable name per source by setting the `apiKeyEnvVar` property in your source configuration (see below). This is useful when you need different API keys for different sources.
+**Per-source API keys:**
+Set `apiKeyEnvVar` to use a different API key per source. The value must be `HF_API_KEY` (the default) or start with `HF_API_KEY_` — for example, `HF_API_KEY_META` for a Meta-specific key. Other env var names are rejected. This lets operators supply separate credentials for different HuggingFace organizations without exposing arbitrary environment variables.
 
 **Important Notes:**
 - **Private Models**: For private models, the API key must belong to an account that has been granted access to the model. Without proper access, the catalog service will not be able to retrieve model information.
@@ -374,10 +374,9 @@ catalogs:
       - "some-org/unwanted-model"
       - "another-org/test-*"  # Excludes all models starting with "test-"
 
-    # Optional: Configure a custom environment variable name for the API key
-    # Defaults to "HF_API_KEY" if not specified
+    # Optional: Use a per-source API key (must be HF_API_KEY or start with HF_API_KEY_)
     properties:
-      apiKeyEnvVar: "MY_CUSTOM_API_KEY_VAR"
+      apiKeyEnvVar: "HF_API_KEY_MYORG"
 ```
 
 #### Organization-Restricted Sources

--- a/catalog/internal/catalog/modelcatalog/hf_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/hf_catalog.go
@@ -24,6 +24,7 @@ import (
 const (
 	defaultHuggingFaceURL = "https://huggingface.co"
 	defaultAPIKeyEnvVar   = "HF_API_KEY"
+	apiKeyEnvVarPrefix    = "HF_API_KEY_"
 	urlKey                = "url"
 	apiKeyEnvVarKey       = "apiKeyEnvVar"
 	maxModelsKey          = "maxModels"
@@ -850,6 +851,29 @@ func (p *hfModelProvider) validateCredentials(ctx context.Context) error {
 	return nil
 }
 
+// sanitizeHFProperties validates security-sensitive properties and returns the env var name to
+// use for the API key. The apiKeyEnvVar property is accepted only when it equals defaultAPIKeyEnvVar
+// ("HF_API_KEY") or starts with apiKeyEnvVarPrefix ("HF_API_KEY_"); all other values are rejected
+// and the default is used. Custom URLs are always rejected to prevent SSRF. In both cases the
+// property is removed from the map to prevent it from leaking into downstream metadata.
+func sanitizeHFProperties(props map[string]any, label string) string {
+	envVarName := defaultAPIKeyEnvVar
+	if envVar, ok := props[apiKeyEnvVarKey].(string); ok && envVar != "" {
+		if envVar == defaultAPIKeyEnvVar || strings.HasPrefix(envVar, apiKeyEnvVarPrefix) {
+			envVarName = envVar
+		} else {
+			glog.Warningf("%s: apiKeyEnvVar %q rejected; must be %q or start with %q — falling back to default",
+				label, envVar, defaultAPIKeyEnvVar, apiKeyEnvVarPrefix)
+		}
+		delete(props, apiKeyEnvVarKey)
+	}
+	if url, ok := props[urlKey].(string); ok && url != "" {
+		glog.Warningf("%s: custom URL %q ignored (SSRF prevention)", label, url)
+		delete(props, urlKey)
+	}
+	return envVarName
+}
+
 func newHFModelProvider(ctx context.Context, source *basecatalog.ModelSource, reldir string) (<-chan ModelProviderRecord, error) {
 	p := &hfModelProvider{}
 	p.client = &http.Client{Timeout: 30 * time.Second}
@@ -861,24 +885,14 @@ func newHFModelProvider(ctx context.Context, source *basecatalog.ModelSource, re
 	}
 	p.sourceId = sourceId
 
-	// Parse API key from environment variable
-	// Allow the environment variable name to be configured via properties, defaulting to HF_API_KEY
-	apiKeyEnvVar := defaultAPIKeyEnvVar
-	if envVar, ok := source.Properties[apiKeyEnvVarKey].(string); ok && envVar != "" {
-		apiKeyEnvVar = envVar
-	}
+	// Reject custom URLs (SSRF prevention) and validate apiKeyEnvVar (must be HF_API_KEY or HF_API_KEY_*).
+	apiKeyEnvVar := sanitizeHFProperties(source.Properties, "HuggingFace catalog")
 	apiKey := os.Getenv(apiKeyEnvVar)
 	if apiKey == "" {
 		glog.Infof("No API key configured for Hugging Face. Only public models and limited data for gated models will be available.")
 	}
 	p.apiKey = apiKey
-
-	// Parse base URL (optional, defaults to huggingface.co)
-	// This allows tests to use mock servers by providing a custom URL
 	p.baseURL = defaultHuggingFaceURL
-	if url, ok := source.Properties[urlKey].(string); ok && url != "" {
-		p.baseURL = strings.TrimSuffix(url, "/")
-	}
 
 	allowedOrg, _ := source.Properties[allowedOrgKey].(string)
 	restrictToOrg(allowedOrg, &source.IncludedModels, &source.ExcludedModels)
@@ -946,21 +960,13 @@ func NewHFPreviewProvider(config *PreviewConfig) (*hfModelProvider, error) {
 		syncInterval: defaultSyncInterval,
 	}
 
-	// Parse API key from environment variable (optional - allows public model access without key)
-	apiKeyEnvVar := defaultAPIKeyEnvVar
-	if envVar, ok := config.Properties[apiKeyEnvVarKey].(string); ok && envVar != "" {
-		apiKeyEnvVar = envVar
-	}
+	// Reject custom URLs (SSRF prevention) and validate apiKeyEnvVar (must be HF_API_KEY or HF_API_KEY_*).
+	apiKeyEnvVar := sanitizeHFProperties(config.Properties, "HuggingFace preview")
 	apiKey := os.Getenv(apiKeyEnvVar)
 	if apiKey == "" {
 		glog.Infof("No API key configured for Hugging Face preview. Only public models and limited data for gated models will be available.")
 	}
 	p.apiKey = apiKey
-
-	// Parse base URL (optional, defaults to huggingface.co)
-	if url, ok := config.Properties[urlKey].(string); ok && url != "" {
-		p.baseURL = strings.TrimSuffix(url, "/")
-	}
 
 	allowedOrg, _ := config.Properties[allowedOrgKey].(string)
 	restrictToOrg(allowedOrg, &config.IncludedModels, &config.ExcludedModels)

--- a/catalog/internal/catalog/modelcatalog/hf_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/hf_catalog_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
 	catalogmodels "github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/models"
 	apimodels "github.com/kubeflow/hub/catalog/pkg/openapi"
 	models "github.com/kubeflow/hub/internal/platform/db/entity"
@@ -795,21 +795,19 @@ func TestListModelsByAuthor(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	os.Setenv("HF_API_KEY", "test-api-key")
-	defer os.Unsetenv("HF_API_KEY")
+	t.Setenv("HF_API_KEY", "test-api-key")
 
 	t.Run("lists all models from org with pagination", func(t *testing.T) {
 		callCount = 0
 		config := &PreviewConfig{
-			Type: "hf",
-			Properties: map[string]any{
-				"url": server.URL,
-			},
+			Type:           "hf",
+			Properties:     map[string]any{},
 			IncludedModels: []string{"test-org/*"},
 		}
 
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 
 		models, err := provider.listModelsByAuthor(context.Background(), "test-org", "")
 		require.NoError(t, err)
@@ -827,15 +825,14 @@ func TestListModelsByAuthor(t *testing.T) {
 
 	t.Run("filters by search prefix", func(t *testing.T) {
 		config := &PreviewConfig{
-			Type: "hf",
-			Properties: map[string]any{
-				"url": server.URL,
-			},
+			Type:           "hf",
+			Properties:     map[string]any{},
 			IncludedModels: []string{"test-org/*"},
 		}
 
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 
 		models, err := provider.listModelsByAuthor(context.Background(), "search-org", "prefix")
 		require.NoError(t, err)
@@ -853,7 +850,6 @@ func TestListModelsByAuthor(t *testing.T) {
 		config := &PreviewConfig{
 			Type: "hf",
 			Properties: map[string]any{
-				"url":       server.URL,
 				"maxModels": 50, // Limit to 50 models
 			},
 			IncludedModels: []string{"test-org/*"},
@@ -861,6 +857,7 @@ func TestListModelsByAuthor(t *testing.T) {
 
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 		assert.Equal(t, 50, provider.maxModels)
 
 		models, err := provider.listModelsByAuthor(context.Background(), "test-org", "")
@@ -875,10 +872,8 @@ func TestListModelsByAuthor(t *testing.T) {
 
 	t.Run("uses default maxModels when not specified", func(t *testing.T) {
 		config := &PreviewConfig{
-			Type: "hf",
-			Properties: map[string]any{
-				"url": server.URL,
-			},
+			Type:           "hf",
+			Properties:     map[string]any{},
 			IncludedModels: []string{"test-org/*"},
 		}
 
@@ -894,7 +889,6 @@ func TestListModelsByAuthor(t *testing.T) {
 		config := &PreviewConfig{
 			Type: "hf",
 			Properties: map[string]any{
-				"url":       server.URL,
 				"maxModels": 0, // No limit
 			},
 			IncludedModels: []string{"test-org/*"},
@@ -902,6 +896,7 @@ func TestListModelsByAuthor(t *testing.T) {
 
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 		assert.Equal(t, 0, provider.maxModels)
 
 		models, err := provider.listModelsByAuthor(context.Background(), "test-org", "")
@@ -946,8 +941,7 @@ func TestFetchModelNamesForPreviewWithPatterns(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	os.Setenv("HF_API_KEY", "test-api-key")
-	defer os.Unsetenv("HF_API_KEY")
+	t.Setenv("HF_API_KEY", "test-api-key")
 
 	t.Run("mixed patterns: org/* and exact", func(t *testing.T) {
 		config := &PreviewConfig{
@@ -956,13 +950,12 @@ func TestFetchModelNamesForPreviewWithPatterns(t *testing.T) {
 				"test-org/*",            // Should use list API
 				"exact-org/exact-model", // Should use direct fetch
 			},
-			Properties: map[string]any{
-				"url": server.URL,
-			},
+			Properties: map[string]any{},
 		}
 
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 
 		names, err := provider.FetchModelNamesForPreview(context.Background(), config.IncludedModels)
 		require.NoError(t, err)
@@ -979,13 +972,12 @@ func TestFetchModelNamesForPreviewWithPatterns(t *testing.T) {
 			IncludedModels: []string{
 				"*",
 			},
-			Properties: map[string]any{
-				"url": server.URL,
-			},
+			Properties: map[string]any{},
 		}
 
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 
 		_, err = provider.FetchModelNamesForPreview(context.Background(), config.IncludedModels)
 		require.Error(t, err)
@@ -999,13 +991,12 @@ func TestFetchModelNamesForPreviewWithPatterns(t *testing.T) {
 			IncludedModels: []string{
 				"*/*",
 			},
-			Properties: map[string]any{
-				"url": server.URL,
-			},
+			Properties: map[string]any{},
 		}
 
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 
 		_, err = provider.FetchModelNamesForPreview(context.Background(), config.IncludedModels)
 		require.Error(t, err)
@@ -1019,13 +1010,12 @@ func TestFetchModelNamesForPreviewWithPatterns(t *testing.T) {
 			IncludedModels: []string{
 				"*/Llama-*",
 			},
-			Properties: map[string]any{
-				"url": server.URL,
-			},
+			Properties: map[string]any{},
 		}
 
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 
 		_, err = provider.FetchModelNamesForPreview(context.Background(), config.IncludedModels)
 		require.Error(t, err)
@@ -1060,8 +1050,7 @@ func TestPreviewSourceModelsWithHFPatterns(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	os.Setenv("HF_API_KEY", "test-api-key")
-	defer os.Unsetenv("HF_API_KEY")
+	t.Setenv("HF_API_KEY", "test-api-key")
 
 	t.Run("org/* pattern with excludedModels filter", func(t *testing.T) {
 		// Note: We test the filtering logic by calling NewHFPreviewProvider directly
@@ -1075,14 +1064,12 @@ func TestPreviewSourceModelsWithHFPatterns(t *testing.T) {
 			Type:           "hf",
 			IncludedModels: includedModels,
 			ExcludedModels: excludedModels,
-			Properties: map[string]any{
-				"url": server.URL,
-			},
+			Properties:     map[string]any{},
 		}
 
-		// Create provider and fetch model names (bypassing SSRF protection for testing)
 		provider, err := NewHFPreviewProvider(config)
 		require.NoError(t, err)
+		provider.baseURL = server.URL
 
 		modelNames, err := provider.FetchModelNamesForPreview(context.Background(), includedModels)
 		require.NoError(t, err)
@@ -1659,4 +1646,127 @@ func TestClassifyModelTypeFromTasks(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewHFPreviewProvider_RejectsCustomURL(t *testing.T) {
+	t.Setenv("HF_API_KEY", "hf_test123")
+
+	config := &PreviewConfig{
+		Type: "hf",
+		Properties: map[string]any{
+			"url": "http://attacker.example.com",
+		},
+		IncludedModels: []string{"test-org/model-1"},
+	}
+
+	provider, err := NewHFPreviewProvider(config)
+	require.NoError(t, err)
+	assert.Equal(t, defaultHuggingFaceURL, provider.baseURL)
+
+	_, exists := config.Properties["url"]
+	assert.False(t, exists, "url property should be deleted from config")
+}
+
+func TestNewHFPreviewProvider_IgnoresCustomApiKeyEnvVar(t *testing.T) {
+	t.Setenv("HF_API_KEY", "hf_real_key")
+	t.Setenv("PGPASSWORD", "db_secret")
+
+	config := &PreviewConfig{
+		Type: "hf",
+		Properties: map[string]any{
+			"apiKeyEnvVar": "PGPASSWORD",
+		},
+		IncludedModels: []string{"test-org/model-1"},
+	}
+
+	provider, err := NewHFPreviewProvider(config)
+	require.NoError(t, err)
+	assert.Equal(t, "hf_real_key", provider.apiKey, "should use HF_API_KEY, not the custom env var")
+}
+
+func TestNewHFPreviewProvider_AcceptsHFAPIKeyPrefixedEnvVar(t *testing.T) {
+	t.Setenv("HF_API_KEY_ORG1", "hf_org1_val")
+	t.Setenv("HF_API_KEY", "hf_default_val")
+
+	config := &PreviewConfig{
+		Type: "hf",
+		Properties: map[string]any{
+			"apiKeyEnvVar": "HF_API_KEY_ORG1",
+		},
+		IncludedModels: []string{"test-org/model-1"},
+	}
+
+	provider, err := NewHFPreviewProvider(config)
+	require.NoError(t, err)
+	assert.Equal(t, "hf_org1_val", provider.apiKey, "should use HF_API_KEY_ORG1 when specified with valid prefix")
+}
+
+func TestNewHFPreviewProvider_RejectsNonPrefixedHFEnvVar(t *testing.T) {
+	t.Setenv("HF_CUSTOM_KEY", "hf_custom_val")
+	t.Setenv("HF_API_KEY", "hf_default_val")
+
+	config := &PreviewConfig{
+		Type: "hf",
+		Properties: map[string]any{
+			"apiKeyEnvVar": "HF_CUSTOM_KEY",
+		},
+		IncludedModels: []string{"test-org/model-1"},
+	}
+
+	provider, err := NewHFPreviewProvider(config)
+	require.NoError(t, err)
+	assert.Equal(t, "hf_default_val", provider.apiKey,
+		"should fall back to HF_API_KEY when apiKeyEnvVar does not match HF_API_KEY or HF_API_KEY_*")
+}
+
+func TestNewHFPreviewProvider_AcceptsExactHFAPIKey(t *testing.T) {
+	t.Setenv("HF_API_KEY", "hf_exact_val")
+
+	config := &PreviewConfig{
+		Type: "hf",
+		Properties: map[string]any{
+			"apiKeyEnvVar": "HF_API_KEY",
+		},
+		IncludedModels: []string{"test-org/model-1"},
+	}
+
+	provider, err := NewHFPreviewProvider(config)
+	require.NoError(t, err)
+	assert.Equal(t, "hf_exact_val", provider.apiKey,
+		"should accept explicit HF_API_KEY as apiKeyEnvVar")
+}
+
+// TestNewHFModelProvider_SanitizesSecurityProperties verifies that the full catalog code path
+// (newHFModelProvider) removes forbidden properties before use, matching the preview path.
+// sanitizeHFProperties is called before p.Models(), so the assertions hold even if Models()
+// returns an error (e.g. network failure reaching huggingface.co in a test environment).
+func TestNewHFModelProvider_SanitizesSecurityProperties(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := &basecatalog.ModelSource{
+		CatalogSource: apimodels.CatalogSource{
+			Id:             "test-source",
+			IncludedModels: []string{"test-org/test-model"},
+		},
+		Properties: map[string]any{
+			"url":          "http://attacker.example.com",
+			"apiKeyEnvVar": "PGPASSWORD",
+		},
+	}
+
+	ch, _ := newHFModelProvider(ctx, source, "") // ignore error: network may fail in test env
+	cancel()
+	if ch != nil {
+		go func() { //nolint:revive
+			for range ch {
+			}
+		}()
+	}
+
+	_, urlExists := source.Properties[urlKey]
+	assert.False(t, urlExists, "url property must be removed to prevent SSRF")
+
+	_, envVarExists := source.Properties[apiKeyEnvVarKey]
+	assert.False(t, envVarExists, "apiKeyEnvVar property must be removed to prevent env var oracle")
 }

--- a/docs/catalog-yaml-reference.md
+++ b/docs/catalog-yaml-reference.md
@@ -131,7 +131,7 @@ model_catalogs:
     type: hf
     enabled: true
     properties:
-      apiKeyEnvVar: "HF_API_KEY"    # Env var name holding the API key
+      apiKeyEnvVar: "HF_API_KEY"    # Default; or use HF_API_KEY_<suffix> for per-source keys
     includedModels:
       - "meta-llama/Llama-3.2-1B"
       - "microsoft/phi-2"
@@ -144,7 +144,7 @@ model_catalogs:
     type: hf
     enabled: true
     properties:
-      apiKeyEnvVar: "HF_API_KEY"
+      apiKeyEnvVar: "HF_API_KEY_META"   # Per-source key; must be HF_API_KEY or HF_API_KEY_*
       allowedOrganization: "meta-llama"   # Auto-prefixes patterns
     includedModels:
       - "*"              # Expands to: meta-llama/*
@@ -155,7 +155,7 @@ model_catalogs:
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `apiKeyEnvVar` | string | No | Name of the environment variable containing the HF API key (default: `HF_API_KEY`) |
+| `apiKeyEnvVar` | string | No | Env var holding the HF API key. Must be `HF_API_KEY` (default) or start with `HF_API_KEY_` (e.g. `HF_API_KEY_ORG1`). Other values are rejected. |
 | `allowedOrganization` | string | No | Restricts to a single HF organization; auto-prefixes all patterns with `org/` |
 
 The API key value itself should be stored in a Kubernetes Secret and exposed as an environment variable in the pod configuration.
@@ -660,8 +660,6 @@ model_catalogs:
     id: my_hf_models
     type: hf
     enabled: true
-    properties:
-      apiKeyEnvVar: "HF_API_KEY"
     includedModels:
       - "meta-llama/Llama-3.2-1B"
       - "microsoft/phi-2"
@@ -933,7 +931,7 @@ model_catalogs:
     type: hf
     enabled: true
     properties:
-      apiKeyEnvVar: "HF_API_KEY"
+      apiKeyEnvVar: "HF_API_KEY_META"   # Per-source key; must be HF_API_KEY or HF_API_KEY_*
       allowedOrganization: "meta-llama"
     includedModels:
       - "*"                # All meta-llama models
@@ -945,8 +943,6 @@ model_catalogs:
     id: hf-curated
     type: hf
     enabled: true
-    properties:
-      apiKeyEnvVar: "HF_API_KEY"
     includedModels:
       - "meta-llama/Llama-3.2-1B"
       - "microsoft/phi-2"

--- a/manifests/kustomize/options/catalog/base/hf-sources-example.yaml
+++ b/manifests/kustomize/options/catalog/base/hf-sources-example.yaml
@@ -11,10 +11,9 @@ catalogs:
     type: hf
     enabled: true
     properties:
-      # Name of the environment variable containing the Hugging Face API key.
-      # The API key value itself should be stored in a Kubernetes Secret and
-      # exposed as an environment variable in the pod/deployment configuration.
-      # Default environment variable name is "HF_API_KEY"
+      # apiKeyEnvVar names the env var holding the Hugging Face API key.
+      # Must be "HF_API_KEY" (default) or start with "HF_API_KEY_" (e.g., "HF_API_KEY_ORG1").
+      # Store the key value in a Kubernetes Secret and expose it as an env var in the deployment.
       apiKeyEnvVar: "HF_API_KEY"
     includedModels:
       - "meta-llama/Llama-3.2-1B"
@@ -30,7 +29,7 @@ catalogs:
     type: hf
     enabled: false  # disabled by default
     properties:
-      apiKeyEnvVar: "HF_API_KEY"
+      apiKeyEnvVar: "HF_API_KEY_META"   # Per-org key; must be HF_API_KEY or HF_API_KEY_*
       allowedOrganization: "meta-llama"
     includedModels:
       # These patterns will be automatically prefixed with "meta-llama/"
@@ -46,8 +45,6 @@ catalogs:
     id: hf-microsoft
     type: hf
     enabled: false  # disabled by default
-    properties:
-      apiKeyEnvVar: "HF_API_KEY"
     includedModels:
       # Full wildcard patterns (organization/model)
       - "microsoft/phi-*"         # All phi variants
@@ -61,8 +58,6 @@ catalogs:
     id: hf-mixed
     type: hf
     enabled: false  # disabled by default
-    properties:
-      apiKeyEnvVar: "HF_API_KEY"
     includedModels:
       # Specific models
       - "huggingface/CodeBERTa-small-v1"


### PR DESCRIPTION
## Description

The HuggingFace loader accepted a custom `url` property, enabling SSRF by redirecting requests to arbitrary endpoints. It also accepted any string as `apiKeyEnvVar`, letting a catalog operator discover secret names by probing whether environment variables are set.

- Block custom `url` values; warn and use https://huggingface.co instead
- Restrict `apiKeyEnvVar` to `HF_API_KEY` or `HF_API_KEY_*`; warn and fall back to the default when the value is rejected
- Strip both properties from the source map after validation to prevent metadata leakage downstream
- Update docs and example manifests to reflect the constraints
- Add tests covering all sanitization branches

## How Has This Been Tested?
On a local kind cluster. I configured it to retrieve models from Hugging Face.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
