### PR TITLE
fix(catalog): use AND for cold-start filters and merge cold-start into performance metrics

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
@@ -328,6 +328,25 @@ describe('Model Catalog Performance Filters API Behavior', () => {
       });
     });
 
+    it('should use AND (not OR) for cold-start filter to exclude non-matching models', () => {
+      visitWithPerformanceToggle(true);
+
+      modelCatalog.openColdStartLatencyFilter();
+      modelCatalog.applyColdStartLatencyFilter();
+
+      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithColdStartAnd');
+
+      triggerFilterRefresh();
+
+      cy.wait('@getModelsWithColdStartAnd').then((interception) => {
+        const decodedUrl = decodeURIComponent(interception.request.url);
+        const filterQuery = decodedUrl.match(/filterQuery=([^&]+)/)?.[1] ?? '';
+        expect(filterQuery).to.include('cold_start_time_to_load_seconds');
+        expect(filterQuery).to.not.include(' OR ');
+        expect(filterQuery).to.not.include('performance_sub_type');
+      });
+    });
+
     it('should pass cold_start_time_to_load_seconds as orderBy when cold start sort is selected', () => {
       visitWithPerformanceToggle(true);
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
@@ -3,14 +3,10 @@ import { DashboardEmptyTableView, Table, ManageColumnsModal } from 'mod-arch-sha
 import { Button, Spinner } from '@patternfly/react-core';
 import { ColumnsIcon } from '@patternfly/react-icons';
 import { InnerScrollContainer } from '@patternfly/react-table';
-import { CatalogPerformanceMetricsArtifact, HardwareConfiguration } from '~/app/modelCatalogTypes';
+import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
-import {
-  getActiveLatencyFieldName,
-  findMatchingHardwareConfig,
-} from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
-import { getStringValue } from '~/app/utils';
-import { SortOrder, PerformancePropertyKey } from '~/concepts/modelCatalog/const';
+import { getActiveLatencyFieldName } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import { SortOrder } from '~/concepts/modelCatalog/const';
 import {
   useHardwareConfigColumns,
   ControlledTableSortProps,
@@ -20,14 +16,12 @@ import HardwareConfigurationFilterToolbar from './HardwareConfigurationFilterToo
 
 type HardwareConfigurationTableProps = {
   performanceArtifacts: CatalogPerformanceMetricsArtifact[];
-  hardwareConfigurations?: HardwareConfiguration[];
   isLoading?: boolean;
   onSortChange?: (sort: { orderBy?: string; sortOrder?: string }) => void;
 };
 
 const HardwareConfigurationTable: React.FC<HardwareConfigurationTableProps> = ({
   performanceArtifacts,
-  hardwareConfigurations,
   isLoading = false,
   onSortChange,
 }) => {
@@ -120,32 +114,13 @@ const HardwareConfigurationTable: React.FC<HardwareConfigurationTableProps> = ({
           {...(hasActiveSort ? { defaultSortColumn: sortIndex } : {})}
           {...controlledSortProps}
           emptyTableView={<DashboardEmptyTableView onClearFilters={handleClearFilters} />}
-          rowRenderer={(artifact: CatalogPerformanceMetricsArtifact) => {
-            const hwConfig = getStringValue(
-              artifact.customProperties,
-              PerformancePropertyKey.HARDWARE_CONFIGURATION,
-            );
-            const hwType = getStringValue(
-              artifact.customProperties,
-              PerformancePropertyKey.HARDWARE_TYPE,
-            );
-            const hwCount = artifact.customProperties?.hardware_count?.int_value
-              ? parseInt(artifact.customProperties.hardware_count.int_value, 10)
-              : 1;
-            return (
-              <HardwareConfigurationTableRow
-                key={artifact.customProperties?.config_id?.string_value}
-                performanceArtifact={artifact}
-                columns={columns}
-                matchedHardwareConfig={findMatchingHardwareConfig(
-                  hardwareConfigurations ?? [],
-                  hwConfig,
-                  hwType,
-                  hwCount,
-                )}
-              />
-            );
-          }}
+          rowRenderer={(artifact: CatalogPerformanceMetricsArtifact) => (
+            <HardwareConfigurationTableRow
+              key={artifact.customProperties?.config_id?.string_value}
+              performanceArtifact={artifact}
+              columns={columns}
+            />
+          )}
         />
       </InnerScrollContainer>
       <ManageColumnsModal

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, Popover } from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
-import { CatalogPerformanceMetricsArtifact, HardwareConfiguration } from '~/app/modelCatalogTypes';
+import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 import {
   formatLatency,
@@ -19,13 +19,11 @@ import {
 type HardwareConfigurationTableRowProps = {
   performanceArtifact: CatalogPerformanceMetricsArtifact;
   columns: HardwareConfigColumn[];
-  matchedHardwareConfig?: HardwareConfiguration;
 };
 
 const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps> = ({
   performanceArtifact,
   columns,
-  matchedHardwareConfig,
 }) => {
   const getCellValue = (field: HardwareConfigColumnField): string | number => {
     const { customProperties } = performanceArtifact;
@@ -78,17 +76,19 @@ const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps
   };
 
   const renderModelLevelCell = (field: HardwareConfigColumnField): React.ReactNode => {
+    const { customProperties } = performanceArtifact;
+
     if (field === 'cold_start_load_time') {
-      return matchedHardwareConfig
-        ? `${matchedHardwareConfig.cold_start_time_to_load_seconds.toFixed(2)} s`
+      const coldStartSeconds = customProperties?.cold_start_time_to_load_seconds?.double_value;
+      return coldStartSeconds !== undefined && coldStartSeconds > 0
+        ? `${coldStartSeconds.toFixed(2)} s`
         : EMPTY_CUSTOM_PROPERTY_VALUE;
     }
     if (field === 'runtime_command') {
-      return matchedHardwareConfig?.runtime_command ? (
+      const runtimeCommand = getStringValue(customProperties, 'runtime_command');
+      return runtimeCommand ? (
         <Popover
-          bodyContent={
-            <CodeBlockComponent>{matchedHardwareConfig.runtime_command}</CodeBlockComponent>
-          }
+          bodyContent={<CodeBlockComponent>{runtimeCommand}</CodeBlockComponent>}
           position="left"
           maxWidth="450px"
         >

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -32,9 +32,6 @@ import { useCatalogPerformanceArtifacts } from '~/app/hooks/modelCatalog/useCata
 import {
   getActiveLatencyFieldName,
   stripArtifactsPrefix,
-  filterRegularPerformanceArtifacts,
-  findMatchingHardwareConfig,
-  resolveHardwareConfigurations,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { formatLatency } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
@@ -99,16 +96,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
       isValidated, // Only fetch if validated
     );
 
-  // Separate cold-start artifacts from regular performance artifacts
-  const performanceMetrics = React.useMemo(
-    () => filterRegularPerformanceArtifacts(performanceArtifactsList.items),
-    [performanceArtifactsList.items],
-  );
-
-  const hardwareConfigurations = React.useMemo(
-    () => resolveHardwareConfigurations(performanceArtifactsList.items, model.customProperties),
-    [performanceArtifactsList.items, model.customProperties],
-  );
+  const performanceMetrics = performanceArtifactsList.items;
 
   // NOTE: Accuracy metrics are not currently returned by the /performance_artifacts endpoint.
   // This is kept as a placeholder for when accuracy metrics support is restored.
@@ -213,13 +201,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
       ? parseLatencyFilterKey(activeLatencyField).metric
       : LatencyMetric.TTFT;
 
-    const matchedConfig = findMatchingHardwareConfig(
-      hardwareConfigurations,
-      metrics.hardwareConfiguration,
-      metrics.hardwareType,
-      parseInt(metrics.hardwareCount, 10) || 1,
-    );
-    const matchedColdStart = matchedConfig?.cold_start_time_to_load_seconds;
+    const coldStartValue = metrics.coldStartTimeToLoadSeconds;
 
     return (
       <Stack hasGutter>
@@ -264,10 +246,10 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
                 </Popover>
               </Flex>
             </Flex>
-            {matchedColdStart !== undefined && (
+            {coldStartValue !== undefined && coldStartValue > 0 && (
               <Flex direction={{ default: 'column' }}>
                 <span className="pf-v6-u-font-weight-bold" data-testid="validated-model-cold-start">
-                  {matchedColdStart.toFixed(2)} s
+                  {coldStartValue.toFixed(2)} s
                 </span>
                 <Flex alignItems={{ default: 'alignItemsBaseline' }} gap={{ default: 'gapXs' }}>
                   <Content component={ContentVariants.small}>Cold start load time</Content>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
@@ -29,8 +29,6 @@ import {
 import {
   decodeParams,
   getActiveLatencyFieldName,
-  filterRegularPerformanceArtifacts,
-  resolveHardwareConfigurations,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { getDefaultFiltersFromNamedQuery } from '~/app/pages/modelCatalog/utils/performanceFilterUtils';
 import TensorTypeComparisonCard from './TensorTypeComparisonCard';
@@ -131,16 +129,6 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
     model.name,
   ]);
 
-  const regularPerformanceArtifacts = React.useMemo(
-    () => filterRegularPerformanceArtifacts(performanceArtifacts.items),
-    [performanceArtifacts.items],
-  );
-
-  const hardwareConfigurations = React.useMemo(
-    () => resolveHardwareConfigurations(performanceArtifacts.items, model.customProperties),
-    [performanceArtifacts.items, model.customProperties],
-  );
-
   if (performanceArtifactsError) {
     return (
       <PageSection padding={{ default: 'noPadding' }}>
@@ -174,8 +162,7 @@ const PerformanceInsightsView: React.FC<PerformanceInsightsViewProps> = ({ model
               </FlexItem>
               <FlexItem>
                 <HardwareConfigurationTable
-                  performanceArtifacts={regularPerformanceArtifacts}
-                  hardwareConfigurations={hardwareConfigurations}
+                  performanceArtifacts={performanceArtifacts.items}
                   isLoading={!performanceArtifactsLoaded && performanceArtifacts.items.length === 0}
                   onSortChange={setTableSort}
                 />

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -257,41 +257,39 @@ describe('filtersToFilterQuery', () => {
     });
 
     it('handles a single array of a single data point', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT] }),
           mockFilterOptions,
         ),
-      ).toBe(`tasks='text-to-text'${orSuffix}`);
+      ).toBe("tasks='text-to-text'");
       expect(
         filtersToFilterQuery(
           mockFormData({ provider: [ModelCatalogProvider.GOOGLE] }),
           mockFilterOptions,
         ),
-      ).toBe(`provider='Google'${orSuffix}`);
+      ).toBe("provider='Google'");
       expect(
         filtersToFilterQuery(mockFormData({ license: ['Apache 2.0'] }), mockFilterOptions),
-      ).toBe(`license='Apache 2.0'${orSuffix}`);
+      ).toBe("license='Apache 2.0'");
       expect(
         filtersToFilterQuery(mockFormData({ language: [AllLanguageCode.CA] }), mockFilterOptions),
-      ).toBe(`language='ca'${orSuffix}`);
+      ).toBe("language='ca'");
       expect(
         filtersToFilterQuery(
           mockFormData({ use_case: [UseCaseOptionValue.CHATBOT] }),
           mockFilterOptions,
         ),
-      ).toBe(`artifacts.use_case.string_value='chatbot'${orSuffix}`);
+      ).toBe("artifacts.use_case.string_value='chatbot'");
       expect(
         filtersToFilterQuery(
           mockFormData({ tensor_type: [ModelCatalogTensorType.FP16] }),
           mockFilterOptions,
         ),
-      ).toBe(`tensor_type.string_value='FP16'${orSuffix}`);
+      ).toBe("tensor_type.string_value='FP16'");
     });
 
     it('handles multiple arrays of a single data point', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -300,48 +298,46 @@ describe('filtersToFilterQuery', () => {
           }),
           mockFilterOptions,
         ),
-      ).toBe(`tasks='text-to-text' AND license='Apache 2.0'${orSuffix}`);
+      ).toBe("tasks='text-to-text' AND license='Apache 2.0'");
       expect(
         filtersToFilterQuery(
           mockFormData({ provider: [ModelCatalogProvider.GOOGLE], language: [AllLanguageCode.CA] }),
           mockFilterOptions,
         ),
-      ).toBe(`provider='Google' AND language='ca'${orSuffix}`);
+      ).toBe("provider='Google' AND language='ca'");
     });
 
     it('handles a single array with multiple data points', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT, ModelCatalogTask.IMAGE_TO_TEXT] }),
           mockFilterOptions,
         ),
-      ).toBe(`tasks IN ('text-to-text','image-to-text')${orSuffix}`);
+      ).toBe("tasks IN ('text-to-text','image-to-text')");
       expect(
         filtersToFilterQuery(
           mockFormData({ provider: [ModelCatalogProvider.GOOGLE, ModelCatalogProvider.DEEPSEEK] }),
           mockFilterOptions,
         ),
-      ).toBe(`provider IN ('Google','DeepSeek')${orSuffix}`);
+      ).toBe("provider IN ('Google','DeepSeek')");
       expect(
         filtersToFilterQuery(mockFormData({ license: ['Apache 2.0', 'MIT'] }), mockFilterOptions),
-      ).toBe(`license IN ('Apache 2.0','MIT')${orSuffix}`);
+      ).toBe("license IN ('Apache 2.0','MIT')");
       expect(
         filtersToFilterQuery(
           mockFormData({ language: [AllLanguageCode.CA, AllLanguageCode.PT] }),
           mockFilterOptions,
         ),
-      ).toBe(`language IN ('ca','pt')${orSuffix}`);
+      ).toBe("language IN ('ca','pt')");
       expect(
         filtersToFilterQuery(
           mockFormData({ tensor_type: [ModelCatalogTensorType.FP16, ModelCatalogTensorType.FP8] }),
           mockFilterOptions,
         ),
-      ).toBe(`tensor_type.string_value IN ('FP16','FP8')${orSuffix}`);
+      ).toBe("tensor_type.string_value IN ('FP16','FP8')");
     });
 
     it('handles all tensor type enum values', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -355,11 +351,10 @@ describe('filtersToFilterQuery', () => {
           }),
           mockFilterOptions,
         ),
-      ).toBe(`tensor_type.string_value IN ('FP16','FP8','INT4','INT8','MXFP4')${orSuffix}`);
+      ).toBe("tensor_type.string_value IN ('FP16','FP8','INT4','INT8','MXFP4')");
     });
 
     it('handles multiple arrays with mixed count of data points', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -376,12 +371,11 @@ describe('filtersToFilterQuery', () => {
           mockFilterOptions,
         ),
       ).toBe(
-        `tasks IN ('text-to-text','image-to-text') AND provider='Google' AND license='MIT' AND language IN ('ca','pt','vi','zsm')${orSuffix}`,
+        "tasks IN ('text-to-text','image-to-text') AND provider='Google' AND license='MIT' AND language IN ('ca','pt','vi','zsm')",
       );
     });
 
     it('handles tensor type combined with other basic filters', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -392,31 +386,28 @@ describe('filtersToFilterQuery', () => {
           mockFilterOptions,
         ),
       ).toBe(
-        `tasks='text-to-text' AND provider='Google' AND tensor_type.string_value IN ('FP16','INT8')${orSuffix}`,
+        "tasks='text-to-text' AND provider='Google' AND tensor_type.string_value IN ('FP16','INT8')",
       );
     });
   });
 
   describe('match-all (AND logic) filters', () => {
     it('handles a single validated configuration value', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(mockFormData({ validatedTasks: ['tool-calling'] }), mockFilterOptions),
-      ).toBe(`validated_tasks='tool-calling'${orSuffix}`);
+      ).toBe("validated_tasks='tool-calling'");
     });
 
     it('handles multiple validated configuration values with AND logic instead of IN', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({ validatedTasks: ['tool-calling', 'text-generation'] }),
           mockFilterOptions,
         ),
-      ).toBe(`validated_tasks='tool-calling' AND validated_tasks='text-generation'${orSuffix}`);
+      ).toBe("validated_tasks='tool-calling' AND validated_tasks='text-generation'");
     });
 
     it('handles validated configuration combined with other OR-logic filters', () => {
-      const orSuffix = " OR artifacts.performance_sub_type.string_value='cold-start'";
       expect(
         filtersToFilterQuery(
           mockFormData({
@@ -427,7 +418,7 @@ describe('filtersToFilterQuery', () => {
           mockFilterOptions,
         ),
       ).toBe(
-        `tasks IN ('text-to-text','image-to-text') AND provider='Google' AND validated_tasks='tool-calling' AND validated_tasks='text-generation'${orSuffix}`,
+        "tasks IN ('text-to-text','image-to-text') AND provider='Google' AND validated_tasks='tool-calling' AND validated_tasks='text-generation'",
       );
     });
   });
@@ -468,7 +459,7 @@ describe('filtersToFilterQuery', () => {
   //   });
 
   describe('numeric filter target behavior', () => {
-    it('includes cold-start and model-level filters for models target, excludes cold-start for artifacts target', () => {
+    it('includes cold-start and model-level filters for models target, includes cold-start for artifacts target', () => {
       const data = mockFormData({ cold_start_latency: 50, min_vram: 24, image_size: 15 });
 
       const modelsQuery = filtersToFilterQuery(data, mockFilterOptions, 'models');
@@ -477,7 +468,7 @@ describe('filtersToFilterQuery', () => {
       expect(modelsQuery).toContain('modelcar_image_size.double_value');
 
       const artifactsQuery = filtersToFilterQuery(data, mockFilterOptions, 'artifacts');
-      expect(artifactsQuery).not.toContain('cold_start_time_to_load_seconds');
+      expect(artifactsQuery).toContain('cold_start_time_to_load_seconds');
       expect(artifactsQuery).not.toContain('min_vram_gb');
       expect(artifactsQuery).not.toContain('modelcar_image_size');
     });
@@ -492,41 +483,43 @@ describe('filtersToFilterQuery', () => {
     });
   });
 
-  describe('includeColdStartClause parameter', () => {
-    it('does not append cold-start OR clause when includeColdStartClause is false', () => {
+  describe('includeColdStart parameter', () => {
+    it('excludes cold-start filter from query when includeColdStart is false', () => {
       const query = filtersToFilterQuery(
-        mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT] }),
+        mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT], cold_start_latency: 50 }),
         mockFilterOptions,
         'models',
         false,
       );
       expect(query).toBe("tasks='text-to-text'");
-      expect(query).not.toContain('performance_sub_type');
-      expect(query).not.toContain('cold-start');
+      expect(query).not.toContain('cold_start_time_to_load_seconds');
     });
 
-    it('appends cold-start OR clause when includeColdStartClause is true (default)', () => {
+    it('includes cold-start filter in AND clause when includeColdStart is true (default)', () => {
       const query = filtersToFilterQuery(
-        mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT] }),
+        mockFormData({ tasks: [ModelCatalogTask.TEXT_TO_TEXT], cold_start_latency: 50 }),
         mockFilterOptions,
         'models',
         true,
       );
-      expect(query).toContain("OR artifacts.performance_sub_type.string_value='cold-start'");
+      expect(query).toContain('cold_start_time_to_load_seconds');
+      expect(query).not.toContain(' OR ');
+      expect(query).not.toContain('performance_sub_type');
     });
 
-    it('does not append cold-start OR clause with multiple basic filters when performance is off', () => {
+    it('does not include cold-start filter with multiple basic filters when includeColdStart is false', () => {
       const query = filtersToFilterQuery(
         mockFormData({
           tasks: [ModelCatalogTask.TEXT_TO_TEXT],
           provider: [ModelCatalogProvider.GOOGLE],
+          cold_start_latency: 50,
         }),
         mockFilterOptions,
         'models',
         false,
       );
       expect(query).toBe("tasks='text-to-text' AND provider='Google'");
-      expect(query).not.toContain('performance_sub_type');
+      expect(query).not.toContain('cold_start_time_to_load_seconds');
     });
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -8,8 +8,6 @@ import {
   CatalogModel,
   CatalogModelArtifact,
   CatalogModelDetailsParams,
-  CatalogPerformanceMetricsArtifact,
-  HardwareConfiguration,
   MetricsType,
   ModelCatalogFilterStates,
   ToolCallingConfig,
@@ -337,20 +335,25 @@ export type FilterQueryTarget = 'models' | 'artifacts';
 
 /**
  * Determines if a filter should be included based on the target endpoint.
- * - For models: Include all filters except RPS (which is passed as a separate param)
- * - For artifacts: Only include filters that have the artifacts.* prefix
- * Cold-start load time is excluded from the main AND clause for both targets;
- * it is placed in the OR clause via buildColdStartOrClause.
+ * - For models: Include all filters except RPS (which is passed as a separate param).
+ *   Cold-start load time is excluded when includeColdStart is false.
+ * - For artifacts: Only include filters that have the artifacts.* prefix.
+ *   The includeColdStart parameter has no effect on the artifacts target.
  */
-const shouldIncludeFilter = (filterId: string, target: FilterQueryTarget): boolean => {
-  // RPS is always passed as a separate param, not in filterQuery
+const shouldIncludeFilter = (
+  filterId: string,
+  target: FilterQueryTarget,
+  includeColdStart: boolean,
+): boolean => {
   if (filterId === ModelCatalogNumberFilterKey.MAX_RPS) {
     return false;
   }
 
-  // Cold-start filter is excluded from the main AND clause for both targets.
-  // It is placed in the OR clause via buildColdStartOrClause.
-  if (filterId === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME) {
+  if (
+    filterId === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME &&
+    target === 'models' &&
+    !includeColdStart
+  ) {
     return false;
   }
 
@@ -358,7 +361,6 @@ const shouldIncludeFilter = (filterId: string, target: FilterQueryTarget): boole
     return true;
   }
 
-  // For artifacts, only include filters with the artifacts.* prefix
   return hasArtifactsPrefix(filterId);
 };
 
@@ -429,7 +431,7 @@ const serializeFilterEntry = (
  * @param target - The target endpoint:
  *   - 'models': Include all filters (except RPS), use filter keys directly
  *   - 'artifacts': Only include artifact-prefixed filters, strip the prefix in output
- * @param includeColdStartClause - Whether to append the cold-start OR clause.
+ * @param includeColdStart - Whether to include the cold-start filter in the AND clause.
  *   Should be true only when performance view is enabled.
  *
  * Note: RPS is NOT included in filterQuery for either target - it's passed as targetRPS param.
@@ -438,56 +440,13 @@ export const filtersToFilterQuery = (
   filterData: ModelCatalogFilterStates,
   options: CatalogFilterOptionsList,
   target: FilterQueryTarget = 'models',
-  includeColdStartClause = true,
-): string => {
-  const serializedFilters: string[] = Object.entries(filterData)
-    .filter(([filterId]) => shouldIncludeFilter(filterId, target))
-    .map(([filterId, data]) => serializeFilterEntry(filterId, data, options, target));
-
-  const nonEmptyFilters = serializedFilters.filter((v) => !!v);
-  if (nonEmptyFilters.length === 0) {
-    return '';
-  }
-
-  const baseQuery = nonEmptyFilters.join(' AND ');
-
-  if (!includeColdStartClause) {
-    return baseQuery;
-  }
-
-  const coldStartClause = buildColdStartOrClause(filterData, options, target);
-  return `${baseQuery} OR ${coldStartClause}`;
-};
-
-/**
- * Builds the OR clause for cold-start artifacts in the filter query.
- * Always includes `performance_sub_type.string_value='cold-start'`.
- * If a cold start load time filter is active, appends it as an AND condition.
- * Uses the appropriate key format based on target (with artifacts.* prefix for models, stripped for artifacts).
- */
-const buildColdStartOrClause = (
-  filterData: ModelCatalogFilterStates,
-  options: CatalogFilterOptionsList,
-  target: FilterQueryTarget,
-): string => {
-  const subTypePrefix = target === 'models' ? 'artifacts.' : '';
-  const subTypeFilter = `${subTypePrefix}performance_sub_type.string_value='cold-start'`;
-  const coldStartValue = filterData[ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME];
-
-  if (coldStartValue === undefined || typeof coldStartValue !== 'number') {
-    return subTypeFilter;
-  }
-
-  const operator = getNumericFilterOperator(
-    options,
-    ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME,
-  );
-  const coldStartKey =
-    target === 'models'
-      ? ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME
-      : stripArtifactsPrefix(ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME);
-  return `${subTypeFilter} AND ${coldStartKey} ${operator} ${coldStartValue}`;
-};
+  includeColdStart = true,
+): string =>
+  Object.entries(filterData)
+    .filter(([filterId]) => shouldIncludeFilter(filterId, target, includeColdStart))
+    .map(([filterId, data]) => serializeFilterEntry(filterId, data, options, target))
+    .filter((v) => !!v)
+    .join(' AND ');
 
 /**
  * Returns a copy of filterData with only basic (non-performance) filters.
@@ -648,94 +607,4 @@ export const getMinimumVramFromCustomProperties = (
     return `${doubleVal.toFixed(2)} GB`;
   }
   return getCustomPropString(customProperties, CatalogModelCustomPropertyKey.MINIMUM_VRAM);
-};
-
-export const getHardwareConfigurationsFromCustomProperties = (
-  customProperties?: ModelRegistryCustomProperties,
-): HardwareConfiguration[] => {
-  if (!customProperties) {
-    return [];
-  }
-  const hwConfigStr = getCustomPropString(
-    customProperties,
-    CatalogModelCustomPropertyKey.HARDWARE_CONFIGURATIONS,
-  );
-  if (!hwConfigStr) {
-    return [];
-  }
-  try {
-    const parsed = JSON.parse(hwConfigStr);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-};
-
-/**
- * Identifies whether a performance artifact is a cold-start sub-type.
- */
-export const isColdStartArtifact = (artifact: CatalogPerformanceMetricsArtifact): boolean => {
-  const subType = artifact.customProperties?.performance_sub_type;
-  return (
-    subType?.metadataType === ModelRegistryMetadataType.STRING &&
-    subType.string_value === 'cold-start'
-  );
-};
-
-/**
- * Extracts HardwareConfiguration[] from cold-start performance artifacts.
- * Cold-start artifacts are identified by `performance_sub_type === "cold-start"` in customProperties
- * and contain gpu_type, gpu_count, cold_start_time_to_load_seconds, and runtime_command.
- */
-export const getHardwareConfigurationsFromArtifacts = (
-  artifacts: CatalogPerformanceMetricsArtifact[],
-): HardwareConfiguration[] =>
-  artifacts.filter(isColdStartArtifact).map((artifact) => {
-    const props = artifact.customProperties;
-    return {
-      // eslint-disable-next-line camelcase
-      gpu_type: props?.gpu_type?.string_value ?? '',
-      // eslint-disable-next-line camelcase
-      gpu_count: props?.gpu_count?.int_value ? parseInt(props.gpu_count.int_value, 10) : 0,
-      // eslint-disable-next-line camelcase
-      cold_start_time_to_load_seconds: props?.cold_start_time_to_load_seconds?.double_value ?? 0,
-      // eslint-disable-next-line camelcase
-      runtime_command: props?.runtime_command?.string_value ?? '',
-    };
-  });
-
-/**
- * Filters out cold-start artifacts, returning only regular performance artifacts.
- */
-export const filterRegularPerformanceArtifacts = (
-  artifacts: CatalogPerformanceMetricsArtifact[],
-): CatalogPerformanceMetricsArtifact[] => artifacts.filter((a) => !isColdStartArtifact(a));
-
-/**
- * Finds the matching HardwareConfiguration for a given hardware description.
- * Requires an exact match on both gpu_type and gpu_count; returns undefined otherwise.
- */
-export const findMatchingHardwareConfig = (
-  configs: HardwareConfiguration[],
-  hwConfig: string,
-  hwType: string,
-  hwCount: number,
-): HardwareConfiguration | undefined =>
-  configs.find(
-    (c) => (hwConfig.startsWith(c.gpu_type) || c.gpu_type === hwType) && c.gpu_count === hwCount,
-  );
-
-/**
- * Resolves hardware configurations from performance artifacts (cold-start sub-type),
- * falling back to the model's customProperties when no artifact-based configs exist.
- */
-export const resolveHardwareConfigurations = (
-  artifacts: CatalogPerformanceMetricsArtifact[],
-  customProperties?: ModelRegistryCustomProperties,
-): HardwareConfiguration[] => {
-  const fromArtifacts = getHardwareConfigurationsFromArtifacts(artifacts);
-  if (fromArtifacts.length > 0) {
-    return fromArtifacts;
-  }
-  return getHardwareConfigurationsFromCustomProperties(customProperties);
 };

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/validatedModelUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/validatedModelUtils.ts
@@ -29,6 +29,7 @@ export type ValidatedModelMetrics = {
   replicas: number | undefined;
   totalRequestsPerSecond: number | undefined;
   latencyMetrics: LatencyMetricsMap;
+  coldStartTimeToLoadSeconds: number | undefined;
 };
 
 export type PerformanceMetrics = {
@@ -40,6 +41,7 @@ export type PerformanceMetrics = {
   replicas: number | undefined;
   totalRequestsPerSecond: number | undefined;
   latencyMetrics: LatencyMetricsMap;
+  coldStartTimeToLoadSeconds: number | undefined;
 };
 
 /**
@@ -83,6 +85,8 @@ export const extractPerformanceMetrics = (
       : undefined,
     totalRequestsPerSecond:
       performanceMetrics.customProperties?.total_requests_per_second?.double_value,
+    coldStartTimeToLoadSeconds:
+      performanceMetrics.customProperties?.cold_start_time_to_load_seconds?.double_value,
     latencyMetrics: extractLatencyMetrics(performanceMetrics.customProperties),
   };
 };


### PR DESCRIPTION
## Description

Fixes cold-start filter query construction to use AND semantics instead of OR, and migrates cold-start data consumption to read directly from merged performance artifacts (per RHOAIENG-69642).

### Problem

When cold-start filters were applied in the Model Catalog, the filter query was constructed using `OR`:

```
tasks='text-generation' OR artifacts.performance_sub_type.string_value='cold-start' AND cold_start_time <= 96
```

This caused models **without** cold-start data to appear when cold-start filters were active, because models matching any branch of the OR were included.

Additionally:
- When cold-start was the **only** active filter, it was silently dropped (early return before the clause was appended)
- The `performance_sub_type='cold-start'` sub-type clause was unnecessarily injected into the models endpoint query
- The cold-start filter had no effect on the Performance Insights tab (artifacts endpoint)
- Cold-start data was read from separate standalone artifacts via `performance_sub_type='cold-start'`, requiring client-side split/join logic

### Fix

**Filter fix:**
- **Remove `buildColdStartOrClause`** entirely — no more OR logic in filter queries
- **Let cold-start pass through normal `serializeFilterEntry` serialization** via `shouldIncludeFilter`, gated by `includeColdStartClause` for the models target
- **Both endpoints now use AND only** — `filtersToFilterQuery` is simplified to a single `.filter().map().filter().join(' AND ')` chain

**Cold-start merge migration:**
- **Remove separate cold-start artifact handling** — no more `isColdStartArtifact`, `filterRegularPerformanceArtifacts`, `resolveHardwareConfigurations`, `findMatchingHardwareConfig`, `getHardwareConfigurationsFromArtifacts`
- **Read `cold_start_time_to_load_seconds` and `runtime_command` directly** from each performance artifact's `customProperties` (aligned with backend merge from RHOAIENG-69642)
- **Simplify table/card components** — no more hardware config join logic; each row reads everything from its own artifact

Validated the fix midstream 
<img width="1043" height="659" alt="Screenshot 2026-07-01 at 5 39 41 PM" src="https://github.com/user-attachments/assets/4e204cc8-1bc7-47e8-8d46-125d76aa18f6" />
<img width="1035" height="624" alt="Screenshot 2026-07-01 at 5 58 58 PM" src="https://github.com/user-attachments/assets/b95399c5-cbd6-4927-b4ac-19ee08ba0203" />

### Files Changed

| File | Change |
|------|--------|
| `modelCatalogUtils.ts` | Simplified `filtersToFilterQuery` to AND-only; removed 5 cold-start artifact functions |
| `modelCatalogUtils.spec.ts` | Updated test expectations from OR to AND, added cold-start-only and artifacts-target tests |
| `modelCatalogPerformanceFiltersApi.cy.ts` | Added Cypress test asserting AND semantics and no OR/performance_sub_type in filterQuery |
| `HardwareConfigurationTableRow.tsx` | Read cold-start/runtime directly from artifact customProperties |
| `HardwareConfigurationTable.tsx` | Removed `hardwareConfigurations` prop and join logic |
| `ModelCatalogCardBody.tsx` | Read cold-start from extracted metrics; removed split/filter logic |
| `PerformanceInsightsView.tsx` | Removed hardware config memos; pass artifacts directly to table |
| `validatedModelUtils.ts` | Added `coldStartTimeToLoadSeconds` to metrics types and extraction |

## How Has This Been Tested?

- Unit tests: `npm run test:unit` — 145 tests pass
- Type check: `npm run test:type-check` — clean
- Lint: `npx eslint` — clean on all changed files
- Apply cold start filters and check whether the filters work correctly in both cards gallery view page and hardware configuration table
- Apply min vRAM and container size filters and check whether they apply correctly by checking respective fields in the details page from the filtered list of models

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.