### PR TITLE
fix(async-upload): avoid auth override with credentials_path

### DIFF
--- a/jobs/async-upload/job/upload.py
+++ b/jobs/async-upload/job/upload.py
@@ -56,6 +56,8 @@ def _get_upload_params(config: AsyncUploadConfig) -> S3Params | OCIParams:
     elif isinstance(destination_config, OCIStorageConfig):
         push_args = []
         pull_args = []
+        username = destination_config.username
+        password = destination_config.password
         # Note: These are all skopeo args, see: https://github.com/containers/skopeo/blob/main/docs/skopeo-copy.1.md
         if not destination_config.enable_tls_verify:
             push_args.append("--dest-tls-verify=false")
@@ -66,13 +68,16 @@ def _get_upload_params(config: AsyncUploadConfig) -> S3Params | OCIParams:
             push_args.append(validated_path)
             pull_args.append("--authfile")
             pull_args.append(validated_path)
+            # Avoid synthesizing a second authfile in save_to_oci_registry().
+            username = None
+            password = None
 
         return OCIParams(
             base_image=destination_config.base_image,
             oci_ref=destination_config.uri,
             dest_dir=config.storage.path,
-            oci_username=destination_config.username,
-            oci_password=destination_config.password,
+            oci_username=username,
+            oci_password=password,
             # Same as the default backend, but with additional args included
             custom_oci_backend=utils._get_skopeo_backend(
                 pull_args=pull_args,

--- a/jobs/async-upload/tests/test_upload.py
+++ b/jobs/async-upload/tests/test_upload.py
@@ -244,6 +244,38 @@ class TestGetUploadParams:
         assert result.base_image == "foo-bar:latest"
         assert result.oci_ref == "quay.io/example/test:latest"
         assert result.dest_dir == "/tmp/test-model"
+        assert result.oci_username is None
+        assert result.oci_password is None
+
+    def test_get_upload_params_oci_preserves_inline_credentials_without_credentials_path(self):
+        """Test inline OCI credentials are kept when no authfile is configured"""
+        config = AsyncUploadConfig(
+            source=S3StorageConfig(
+                bucket="source-bucket",
+                key="source-key",
+                access_key_id="source-key-id",
+                secret_access_key="source-secret",
+                region="us-west-1"
+            ),
+            destination=OCIStorageConfig(
+                uri="quay.io/example/test:latest",
+                registry="quay.io",
+                username="test-user",
+                password="test-password",
+                base_image="foo-bar:latest",
+                enable_tls_verify=True,
+                credentials_path=None
+            ),
+            model=ModelConfig(
+                intent=UpdateArtifactIntent(artifact_id="123")
+            ),
+            storage=StorageConfig(path="/tmp/test-model"),
+            registry=RegistryConfig(server_address="test-server")
+        )
+
+        result = _get_upload_params(config)
+
+        assert isinstance(result, OCIParams)
         assert result.oci_username == "test-user"
         assert result.oci_password == "test-password"
 
@@ -334,6 +366,8 @@ class TestPerformUpload:
 
         # - And the returned URI is forwarded
         assert result_uri == "quay.io/example/oci/abc:def"
+        assert mock_save_to_oci_registry.call_args.kwargs["oci_username"] is None
+        assert mock_save_to_oci_registry.call_args.kwargs["oci_password"] is None
 
     @patch("job.upload._get_upload_params")
     def test_perform_upload_propagates_exceptions_from_get_upload_params(
@@ -426,12 +460,15 @@ class TestValidateCredentialsPath:
         result = _validate_credentials_path(str(creds_file))
         assert result == str(creds_file)
 
-    def test_rejects_relative_path(self, tmp_path):
-        """Test that a relative path is rejected"""
-        creds_file = tmp_path / "auth.json"
+    def test_rejects_tilde_expanded_path(self, tmp_path, monkeypatch):
+        """Test that a home-relative path is rejected unless already absolute"""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        creds_file = home_dir / "auth.json"
         creds_file.write_text("{}")
+        monkeypatch.setenv("HOME", str(home_dir))
         with pytest.raises(ValueError, match="must be an absolute path"):
-            _validate_credentials_path("auth.json")
+            _validate_credentials_path("~/auth.json")
 
     def test_accepts_symlink_to_regular_file(self, tmp_path):
         """Test that a symlink to a regular file is accepted (Kubernetes Secret mounts use symlinks)"""


### PR DESCRIPTION
When async-upload passes an OCI authfile through to skopeo, stop also forwarding inline OCI credentials so save_to_oci_registry does not synthesize a competing src authfile. Keep tests focused on the authfile path taking precedence only when configured.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
