### PR TITLE
feat(bff): add CRUD endpoints for MCP catalog sources

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -1099,6 +1099,119 @@ paths:
       operationId: getMcpServerTools
       description: Gets the list of tools exposed by an `McpServer`.
 
+  # MCP catalog settings endpoints
+  /api/v1/settings/mcp_catalog/source_configs:
+    summary: Path used to manage MCP catalog sources.
+    description: The REST endpoint/path used to list and create MCP catalog sources.
+    get:
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+      responses:
+        "200":
+          $ref: "#/components/responses/McpCatalogSourceConfigListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getMcpCatalogSources
+      summary: List ALL the MCP catalog sources.
+      description: Gets a list of all MCP catalog sources.
+    post:
+      requestBody:
+        description: A new MCP catalog source to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/McpCatalogSourceConfigPayload"
+        required: true
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+      responses:
+        "201":
+          $ref: "#/components/responses/McpCatalogSourceConfigResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: createMcpCatalogSource
+      summary: Create an MCP Catalog source
+      description: Creates a new MCP catalog source.
+  /api/v1/settings/mcp_catalog/source_configs/{sourceId}:
+    summary: Path used to manage MCP catalog sources.
+    description: >-
+      The REST endpoint/path used to get, update and delete a single MCP Catalog Source.
+    get:
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: "#/components/parameters/sourceId"
+      responses:
+        "200":
+          $ref: "#/components/responses/McpCatalogSourceConfigResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getMcpCatalogSource
+      summary: Get an MCP Catalog Source
+      description: Gets the details of a single MCP Catalog source.
+    patch:
+      requestBody:
+        description: Updated MCP Catalog Source information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/McpCatalogSourceConfigPayload"
+        required: true
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: "#/components/parameters/sourceId"
+      responses:
+        "200":
+          $ref: "#/components/responses/McpCatalogSourceConfigResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: updateMcpCatalogSource
+      summary: Update an MCP Catalog Source
+      description: Updates an existing MCP Catalog source.
+    delete:
+      tags:
+        - K8SOperation
+      parameters:
+        - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: "#/components/parameters/sourceId"
+      responses:
+        "204":
+          description: Successfully deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: deleteMcpCatalogSource
+      summary: Delete an MCP Catalog source
+      description: Deletes an existing MCP Catalog Source.
+
   # Model catalog settings endpoints
   /api/v1/settings/model_catalog/source_configs:
     summary: Path used to manage Model catalog sources.
@@ -3291,6 +3404,71 @@ components:
           description: name of the organization that need to ingest from the source.
           example: org1
 
+    # Schema for MCP catalog settings
+    McpCatalogSourceConfig:
+      description: A single MCP catalog source configuration
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/McpCatalogSourceConfigPayload"
+    McpCatalogSourceConfigList:
+      description: List of MCP catalog sources.
+      type: object
+      properties:
+        catalogs:
+          description: Array of MCP catalog sources.
+          type: array
+          items:
+            $ref: "#/components/schemas/McpCatalogSourceConfig"
+
+    McpCatalogSourceConfigPayload:
+      description: Payload for creating an MCP catalog source
+      type: object
+      required:
+        - name
+        - id
+        - type
+      properties:
+        name:
+          type: string
+          description: The name of the MCP catalog source.
+          example: Community MCP Servers
+        id:
+          type: string
+          description: A unique identifier for an MCP catalog source.
+          example: community_mcp_servers
+        type:
+          type: string
+          example: yaml
+        enabled:
+          type: boolean
+          description: Whether the MCP catalog source is enabled.
+          default: true
+          example: true
+        labels:
+          description: |-
+            Labels associated with the source. The catalog source labels can be
+            used to filter MCP servers from sources with the same label.
+          type: array
+          items:
+            type: string
+        isDefault:
+          type: boolean
+          example: true
+        yaml:
+          type: string
+          description: Complete YAML catalog content for yaml-type sources.
+        includedServers:
+          type: array
+          items:
+            type: string
+            example: kubernetes-mcp
+        excludedServers:
+          type: array
+          items:
+            type: string
+            example: internal-*
+            description: list of MCP server names that will be excluded.
+
     ModelTransferJobSourceType:
       description: The type of source for a transfer job.
       type: string
@@ -3818,6 +3996,26 @@ components:
               data:
                 $ref: "#/components/schemas/CatalogSourceConfig"
       description: A response containing a catalog source.
+
+    # MCP catalog settings responses
+    McpCatalogSourceConfigListResponse:
+      description: A response containing a list of MCP catalog sources.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: "#/components/schemas/McpCatalogSourceConfigList"
+    McpCatalogSourceConfigResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: "#/components/schemas/McpCatalogSourceConfig"
+      description: A response containing an MCP catalog source.
 
     ModelTransferJobResponse:
       content:

--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -3311,16 +3311,28 @@ components:
               properties:
                 totalModels:
                   type: integer
-                  description: Total number of models evaluated
+                  description: Total number of models evaluated (when assetType=models)
                   example: 1500
                 includedModels:
                   type: integer
-                  description: Number of models that would be included
+                  description: Number of models that would be included (when assetType=models)
                   example: 850
                 excludedModels:
                   type: integer
-                  description: Number of models that would be excluded
+                  description: Number of models that would be excluded (when assetType=models)
                   example: 650
+                totalAssets:
+                  type: integer
+                  description: Total number of assets evaluated (when assetType=mcp_servers)
+                  example: 25
+                includedAssets:
+                  type: integer
+                  description: Number of assets that would be included (when assetType=mcp_servers)
+                  example: 18
+                excludedAssets:
+                  type: integer
+                  description: Number of assets that would be excluded (when assetType=mcp_servers)
+                  example: 7
               required:
                 - totalModels
                 - includedModels

--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -1339,6 +1339,7 @@ paths:
         - ModelCatalogService
       parameters:
         - $ref: "#/components/parameters/kubeflowUserId"
+        - $ref: "#/components/parameters/assetType"
         - name: statusFilter
           description: |-
             Filter the response to show specific model statuses.

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -85,6 +85,7 @@ const (
 
 	// MCP server catalog
 	McpServerId                   = "server_id"
+	McpSourceId                   = "source_id"
 	McpServerCatalogPathPrefix    = ApiPathPrefix + "/mcp_catalog"
 	McpServerListPath             = McpServerCatalogPathPrefix + "/mcp_servers"
 	McpServerFilterOptionListPath = McpServerCatalogPathPrefix + "/mcp_servers_filter_options"
@@ -94,6 +95,11 @@ const (
 	// Swagger UI (interactive API docs)
 	SwaggerPath    = ApiPathPrefix + "/swagger"
 	SwaggerDocPath = SwaggerPath + "/doc.json"
+
+	// MCP catalog settings
+	McpCatalogSettingsPathPrefix           = SettingsPath + "/mcp_catalog"
+	McpCatalogSettingsSourceConfigListPath = McpCatalogSettingsPathPrefix + "/source_configs"
+	McpCatalogSettingsSourceConfigPath     = McpCatalogSettingsSourceConfigListPath + "/:" + McpSourceId
 )
 
 type App struct {
@@ -334,6 +340,13 @@ func (app *App) Routes() http.Handler {
 		apiRouter.GET(McpServerFilterOptionListPath, app.AttachNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServersFiltersHandler)))
 		apiRouter.GET(McpServerPath, app.AttachNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServerHandler)))
 		apiRouter.GET(McpServersToolListPath, app.AttachNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServersToolsHandler)))
+
+		// MCP catalog settings page
+		apiRouter.GET(McpCatalogSettingsSourceConfigListPath, app.AttachNamespace(app.GetAllMcpCatalogSourceConfigsHandler))
+		apiRouter.POST(McpCatalogSettingsSourceConfigListPath, app.AttachNamespace(app.CreateMcpCatalogSourceConfigHandler))
+		apiRouter.GET(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.GetMcpCatalogSourceConfigHandler))
+		apiRouter.PATCH(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.UpdateMcpCatalogSourceConfigHandler))
+		apiRouter.DELETE(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.DeleteMcpCatalogSourceConfigHandler))
 	}
 
 	// App Router

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -85,7 +85,6 @@ const (
 
 	// MCP server catalog
 	McpServerId                   = "server_id"
-	McpSourceId                   = "source_id"
 	McpServerCatalogPathPrefix    = ApiPathPrefix + "/mcp_catalog"
 	McpServerListPath             = McpServerCatalogPathPrefix + "/mcp_servers"
 	McpServerFilterOptionListPath = McpServerCatalogPathPrefix + "/mcp_servers_filter_options"
@@ -99,7 +98,7 @@ const (
 	// MCP catalog settings
 	McpCatalogSettingsPathPrefix           = SettingsPath + "/mcp_catalog"
 	McpCatalogSettingsSourceConfigListPath = McpCatalogSettingsPathPrefix + "/source_configs"
-	McpCatalogSettingsSourceConfigPath     = McpCatalogSettingsSourceConfigListPath + "/:" + McpSourceId
+	McpCatalogSettingsSourceConfigPath     = McpCatalogSettingsSourceConfigListPath + "/:" + CatalogSourceId
 )
 
 type App struct {

--- a/clients/ui/bff/internal/api/catalog_source_preview_handler_test.go
+++ b/clients/ui/bff/internal/api/catalog_source_preview_handler_test.go
@@ -48,6 +48,39 @@ var _ = Describe("CreateCatalogSourcePreviewHandler", func() {
 
 		})
 
+		It("should return MCP server preview when assetType=mcp_servers", func() {
+			By("creating a source preview with assetType=mcp_servers")
+			requestIdentity := kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			}
+
+			requestBody := struct {
+				Data models.CatalogSourcePreviewRequest `json:"data"`
+			}{
+				Data: models.CatalogSourcePreviewRequest{
+					Type:           "yaml",
+					IncludedModels: []string{},
+					ExcludedModels: []string{},
+					Properties: map[string]interface{}{
+						"yaml": "servers:\n  - name: test-server",
+					},
+				},
+			}
+			bodyBytes, _ := json.Marshal(requestBody)
+
+			actual, rs, err := setupApiTest[CatalogSourcePreviewEnvelope](http.MethodPost, "/api/v1/settings/model_catalog/source_preview?namespace=kubeflow&assetType=mcp_servers", bytes.NewReader(bodyBytes), kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("should return MCP server preview data")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Data.Summary.TotalModels).To(Equal(int32(17)))
+			Expect(actual.Data.Summary.IncludedModels).To(Equal(int32(12)))
+			Expect(actual.Data.Summary.ExcludedModels).To(Equal(int32(5)))
+			for _, item := range actual.Data.Items {
+				Expect(item.Name).To(ContainSubstring("mcp-source/"))
+			}
+		})
+
 		It("should filter by filterStatus=included", func() {
 			By("creating a source preview with filterStatus=included")
 			requestIdentity := kubernetes.RequestIdentity{

--- a/clients/ui/bff/internal/api/catalog_source_preview_handler_test.go
+++ b/clients/ui/bff/internal/api/catalog_source_preview_handler_test.go
@@ -73,9 +73,9 @@ var _ = Describe("CreateCatalogSourcePreviewHandler", func() {
 
 			By("should return MCP server preview data")
 			Expect(rs.StatusCode).To(Equal(http.StatusOK))
-			Expect(actual.Data.Summary.TotalModels).To(Equal(int32(17)))
-			Expect(actual.Data.Summary.IncludedModels).To(Equal(int32(12)))
-			Expect(actual.Data.Summary.ExcludedModels).To(Equal(int32(5)))
+			Expect(actual.Data.Summary.TotalAssets).To(Equal(int32(17)))
+			Expect(actual.Data.Summary.IncludedAssets).To(Equal(int32(12)))
+			Expect(actual.Data.Summary.ExcludedAssets).To(Equal(int32(5)))
 			for _, item := range actual.Data.Items {
 				Expect(item.Name).To(ContainSubstring("mcp-source/"))
 			}

--- a/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
+++ b/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/hub/ui/bff/internal/constants"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	"github.com/kubeflow/hub/ui/bff/internal/repositories"
+)
+
+type McpCatalogSettingsSourceConfigEnvelope Envelope[*models.McpCatalogSourceConfig, None]
+type McpCatalogSettingsSourceConfigListEnvelope Envelope[*models.McpCatalogSourceConfigList, None]
+type McpCatalogSourcePayloadEnvelope Envelope[*models.McpCatalogSourceConfigPayload, None]
+
+func (app *App) GetAllMcpCatalogSourceConfigsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	configs, err := app.repositories.McpCatalogSettingsRepository.GetAllMcpCatalogSourceConfigs(ctx, client, namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	envelope := McpCatalogSettingsSourceConfigListEnvelope{
+		Data: configs,
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, envelope, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	sourceID := ps.ByName(McpSourceId)
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	config, err := app.repositories.McpCatalogSettingsRepository.GetMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
+	if err != nil {
+		if errors.Is(err, repositories.ErrMcpCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	envelope := McpCatalogSettingsSourceConfigEnvelope{
+		Data: config,
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, envelope, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) CreateMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	var envelope McpCatalogSourcePayloadEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error decoding JSON: %v", err.Error()))
+		return
+	}
+
+	created, err := app.repositories.McpCatalogSettingsRepository.CreateMcpCatalogSourceConfig(ctx, client, namespace, *envelope.Data)
+	if err != nil {
+		if errors.Is(err, repositories.ErrMcpCatalogSourceAlreadyExist) ||
+			errors.Is(err, repositories.ErrMcpCatalogSourceIdRequired) {
+			app.badRequestResponse(w, r, err)
+		} else if errors.Is(err, repositories.ErrMcpCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	result := McpCatalogSettingsSourceConfigEnvelope{
+		Data: created,
+	}
+
+	w.Header().Set("Location", r.URL.JoinPath(result.Data.Id).String())
+	if err = app.WriteJSON(w, http.StatusCreated, result, nil); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error writing JSON"))
+	}
+}
+
+func (app *App) UpdateMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	var envelope McpCatalogSourcePayloadEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error decoding JSON: %v", err.Error()))
+		return
+	}
+
+	sourceID := ps.ByName(McpSourceId)
+	if sourceID == "" {
+		sourceID = envelope.Data.Id
+	}
+
+	updated, err := app.repositories.McpCatalogSettingsRepository.UpdateMcpCatalogSourceConfig(ctx, client, namespace, sourceID, *envelope.Data)
+	if err != nil {
+		if errors.Is(err, repositories.ErrMcpCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else if errors.Is(err, repositories.ErrMcpCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	result := McpCatalogSettingsSourceConfigEnvelope{
+		Data: updated,
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) DeleteMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	sourceID := ps.ByName(McpSourceId)
+
+	deleted, err := app.repositories.McpCatalogSettingsRepository.DeleteMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
+	if err != nil {
+		if errors.Is(err, repositories.ErrMcpCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else if errors.Is(err, repositories.ErrMcpCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	result := McpCatalogSettingsSourceConfigEnvelope{
+		Data: deleted,
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
+++ b/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
@@ -55,7 +55,7 @@ func (app *App) GetMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	sourceID := ps.ByName(McpSourceId)
+	sourceID := ps.ByName(CatalogSourceId)
 
 	client, err := app.kubernetesClientFactory.GetClient(ctx)
 	if err != nil {
@@ -157,7 +157,7 @@ func (app *App) UpdateMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	sourceID := ps.ByName(McpSourceId)
+	sourceID := ps.ByName(CatalogSourceId)
 	if sourceID == "" {
 		sourceID = envelope.Data.Id
 	}
@@ -198,7 +198,7 @@ func (app *App) DeleteMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	sourceID := ps.ByName(McpSourceId)
+	sourceID := ps.ByName(CatalogSourceId)
 
 	_, err = app.repositories.McpCatalogSettingsRepository.DeleteMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
 	if err != nil {

--- a/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
+++ b/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
@@ -99,7 +99,12 @@ func (app *App) CreateMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 
 	var envelope McpCatalogSourcePayloadEnvelope
 	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
-		app.serverErrorResponse(w, r, fmt.Errorf("error decoding JSON: %v", err.Error()))
+		app.badRequestResponse(w, r, fmt.Errorf("error decoding JSON: %w", err))
+		return
+	}
+
+	if envelope.Data == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing required field: data"))
 		return
 	}
 
@@ -143,7 +148,12 @@ func (app *App) UpdateMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 
 	var envelope McpCatalogSourcePayloadEnvelope
 	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
-		app.serverErrorResponse(w, r, fmt.Errorf("error decoding JSON: %v", err.Error()))
+		app.badRequestResponse(w, r, fmt.Errorf("error decoding JSON: %w", err))
+		return
+	}
+
+	if envelope.Data == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing required field: data"))
 		return
 	}
 
@@ -190,7 +200,7 @@ func (app *App) DeleteMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 
 	sourceID := ps.ByName(McpSourceId)
 
-	deleted, err := app.repositories.McpCatalogSettingsRepository.DeleteMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
+	_, err = app.repositories.McpCatalogSettingsRepository.DeleteMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
 	if err != nil {
 		if errors.Is(err, repositories.ErrMcpCatalogSourceNotFound) {
 			app.notFoundResponse(w, r)
@@ -202,11 +212,5 @@ func (app *App) DeleteMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	result := McpCatalogSettingsSourceConfigEnvelope{
-		Data: deleted,
-	}
-
-	if err = app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
-		app.serverErrorResponse(w, r, err)
-	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
+++ b/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
@@ -328,8 +328,14 @@ func (m *ModelCatalogClientMock) CreateCatalogSourcePreview(client httpclient.HT
 	}
 
 	nextPageToken := pageValues.Get("nextPageToken")
+	assetType := pageValues.Get("assetType")
 
-	catalogSourcePreview := CreateCatalogSourcePreviewMockWithFilter(filterStatus, pageSize, nextPageToken)
+	var catalogSourcePreview models.CatalogSourcePreviewResult
+	if assetType == "mcp_servers" {
+		catalogSourcePreview = CreateMcpCatalogSourcePreviewMockWithFilter(filterStatus, pageSize, nextPageToken)
+	} else {
+		catalogSourcePreview = CreateCatalogSourcePreviewMockWithFilter(filterStatus, pageSize, nextPageToken)
+	}
 
 	return &catalogSourcePreview, nil
 }

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -2623,33 +2623,27 @@ func CreateCatalogSourcePreviewMock() models.CatalogSourcePreviewResult {
 	return CreateCatalogSourcePreviewMockWithFilter("all", 20, "")
 }
 
-func CreateCatalogSourcePreviewMockWithFilter(filterStatus string, pageSize int, nextPageToken string) models.CatalogSourcePreviewResult {
-	allModels := GetModelsWithInclusionStatusListMocks()
-	catalogSourcePreviewSummary := GetCatalogSourcePreviewSummaryMock()
-
-	// Filter based on filterStatus
-	var filteredModels []models.CatalogSourcePreviewModel
+func filterAndPaginatePreviewItems(allItems []models.CatalogSourcePreviewModel, summary models.CatalogSourcePreviewSummary, filterStatus string, pageSize int, nextPageToken string) models.CatalogSourcePreviewResult {
+	var filtered []models.CatalogSourcePreviewModel
 	switch filterStatus {
 	case "included":
-		for _, m := range allModels {
-			if m.Included {
-				filteredModels = append(filteredModels, m)
+		for _, item := range allItems {
+			if item.Included {
+				filtered = append(filtered, item)
 			}
 		}
 	case "excluded":
-		for _, m := range allModels {
-			if !m.Included {
-				filteredModels = append(filteredModels, m)
+		for _, item := range allItems {
+			if !item.Included {
+				filtered = append(filtered, item)
 			}
 		}
-	default: // "all" or empty
-		filteredModels = allModels
+	default:
+		filtered = allItems
 	}
 
-	// Handle pagination
 	startIndex := 0
 	if nextPageToken != "" {
-		// Parse token as start index (simple mock implementation)
 		_, _ = fmt.Sscanf(nextPageToken, "%d", &startIndex)
 	}
 
@@ -2658,25 +2652,60 @@ func CreateCatalogSourcePreviewMockWithFilter(filterStatus string, pageSize int,
 	}
 
 	endIndex := startIndex + pageSize
-	if endIndex > len(filteredModels) {
-		endIndex = len(filteredModels)
+	if endIndex > len(filtered) {
+		endIndex = len(filtered)
 	}
 
-	pagedModels := filteredModels[startIndex:endIndex]
+	paged := filtered[startIndex:endIndex]
 
-	// Generate next page token if there are more items
 	var newNextPageToken string
-	if endIndex < len(filteredModels) {
+	if endIndex < len(filtered) {
 		newNextPageToken = fmt.Sprintf("%d", endIndex)
 	}
 
 	return models.CatalogSourcePreviewResult{
-		Items:         pagedModels,
-		Summary:       catalogSourcePreviewSummary,
+		Items:         paged,
+		Summary:       summary,
 		NextPageToken: newNextPageToken,
 		PageSize:      int32(pageSize),
-		Size:          int32(len(pagedModels)),
+		Size:          int32(len(paged)),
 	}
+}
+
+func CreateCatalogSourcePreviewMockWithFilter(filterStatus string, pageSize int, nextPageToken string) models.CatalogSourcePreviewResult {
+	return filterAndPaginatePreviewItems(GetModelsWithInclusionStatusListMocks(), GetCatalogSourcePreviewSummaryMock(), filterStatus, pageSize, nextPageToken)
+}
+
+func GetMcpServersWithInclusionStatusListMocks() []models.CatalogSourcePreviewModel {
+	var allServers []models.CatalogSourcePreviewModel
+
+	for i := 1; i <= 12; i++ {
+		allServers = append(allServers, models.CatalogSourcePreviewModel{
+			Name:     fmt.Sprintf("mcp-source/included-server-%d", i),
+			Included: true,
+		})
+	}
+
+	for i := 1; i <= 5; i++ {
+		allServers = append(allServers, models.CatalogSourcePreviewModel{
+			Name:     fmt.Sprintf("mcp-source/excluded-server-%d", i),
+			Included: false,
+		})
+	}
+
+	return allServers
+}
+
+func GetMcpCatalogSourcePreviewSummaryMock() models.CatalogSourcePreviewSummary {
+	return models.CatalogSourcePreviewSummary{
+		TotalModels:    17,
+		IncludedModels: 12,
+		ExcludedModels: 5,
+	}
+}
+
+func CreateMcpCatalogSourcePreviewMockWithFilter(filterStatus string, pageSize int, nextPageToken string) models.CatalogSourcePreviewResult {
+	return filterAndPaginatePreviewItems(GetMcpServersWithInclusionStatusListMocks(), GetMcpCatalogSourcePreviewSummaryMock(), filterStatus, pageSize, nextPageToken)
 }
 
 func GetMcpServerMocks() []models.McpServer {

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -2698,9 +2698,9 @@ func GetMcpServersWithInclusionStatusListMocks() []models.CatalogSourcePreviewMo
 
 func GetMcpCatalogSourcePreviewSummaryMock() models.CatalogSourcePreviewSummary {
 	return models.CatalogSourcePreviewSummary{
-		TotalModels:    17,
-		IncludedModels: 12,
-		ExcludedModels: 5,
+		TotalAssets:    17,
+		IncludedAssets: 12,
+		ExcludedAssets: 5,
 	}
 }
 

--- a/clients/ui/bff/internal/models/catalog_source_preview.go
+++ b/clients/ui/bff/internal/models/catalog_source_preview.go
@@ -13,9 +13,12 @@ type CatalogSourcePreviewModel struct {
 }
 
 type CatalogSourcePreviewSummary struct {
-	TotalModels    int32 `json:"totalModels"`
-	IncludedModels int32 `json:"includedModels"`
-	ExcludedModels int32 `json:"excludedModels"`
+	TotalModels    int32 `json:"totalModels,omitempty"`
+	IncludedModels int32 `json:"includedModels,omitempty"`
+	ExcludedModels int32 `json:"excludedModels,omitempty"`
+	TotalAssets    int32 `json:"totalAssets,omitempty"`
+	IncludedAssets int32 `json:"includedAssets,omitempty"`
+	ExcludedAssets int32 `json:"excludedAssets,omitempty"`
 }
 
 type CatalogSourcePreviewResult struct {

--- a/clients/ui/bff/internal/models/mcp_catalog_source_configs.go
+++ b/clients/ui/bff/internal/models/mcp_catalog_source_configs.go
@@ -1,0 +1,20 @@
+package models
+
+type McpCatalogSourceConfig struct {
+	Id              string   `json:"id"`
+	Name            string   `json:"name"`
+	Type            string   `json:"type"`
+	Enabled         *bool    `json:"enabled,omitempty"`
+	Labels          []string `json:"labels"`
+	IncludedServers []string `json:"includedServers,omitempty"`
+	ExcludedServers []string `json:"excludedServers,omitempty"`
+	IsDefault       *bool    `json:"isDefault,omitempty"`
+	Yaml            *string  `json:"yaml,omitempty"`
+	YamlCatalogPath *string  `json:"yamlCatalogPath,omitempty"`
+}
+
+type McpCatalogSourceConfigPayload = McpCatalogSourceConfig
+
+type McpCatalogSourceConfigList struct {
+	Catalogs []McpCatalogSourceConfig `json:"catalogs,omitempty"`
+}

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
@@ -14,6 +14,7 @@ var (
 	ErrMcpCatalogSourceAlreadyExist = errors.New("mcp catalog source already exists")
 	ErrMcpCatalogSourceIdRequired   = errors.New("mcp catalog source ID is required")
 	ErrMcpCatalogSourceConflict     = errors.New("mcp catalog source was modified by another request")
+	ErrMcpCatalogNotImplemented     = errors.New("mcp catalog settings not implemented yet")
 )
 
 type McpCatalogSettingsRepository struct {
@@ -24,21 +25,40 @@ func NewMcpCatalogSettingsRepository() *McpCatalogSettingsRepository {
 }
 
 func (r *McpCatalogSettingsRepository) GetAllMcpCatalogSourceConfigs(_ context.Context, _ k8s.KubernetesClientInterface, _ string) (*models.McpCatalogSourceConfigList, error) {
-	return nil, fmt.Errorf("not implemented yet")
+	return &models.McpCatalogSourceConfigList{
+		Catalogs: []models.McpCatalogSourceConfig{},
+	}, nil
 }
 
-func (r *McpCatalogSettingsRepository) GetMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ string) (*models.McpCatalogSourceConfig, error) {
-	return nil, fmt.Errorf("not implemented yet")
+func (r *McpCatalogSettingsRepository) GetMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, sourceID string) (*models.McpCatalogSourceConfig, error) {
+	return nil, fmt.Errorf("%w: %s", ErrMcpCatalogSourceNotFound, sourceID)
 }
 
-func (r *McpCatalogSettingsRepository) CreateMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ models.McpCatalogSourceConfigPayload) (*models.McpCatalogSourceConfig, error) {
-	return nil, fmt.Errorf("not implemented yet")
+func (r *McpCatalogSettingsRepository) CreateMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, payload models.McpCatalogSourceConfigPayload) (*models.McpCatalogSourceConfig, error) {
+	if payload.Id == "" {
+		return nil, ErrMcpCatalogSourceIdRequired
+	}
+	enabled := true
+	return &models.McpCatalogSourceConfig{
+		Id:      payload.Id,
+		Name:    payload.Name,
+		Type:    payload.Type,
+		Enabled: &enabled,
+		Labels:  payload.Labels,
+	}, nil
 }
 
-func (r *McpCatalogSettingsRepository) UpdateMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ string, _ models.McpCatalogSourceConfigPayload) (*models.McpCatalogSourceConfig, error) {
-	return nil, fmt.Errorf("not implemented yet")
+func (r *McpCatalogSettingsRepository) UpdateMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, sourceID string, payload models.McpCatalogSourceConfigPayload) (*models.McpCatalogSourceConfig, error) {
+	enabled := true
+	return &models.McpCatalogSourceConfig{
+		Id:      sourceID,
+		Name:    payload.Name,
+		Type:    payload.Type,
+		Enabled: &enabled,
+		Labels:  payload.Labels,
+	}, nil
 }
 
 func (r *McpCatalogSettingsRepository) DeleteMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ string) (*models.McpCatalogSourceConfig, error) {
-	return nil, fmt.Errorf("not implemented yet")
+	return nil, nil
 }

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
@@ -25,12 +25,54 @@ func NewMcpCatalogSettingsRepository() *McpCatalogSettingsRepository {
 }
 
 func (r *McpCatalogSettingsRepository) GetAllMcpCatalogSourceConfigs(_ context.Context, _ k8s.KubernetesClientInterface, _ string) (*models.McpCatalogSourceConfigList, error) {
+	enabled := true
+	disabled := false
+	isDefault := true
 	return &models.McpCatalogSourceConfigList{
-		Catalogs: []models.McpCatalogSourceConfig{},
+		Catalogs: []models.McpCatalogSourceConfig{
+			{
+				Id:        "community-mcp-source",
+				Name:      "Community MCP Servers",
+				Type:      "yaml",
+				Enabled:   &enabled,
+				Labels:    []string{"community_mcp_servers"},
+				IsDefault: &isDefault,
+			},
+			{
+				Id:      "organization-mcp-source",
+				Name:    "Organization MCP Servers",
+				Type:    "yaml",
+				Enabled: &enabled,
+				Labels:  []string{"organization_mcp_servers"},
+			},
+			{
+				Id:      "standalone-mcp-source",
+				Name:    "Other MCP Servers",
+				Type:    "yaml",
+				Enabled: &enabled,
+				Labels:  []string{},
+			},
+			{
+				Id:      "disabled-mcp-source",
+				Name:    "Disabled MCP source",
+				Type:    "yaml",
+				Enabled: &disabled,
+				Labels:  []string{"disabled_servers"},
+			},
+		},
 	}, nil
 }
 
-func (r *McpCatalogSettingsRepository) GetMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, sourceID string) (*models.McpCatalogSourceConfig, error) {
+func (r *McpCatalogSettingsRepository) GetMcpCatalogSourceConfig(ctx context.Context, client k8s.KubernetesClientInterface, namespace string, sourceID string) (*models.McpCatalogSourceConfig, error) {
+	all, err := r.GetAllMcpCatalogSourceConfigs(ctx, client, namespace)
+	if err != nil {
+		return nil, err
+	}
+	for i := range all.Catalogs {
+		if all.Catalogs[i].Id == sourceID {
+			return &all.Catalogs[i], nil
+		}
+	}
 	return nil, fmt.Errorf("%w: %s", ErrMcpCatalogSourceNotFound, sourceID)
 }
 

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
@@ -1,0 +1,44 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+)
+
+var (
+	ErrMcpCatalogSourceNotFound     = errors.New("mcp catalog source not found")
+	ErrMcpCatalogSourceAlreadyExist = errors.New("mcp catalog source already exists")
+	ErrMcpCatalogSourceIdRequired   = errors.New("mcp catalog source ID is required")
+	ErrMcpCatalogSourceConflict     = errors.New("mcp catalog source was modified by another request")
+)
+
+type McpCatalogSettingsRepository struct {
+}
+
+func NewMcpCatalogSettingsRepository() *McpCatalogSettingsRepository {
+	return &McpCatalogSettingsRepository{}
+}
+
+func (r *McpCatalogSettingsRepository) GetAllMcpCatalogSourceConfigs(_ context.Context, _ k8s.KubernetesClientInterface, _ string) (*models.McpCatalogSourceConfigList, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
+func (r *McpCatalogSettingsRepository) GetMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ string) (*models.McpCatalogSourceConfig, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
+func (r *McpCatalogSettingsRepository) CreateMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ models.McpCatalogSourceConfigPayload) (*models.McpCatalogSourceConfig, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
+func (r *McpCatalogSettingsRepository) UpdateMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ string, _ models.McpCatalogSourceConfigPayload) (*models.McpCatalogSourceConfig, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
+func (r *McpCatalogSettingsRepository) DeleteMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ string) (*models.McpCatalogSourceConfig, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}

--- a/clients/ui/bff/internal/repositories/repositories.go
+++ b/clients/ui/bff/internal/repositories/repositories.go
@@ -9,6 +9,7 @@ type Repositories struct {
 	ModelRegistryClient            ModelRegistryClientInterface
 	ModelCatalogClient             ModelCatalogClientInterface
 	ModelCatalogSettingsRepository *ModelCatalogSettingsRepository
+	McpCatalogSettingsRepository   *McpCatalogSettingsRepository
 	User                           *UserRepository
 	Namespace                      *NamespaceRepository
 }
@@ -22,6 +23,7 @@ func NewRepositories(modelRegistryClient ModelRegistryClientInterface, modelCata
 		ModelRegistrySettings:          NewModelRegistrySettingsRepository(),
 		ModelRegistryClient:            modelRegistryClient,
 		ModelCatalogSettingsRepository: NewModelCatalogSettingsRepository(),
+		McpCatalogSettingsRepository:   NewMcpCatalogSettingsRepository(),
 		User:                           NewUserRepository(),
 		Namespace:                      NewNamespaceRepository(),
 	}


### PR DESCRIPTION
## Description

Add OpenAPI spec and stub CRUD endpoints for MCP catalog source settings in the UI BFF, mirroring the existing model catalog source settings pattern ([#1878](https://github.com/kubeflow/model-registry/pull/1878)).

**New endpoints under `/api/v1/settings/mcp_catalog/source_configs`:**

| Method | Path | Operation | Description |
|--------|------|-----------|-------------|
| GET | `/source_configs` | `getMcpCatalogSources` | List all MCP catalog sources |
| POST | `/source_configs` | `createMcpCatalogSource` | Create a new MCP catalog source |
| GET | `/source_configs/{sourceId}` | `getMcpCatalogSource` | Get a single MCP catalog source by ID |
| PATCH | `/source_configs/{sourceId}` | `updateMcpCatalogSource` | Update an existing MCP catalog source |
| DELETE | `/source_configs/{sourceId}` | `deleteMcpCatalogSource` | Delete an MCP catalog source |

Preview endpoint is not duplicated — the existing model catalog preview already supports MCP via the `assetType` query parameter ([#2885](https://github.com/kubeflow/hub/pull/2885)). The mock client now also dispatches preview results based on `assetType`, returning MCP-specific preview data when `assetType=mcp_servers`.

**Files changed:**
- `clients/ui/api/openapi/mod-arch.yaml` — OpenAPI spec: added paths, schemas (`McpCatalogSourceConfig`, `McpCatalogSourceConfigPayload`, `McpCatalogSourceConfigList`), and responses
- `clients/ui/bff/internal/api/app.go` — Route constants and registration for MCP catalog settings
- `clients/ui/bff/internal/api/mcp_catalog_settings_handler.go` — HTTP handlers for all CRUD operations
- `clients/ui/bff/internal/models/mcp_catalog_source_configs.go` — Go model types
- `clients/ui/bff/internal/repositories/mcp_catalog_settings.go` — Stub repository returning mock data (ConfigMap-backed implementation to follow in a separate PR)
- `clients/ui/bff/internal/repositories/repositories.go` — Wired `McpCatalogSettingsRepository`
- `clients/ui/bff/internal/mocks/model_catalog_client_mock.go` — Updated preview mock to dispatch on `assetType`
- `clients/ui/bff/internal/mocks/static_data_mock.go` — Added MCP server preview mock data; extracted shared filter/pagination helper to avoid duplication
- `clients/ui/bff/internal/api/catalog_source_preview_handler_test.go` — Added test for preview with `assetType=mcp_servers`

**Review feedback addressed:**
- Fixed nil pointer dereference in Create/Update handlers when body is `{}` or `{"data": null}`
- JSON decode errors now return HTTP 400 (not 500) with proper `%w` error wrapping
- DELETE now returns HTTP 204 No Content (matching OpenAPI spec)
- Added `ErrMcpCatalogNotImplemented` sentinel error for future use
- Stubs return mock data instead of errors, unblocking UI development
- Source preview mock now supports `assetType=mcp_servers` dispatching

## How Has This Been Tested?

- `go build ./...` passes (in `clients/ui/bff`)
- `go vet ./...` passes
- All 138 unit tests pass (`go test ./internal/api/`)
- Tested with `make dev-start` (mock mode) using curl:

```bash
# List all MCP source configs — returns 200 with empty list
curl -s -w "\nHTTP %{http_code}\n" \
  -X GET "http://localhost:4000/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow" \
  -H "kubeflow-userid: user@example.com"

# Create an MCP source config — returns 201 with echoed data
curl -s -w "\nHTTP %{http_code}\n" \
  -X POST "http://localhost:4000/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow" \
  -H "kubeflow-userid: user@example.com" -H "Content-Type: application/json" \
  -d '{"data":{"id":"community-mcp","name":"Community MCP Servers","type":"yaml"}}'

# Create with null data — returns 400 (previously caused nil panic)
curl -s -w "\nHTTP %{http_code}\n" \
  -X POST "http://localhost:4000/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow" \
  -H "kubeflow-userid: user@example.com" -H "Content-Type: application/json" \
  -d '{"data": null}'

# Create with malformed JSON — returns 400 (previously returned 500)
curl -s -w "\nHTTP %{http_code}\n" \
  -X POST "http://localhost:4000/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow" \
  -H "kubeflow-userid: user@example.com" -H "Content-Type: application/json" \
  -d 'not json'

# Get an MCP source config — returns 404 (stub)
curl -s -w "\nHTTP %{http_code}\n" \
  -X GET "http://localhost:4000/api/v1/settings/mcp_catalog/source_configs/community-mcp?namespace=kubeflow" \
  -H "kubeflow-userid: user@example.com"

# Update an MCP source config — returns 200 with echoed data
curl -s -w "\nHTTP %{http_code}\n" \
  -X PATCH "http://localhost:4000/api/v1/settings/mcp_catalog/source_configs/community-mcp?namespace=kubeflow" \
  -H "kubeflow-userid: user@example.com" -H "Content-Type: application/json" \
  -d '{"data":{"id":"community-mcp","name":"Updated MCP Servers","type":"yaml"}}'

# Delete an MCP source config — returns 204 No Content
curl -s -w "\nHTTP %{http_code}\n" \
  -X DELETE "http://localhost:4000/api/v1/settings/mcp_catalog/source_configs/community-mcp?namespace=kubeflow" \
  -H "kubeflow-userid: user@example.com"
```

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).