### PR TITLE
feat(catalog): add artifactCounts to CatalogModel

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -889,6 +889,18 @@ components:
               description: List of tasks for this model which have been validated by the catalog provider.
             servingConfig:
               $ref: "#/components/schemas/ServingConfig"
+            artifactCounts:
+              type: object
+              description: >-
+                Read-only counts of artifacts by category. Only populated on the single-model detail endpoint (GetModel). Keys with zero count are omitted. When no artifacts exist, the field is omitted entirely.
+              readOnly: true
+              additionalProperties:
+                type: integer
+                format: int32
+              example:
+                model-artifact: 3
+                performance-metrics: 12
+                accuracy-metrics: 2
         - $ref: "#/components/schemas/BaseModel"
         - $ref: "#/components/schemas/BaseResource"
     CatalogModelArtifact:

--- a/api/openapi/src/plugins/model.yaml
+++ b/api/openapi/src/plugins/model.yaml
@@ -366,6 +366,20 @@ components:
               description: List of tasks for this model which have been validated by the catalog provider.
             servingConfig:
               $ref: "#/components/schemas/ServingConfig"
+            artifactCounts:
+              type: object
+              description: >-
+                Read-only counts of artifacts by category. Only populated on the
+                single-model detail endpoint (GetModel). Keys with zero count are omitted.
+                When no artifacts exist, the field is omitted entirely.
+              readOnly: true
+              additionalProperties:
+                type: integer
+                format: int32
+              example:
+                model-artifact: 3
+                performance-metrics: 12
+                accuracy-metrics: 2
         - $ref: "#/components/schemas/BaseModel"
         - $ref: "#/components/schemas/BaseResource"
     ServingConfig:

--- a/catalog/internal/catalog/modelcatalog/api_test.go
+++ b/catalog/internal/catalog/modelcatalog/api_test.go
@@ -977,6 +977,10 @@ func (m *MockCatalogArtifactRepository) DeleteByParentID(artifactType string, pa
 	return nil
 }
 
+func (m *MockCatalogArtifactRepository) CountByParentIDs(parentIDs []int32) (map[int32]map[string]int32, error) {
+	return make(map[int32]map[string]int32), nil
+}
+
 // MockNotFoundError represents an error when an entity is not found.
 type MockNotFoundError struct {
 	Entity string

--- a/catalog/internal/catalog/modelcatalog/db_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog.go
@@ -38,8 +38,8 @@ func NewDBCatalog(services Services, sources *SourceCollection) APIProvider {
 	}
 }
 
-func (d *dbCatalogImpl) GetModel(ctx context.Context, modelName string, sourceID string) (*apimodels.CatalogModel, error) {
-	// Resolve by namespaced identifier: sourceId:modelName
+// resolveModel looks up a single model by display name and source ID, returning the DB model.
+func (d *dbCatalogImpl) resolveModel(modelName, sourceID string) (models.CatalogModel, error) {
 	namespacedName := sourceID + ":" + modelName
 	modelsList, err := d.catalogModelRepository.List(models.CatalogModelListOptions{
 		Name:      &namespacedName,
@@ -48,18 +48,33 @@ func (d *dbCatalogImpl) GetModel(ctx context.Context, modelName string, sourceID
 	if err != nil {
 		return nil, err
 	}
-
 	if len(modelsList.Items) == 0 {
 		return nil, fmt.Errorf("no models found for name=%v: %w", modelName, api.ErrNotFound)
 	}
-
 	if len(modelsList.Items) > 1 {
 		return nil, fmt.Errorf("multiple models found for name=%v: %w", modelName, api.ErrNotFound)
 	}
+	return modelsList.Items[0], nil
+}
 
-	model, err := mapDBModelToAPIModel(modelsList.Items[0])
+func (d *dbCatalogImpl) GetModel(ctx context.Context, modelName string, sourceID string) (*apimodels.CatalogModel, error) {
+	dbModel, err := d.resolveModel(modelName, sourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	model, err := mapDBModelToAPIModel(dbModel)
 	if err != nil {
 		return nil, fmt.Errorf("error mapping model %s: %w", modelName, err)
+	}
+
+	modelDBID := *dbModel.GetID()
+	artifactCounts, err := d.catalogArtifactRepository.CountByParentIDs([]int32{modelDBID})
+	if err != nil {
+		return nil, fmt.Errorf("error counting artifacts for model %s: %w", modelName, err)
+	}
+	if counts, ok := artifactCounts[modelDBID]; ok && len(counts) > 0 {
+		model.ArtifactCounts = &counts
 	}
 
 	return &model, nil
@@ -141,7 +156,7 @@ func (d *dbCatalogImpl) GetArtifacts(ctx context.Context, modelName string, sour
 
 	nextPageToken := params.NextPageToken
 
-	m, err := d.GetModel(ctx, modelName, sourceID)
+	dbModel, err := d.resolveModel(modelName, sourceID)
 	if err != nil {
 		if errors.Is(err, api.ErrNotFound) {
 			return apimodels.CatalogArtifactList{}, fmt.Errorf("invalid model name '%s' for source '%s': %w", modelName, sourceID, api.ErrBadRequest)
@@ -149,12 +164,7 @@ func (d *dbCatalogImpl) GetArtifacts(ctx context.Context, modelName string, sour
 		return apimodels.CatalogArtifactList{}, err
 	}
 
-	parentResourceID, err := strconv.ParseInt(*m.Id, 10, 32)
-	if err != nil {
-		return apimodels.CatalogArtifactList{}, err
-	}
-
-	parentResourceID32 := int32(parentResourceID)
+	parentResourceID32 := *dbModel.GetID()
 
 	var filterQueryPtr *string
 	if params.FilterQuery != "" {
@@ -251,29 +261,13 @@ func (d *dbCatalogImpl) GetFilterOptions(ctx context.Context) (*apimodels.Filter
 }
 
 func (d *dbCatalogImpl) GetPerformanceArtifacts(ctx context.Context, modelName string, sourceID string, params ListPerformanceArtifactsParams) (apimodels.CatalogArtifactList, error) {
-	// Resolve by namespaced identifier: sourceId:modelName
-	namespacedName := sourceID + ":" + modelName
-	// Get the model to validate it exists and get its ID
-	modelsList, err := d.catalogModelRepository.List(models.CatalogModelListOptions{
-		Name:      &namespacedName,
-		SourceIDs: &[]string{sourceID},
-	})
+	dbModel, err := d.resolveModel(modelName, sourceID)
 	if err != nil {
 		return apimodels.CatalogArtifactList{}, err
 	}
 
-	if len(modelsList.Items) == 0 {
-		return apimodels.CatalogArtifactList{}, fmt.Errorf("no models found for name=%v: %w", modelName, api.ErrNotFound)
-	}
-
-	if len(modelsList.Items) > 1 {
-		return apimodels.CatalogArtifactList{}, fmt.Errorf("multiple models found for name=%v: %w", modelName, api.ErrNotFound)
-	}
-
-	model := modelsList.Items[0]
-
 	serviceParams := PerformanceArtifactParams{
-		ModelID:               *model.GetID(),
+		ModelID:               *dbModel.GetID(),
 		TargetRPS:             params.TargetRPS,
 		Recommendations:       params.Recommendations,
 		FilterQuery:           params.FilterQuery,

--- a/catalog/internal/catalog/modelcatalog/db_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/db_catalog_test.go
@@ -107,6 +107,117 @@ func TestDBCatalog(t *testing.T) {
 		assert.ErrorIs(t, err, api.ErrNotFound)
 	})
 
+	t.Run("TestGetModel_ArtifactCounts_NoArtifacts", func(t *testing.T) {
+		testModel := &models.CatalogModelImpl{
+			TypeID: new(int32(catalogModelTypeID)),
+			Attributes: &models.CatalogModelAttributes{
+				Name:       new("artifact-counts-source:artifact-counts-no-artifacts"),
+				ExternalID: new("artifact-counts-no-artifacts-ext"),
+			},
+			Properties: &[]mr_models.Properties{
+				{Name: "source_id", StringValue: new("artifact-counts-source")},
+			},
+		}
+		_, err := catalogModelRepo.Save(testModel)
+		require.NoError(t, err)
+
+		retrieved, err := dbCatalog.GetModel(ctx, "artifact-counts-no-artifacts", "artifact-counts-source")
+		require.NoError(t, err)
+		assert.Nil(t, retrieved.ArtifactCounts, "ArtifactCounts should be nil when no artifacts exist")
+	})
+
+	t.Run("TestGetModel_ArtifactCounts_WithArtifacts", func(t *testing.T) {
+		testModel := &models.CatalogModelImpl{
+			TypeID: new(int32(catalogModelTypeID)),
+			Attributes: &models.CatalogModelAttributes{
+				Name:       new("artifact-counts-source:artifact-counts-with-artifacts"),
+				ExternalID: new("artifact-counts-with-artifacts-ext"),
+			},
+			Properties: &[]mr_models.Properties{
+				{Name: "source_id", StringValue: new("artifact-counts-source")},
+			},
+		}
+		savedModel, err := catalogModelRepo.Save(testModel)
+		require.NoError(t, err)
+
+		// Create: 1 model artifact, 2 performance, 1 accuracy
+		modelArt := &models.CatalogModelArtifactImpl{
+			TypeID: new(int32(modelArtifactTypeID)),
+			Attributes: &models.CatalogModelArtifactAttributes{
+				Name:         new("ac-model-art-1"),
+				URI:          new("s3://bucket/model.bin"),
+				ArtifactType: new(models.CatalogModelArtifactType),
+			},
+		}
+		_, err = modelArtifactRepo.Save(modelArt, savedModel.GetID())
+		require.NoError(t, err)
+
+		for i, mt := range []models.MetricsType{
+			models.MetricsTypePerformance,
+			models.MetricsTypePerformance,
+			models.MetricsTypeAccuracy,
+		} {
+			ma := &models.CatalogMetricsArtifactImpl{
+				TypeID: new(int32(metricsArtifactTypeID)),
+				Attributes: &models.CatalogMetricsArtifactAttributes{
+					Name:         new(fmt.Sprintf("ac-metrics-art-%d", i)),
+					MetricsType:  mt,
+					ArtifactType: new(models.CatalogMetricsArtifactType),
+				},
+			}
+			_, err = metricsArtifactRepo.Save(ma, savedModel.GetID())
+			require.NoError(t, err)
+		}
+
+		retrieved, err := dbCatalog.GetModel(ctx, "artifact-counts-with-artifacts", "artifact-counts-source")
+		require.NoError(t, err)
+		require.NotNil(t, retrieved.ArtifactCounts)
+		assert.Equal(t, map[string]int32{
+			"model-artifact":      1,
+			"performance-metrics": 2,
+			"accuracy-metrics":    1,
+		}, *retrieved.ArtifactCounts)
+		_, hasSecurityKey := (*retrieved.ArtifactCounts)["security-metrics"]
+		assert.False(t, hasSecurityKey, "security-metrics key should be absent when count is zero")
+	})
+
+	t.Run("TestListModels_ArtifactCountsNotPopulated", func(t *testing.T) {
+		// Create a model with artifacts and confirm ListModels does not populate ArtifactCounts
+		testModel := &models.CatalogModelImpl{
+			TypeID: new(int32(catalogModelTypeID)),
+			Attributes: &models.CatalogModelAttributes{
+				Name:       new("list-no-counts-source:list-no-counts-model"),
+				ExternalID: new("list-no-counts-ext"),
+			},
+			Properties: &[]mr_models.Properties{
+				{Name: "source_id", StringValue: new("list-no-counts-source")},
+			},
+		}
+		savedModel, err := catalogModelRepo.Save(testModel)
+		require.NoError(t, err)
+
+		modelArt := &models.CatalogModelArtifactImpl{
+			TypeID: new(int32(modelArtifactTypeID)),
+			Attributes: &models.CatalogModelArtifactAttributes{
+				Name:         new("list-no-counts-art-1"),
+				URI:          new("s3://bucket/list-model.bin"),
+				ArtifactType: new(models.CatalogModelArtifactType),
+			},
+		}
+		_, err = modelArtifactRepo.Save(modelArt, savedModel.GetID())
+		require.NoError(t, err)
+
+		listResult, err := dbCatalog.ListModels(ctx, ListModelsParams{
+			SourceIDs: []string{"list-no-counts-source"},
+			PageSize:  10,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, listResult.Items)
+		for _, m := range listResult.Items {
+			assert.Nil(t, m.ArtifactCounts, "ArtifactCounts must not be populated on list endpoints")
+		}
+	})
+
 	t.Run("TestListModels_Success", func(t *testing.T) {
 		// Create test models
 		sourceIDs := []string{"list-test-source"}

--- a/catalog/internal/catalog/modelcatalog/performance_artifact_service_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_artifact_service_test.go
@@ -73,6 +73,10 @@ func (m *mockPerfArtifactRepo) DeleteByParentID(artifactType string, parentResou
 	return args.Error(0)
 }
 
+func (m *mockPerfArtifactRepo) CountByParentIDs(parentIDs []int32) (map[int32]map[string]int32, error) {
+	return make(map[int32]map[string]int32), nil
+}
+
 func TestPerformanceArtifactService_GetArtifacts(t *testing.T) {
 	// Mock repository for testing
 	mockArtifactRepo := &mockPerfArtifactRepo{}

--- a/catalog/internal/db/models/catalog_artifact.go
+++ b/catalog/internal/db/models/catalog_artifact.go
@@ -74,4 +74,9 @@ type CatalogArtifactRepository interface {
 	GetByID(id int32) (CatalogArtifact, error)
 	List(listOptions CatalogArtifactListOptions) (*models.ListWrapper[CatalogArtifact], error)
 	DeleteByParentID(artifactType string, parentResourceID int32) error
+	// CountByParentIDs returns artifact counts grouped by category for each parent model ID.
+	// The outer map key is the parent model ID; the inner map key is the artifact category
+	// ("model-artifact", "performance-metrics", "accuracy-metrics", "security-metrics").
+	// Categories with zero count are omitted. Parents with no artifacts have no entry.
+	CountByParentIDs(parentIDs []int32) (map[int32]map[string]int32, error)
 }

--- a/catalog/internal/db/service/catalog_artifact.go
+++ b/catalog/internal/db/service/catalog_artifact.go
@@ -11,9 +11,9 @@ import (
 	"github.com/kubeflow/hub/internal/platform/datastore"
 	"github.com/kubeflow/hub/internal/platform/db/dbutil"
 	dbmodels "github.com/kubeflow/hub/internal/platform/db/entity"
+	service "github.com/kubeflow/hub/internal/platform/db/repository"
 	"github.com/kubeflow/hub/internal/platform/db/schema"
 	"github.com/kubeflow/hub/internal/platform/db/scopes"
-	service "github.com/kubeflow/hub/internal/platform/db/repository"
 	"github.com/kubeflow/hub/internal/platform/db/utils"
 	"github.com/kubeflow/hub/pkg/api"
 	"gorm.io/gorm"
@@ -456,6 +456,66 @@ func (r *CatalogArtifactRepositoryImpl) applyCursorPagination(query *gorm.DB, cu
 	// Note that we sort ID ASCENDING as a tie-breaker, so ">" is correct below.
 	return query.Where(fmt.Sprintf("(sort_value.%s %s ? OR (sort_value.%s = ? AND %s.id > ?) OR sort_value.%s IS NULL)", sortColumn, cmp, sortColumn, artifactTable, sortColumn),
 		cursor.Value, cursor.Value, cursor.ID)
+}
+
+// CountByParentIDs returns artifact counts grouped by category for each parent model.
+// The outer map key is the parent model ID (context_id from Attribution).
+// The inner map key is the artifact category: "model-artifact" for CatalogModelArtifacts,
+// or the metricsType value ("performance-metrics", "accuracy-metrics", etc.) for CatalogMetricsArtifacts.
+// Categories with zero count are omitted from the inner map.
+// Parents with no artifacts have no entry in the outer map.
+func (r *CatalogArtifactRepositoryImpl) CountByParentIDs(parentIDs []int32) (map[int32]map[string]int32, error) {
+	result := make(map[int32]map[string]int32, len(parentIDs))
+	if len(parentIDs) == 0 {
+		return result, nil
+	}
+
+	modelArtifactTypeID := r.nameToID[CatalogModelArtifactTypeName]
+	metricsArtifactTypeID := r.nameToID[CatalogMetricsArtifactTypeName]
+
+	artifactTable := utils.GetTableName(r.db, &schema.Artifact{})
+	attributionTable := utils.GetTableName(r.db, &schema.Attribution{})
+	propertyTable := utils.GetTableName(r.db, &schema.ArtifactProperty{})
+
+	selectClause := fmt.Sprintf(
+		`%s.context_id,
+		CASE
+			WHEN %s.type_id = %d THEN 'model-artifact'
+			WHEN %s.type_id = %d THEN COALESCE(%s.string_value, 'unknown')
+		END AS category,
+		COUNT(*) AS count`,
+		attributionTable,
+		artifactTable, modelArtifactTypeID,
+		artifactTable, metricsArtifactTypeID,
+		propertyTable,
+	)
+
+	type countRow struct {
+		ContextID int32  `gorm:"column:context_id"`
+		Category  string `gorm:"column:category"`
+		Count     int32  `gorm:"column:count"`
+	}
+
+	var rows []countRow
+	err := r.db.Table(artifactTable).
+		Select(selectClause).
+		Joins(fmt.Sprintf("INNER JOIN %s ON %s.artifact_id = %s.id", attributionTable, attributionTable, artifactTable)).
+		Joins(fmt.Sprintf("LEFT JOIN %s ON %s.artifact_id = %s.id AND %s.name = 'metricsType' AND %s.is_custom_property = false", propertyTable, propertyTable, artifactTable, propertyTable, propertyTable)).
+		Where(fmt.Sprintf("%s.context_id IN ? AND %s.type_id IN ?", attributionTable, artifactTable), parentIDs, []int32{modelArtifactTypeID, metricsArtifactTypeID}).
+		Group(fmt.Sprintf("%s.context_id, category", attributionTable)).
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("error counting catalog artifacts by parents: %w", err)
+	}
+
+	for _, row := range rows {
+		if result[row.ContextID] == nil {
+			result[row.ContextID] = make(map[string]int32)
+		}
+		result[row.ContextID][row.Category] = row.Count
+	}
+
+	return result, nil
 }
 
 func (r *CatalogArtifactRepositoryImpl) DeleteByParentID(artifactTypeName string, parentResourceID int32) error {

--- a/catalog/internal/db/service/catalog_artifact_test.go
+++ b/catalog/internal/db/service/catalog_artifact_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kubeflow/hub/catalog/internal/testhelpers"
 	modelcatalogmodels "github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/models"
 	modelcatalogservice "github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/service"
 	"github.com/kubeflow/hub/catalog/internal/db/models"
 	"github.com/kubeflow/hub/catalog/internal/db/service"
+	"github.com/kubeflow/hub/catalog/internal/testhelpers"
 	dbmodels "github.com/kubeflow/hub/internal/platform/db/entity"
 	"github.com/kubeflow/hub/internal/testutils"
 	"github.com/stretchr/testify/assert"
@@ -1704,5 +1704,149 @@ func TestCatalogArtifactRepository(t *testing.T) {
 			assert.Less(t, withoutPropertyArtifacts[i].id, withoutPropertyArtifacts[i+1].id,
 				"Artifacts without property should be ordered by ID (even in DESC mode)")
 		}
+	})
+}
+
+func TestCountByParentIDs(t *testing.T) {
+	sharedDB, cleanup := testutils.SetupPostgresWithMigrations(t, testhelpers.MustDatastoreSpec(t))
+	defer cleanup()
+
+	modelArtifactTypeID := getCatalogModelArtifactTypeID(t, sharedDB)
+	metricsArtifactTypeID := getCatalogMetricsArtifactTypeID(t, sharedDB)
+	catalogModelTypeID := getCatalogModelTypeID(t, sharedDB)
+
+	artifactTypeMap := map[string]int32{
+		service.CatalogModelArtifactTypeName:   modelArtifactTypeID,
+		service.CatalogMetricsArtifactTypeName: metricsArtifactTypeID,
+	}
+	repo := service.NewCatalogArtifactRepository(sharedDB, artifactTypeMap)
+	catalogModelRepo := modelcatalogservice.NewCatalogModelRepository(sharedDB, catalogModelTypeID)
+	modelArtifactRepo := modelcatalogservice.NewCatalogModelArtifactRepository(sharedDB, modelArtifactTypeID)
+	metricsArtifactRepo := modelcatalogservice.NewCatalogMetricsArtifactRepository(sharedDB, metricsArtifactTypeID)
+
+	saveModel := func(name string) modelcatalogmodels.CatalogModel {
+		m := &modelcatalogmodels.CatalogModelImpl{
+			TypeID: new(int32(catalogModelTypeID)),
+			Attributes: &modelcatalogmodels.CatalogModelAttributes{
+				Name:       new(name),
+				ExternalID: new(name + "-ext"),
+			},
+		}
+		saved, err := catalogModelRepo.Save(m)
+		require.NoError(t, err)
+		return saved
+	}
+
+	saveModelArtifact := func(parentID *int32, name string) {
+		a := &modelcatalogmodels.CatalogModelArtifactImpl{
+			TypeID: new(int32(modelArtifactTypeID)),
+			Attributes: &modelcatalogmodels.CatalogModelArtifactAttributes{
+				Name:         new(name),
+				URI:          new("s3://bucket/" + name),
+				ArtifactType: new(modelcatalogmodels.CatalogModelArtifactType),
+			},
+		}
+		_, err := modelArtifactRepo.Save(a, parentID)
+		require.NoError(t, err)
+	}
+
+	saveMetricsArtifact := func(parentID *int32, name string, mt modelcatalogmodels.MetricsType) {
+		a := &modelcatalogmodels.CatalogMetricsArtifactImpl{
+			TypeID: new(int32(metricsArtifactTypeID)),
+			Attributes: &modelcatalogmodels.CatalogMetricsArtifactAttributes{
+				Name:         new(name),
+				MetricsType:  mt,
+				ArtifactType: new(modelcatalogmodels.CatalogMetricsArtifactType),
+			},
+		}
+		_, err := metricsArtifactRepo.Save(a, parentID)
+		require.NoError(t, err)
+	}
+
+	t.Run("EmptyParentList", func(t *testing.T) {
+		counts, err := repo.CountByParentIDs([]int32{})
+		require.NoError(t, err)
+		assert.Empty(t, counts)
+	})
+
+	t.Run("ParentWithNoArtifacts", func(t *testing.T) {
+		model := saveModel("count-test-no-artifacts")
+		counts, err := repo.CountByParentIDs([]int32{*model.GetID()})
+		require.NoError(t, err)
+		_, found := counts[*model.GetID()]
+		assert.False(t, found, "model with no artifacts should have no entry")
+	})
+
+	t.Run("OnlyModelArtifacts", func(t *testing.T) {
+		model := saveModel("count-test-model-only")
+		saveModelArtifact(model.GetID(), "count-model-only-art-1")
+		saveModelArtifact(model.GetID(), "count-model-only-art-2")
+
+		counts, err := repo.CountByParentIDs([]int32{*model.GetID()})
+		require.NoError(t, err)
+		require.Contains(t, counts, *model.GetID())
+		assert.Equal(t, map[string]int32{"model-artifact": 2}, counts[*model.GetID()])
+	})
+
+	t.Run("OnlyMetricsArtifactsMultipleTypes", func(t *testing.T) {
+		model := saveModel("count-test-metrics-only")
+		saveMetricsArtifact(model.GetID(), "count-perf-1", modelcatalogmodels.MetricsTypePerformance)
+		saveMetricsArtifact(model.GetID(), "count-perf-2", modelcatalogmodels.MetricsTypePerformance)
+		saveMetricsArtifact(model.GetID(), "count-perf-3", modelcatalogmodels.MetricsTypePerformance)
+		saveMetricsArtifact(model.GetID(), "count-acc-1", modelcatalogmodels.MetricsTypeAccuracy)
+
+		counts, err := repo.CountByParentIDs([]int32{*model.GetID()})
+		require.NoError(t, err)
+		require.Contains(t, counts, *model.GetID())
+		assert.Equal(t, map[string]int32{
+			"performance-metrics": 3,
+			"accuracy-metrics":    1,
+		}, counts[*model.GetID()])
+		_, hasSecurity := counts[*model.GetID()]["security-metrics"]
+		assert.False(t, hasSecurity, "security-metrics key should be absent when count is zero")
+	})
+
+	t.Run("MixedArtifactTypes", func(t *testing.T) {
+		model := saveModel("count-test-mixed")
+		saveModelArtifact(model.GetID(), "count-mixed-model-1")
+		saveMetricsArtifact(model.GetID(), "count-mixed-perf-1", modelcatalogmodels.MetricsTypePerformance)
+		saveMetricsArtifact(model.GetID(), "count-mixed-acc-1", modelcatalogmodels.MetricsTypeAccuracy)
+		saveMetricsArtifact(model.GetID(), "count-mixed-sec-1", modelcatalogmodels.MetricsTypeSecurityMetrics)
+
+		counts, err := repo.CountByParentIDs([]int32{*model.GetID()})
+		require.NoError(t, err)
+		require.Contains(t, counts, *model.GetID())
+		assert.Equal(t, map[string]int32{
+			"model-artifact":      1,
+			"performance-metrics": 1,
+			"accuracy-metrics":    1,
+			"security-metrics":    1,
+		}, counts[*model.GetID()])
+	})
+
+	t.Run("MultipleParentIDs", func(t *testing.T) {
+		modelA := saveModel("count-test-multi-a")
+		modelB := saveModel("count-test-multi-b")
+
+		saveModelArtifact(modelA.GetID(), "count-multi-a-model-1")
+		saveModelArtifact(modelA.GetID(), "count-multi-a-model-2")
+		saveMetricsArtifact(modelA.GetID(), "count-multi-a-perf-1", modelcatalogmodels.MetricsTypePerformance)
+
+		saveMetricsArtifact(modelB.GetID(), "count-multi-b-acc-1", modelcatalogmodels.MetricsTypeAccuracy)
+		saveMetricsArtifact(modelB.GetID(), "count-multi-b-acc-2", modelcatalogmodels.MetricsTypeAccuracy)
+
+		counts, err := repo.CountByParentIDs([]int32{*modelA.GetID(), *modelB.GetID()})
+		require.NoError(t, err)
+
+		require.Contains(t, counts, *modelA.GetID())
+		assert.Equal(t, map[string]int32{
+			"model-artifact":      2,
+			"performance-metrics": 1,
+		}, counts[*modelA.GetID()])
+
+		require.Contains(t, counts, *modelB.GetID())
+		assert.Equal(t, map[string]int32{
+			"accuracy-metrics": 2,
+		}, counts[*modelB.GetID()])
 	})
 }

--- a/catalog/pkg/openapi/model_catalog_model.go
+++ b/catalog/pkg/openapi/model_catalog_model.go
@@ -55,6 +55,8 @@ type CatalogModel struct {
 	// List of tasks for this model which have been validated by the catalog provider.
 	ValidatedTasks []string       `json:"validatedTasks,omitempty"`
 	ServingConfig  *ServingConfig `json:"servingConfig,omitempty"`
+	// Read-only counts of artifacts by category. Only populated on the single-model detail endpoint (GetModel). Keys with zero count are omitted. When no artifacts exist, the field is omitted entirely.
+	ArtifactCounts *map[string]int32 `json:"artifactCounts,omitempty"`
 }
 
 type _CatalogModel CatalogModel
@@ -677,6 +679,38 @@ func (o *CatalogModel) SetServingConfig(v ServingConfig) {
 	o.ServingConfig = &v
 }
 
+// GetArtifactCounts returns the ArtifactCounts field value if set, zero value otherwise.
+func (o *CatalogModel) GetArtifactCounts() map[string]int32 {
+	if o == nil || IsNil(o.ArtifactCounts) {
+		var ret map[string]int32
+		return ret
+	}
+	return *o.ArtifactCounts
+}
+
+// GetArtifactCountsOk returns a tuple with the ArtifactCounts field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CatalogModel) GetArtifactCountsOk() (*map[string]int32, bool) {
+	if o == nil || IsNil(o.ArtifactCounts) {
+		return nil, false
+	}
+	return o.ArtifactCounts, true
+}
+
+// HasArtifactCounts returns a boolean if a field has been set.
+func (o *CatalogModel) HasArtifactCounts() bool {
+	if o != nil && !IsNil(o.ArtifactCounts) {
+		return true
+	}
+
+	return false
+}
+
+// SetArtifactCounts gets a reference to the given map[string]int32 and assigns it to the ArtifactCounts field.
+func (o *CatalogModel) SetArtifactCounts(v map[string]int32) {
+	o.ArtifactCounts = &v
+}
+
 func (o CatalogModel) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -741,6 +775,9 @@ func (o CatalogModel) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.ServingConfig) {
 		toSerialize["servingConfig"] = o.ServingConfig
+	}
+	if !IsNil(o.ArtifactCounts) {
+		toSerialize["artifactCounts"] = o.ArtifactCounts
 	}
 	return toSerialize, nil
 }


### PR DESCRIPTION
## Description
Add a read-only `artifactCounts` field to `CatalogModel`. `GetModel` populates it via a single `SQL GROUP BY` query; `ListModels` omits it to avoid per-row overhead. Keys with zero count are omitted; the field is absent when no artifacts exist.

## How Has This Been Tested?
With the demo data loaded:

```
$ curl -s 'http://localhost:8082/api/model_catalog/v1alpha1/sources/validated_ai_models/models/certified/production-llm-8b' | jq '.artifactCounts'
{
  "accuracy-metrics": 7,
  "model-artifact": 1,
  "performance-metrics": 6
}
```

Confirmed the `model-artifact` and `metrics-artifact` counts:

```
$ curl -s 'http://localhost:8082/api/model_catalog/v1alpha1/sources/validated_ai_models/models/certified/production-llm-8b/artifacts?pageSize=100' | jq '.items[].artifactType' | sort | uniq -c
     13 "metrics-artifact"
      1 "model-artifact"
```

And confirmed the accuracy / performance counts:

```
$ curl -s 'http://localhost:8082/api/model_catalog/v1alpha1/sources/validated_ai_models/models/certified/production-llm-8b/artifacts?pageSize=100' | jq '.items[].metricsType' | sort | uniq -c
      7 "accuracy-metrics"
      1 null
      6 "performance-metrics"
```

(The `null` is from the `model-artifact`, which does not have a `metricsType` field.)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
