### PR TITLE
fix(async-upload): pass pull_args to skopeo and validate credentials_path

### DIFF
--- a/jobs/async-upload/job/upload.py
+++ b/jobs/async-upload/job/upload.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict, fields
 import logging
+from pathlib import Path
 from typing import Any, Dict
 from model_registry import utils
 from model_registry.utils import OCIParams, S3Params, save_to_oci_registry
@@ -7,6 +8,32 @@ from model_registry.utils import OCIParams, S3Params, save_to_oci_registry
 from .models import AsyncUploadConfig, DestinationConfig, OCIStorageConfig, S3StorageConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_credentials_path(path: str) -> str:
+    """Validate that a credentials path is safe to pass to skopeo --authfile.
+
+    Args:
+        path: The credentials file path to validate.
+
+    Returns:
+        The resolved absolute path string.
+
+    Raises:
+        ValueError: If the path is not absolute, does not exist,
+            or is not a regular file.
+    """
+    p = Path(path)
+    if not p.is_absolute():
+        raise ValueError(f"credentials_path must be an absolute path, got: {path}")
+    try:
+        resolved = p.resolve(strict=True)
+    except OSError as e:
+        raise ValueError(f"credentials_path does not exist or cannot be resolved: {path}") from e
+    if not resolved.is_file():
+        raise ValueError(f"credentials_path must be a regular file, got: {path}")
+    return str(resolved)
+
 
 def _get_upload_params(config: AsyncUploadConfig) -> S3Params | OCIParams:
     """
@@ -28,12 +55,17 @@ def _get_upload_params(config: AsyncUploadConfig) -> S3Params | OCIParams:
         )
     elif isinstance(destination_config, OCIStorageConfig):
         push_args = []
+        pull_args = []
         # Note: These are all skopeo args, see: https://github.com/containers/skopeo/blob/main/docs/skopeo-copy.1.md
         if not destination_config.enable_tls_verify:
             push_args.append("--dest-tls-verify=false")
+            pull_args.append("--src-tls-verify=false")
         if destination_config.credentials_path:
+            validated_path = _validate_credentials_path(destination_config.credentials_path)
             push_args.append("--authfile")
-            push_args.append(destination_config.credentials_path)
+            push_args.append(validated_path)
+            pull_args.append("--authfile")
+            pull_args.append(validated_path)
 
         return OCIParams(
             base_image=destination_config.base_image,
@@ -43,6 +75,7 @@ def _get_upload_params(config: AsyncUploadConfig) -> S3Params | OCIParams:
             oci_password=destination_config.password,
             # Same as the default backend, but with additional args included
             custom_oci_backend=utils._get_skopeo_backend(
+                pull_args=pull_args,
                 push_args=push_args
             ),
         )

--- a/jobs/async-upload/tests/test_upload.py
+++ b/jobs/async-upload/tests/test_upload.py
@@ -2,7 +2,7 @@ from dataclasses import asdict
 import pytest
 from unittest.mock import Mock, patch
 from model_registry.utils import S3Params, OCIParams
-from job.upload import _get_upload_params, perform_upload
+from job.upload import _get_upload_params, _validate_credentials_path, perform_upload
 from job.models import (
     AsyncUploadConfig,
     S3StorageConfig,
@@ -15,6 +15,166 @@ from job.models import (
 
 class TestGetUploadParams:
     """Test cases for _get_upload_params function"""
+
+    @patch("job.upload.utils._get_skopeo_backend")
+    def test_get_upload_params_oci_passes_pull_args_tls_disabled(self, mock_get_skopeo_backend):
+        """Test that pull_args include --src-tls-verify=false when TLS verification is disabled"""
+        mock_get_skopeo_backend.return_value = Mock()
+
+        config = AsyncUploadConfig(
+            source=S3StorageConfig(
+                bucket="source-bucket",
+                key="source-key",
+                access_key_id="source-key-id",
+                secret_access_key="source-secret",
+                region="us-west-1"
+            ),
+            destination=OCIStorageConfig(
+                uri="quay.io/example/test:latest",
+                registry="quay.io",
+                username="test-user",
+                password="test-password",
+                base_image="foo-bar:latest",
+                enable_tls_verify=False,
+                credentials_path=None
+            ),
+            model=ModelConfig(
+                intent=UpdateArtifactIntent(artifact_id="123")
+            ),
+            storage=StorageConfig(path="/tmp/test-model"),
+            registry=RegistryConfig(server_address="test-server")
+        )
+
+        _get_upload_params(config)
+
+        mock_get_skopeo_backend.assert_called_once()
+        call_kwargs = mock_get_skopeo_backend.call_args
+        pull_args = call_kwargs.kwargs.get("pull_args") or call_kwargs[1].get("pull_args")
+        push_args = call_kwargs.kwargs.get("push_args") or call_kwargs[1].get("push_args")
+        assert "--src-tls-verify=false" in pull_args
+        assert "--dest-tls-verify=false" in push_args
+
+    @patch("job.upload._validate_credentials_path", side_effect=lambda p: p)
+    @patch("job.upload.utils._get_skopeo_backend")
+    def test_get_upload_params_oci_passes_pull_args_with_authfile(self, mock_get_skopeo_backend, _mock_validate):
+        """Test that pull_args include --authfile when credentials_path is set"""
+        mock_get_skopeo_backend.return_value = Mock()
+
+        config = AsyncUploadConfig(
+            source=S3StorageConfig(
+                bucket="source-bucket",
+                key="source-key",
+                access_key_id="source-key-id",
+                secret_access_key="source-secret",
+                region="us-west-1"
+            ),
+            destination=OCIStorageConfig(
+                uri="quay.io/example/test:latest",
+                registry="quay.io",
+                username="test-user",
+                password="test-password",
+                base_image="foo-bar:latest",
+                enable_tls_verify=True,
+                credentials_path="/tmp/test-creds"
+            ),
+            model=ModelConfig(
+                intent=UpdateArtifactIntent(artifact_id="123")
+            ),
+            storage=StorageConfig(path="/tmp/test-model"),
+            registry=RegistryConfig(server_address="test-server")
+        )
+
+        _get_upload_params(config)
+
+        mock_get_skopeo_backend.assert_called_once()
+        call_kwargs = mock_get_skopeo_backend.call_args
+        pull_args = call_kwargs.kwargs.get("pull_args") or call_kwargs[1].get("pull_args")
+        push_args = call_kwargs.kwargs.get("push_args") or call_kwargs[1].get("push_args")
+        assert "--authfile" in pull_args
+        assert "/tmp/test-creds" in pull_args
+        assert "--authfile" in push_args
+        assert "/tmp/test-creds" in push_args
+
+    @patch("job.upload._validate_credentials_path", side_effect=lambda p: p)
+    @patch("job.upload.utils._get_skopeo_backend")
+    def test_get_upload_params_oci_passes_pull_args_tls_and_authfile(self, mock_get_skopeo_backend, _mock_validate):
+        """Test that pull_args include both TLS and authfile flags when both are configured"""
+        mock_get_skopeo_backend.return_value = Mock()
+
+        config = AsyncUploadConfig(
+            source=S3StorageConfig(
+                bucket="source-bucket",
+                key="source-key",
+                access_key_id="source-key-id",
+                secret_access_key="source-secret",
+                region="us-west-1"
+            ),
+            destination=OCIStorageConfig(
+                uri="quay.io/example/test:latest",
+                registry="quay.io",
+                username="test-user",
+                password="test-password",
+                base_image="foo-bar:latest",
+                enable_tls_verify=False,
+                credentials_path="/tmp/test-creds"
+            ),
+            model=ModelConfig(
+                intent=UpdateArtifactIntent(artifact_id="123")
+            ),
+            storage=StorageConfig(path="/tmp/test-model"),
+            registry=RegistryConfig(server_address="test-server")
+        )
+
+        _get_upload_params(config)
+
+        mock_get_skopeo_backend.assert_called_once()
+        call_kwargs = mock_get_skopeo_backend.call_args
+        pull_args = call_kwargs.kwargs.get("pull_args") or call_kwargs[1].get("pull_args")
+        push_args = call_kwargs.kwargs.get("push_args") or call_kwargs[1].get("push_args")
+        assert "--src-tls-verify=false" in pull_args
+        assert "--authfile" in pull_args
+        assert "/tmp/test-creds" in pull_args
+        assert "--dest-tls-verify=false" in push_args
+        assert "--authfile" in push_args
+        assert "/tmp/test-creds" in push_args
+
+    @patch("job.upload.utils._get_skopeo_backend")
+    def test_get_upload_params_oci_empty_pull_args_when_tls_enabled_no_creds(self, mock_get_skopeo_backend):
+        """Test that pull_args is empty when TLS is enabled and no credentials_path"""
+        mock_get_skopeo_backend.return_value = Mock()
+
+        config = AsyncUploadConfig(
+            source=S3StorageConfig(
+                bucket="source-bucket",
+                key="source-key",
+                access_key_id="source-key-id",
+                secret_access_key="source-secret",
+                region="us-west-1"
+            ),
+            destination=OCIStorageConfig(
+                uri="quay.io/example/test:latest",
+                registry="quay.io",
+                username="test-user",
+                password="test-password",
+                base_image="foo-bar:latest",
+                enable_tls_verify=True,
+                credentials_path=None
+            ),
+            model=ModelConfig(
+                intent=UpdateArtifactIntent(artifact_id="123")
+            ),
+            storage=StorageConfig(path="/tmp/test-model"),
+            registry=RegistryConfig(server_address="test-server")
+        )
+
+        _get_upload_params(config)
+
+        mock_get_skopeo_backend.assert_called_once()
+        call_kwargs = mock_get_skopeo_backend.call_args
+        pull_args = call_kwargs.kwargs.get("pull_args") or call_kwargs[1].get("pull_args")
+        push_args = call_kwargs.kwargs.get("push_args") or call_kwargs[1].get("push_args")
+        assert pull_args == []
+        assert push_args == []
 
     def test_get_upload_params_s3_config(self):
         """Test _get_upload_params with S3 configuration returns S3Params"""
@@ -51,7 +211,8 @@ class TestGetUploadParams:
         assert result.secret_access_key == "test-secret-key"
         assert result.region == "us-east-1"
 
-    def test_get_upload_params_oci_config(self):
+    @patch("job.upload._validate_credentials_path", side_effect=lambda p: p)
+    def test_get_upload_params_oci_config(self, _mock_validate):
         """Test _get_upload_params with OCI configuration returns OCIParams"""
         config = AsyncUploadConfig(
             source=S3StorageConfig(
@@ -85,14 +246,14 @@ class TestGetUploadParams:
         assert result.dest_dir == "/tmp/test-model"
         assert result.oci_username == "test-user"
         assert result.oci_password == "test-password"
-        
+
     def test_get_upload_params_unsupported_type(self):
         """Test _get_upload_params with unsupported destination type raises ValueError"""
         # Create a mock config with an unsupported destination type
         config = Mock(spec=AsyncUploadConfig)
         config.destination = Mock()
         config.destination.__class__.__name__ = "UnsupportedStorageConfig"
-        
+
         with pytest.raises(ValueError, match="Unsupported destination type"):
             _get_upload_params(config)
 
@@ -135,9 +296,10 @@ class TestGetUploadParams:
 class TestPerformUpload:
     """Test cases for perform_upload function"""
 
+    @patch("job.upload._validate_credentials_path", side_effect=lambda p: p)
     @patch("job.upload.save_to_oci_registry")
     def test_perform_upload_oci(
-        self, mock_save_to_oci_registry
+        self, mock_save_to_oci_registry, _mock_validate
     ):
         """Test perform_upload with OCI destination"""
 
@@ -189,7 +351,7 @@ class TestPerformUpload:
                 access_key_id="source-key-id",
                 secret_access_key="source-secret",
                 region="us-west-1"
-            ), 
+            ),
             destination=S3StorageConfig(
                 bucket="test-bucket",
                 key="test-key",
@@ -211,9 +373,10 @@ class TestPerformUpload:
         # Verify client method was not called
         mock_client.upload_artifact_and_register_model.assert_not_called()
 
+    @patch("job.upload._validate_credentials_path", side_effect=lambda p: p)
     @patch("job.upload.save_to_oci_registry")
     def test_perform_upload_propagates_exceptions_from_client(
-        self, mock_save_to_oci_registry
+        self, mock_save_to_oci_registry, _mock_validate
     ):
         """Test perform_upload propagates exceptions from client method"""
         # Setup
@@ -251,3 +414,46 @@ class TestPerformUpload:
 
         # Verify client method was called
         mock_save_to_oci_registry.assert_called_once()
+
+
+class TestValidateCredentialsPath:
+    """Test cases for _validate_credentials_path function"""
+
+    def test_valid_absolute_regular_file(self, tmp_path):
+        """Test that a valid absolute path to a regular file passes validation"""
+        creds_file = tmp_path / "auth.json"
+        creds_file.write_text("{}")
+        result = _validate_credentials_path(str(creds_file))
+        assert result == str(creds_file)
+
+    def test_rejects_relative_path(self, tmp_path):
+        """Test that a relative path is rejected"""
+        creds_file = tmp_path / "auth.json"
+        creds_file.write_text("{}")
+        with pytest.raises(ValueError, match="must be an absolute path"):
+            _validate_credentials_path("auth.json")
+
+    def test_accepts_symlink_to_regular_file(self, tmp_path):
+        """Test that a symlink to a regular file is accepted (Kubernetes Secret mounts use symlinks)"""
+        real_file = tmp_path / "real_auth.json"
+        real_file.write_text("{}")
+        link_file = tmp_path / "link_auth.json"
+        link_file.symlink_to(real_file)
+        result = _validate_credentials_path(str(link_file))
+        assert result == str(real_file)
+
+    def test_rejects_nonexistent_path(self, tmp_path):
+        """Test that a nonexistent path is rejected"""
+        nonexistent = tmp_path / "does_not_exist.json"
+        with pytest.raises(ValueError, match="does not exist or cannot be resolved"):
+            _validate_credentials_path(str(nonexistent))
+
+    def test_rejects_directory(self, tmp_path):
+        """Test that a directory path is rejected"""
+        with pytest.raises(ValueError, match="must be a regular file"):
+            _validate_credentials_path(str(tmp_path))
+
+    def test_rejects_relative_path_with_traversal(self):
+        """Test that a relative path with directory traversal is rejected"""
+        with pytest.raises(ValueError, match="must be an absolute path"):
+            _validate_credentials_path("../etc/passwd")


### PR DESCRIPTION
## Description
`async-upload` had a mechanism to specify push args to skopeo, but it assumed that pulls would work with the default args. This adds pull args to `async-upload` to aid with private registries or those with self-signed certs.

## How Has This Been Tested?
Unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
