### PR TITLE
feat(ui): show min vRAM, container size, and other catalog UX fixes

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -364,6 +364,15 @@ class ModelCatalog {
     return this;
   }
 
+  // Hardware slider filter helpers (sidebar)
+  findMinVramFilter() {
+    return cy.findByTestId('minimum-vram-filter');
+  }
+
+  findContainerSizeFilter() {
+    return cy.findByTestId('container-size-filter');
+  }
+
   // Cold start latency filter helpers
   findColdStartLatencyFilter() {
     return cy.findByTestId('cold-start-load-time-filter');

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -243,8 +243,10 @@ describe('Model Catalog Page', () => {
     modelCatalog.findFilter('Provider').should('be.visible');
     modelCatalog.findFilter('License').should('be.visible');
     modelCatalog.findFilter('Task').should('be.visible');
-    modelCatalog.findFilter('Language').should('be.visible');
+    modelCatalog.findFilter('Language').scrollIntoView().should('be.visible');
     modelCatalog.findFilter('Tensor type').scrollIntoView().should('be.visible');
+    modelCatalog.findMinVramFilter().scrollIntoView().should('be.visible');
+    modelCatalog.findContainerSizeFilter().scrollIntoView().should('be.visible');
   });
 
   it('filters show more and show less button should work', () => {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -371,7 +371,7 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
   },
   {
     field: 'runtime_command',
-    label: 'Runtime Command',
+    label: 'Runtime command',
     info: {
       popover:
         'The vLLM runtime command used to validate the model with the selected hardware configuration.',
@@ -406,6 +406,7 @@ export const DEFAULT_VISIBLE_COLUMN_FIELDS: HardwareConfigColumnField[] = [
   'requests_per_second',
   'ttft_p90',
   'tps_p90',
+  'cold_start_load_time',
   'mean_input_tokens',
   'mean_output_tokens',
   'framework_version',

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -275,8 +275,8 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
                     bodyContent={
                       <div>
                         <p>
-                          This is the initial delay that occurs when a model is triggered after a
-                          period of inactivity.
+                          The time it takes for vLLM to load the model. This does not include the
+                          time it takes to download the model.
                         </p>
                       </div>
                     }

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -47,14 +47,8 @@ const LABEL_MAPPINGS: Record<string, Record<string, string>> = {
 };
 
 const ModelCatalogFilters: React.FC = () => {
-  const {
-    filterOptions,
-    filterOptionsLoaded,
-    filterOptionsLoadError,
-    filters,
-    setFilters,
-    performanceViewEnabled,
-  } = React.useContext(ModelCatalogContext);
+  const { filterOptions, filterOptionsLoaded, filterOptionsLoadError, filters, setFilters } =
+    React.useContext(ModelCatalogContext);
   const onFilterChange = React.useCallback(
     (key: string, values: string[]) => {
       const match = BASIC_STRING_FILTER_KEYS.find((k) => k === key);
@@ -114,7 +108,6 @@ const ModelCatalogFilters: React.FC = () => {
       {
         key: 'hardware-slider-filters',
         title: 'Hardware filters',
-        visible: performanceViewEnabled,
         customContent: (
           <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
             <SidebarSliderFilter
@@ -124,7 +117,7 @@ const ModelCatalogFilters: React.FC = () => {
               fallbackMin={4}
               fallbackMax={480}
             />
-            <Divider />
+            <Divider className="pf-v6-u-my-sm" />
             <SidebarSliderFilter
               filterKey={ModelCatalogNumberFilterKey.IMAGE_SIZE}
               label="Container size"
@@ -139,7 +132,7 @@ const ModelCatalogFilters: React.FC = () => {
 
     items.splice(insertIndex, 0, ...sliderItems);
     return items;
-  }, [baseFilterItems, performanceViewEnabled]);
+  }, [baseFilterItems]);
 
   return (
     <CatalogFilterPanel

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/SidebarSliderFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/SidebarSliderFilter.tsx
@@ -27,8 +27,7 @@ const SidebarSliderFilter: React.FC<SidebarSliderFilterProps> = ({
   fallbackMin,
   fallbackMax,
 }) => {
-  const { filterOptions, filterOptionsLoaded, performanceViewEnabled } =
-    React.useContext(ModelCatalogContext);
+  const { filterOptions, filterOptionsLoaded } = React.useContext(ModelCatalogContext);
   const { value: filterValue, setValue: setFilterValue } = useCatalogNumberFilterState(filterKey);
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -53,7 +52,7 @@ const SidebarSliderFilter: React.FC<SidebarSliderFilterProps> = ({
     }
   }, [isOpen, filterValue, range.max]);
 
-  if (!performanceViewEnabled || !filterOptionsLoaded || !filterOptions?.filters?.[filterKey]) {
+  if (!filterOptionsLoaded || !filterOptions?.filters?.[filterKey]) {
     return null;
   }
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
@@ -56,7 +56,7 @@ const ColdStartLatencyFilter: React.FC = () => {
     if (hasActiveFilter) {
       return (
         <>
-          <strong>Cold start load time:</strong> {filterValue} s
+          <strong>Cold start load time:</strong> ≤ {filterValue} s
         </>
       );
     }

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceFilterUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceFilterUtils.ts
@@ -89,10 +89,6 @@ export const applyFilterValue = (
     const numberValue = extractNumberValue(value);
     if (filterKey === ModelCatalogNumberFilterKey.MAX_RPS) {
       setFilterData(ModelCatalogNumberFilterKey.MAX_RPS, numberValue);
-    } else if (filterKey === ModelCatalogNumberFilterKey.MIN_VRAM) {
-      setFilterData(ModelCatalogNumberFilterKey.MIN_VRAM, numberValue);
-    } else if (filterKey === ModelCatalogNumberFilterKey.IMAGE_SIZE) {
-      setFilterData(ModelCatalogNumberFilterKey.IMAGE_SIZE, numberValue);
     } else {
       setFilterData(ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME, numberValue);
     }
@@ -199,12 +195,8 @@ export const getDefaultFiltersFromNamedQuery = (
       if (resolvedValue !== undefined) {
         if (fieldName === ModelCatalogNumberFilterKey.MAX_RPS) {
           result[ModelCatalogNumberFilterKey.MAX_RPS] = resolvedValue;
-        } else if (fieldName === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME) {
-          result[ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME] = resolvedValue;
-        } else if (fieldName === ModelCatalogNumberFilterKey.MIN_VRAM) {
-          result[ModelCatalogNumberFilterKey.MIN_VRAM] = resolvedValue;
         } else {
-          result[ModelCatalogNumberFilterKey.IMAGE_SIZE] = resolvedValue;
+          result[ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME] = resolvedValue;
         }
       }
       return;

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -468,6 +468,8 @@ export const BASIC_FILTER_KEYS: ModelCatalogFilterKey[] = [
   ModelCatalogStringFilterKey.LANGUAGE,
   ModelCatalogStringFilterKey.TENSOR_TYPE,
   ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION,
+  ModelCatalogNumberFilterKey.MIN_VRAM,
+  ModelCatalogNumberFilterKey.IMAGE_SIZE,
 ];
 
 /**
@@ -490,7 +492,6 @@ export const DEPLOYMENT_RESOURCE_PREFIXES = ['vllm'];
 /**
  * Performance filter keys that are shown as chips in the performance toolbar.
  * These filters should reset to default values (from namedQueries) instead of clearing.
- * Note: MIN_VRAM and IMAGE_SIZE are sidebar-only filters (not shown as chips on the details page).
  * Note: HARDWARE_CONFIGURATION is NOT included here because it should clear normally
  * like basic filters, not reset to defaults.
  */
@@ -523,8 +524,6 @@ export const PERFORMANCE_STRING_FILTER_KEYS: ModelCatalogStringFilterKey[] = [
 export const PERFORMANCE_NUMBER_FILTER_KEYS: ModelCatalogNumberFilterKey[] = [
   ModelCatalogNumberFilterKey.MAX_RPS,
   ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME,
-  ModelCatalogNumberFilterKey.MIN_VRAM,
-  ModelCatalogNumberFilterKey.IMAGE_SIZE,
 ];
 
 /**
@@ -570,15 +569,10 @@ export const getAllFiltersToShow = (
   filterData: Partial<Record<LatencyMetricFieldName, number | undefined>>,
 ): ModelCatalogFilterKey[] => {
   const activeLatencyKeys = ALL_LATENCY_FILTER_KEYS.filter((key) => filterData[key] !== undefined);
-  // Use Set to deduplicate since PERFORMANCE_FILTER_KEYS already includes latency fields
-  // Include HARDWARE_CONFIGURATION which shows in performance toolbar but clears normally
-  // Include MIN_VRAM and IMAGE_SIZE which are sidebar-only filters shown on the landing page
   return [
     ...new Set([
       ...BASIC_FILTER_KEYS,
       ...PERFORMANCE_FILTER_KEYS,
-      ModelCatalogNumberFilterKey.MIN_VRAM,
-      ModelCatalogNumberFilterKey.IMAGE_SIZE,
       ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION,
       ...activeLatencyKeys,
     ]),


### PR DESCRIPTION
## Description

Moves the **Minimum vRAM** and **Container size** slider filters from performance-only to always-visible basic filters in the sidebar, adds **Cold start load time** as a default column in the hardware configuration table, and fixes minor UI inconsistencies.

### Changes

- **SidebarSliderFilter.tsx**: Remove `performanceViewEnabled` guard so sliders render regardless of toggle state
<img width="241" height="470" alt="Screenshot 2026-06-22 at 2 54 10 PM" src="https://github.com/user-attachments/assets/bccb303e-e0c5-432c-a35e-d97b95e10d33" />

- **ModelCatalogFilters.tsx**: Remove `visible: performanceViewEnabled` from hardware filters section; add consistent margin around the Divider between sliders
<img width="241" height="470" alt="Screenshot 2026-06-22 at 2 54 10 PM" src="https://github.com/user-attachments/assets/00965b52-614c-4422-a7a3-49216fc3b81a" />

- **const.ts**: Add `MIN_VRAM` and `IMAGE_SIZE` to `BASIC_FILTER_KEYS`; clean up redundant entries in `getAllFiltersToShow`; update `PERFORMANCE_FILTER_KEYS` comment
- **HardwareConfigurationTableColumns.ts**: Add `cold_start_load_time` to `DEFAULT_VISIBLE_COLUMN_FIELDS`; fix `Runtime command` casing
<img width="92" height="76" alt="Screenshot 2026-06-22 at 2 55 01 PM" src="https://github.com/user-attachments/assets/e9b94449-8763-4de8-8793-26ae6fb13d07" />

- **ColdStartLatencyFilter.tsx**: Add `≤` symbol to the active filter display text for consistency with other slider filters
<img width="207" height="73" alt="Screenshot 2026-06-22 at 2 55 41 PM" src="https://github.com/user-attachments/assets/4685225d-7f30-4905-922d-e27db4e29239" />

- **ModelCatalogCardBody.tsx**: Update cold start popover description to match the hardware configuration table
<img width="273" height="127" alt="Screenshot 2026-06-22 at 2 55 22 PM" src="https://github.com/user-attachments/assets/70fbf0cc-7173-4063-a91c-433d58512987" />
 
- Cold start load time is added to default visible columns in Hardware configuration table
<img width="1050" height="530" alt="Screenshot 2026-06-22 at 2 54 43 PM" src="https://github.com/user-attachments/assets/1889eebd-42f6-4536-b806-fb507f5428ac" />

## How Has This Been Tested?

Tested locally by running the frontend dev server and verifying:
- Min vRAM and Container size sliders appear in the sidebar regardless of performance toggle state
- Cold start load time column is visible by default in the hardware configuration table
- Filter chips display correctly when filters are applied
- Existing Cypress tests pass without modification

## Merge criteria:

- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.