### PR TITLE
feat(catalog): add MCP server displayName support

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -1631,6 +1631,10 @@ components:
             name:
               type: string
               description: Human-readable MCP server name. Must be unique within a source.
+            displayName:
+              type: string
+              description: Optional human-friendly display label for this MCP server.
+              maxLength: 255
             source_id:
               type: string
               description: Catalog source that provides this server.

--- a/api/openapi/src/plugins/mcp.yaml
+++ b/api/openapi/src/plugins/mcp.yaml
@@ -165,6 +165,10 @@ components:
             name:
               type: string
               description: Human-readable MCP server name. Must be unique within a source.
+            displayName:
+              type: string
+              description: Optional human-friendly display label for this MCP server.
+              maxLength: 255
             source_id:
               type: string
               description: Catalog source that provides this server.

--- a/catalog/internal/catalog/mcpcatalog/providers.go
+++ b/catalog/internal/catalog/mcpcatalog/providers.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	yamlMCPCatalogPathKey = "yamlCatalogPath"
+	maxMCPDisplayNameLen  = 255
 )
 
 // yamlMCPParameter represents a single input parameter for an MCP tool.
@@ -104,6 +105,7 @@ type yamlMCPSecurityIndicator struct {
 // yamlMCPServer represents an MCP server definition in YAML
 type yamlMCPServer struct {
 	Name                     string                              `yaml:"name"`
+	DisplayName              *string                             `yaml:"displayName,omitempty"`
 	ExternalID               *string                             `yaml:"externalId,omitempty"`
 	Description              *string                             `yaml:"description,omitempty"`
 	Provider                 *string                             `yaml:"provider,omitempty"`
@@ -262,6 +264,16 @@ func (yp *yamlMCPProvider) emit(ctx context.Context, path string, recordChan cha
 
 // ToMCPServerProviderRecord converts a yamlMCPServer to an MCPServerProviderRecord
 func (ys *yamlMCPServer) ToMCPServerProviderRecord() MCPServerProviderRecord {
+	if ys.DisplayName != nil && len(*ys.DisplayName) > maxMCPDisplayNameLen {
+		return MCPServerProviderRecord{
+			Error: fmt.Errorf(
+				"server %q displayName exceeds maximum length of %d characters",
+				ys.Name,
+				maxMCPDisplayNameLen,
+			),
+		}
+	}
+
 	attrs := &models.MCPServerAttributes{
 		Name:       &ys.Name,
 		ExternalID: ys.ExternalID,
@@ -287,6 +299,9 @@ func (ys *yamlMCPServer) ToMCPServerProviderRecord() MCPServerProviderRecord {
 	// Convert standard properties
 	properties := []mrmodels.Properties{}
 
+	if ys.DisplayName != nil {
+		properties = append(properties, mrmodels.NewStringProperty("displayName", *ys.DisplayName, false))
+	}
 	if ys.Description != nil {
 		properties = append(properties, mrmodels.NewStringProperty("description", *ys.Description, false))
 	}

--- a/catalog/internal/catalog/mcpcatalog/providers_test.go
+++ b/catalog/internal/catalog/mcpcatalog/providers_test.go
@@ -3,6 +3,7 @@ package mcpcatalog
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 func TestYamlMCPServerConversion(t *testing.T) {
 	yamlServer := &yamlMCPServer{
 		Name:        "test-server",
+		DisplayName: new("Test Server"),
 		Description: new("Test MCP server"),
 		Provider:    new("Test Provider"),
 		Version:     new("1.0.0"),
@@ -43,9 +45,14 @@ func TestYamlMCPServerConversion(t *testing.T) {
 	require.NotNil(t, props)
 
 	// Check that basic properties are set
+	foundDisplayName := false
 	foundDescription := false
 	foundProvider := false
 	for _, prop := range *props {
+		if prop.Name == "displayName" && prop.StringValue != nil {
+			assert.Equal(t, "Test Server", *prop.StringValue)
+			foundDisplayName = true
+		}
 		if prop.Name == "description" && prop.StringValue != nil {
 			assert.Equal(t, "Test MCP server", *prop.StringValue)
 			foundDescription = true
@@ -55,8 +62,63 @@ func TestYamlMCPServerConversion(t *testing.T) {
 			foundProvider = true
 		}
 	}
+	assert.True(t, foundDisplayName, "displayName property should be set")
 	assert.True(t, foundDescription, "description property should be set")
 	assert.True(t, foundProvider, "provider property should be set")
+}
+
+func TestYamlMCPServerDisplayNameTooLong(t *testing.T) {
+	displayName := strings.Repeat("a", maxMCPDisplayNameLen+1)
+	yamlServer := &yamlMCPServer{
+		Name:        "test-server",
+		DisplayName: &displayName,
+	}
+
+	record := yamlServer.ToMCPServerProviderRecord()
+	require.Error(t, record.Error)
+	assert.Contains(t, record.Error.Error(), "displayName exceeds maximum length")
+}
+
+func TestYamlMCPProviderEmitWithDisplayNameKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test-catalog.yaml")
+
+	yamlContent := `mcp_servers:
+  - name: "test-server-1"
+    displayName: "Test Server One"
+    description: "First test server"
+    provider: "Test Provider"
+    version: "1.0.0"
+`
+	err := os.WriteFile(testFile, []byte(yamlContent), 0644)
+	require.NoError(t, err)
+
+	source := basecatalog.MCPSource{
+		Type: "yaml",
+		Properties: map[string]any{
+			yamlMCPCatalogPathKey: testFile,
+		},
+	}
+
+	provider, err := NewYamlMCPProvider(source)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	recordChan := provider.Servers(ctx)
+
+	record, ok := <-recordChan
+	require.True(t, ok)
+	require.Nil(t, record.Error)
+	require.NotNil(t, record.Server)
+	require.NotNil(t, record.Server.Properties)
+
+	var foundDisplayName string
+	for _, prop := range *record.Server.Properties {
+		if prop.Name == "displayName" && prop.StringValue != nil {
+			foundDisplayName = *prop.StringValue
+		}
+	}
+	assert.Equal(t, "Test Server One", foundDisplayName)
 }
 
 func TestNewYamlMCPProviderPaths(t *testing.T) {
@@ -180,9 +242,8 @@ func TestYamlMCPProviderEmitWithCancellation(t *testing.T) {
 	var yamlContent strings.Builder
 	yamlContent.WriteString("mcp_servers:\n")
 	for i := range 10 {
-		yamlContent.WriteString(`  - name: "test-server-` + string(rune('0'+i)) + `"
-    description: "Test server"
-`)
+		_, err := fmt.Fprintf(&yamlContent, "  - name: \"test-server-%c\"\n    description: \"Test server\"\n", rune('0'+i))
+		require.NoError(t, err)
 	}
 	err := os.WriteFile(testFile, []byte(yamlContent.String()), 0644)
 	require.NoError(t, err)

--- a/catalog/internal/catalog/mcpcatalog/service/entity_mappings_mcp_server.go
+++ b/catalog/internal/catalog/mcpcatalog/service/entity_mappings_mcp_server.go
@@ -35,6 +35,7 @@ var mcpServerProperties = map[string]filter.PropertyDefinition{
 	"lastUpdateTimeSinceEpoch": {Location: filter.EntityTable, ValueType: filter.IntValueType, Column: "last_update_time_since_epoch"},
 	"source_id":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "source_id"},
 	"base_name":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "base_name"},
+	"displayName":              {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "displayName"},
 	"description":              {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "description"},
 	"provider":                 {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "provider"},
 	"license":                  {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "license"},

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server.go
@@ -22,6 +22,7 @@ var (
 	ErrBaseNameContainsAtSign = errors.New("base_name cannot contain '@' character")
 	ErrBaseNameEmpty          = errors.New("base_name cannot be empty")
 	ErrBaseNameTooLong        = errors.New("base_name exceeds maximum length of 255 characters")
+	ErrDisplayNameTooLong     = errors.New("displayName exceeds maximum length of 255 characters")
 	ErrVersionTooLong         = errors.New("version exceeds maximum length of 100 characters")
 	ErrVersionContainsAtSign  = errors.New("version cannot contain '@' character")
 )
@@ -71,6 +72,7 @@ func (r *MCPServerRepositoryImpl) Save(server models.MCPServer) (models.MCPServe
 	if attr != nil && attr.Name != nil {
 		baseName := strings.TrimSpace(*attr.Name)
 		version := extractVersionProperty(server)
+		displayName := extractDisplayNameProperty(server)
 
 		// Validate base_name
 		if baseName == "" {
@@ -89,6 +91,9 @@ func (r *MCPServerRepositoryImpl) Save(server models.MCPServer) (models.MCPServe
 		}
 		if strings.Contains(version, "@") {
 			return nil, fmt.Errorf("%w: %s", ErrVersionContainsAtSign, version)
+		}
+		if displayName != nil && len(*displayName) > 255 {
+			return nil, fmt.Errorf("%w: length %d", ErrDisplayNameTooLong, len(*displayName))
 		}
 
 		// Build composite name for Context.name field
@@ -190,6 +195,22 @@ func extractVersionProperty(server models.MCPServer) string {
 	}
 
 	return ""
+}
+
+// extractDisplayNameProperty extracts the displayName property value from an MCP server.
+// Returns nil if no displayName property exists.
+func extractDisplayNameProperty(server models.MCPServer) *string {
+	if server.GetProperties() == nil {
+		return nil
+	}
+
+	for _, prop := range *server.GetProperties() {
+		if prop.Name == "displayName" && prop.StringValue != nil {
+			return prop.StringValue
+		}
+	}
+
+	return nil
 }
 
 // buildCompositeName constructs the composite name (name@version) for storage in Context.name.
@@ -349,13 +370,13 @@ func applyMCPServerListFilters(query *gorm.DB, listOptions *models.MCPServerList
 		// Search in name (context table)
 		nameCondition := fmt.Sprintf("LOWER(%s.name) LIKE ?", contextTable)
 
-		// Search in description, provider properties
-		propertyCondition := fmt.Sprintf("EXISTS (SELECT 1 FROM %s cp WHERE cp.context_id = %s.id AND cp.name IN (?, ?) AND LOWER(cp.string_value) LIKE ?)",
+		// Search in displayName, description, and provider properties
+		propertyCondition := fmt.Sprintf("EXISTS (SELECT 1 FROM %s cp WHERE cp.context_id = %s.id AND cp.name IN (?, ?, ?) AND LOWER(cp.string_value) LIKE ?)",
 			propertyTable, contextTable)
 
 		query = query.Where(fmt.Sprintf("(%s OR %s)", nameCondition, propertyCondition),
 			queryPattern,
-			"description", "provider", queryPattern,
+			"displayName", "description", "provider", queryPattern,
 		)
 	}
 

--- a/catalog/internal/catalog/mcpcatalog/service/mcp_server_test.go
+++ b/catalog/internal/catalog/mcpcatalog/service/mcp_server_test.go
@@ -519,6 +519,21 @@ func TestMCPServerRepository(t *testing.T) {
 					},
 				},
 			},
+			{
+				Attributes: &models.MCPServerAttributes{
+					Name: new("display-name-server"),
+				},
+				Properties: &[]dbmodels.Properties{
+					{
+						Name:        "source_id",
+						StringValue: new("query-source-3"),
+					},
+					{
+						Name:        "displayName",
+						StringValue: new("Special Display Server"),
+					},
+				},
+			},
 		}
 
 		for _, server := range testServers {
@@ -526,14 +541,15 @@ func TestMCPServerRepository(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// Search for "special" (should find both: one in description, one in provider)
+		// Search for "special" (should find all three: one in description,
+		// one in provider, and one in displayName)
 		query := "special"
 		listOptions := models.MCPServerListOptions{
 			Query: &query,
 		}
 		result, err := repo.List(listOptions)
 		require.NoError(t, err)
-		assert.GreaterOrEqual(t, len(result.Items), 2)
+		assert.GreaterOrEqual(t, len(result.Items), 3)
 	})
 
 	t.Run("TestList_FilterBySourceIDs", func(t *testing.T) {
@@ -878,6 +894,28 @@ func TestMCPServerRepository(t *testing.T) {
 		_, err := repo.Save(server)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrVersionTooLong)
+	})
+
+	t.Run("TestValidation_DisplayNameTooLong", func(t *testing.T) {
+		longDisplayName := strings.Repeat("a", 256)
+		server := &models.MCPServerImpl{
+			Attributes: &models.MCPServerAttributes{
+				Name: new("test-server"),
+			},
+			Properties: &[]dbmodels.Properties{
+				{
+					Name:        "source_id",
+					StringValue: new("test-source"),
+				},
+				{
+					Name:        "displayName",
+					StringValue: new(longDisplayName),
+				},
+			},
+		}
+		_, err := repo.Save(server)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDisplayNameTooLong)
 	})
 
 	t.Run("TestValidation_ValidBaseNameWithSpecialChars", func(t *testing.T) {

--- a/catalog/internal/catalog/mcpcatalog/service/test_helpers_test.go
+++ b/catalog/internal/catalog/mcpcatalog/service/test_helpers_test.go
@@ -22,6 +22,7 @@ func testDatastoreSpec() *datastore.Spec {
 		AddContext(testMCPServerTypeName, datastore.NewSpecType(NewMCPServerRepository).
 			AddString("source_id").
 			AddString("base_name").
+			AddString("displayName").
 			AddString("description").
 			AddString("provider").
 			AddString("license").

--- a/catalog/internal/converter/mcp_converter.go
+++ b/catalog/internal/converter/mcp_converter.go
@@ -33,6 +33,7 @@ func ConvertOpenapiMCPServerToDb(openapiServer *openapi.MCPServer) models.MCPSer
 
 	// Simple string fields
 	addStringProperty(&properties, "source_id", openapiServer.SourceId)
+	addStringProperty(&properties, "displayName", openapiServer.DisplayName)
 	addStringProperty(&properties, "provider", openapiServer.Provider)
 	addStringProperty(&properties, "logo", openapiServer.Logo)
 	addStringProperty(&properties, "version", openapiServer.Version)
@@ -167,6 +168,7 @@ func convertDbMCPServerToOpenapiInternal(dbServer models.MCPServer, tools []open
 
 	// Extract simple string properties
 	openapiServer.SourceId = pa.GetStringPtr("source_id")
+	openapiServer.DisplayName = pa.GetStringPtr("displayName")
 	openapiServer.Provider = pa.GetStringPtr("provider")
 	openapiServer.Logo = pa.GetStringPtr("logo")
 	openapiServer.Version = &version

--- a/catalog/internal/converter/mcp_converter_test.go
+++ b/catalog/internal/converter/mcp_converter_test.go
@@ -10,6 +10,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestConvertDbMCPServerToOpenapi_IncludesDisplayName(t *testing.T) {
+	baseName := "test-server"
+	displayName := "Test Server"
+	version := "1.0.0"
+	server := &models.MCPServerImpl{
+		Attributes: &models.MCPServerAttributes{
+			Name: &baseName,
+		},
+		Properties: &[]dbmodels.Properties{
+			{Name: "displayName", StringValue: &displayName},
+			{Name: "version", StringValue: &version},
+		},
+	}
+
+	result := converter.ConvertDbMCPServerToOpenapi(server)
+	require.NotNil(t, result)
+	require.NotNil(t, result.DisplayName)
+	assert.Equal(t, displayName, *result.DisplayName)
+}
+
 func TestConvertDbMCPToolToOpenapi_StripsQualifiedPrefix(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/catalog/internal/plugins/mcp/plugin.go
+++ b/catalog/internal/plugins/mcp/plugin.go
@@ -42,6 +42,7 @@ func (p *Plugin) DatastoreEntries() []plugin.DatastoreEntry {
 			Spec: datastore.NewSpecType(mcpcatalogservice.NewMCPServerRepository).
 				AddString("source_id").
 				AddString("base_name").
+				AddString("displayName").
 				AddString("description").
 				AddString("provider").
 				AddString("license").

--- a/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/api_mcp_catalog_service_service_test.go
@@ -202,6 +202,7 @@ func TestFindMCPServers(t *testing.T) {
 
 	openAIServer := &model.MCPServer{
 		Name:                     "openai-assistant",
+		DisplayName:              new("OpenAI Assistant"),
 		Description:              new("OpenAI Assistant MCP server"),
 		Provider:                 new("OpenAI"),
 		Version:                  new("1.2.0"),
@@ -212,6 +213,7 @@ func TestFindMCPServers(t *testing.T) {
 
 	githubServer := &model.MCPServer{
 		Name:                     "github-integration",
+		DisplayName:              new("GitHub Integration"),
 		Description:              new("GitHub MCP server"),
 		Provider:                 new("GitHub Inc"),
 		Version:                  new("2.1.3"),

--- a/catalog/pkg/openapi/model_mcp_server.go
+++ b/catalog/pkg/openapi/model_mcp_server.go
@@ -34,6 +34,8 @@ type MCPServer struct {
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`
 	// Output only. Last update time of the resource since epoch in millisecond since epoch.
 	LastUpdateTimeSinceEpoch *string `json:"lastUpdateTimeSinceEpoch,omitempty"`
+	// Optional human-friendly display label for this MCP server.
+	DisplayName *string `json:"displayName,omitempty"`
 	// Catalog source that provides this server.
 	SourceId *string `json:"source_id,omitempty"`
 	// Organization providing the server.
@@ -310,6 +312,38 @@ func (o *MCPServer) HasLastUpdateTimeSinceEpoch() bool {
 // SetLastUpdateTimeSinceEpoch gets a reference to the given string and assigns it to the LastUpdateTimeSinceEpoch field.
 func (o *MCPServer) SetLastUpdateTimeSinceEpoch(v string) {
 	o.LastUpdateTimeSinceEpoch = &v
+}
+
+// GetDisplayName returns the DisplayName field value if set, zero value otherwise.
+func (o *MCPServer) GetDisplayName() string {
+	if o == nil || IsNil(o.DisplayName) {
+		var ret string
+		return ret
+	}
+	return *o.DisplayName
+}
+
+// GetDisplayNameOk returns a tuple with the DisplayName field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *MCPServer) GetDisplayNameOk() (*string, bool) {
+	if o == nil || IsNil(o.DisplayName) {
+		return nil, false
+	}
+	return o.DisplayName, true
+}
+
+// HasDisplayName returns a boolean if a field has been set.
+func (o *MCPServer) HasDisplayName() bool {
+	if o != nil && !IsNil(o.DisplayName) {
+		return true
+	}
+
+	return false
+}
+
+// SetDisplayName gets a reference to the given string and assigns it to the DisplayName field.
+func (o *MCPServer) SetDisplayName(v string) {
+	o.DisplayName = &v
 }
 
 // GetSourceId returns the SourceId field value if set, zero value otherwise.
@@ -1004,6 +1038,9 @@ func (o MCPServer) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.LastUpdateTimeSinceEpoch) {
 		toSerialize["lastUpdateTimeSinceEpoch"] = o.LastUpdateTimeSinceEpoch
+	}
+	if !IsNil(o.DisplayName) {
+		toSerialize["displayName"] = o.DisplayName
 	}
 	if !IsNil(o.SourceId) {
 		toSerialize["source_id"] = o.SourceId


### PR DESCRIPTION
Allow MCP catalog entries to carry an optional displayName so that the backend can preserve a human-friendly label without changing existing BFF and frontend behavior.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Additional info - summarized with Cursor:

This backend-only `displayName` addition should be backward compatible for the current stack.

Why it is not breaking:
- The backend field is optional and uses `omitempty`, so if `displayName` is not populated it is omitted from the JSON response rather than emitted as `null`.
- The BFF decodes MCP catalog responses with Go `json.Unmarshal`, which ignores unknown JSON fields by default. So if the catalog backend starts returning `displayName`, the current BFF will not fail decoding; it will simply ignore the extra field until its model is updated.
- The frontend consumes MCP catalog data through the BFF, not directly from the catalog backend. Since the BFF currently drops unknown fields, the frontend continues to receive the same effective shape it receives today.
- Current MCP catalog UI code only reads known fields like `name`, `description`, `logo`, `provider`, and `version`; it does not do strict runtime schema matching that would break on an added response field.

Current implication:
- This change is safe to merge independently as backend/API groundwork.
- It does not make `displayName` user-visible yet. A follow-up BFF/frontend ticket is still needed to plumb the field through and render it.

Also included in this backend change:
- `displayName` length is validated to a max length of 255
- Free-text MCP server search now includes `displayName`, so once the field is populated it behaves like other user-facing descriptive fields.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
