### PR TITLE
add MCP catalog settings API state, types and mocks

### DIFF
--- a/clients/ui/frontend/src/__mocks__/index.ts
+++ b/clients/ui/frontend/src/__mocks__/index.ts
@@ -8,5 +8,6 @@ export * from './mockCatalogModelList';
 export * from './mockCatalogModelArtifactList';
 export * from './mockCatalogLabelList';
 export * from './mockMcpCatalogTestData';
+export * from './mockMcpCatalogSourceConfigList';
 export * from './mockModelArtifact';
 export * from './mockModelTransferJob';

--- a/clients/ui/frontend/src/__mocks__/mockMcpCatalogSourceConfigList.ts
+++ b/clients/ui/frontend/src/__mocks__/mockMcpCatalogSourceConfigList.ts
@@ -1,11 +1,15 @@
-import { McpCatalogSourceConfigList, McpCatalogSourceConfig } from '~/app/mcpServerCatalogTypes';
+import {
+  McpCatalogSourceConfigList,
+  McpCatalogSourceConfig,
+  McpCatalogSourceType,
+} from '~/app/mcpServerCatalogTypes';
 
 export const mockMcpCatalogSourceConfig = (
   partial?: Partial<McpCatalogSourceConfig>,
 ): McpCatalogSourceConfig => ({
   id: 'sample_mcp_source_1',
   name: 'MCP Source 1',
-  type: 'yaml',
+  type: McpCatalogSourceType.YAML,
   enabled: true,
   includedServers: [],
   excludedServers: [],

--- a/clients/ui/frontend/src/__mocks__/mockMcpCatalogSourceConfigList.ts
+++ b/clients/ui/frontend/src/__mocks__/mockMcpCatalogSourceConfigList.ts
@@ -1,0 +1,44 @@
+import { McpCatalogSourceConfigList, McpCatalogSourceConfig } from '~/app/mcpServerCatalogTypes';
+
+export const mockMcpCatalogSourceConfig = (
+  partial?: Partial<McpCatalogSourceConfig>,
+): McpCatalogSourceConfig => ({
+  id: 'sample_mcp_source_1',
+  name: 'MCP Source 1',
+  type: 'yaml',
+  enabled: true,
+  includedServers: [],
+  excludedServers: [],
+  isDefault: true,
+  ...partial,
+});
+
+export const mockMcpCatalogSourceConfigList = (
+  partial?: Partial<McpCatalogSourceConfigList>,
+): McpCatalogSourceConfigList => ({
+  catalogs: [
+    mockMcpCatalogSourceConfig({
+      id: 'sample_mcp_source_1',
+      name: 'Sample MCP source 1',
+      isDefault: true,
+      includedServers: [],
+      excludedServers: [],
+    }),
+    mockMcpCatalogSourceConfig({
+      id: 'mcp_source_2',
+      name: 'MCP Source 2',
+      isDefault: false,
+      includedServers: ['server1', 'server2'],
+      excludedServers: ['server3'],
+      enabled: false,
+    }),
+    mockMcpCatalogSourceConfig({
+      id: 'sample_mcp_source_4',
+      name: 'Sample MCP source 4',
+      isDefault: false,
+      includedServers: ['server1', 'server2'],
+      excludedServers: ['server3'],
+    }),
+  ],
+  ...partial,
+});

--- a/clients/ui/frontend/src/app/api/mcpCatalogSettings/__tests__/service.spec.ts
+++ b/clients/ui/frontend/src/app/api/mcpCatalogSettings/__tests__/service.spec.ts
@@ -1,6 +1,7 @@
 import { restCREATE, handleRestFailures } from 'mod-arch-core';
 import { previewMcpCatalogSource } from '~/app/api/mcpCatalogSettings/service';
 import { McpCatalogSourceType } from '~/app/mcpServerCatalogTypes';
+import { PreviewCatalogSourceQueryParams } from '~/app/modelCatalogTypes';
 
 const mockRestPromise = Promise.resolve({ data: {} });
 
@@ -109,7 +110,9 @@ describe('previewMcpCatalogSource', () => {
     await previewMcpCatalogSource('/api/v1/settings/mcp_catalog', { someKey: 'base' })(
       APIOptionsMock,
       mockData,
-      { filterStatus: 'all' },
+      { filterStatus: 'all', assetType: 'models' } as PreviewCatalogSourceQueryParams & {
+        assetType: string;
+      },
     );
 
     expect(restCREATEMock).toHaveBeenCalledWith(

--- a/clients/ui/frontend/src/app/api/mcpCatalogSettings/__tests__/service.spec.ts
+++ b/clients/ui/frontend/src/app/api/mcpCatalogSettings/__tests__/service.spec.ts
@@ -1,0 +1,122 @@
+import { restCREATE, handleRestFailures } from 'mod-arch-core';
+import { previewMcpCatalogSource } from '~/app/api/mcpCatalogSettings/service';
+
+const mockRestPromise = Promise.resolve({ data: {} });
+
+jest.mock('mod-arch-core', () => ({
+  restCREATE: jest.fn(() => mockRestPromise),
+  assembleModArchBody: jest.fn((data) => data),
+  isModArchResponse: jest.fn(() => true),
+  handleRestFailures: jest.fn(() => mockRestPromise),
+}));
+
+const handleRestFailuresMock = jest.mocked(handleRestFailures);
+const restCREATEMock = jest.mocked(restCREATE);
+
+const APIOptionsMock = {};
+
+describe('previewMcpCatalogSource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should include assetType mcp_servers in query params', async () => {
+    const mockData = {
+      type: 'yaml',
+      includedServers: ['*'],
+      excludedServers: [],
+      properties: { yaml: 'servers:\n  - name: test' },
+    };
+
+    await previewMcpCatalogSource('/api/v1/settings/mcp_catalog', { namespace: 'kubeflow' })(
+      APIOptionsMock,
+      mockData,
+    );
+
+    expect(restCREATEMock).toHaveBeenCalledTimes(1);
+    expect(restCREATEMock).toHaveBeenCalledWith(
+      '/api/v1/settings/mcp_catalog',
+      '/source_preview',
+      mockData,
+      { namespace: 'kubeflow', assetType: 'mcp_servers' },
+      APIOptionsMock,
+    );
+    expect(handleRestFailuresMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should merge additional query params with assetType', async () => {
+    const mockData = {
+      type: 'yaml',
+      includedServers: ['*'],
+      excludedServers: [],
+      properties: { yaml: 'servers:\n  - name: test' },
+    };
+
+    await previewMcpCatalogSource('/api/v1/settings/mcp_catalog', { namespace: 'kubeflow' })(
+      APIOptionsMock,
+      mockData,
+      { filterStatus: 'included', pageSize: 20 },
+    );
+
+    expect(restCREATEMock).toHaveBeenCalledTimes(1);
+    expect(restCREATEMock).toHaveBeenCalledWith(
+      '/api/v1/settings/mcp_catalog',
+      '/source_preview',
+      mockData,
+      { namespace: 'kubeflow', assetType: 'mcp_servers', filterStatus: 'included', pageSize: 20 },
+      APIOptionsMock,
+    );
+  });
+
+  it('should include nextPageToken in query params when provided', async () => {
+    const mockData = {
+      type: 'yaml',
+      includedServers: ['*'],
+      excludedServers: [],
+      properties: { yaml: 'servers:\n  - name: test' },
+    };
+
+    await previewMcpCatalogSource('/api/v1/settings/mcp_catalog', { namespace: 'kubeflow' })(
+      APIOptionsMock,
+      mockData,
+      { filterStatus: 'excluded', pageSize: 10, nextPageToken: 'abc123' },
+    );
+
+    expect(restCREATEMock).toHaveBeenCalledWith(
+      '/api/v1/settings/mcp_catalog',
+      '/source_preview',
+      mockData,
+      {
+        namespace: 'kubeflow',
+        assetType: 'mcp_servers',
+        filterStatus: 'excluded',
+        pageSize: 10,
+        nextPageToken: 'abc123',
+      },
+      APIOptionsMock,
+    );
+  });
+
+  it('should preserve assetType even when additional params override base params', async () => {
+    const mockData = {
+      type: 'yaml',
+      includedServers: [],
+      excludedServers: [],
+      properties: {},
+    };
+
+    await previewMcpCatalogSource('/api/v1/settings/mcp_catalog', { someKey: 'base' })(
+      APIOptionsMock,
+      mockData,
+      { filterStatus: 'all' },
+    );
+
+    expect(restCREATEMock).toHaveBeenCalledWith(
+      '/api/v1/settings/mcp_catalog',
+      '/source_preview',
+      mockData,
+      { someKey: 'base', assetType: 'mcp_servers', filterStatus: 'all' },
+      APIOptionsMock,
+    );
+  });
+});

--- a/clients/ui/frontend/src/app/api/mcpCatalogSettings/__tests__/service.spec.ts
+++ b/clients/ui/frontend/src/app/api/mcpCatalogSettings/__tests__/service.spec.ts
@@ -1,5 +1,6 @@
 import { restCREATE, handleRestFailures } from 'mod-arch-core';
 import { previewMcpCatalogSource } from '~/app/api/mcpCatalogSettings/service';
+import { McpCatalogSourceType } from '~/app/mcpServerCatalogTypes';
 
 const mockRestPromise = Promise.resolve({ data: {} });
 
@@ -22,7 +23,7 @@ describe('previewMcpCatalogSource', () => {
 
   it('should include assetType mcp_servers in query params', async () => {
     const mockData = {
-      type: 'yaml',
+      type: McpCatalogSourceType.YAML,
       includedServers: ['*'],
       excludedServers: [],
       properties: { yaml: 'servers:\n  - name: test' },
@@ -46,7 +47,7 @@ describe('previewMcpCatalogSource', () => {
 
   it('should merge additional query params with assetType', async () => {
     const mockData = {
-      type: 'yaml',
+      type: McpCatalogSourceType.YAML,
       includedServers: ['*'],
       excludedServers: [],
       properties: { yaml: 'servers:\n  - name: test' },
@@ -63,14 +64,14 @@ describe('previewMcpCatalogSource', () => {
       '/api/v1/settings/mcp_catalog',
       '/source_preview',
       mockData,
-      { namespace: 'kubeflow', assetType: 'mcp_servers', filterStatus: 'included', pageSize: 20 },
+      { namespace: 'kubeflow', filterStatus: 'included', pageSize: 20, assetType: 'mcp_servers' },
       APIOptionsMock,
     );
   });
 
   it('should include nextPageToken in query params when provided', async () => {
     const mockData = {
-      type: 'yaml',
+      type: McpCatalogSourceType.YAML,
       includedServers: ['*'],
       excludedServers: [],
       properties: { yaml: 'servers:\n  - name: test' },
@@ -88,18 +89,18 @@ describe('previewMcpCatalogSource', () => {
       mockData,
       {
         namespace: 'kubeflow',
-        assetType: 'mcp_servers',
         filterStatus: 'excluded',
         pageSize: 10,
         nextPageToken: 'abc123',
+        assetType: 'mcp_servers',
       },
       APIOptionsMock,
     );
   });
 
-  it('should preserve assetType even when additional params override base params', async () => {
+  it('should ensure assetType cannot be overridden by additional params', async () => {
     const mockData = {
-      type: 'yaml',
+      type: McpCatalogSourceType.YAML,
       includedServers: [],
       excludedServers: [],
       properties: {},
@@ -115,7 +116,7 @@ describe('previewMcpCatalogSource', () => {
       '/api/v1/settings/mcp_catalog',
       '/source_preview',
       mockData,
-      { someKey: 'base', assetType: 'mcp_servers', filterStatus: 'all' },
+      { someKey: 'base', filterStatus: 'all', assetType: 'mcp_servers' },
       APIOptionsMock,
     );
   });

--- a/clients/ui/frontend/src/app/api/mcpCatalogSettings/service.ts
+++ b/clients/ui/frontend/src/app/api/mcpCatalogSettings/service.ts
@@ -1,0 +1,103 @@
+import {
+  APIOptions,
+  assembleModArchBody,
+  handleRestFailures,
+  isModArchResponse,
+  restCREATE,
+  restDELETE,
+  restGET,
+  restPATCH,
+} from 'mod-arch-core';
+import {
+  CatalogSourcePreviewResult,
+  PreviewCatalogSourceQueryParams,
+} from '~/app/modelCatalogTypes';
+import {
+  McpCatalogSourceConfig,
+  McpCatalogSourceConfigList,
+  McpCatalogSourceConfigPayload,
+  McpCatalogSourcePreviewRequest,
+} from '~/app/mcpServerCatalogTypes';
+
+export const getMcpCatalogSourceConfigs =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (opts: APIOptions): Promise<McpCatalogSourceConfigList> =>
+    handleRestFailures(restGET(hostPath, '/source_configs', queryParams, opts)).then((response) => {
+      if (isModArchResponse<McpCatalogSourceConfigList>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const createMcpCatalogSourceConfig =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (opts: APIOptions, data: McpCatalogSourceConfigPayload): Promise<McpCatalogSourceConfig> =>
+    handleRestFailures(
+      restCREATE(hostPath, '/source_configs', assembleModArchBody(data), queryParams, opts),
+    ).then((response) => {
+      if (isModArchResponse<McpCatalogSourceConfig>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const getMcpCatalogSourceConfig =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (opts: APIOptions, sourceId: string): Promise<McpCatalogSourceConfig> =>
+    handleRestFailures(restGET(hostPath, `/source_configs/${sourceId}`, queryParams, opts)).then(
+      (response) => {
+        if (isModArchResponse<McpCatalogSourceConfig>(response)) {
+          return response.data;
+        }
+        throw new Error('Invalid response format');
+      },
+    );
+
+export const updateMcpCatalogSourceConfig =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (
+    opts: APIOptions,
+    sourceId: string,
+    data: Partial<McpCatalogSourceConfigPayload>,
+  ): Promise<McpCatalogSourceConfig> =>
+    handleRestFailures(
+      restPATCH(
+        hostPath,
+        `/source_configs/${sourceId}`,
+        assembleModArchBody(data),
+        queryParams,
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<McpCatalogSourceConfig>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const deleteMcpCatalogSourceConfig =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (opts: APIOptions, sourceId: string): Promise<void> =>
+    handleRestFailures(restDELETE(hostPath, `/source_configs/${sourceId}`, {}, queryParams, opts));
+
+export const previewMcpCatalogSource =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (
+    opts: APIOptions,
+    data: McpCatalogSourcePreviewRequest,
+    additionalQueryParams?: PreviewCatalogSourceQueryParams,
+  ): Promise<CatalogSourcePreviewResult> =>
+    handleRestFailures(
+      restCREATE(
+        hostPath,
+        '/source_preview',
+        assembleModArchBody(data),
+        { ...queryParams, assetType: 'mcp_servers', ...additionalQueryParams },
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<CatalogSourcePreviewResult>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });

--- a/clients/ui/frontend/src/app/api/mcpCatalogSettings/service.ts
+++ b/clients/ui/frontend/src/app/api/mcpCatalogSettings/service.ts
@@ -8,15 +8,13 @@ import {
   restGET,
   restPATCH,
 } from 'mod-arch-core';
-import {
-  CatalogSourcePreviewResult,
-  PreviewCatalogSourceQueryParams,
-} from '~/app/modelCatalogTypes';
+import { PreviewCatalogSourceQueryParams } from '~/app/modelCatalogTypes';
 import {
   McpCatalogSourceConfig,
   McpCatalogSourceConfigList,
   McpCatalogSourceConfigPayload,
   McpCatalogSourcePreviewRequest,
+  McpCatalogSourcePreviewResult,
 } from '~/app/mcpServerCatalogTypes';
 
 export const getMcpCatalogSourceConfigs =
@@ -86,17 +84,17 @@ export const previewMcpCatalogSource =
     opts: APIOptions,
     data: McpCatalogSourcePreviewRequest,
     additionalQueryParams?: PreviewCatalogSourceQueryParams,
-  ): Promise<CatalogSourcePreviewResult> =>
+  ): Promise<McpCatalogSourcePreviewResult> =>
     handleRestFailures(
       restCREATE(
         hostPath,
         '/source_preview',
         assembleModArchBody(data),
-        { ...queryParams, assetType: 'mcp_servers', ...additionalQueryParams },
+        { ...queryParams, ...additionalQueryParams, assetType: 'mcp_servers' },
         opts,
       ),
     ).then((response) => {
-      if (isModArchResponse<CatalogSourcePreviewResult>(response)) {
+      if (isModArchResponse<McpCatalogSourcePreviewResult>(response)) {
         return response.data;
       }
       throw new Error('Invalid response format');

--- a/clients/ui/frontend/src/app/context/mcpCatalogSettings/McpCatalogSettingsContext.tsx
+++ b/clients/ui/frontend/src/app/context/mcpCatalogSettings/McpCatalogSettingsContext.tsx
@@ -1,17 +1,66 @@
 import * as React from 'react';
+import { useQueryParamNamespaces } from 'mod-arch-core';
+import useMcpCatalogSettingsAPIState, {
+  McpCatalogSettingsAPIState,
+} from '~/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPIState';
+import { useMcpCatalogSourceConfigs } from '~/app/hooks/mcpCatalogSettings/useMcpCatalogSourceConfigs';
+import type { McpCatalogSourceConfigList } from '~/app/mcpServerCatalogTypes';
+import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
 
-export type McpCatalogSettingsContextType = Record<string, never>;
+export type McpCatalogSettingsContextType = {
+  apiState: McpCatalogSettingsAPIState;
+  refreshAPIState: () => void;
+  mcpCatalogSourceConfigs: McpCatalogSourceConfigList | null;
+  mcpCatalogSourceConfigsLoaded: boolean;
+  mcpCatalogSourceConfigsLoadError?: Error;
+  refreshMcpCatalogSourceConfigs: () => void;
+};
 
 type McpCatalogSettingsContextProviderProps = {
   children: React.ReactNode;
 };
 
-export const McpCatalogSettingsContext = React.createContext<McpCatalogSettingsContextType>({});
+export const McpCatalogSettingsContext = React.createContext<McpCatalogSettingsContextType>({
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  apiState: { apiAvailable: false, api: null as unknown as McpCatalogSettingsAPIState['api'] },
+  refreshAPIState: () => undefined,
+  mcpCatalogSourceConfigs: null,
+  mcpCatalogSourceConfigsLoaded: false,
+  mcpCatalogSourceConfigsLoadError: undefined,
+  refreshMcpCatalogSourceConfigs: () => undefined,
+});
 
 export const McpCatalogSettingsContextProvider: React.FC<
   McpCatalogSettingsContextProviderProps
 > = ({ children }) => {
-  const contextValue = React.useMemo(() => ({}), []);
+  const hostPath = `${URL_PREFIX}/api/${BFF_API_VERSION}/settings/mcp_catalog`;
+  const queryParams = useQueryParamNamespaces();
+  const [apiState, refreshAPIState] = useMcpCatalogSettingsAPIState(hostPath, queryParams);
+  const [
+    mcpCatalogSourceConfigs,
+    mcpCatalogSourceConfigsLoaded,
+    mcpCatalogSourceConfigsLoadError,
+    refreshMcpCatalogSourceConfigs,
+  ] = useMcpCatalogSourceConfigs(apiState);
+
+  const contextValue = React.useMemo(
+    () => ({
+      apiState,
+      refreshAPIState,
+      mcpCatalogSourceConfigs,
+      mcpCatalogSourceConfigsLoaded,
+      mcpCatalogSourceConfigsLoadError,
+      refreshMcpCatalogSourceConfigs,
+    }),
+    [
+      apiState,
+      refreshAPIState,
+      mcpCatalogSourceConfigs,
+      mcpCatalogSourceConfigsLoaded,
+      mcpCatalogSourceConfigsLoadError,
+      refreshMcpCatalogSourceConfigs,
+    ],
+  );
 
   return (
     <McpCatalogSettingsContext.Provider value={contextValue}>

--- a/clients/ui/frontend/src/app/context/mcpCatalogSettings/McpCatalogSettingsContext.tsx
+++ b/clients/ui/frontend/src/app/context/mcpCatalogSettings/McpCatalogSettingsContext.tsx
@@ -5,7 +5,10 @@ import useMcpCatalogSettingsAPIState, {
 } from '~/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPIState';
 import { useMcpCatalogSourceConfigs } from '~/app/hooks/mcpCatalogSettings/useMcpCatalogSourceConfigs';
 import type { McpCatalogSourceConfigList } from '~/app/mcpServerCatalogTypes';
+import type { CatalogSourceList } from '~/app/shared/types/catalogTypes';
 import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
+import useModelCatalogAPIState from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
+import { useMcpCatalogSourcesWithPolling } from '~/app/hooks/mcpCatalogSettings/useMcpCatalogSourcesWithPolling';
 
 export type McpCatalogSettingsContextType = {
   apiState: McpCatalogSettingsAPIState;
@@ -14,6 +17,10 @@ export type McpCatalogSettingsContextType = {
   mcpCatalogSourceConfigsLoaded: boolean;
   mcpCatalogSourceConfigsLoadError?: Error;
   refreshMcpCatalogSourceConfigs: () => void;
+  mcpCatalogSources: CatalogSourceList | null;
+  mcpCatalogSourcesLoaded: boolean;
+  mcpCatalogSourcesLoadError?: Error;
+  refreshMcpCatalogSources: () => void;
 };
 
 type McpCatalogSettingsContextProviderProps = {
@@ -28,20 +35,33 @@ export const McpCatalogSettingsContext = React.createContext<McpCatalogSettingsC
   mcpCatalogSourceConfigsLoaded: false,
   mcpCatalogSourceConfigsLoadError: undefined,
   refreshMcpCatalogSourceConfigs: () => undefined,
+  mcpCatalogSources: null,
+  mcpCatalogSourcesLoaded: false,
+  mcpCatalogSourcesLoadError: undefined,
+  refreshMcpCatalogSources: () => undefined,
 });
 
 export const McpCatalogSettingsContextProvider: React.FC<
   McpCatalogSettingsContextProviderProps
 > = ({ children }) => {
   const hostPath = `${URL_PREFIX}/api/${BFF_API_VERSION}/settings/mcp_catalog`;
+  const mcpCatalogHostPath = `${URL_PREFIX}/api/${BFF_API_VERSION}/model_catalog`;
   const queryParams = useQueryParamNamespaces();
   const [apiState, refreshAPIState] = useMcpCatalogSettingsAPIState(hostPath, queryParams);
+  const [mcpCatalogAPIState] = useModelCatalogAPIState(mcpCatalogHostPath, queryParams);
   const [
     mcpCatalogSourceConfigs,
     mcpCatalogSourceConfigsLoaded,
     mcpCatalogSourceConfigsLoadError,
     refreshMcpCatalogSourceConfigs,
   ] = useMcpCatalogSourceConfigs(apiState);
+
+  const [
+    mcpCatalogSources,
+    mcpCatalogSourcesLoaded,
+    mcpCatalogSourcesLoadError,
+    refreshMcpCatalogSources,
+  ] = useMcpCatalogSourcesWithPolling(mcpCatalogAPIState);
 
   const contextValue = React.useMemo(
     () => ({
@@ -51,6 +71,10 @@ export const McpCatalogSettingsContextProvider: React.FC<
       mcpCatalogSourceConfigsLoaded,
       mcpCatalogSourceConfigsLoadError,
       refreshMcpCatalogSourceConfigs,
+      mcpCatalogSources,
+      mcpCatalogSourcesLoaded,
+      mcpCatalogSourcesLoadError,
+      refreshMcpCatalogSources,
     }),
     [
       apiState,
@@ -59,6 +83,10 @@ export const McpCatalogSettingsContextProvider: React.FC<
       mcpCatalogSourceConfigsLoaded,
       mcpCatalogSourceConfigsLoadError,
       refreshMcpCatalogSourceConfigs,
+      mcpCatalogSources,
+      mcpCatalogSourcesLoaded,
+      mcpCatalogSourcesLoadError,
+      refreshMcpCatalogSources,
     ],
   );
 

--- a/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPI.ts
+++ b/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPI.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+import { McpCatalogSettingsContext } from '~/app/context/mcpCatalogSettings/McpCatalogSettingsContext';
+import { McpCatalogSettingsAPIState } from './useMcpCatalogSettingsAPIState';
+
+type UseMcpCatalogSettingsAPI = McpCatalogSettingsAPIState & {
+  refreshAllAPI: () => void;
+};
+
+export const useMcpCatalogSettingsAPI = (): UseMcpCatalogSettingsAPI => {
+  const { apiState, refreshAPIState: refreshAllAPI } = React.useContext(McpCatalogSettingsContext);
+
+  return {
+    refreshAllAPI,
+    ...apiState,
+  };
+};

--- a/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPIState.tsx
+++ b/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPIState.tsx
@@ -1,0 +1,34 @@
+import { APIState, useAPIState } from 'mod-arch-core';
+import React from 'react';
+import {
+  createMcpCatalogSourceConfig,
+  deleteMcpCatalogSourceConfig,
+  getMcpCatalogSourceConfig,
+  getMcpCatalogSourceConfigs,
+  updateMcpCatalogSourceConfig,
+  previewMcpCatalogSource,
+} from '~/app/api/mcpCatalogSettings/service';
+import { McpCatalogSettingsAPIs } from '~/app/mcpServerCatalogTypes';
+
+export type McpCatalogSettingsAPIState = APIState<McpCatalogSettingsAPIs>;
+
+const useMcpCatalogSettingsAPIState = (
+  hostPath: string | null,
+  queryParameters?: Record<string, unknown>,
+): [apiState: McpCatalogSettingsAPIState, refreshAPIState: () => void] => {
+  const createAPI = React.useCallback(
+    (path: string) => ({
+      getMcpCatalogSourceConfigs: getMcpCatalogSourceConfigs(path, queryParameters),
+      createMcpCatalogSourceConfig: createMcpCatalogSourceConfig(path, queryParameters),
+      getMcpCatalogSourceConfig: getMcpCatalogSourceConfig(path, queryParameters),
+      updateMcpCatalogSourceConfig: updateMcpCatalogSourceConfig(path, queryParameters),
+      deleteMcpCatalogSourceConfig: deleteMcpCatalogSourceConfig(path, queryParameters),
+      previewMcpCatalogSource: previewMcpCatalogSource(path, queryParameters),
+    }),
+    [queryParameters],
+  );
+
+  return useAPIState(hostPath, createAPI);
+};
+
+export default useMcpCatalogSettingsAPIState;

--- a/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPIState.tsx
+++ b/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPIState.tsx
@@ -6,7 +6,6 @@ import {
   getMcpCatalogSourceConfig,
   getMcpCatalogSourceConfigs,
   updateMcpCatalogSourceConfig,
-  previewMcpCatalogSource,
 } from '~/app/api/mcpCatalogSettings/service';
 import { McpCatalogSettingsAPIs } from '~/app/mcpServerCatalogTypes';
 
@@ -23,7 +22,6 @@ const useMcpCatalogSettingsAPIState = (
       getMcpCatalogSourceConfig: getMcpCatalogSourceConfig(path, queryParameters),
       updateMcpCatalogSourceConfig: updateMcpCatalogSourceConfig(path, queryParameters),
       deleteMcpCatalogSourceConfig: deleteMcpCatalogSourceConfig(path, queryParameters),
-      previewMcpCatalogSource: previewMcpCatalogSource(path, queryParameters),
     }),
     [queryParameters],
   );

--- a/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSourceConfigBySourceId.ts
+++ b/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSourceConfigBySourceId.ts
@@ -1,0 +1,24 @@
+import { FetchState, FetchStateCallbackPromise, NotReadyError, useFetchState } from 'mod-arch-core';
+import * as React from 'react';
+import { McpCatalogSourceConfig } from '~/app/mcpServerCatalogTypes';
+import { McpCatalogSettingsContext } from '~/app/context/mcpCatalogSettings/McpCatalogSettingsContext';
+
+type State = McpCatalogSourceConfig | null;
+
+export const useMcpCatalogSourceConfigBySourceId = (sourceId: string): FetchState<State> => {
+  const { apiState } = React.useContext(McpCatalogSettingsContext);
+  const call = React.useCallback<FetchStateCallbackPromise<State>>(
+    (opts) => {
+      if (!apiState.apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+      if (!sourceId) {
+        return Promise.reject(new NotReadyError('No source id'));
+      }
+
+      return apiState.api.getMcpCatalogSourceConfig(opts, sourceId);
+    },
+    [apiState, sourceId],
+  );
+  return useFetchState(call, null, { initialPromisePurity: true });
+};

--- a/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSourceConfigs.ts
+++ b/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSourceConfigs.ts
@@ -1,0 +1,20 @@
+import { FetchState, FetchStateCallbackPromise, useFetchState } from 'mod-arch-core';
+import React from 'react';
+import { McpCatalogSourceConfigList } from '~/app/mcpServerCatalogTypes';
+import { McpCatalogSettingsAPIState } from './useMcpCatalogSettingsAPIState';
+
+export const useMcpCatalogSourceConfigs = (
+  apiState: McpCatalogSettingsAPIState,
+): FetchState<McpCatalogSourceConfigList> => {
+  const call = React.useCallback<FetchStateCallbackPromise<McpCatalogSourceConfigList>>(
+    (opts) => {
+      if (!apiState.apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+
+      return apiState.api.getMcpCatalogSourceConfigs(opts);
+    },
+    [apiState],
+  );
+  return useFetchState(call, { catalogs: [] }, { initialPromisePurity: true });
+};

--- a/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSourcesWithPolling.ts
+++ b/clients/ui/frontend/src/app/hooks/mcpCatalogSettings/useMcpCatalogSourcesWithPolling.ts
@@ -1,0 +1,24 @@
+import { FetchState, FetchStateCallbackPromise, useFetchState, POLL_INTERVAL } from 'mod-arch-core';
+import * as React from 'react';
+import { CatalogSourceList } from '~/app/shared/types/catalogTypes';
+import { ModelCatalogAPIState } from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
+
+export const useMcpCatalogSourcesWithPolling = (
+  apiState: ModelCatalogAPIState,
+): FetchState<CatalogSourceList> => {
+  const call = React.useCallback<FetchStateCallbackPromise<CatalogSourceList>>(
+    (opts) => {
+      if (!apiState.apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+
+      return apiState.api.getListSources(opts);
+    },
+    [apiState],
+  );
+  return useFetchState(
+    call,
+    { items: [], size: 0, pageSize: 0, nextPageToken: '' },
+    { initialPromisePurity: true, refreshRate: POLL_INTERVAL },
+  );
+};

--- a/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
@@ -1,4 +1,9 @@
+import { APIOptions } from 'mod-arch-core';
 import { PaginationParams } from '~/app/shared/types/catalogTypes';
+import {
+  CatalogSourcePreviewResult,
+  PreviewCatalogSourceQueryParams,
+} from '~/app/modelCatalogTypes';
 
 export type McpDeploymentMode = 'local' | 'remote';
 
@@ -172,4 +177,62 @@ export type McpServerListParams = {
   sortOrder?: string;
   name?: string;
   q?: string;
+};
+
+export type McpCatalogSourceConfig = {
+  id: string;
+  name: string;
+  type: string;
+  enabled?: boolean;
+  labels?: string[];
+  isDefault?: boolean;
+  yaml?: string;
+  includedServers?: string[];
+  excludedServers?: string[];
+};
+
+export type McpCatalogSourceConfigPayload =
+  | McpCatalogSourceConfig
+  | Pick<McpCatalogSourceConfig, 'enabled' | 'includedServers' | 'excludedServers'>;
+
+export type McpCatalogSourceConfigList = {
+  catalogs: McpCatalogSourceConfig[];
+};
+
+export type GetMcpCatalogSourceConfigs = (opts: APIOptions) => Promise<McpCatalogSourceConfigList>;
+export type CreateMcpCatalogSourceConfig = (
+  opts: APIOptions,
+  data: McpCatalogSourceConfigPayload,
+) => Promise<McpCatalogSourceConfig>;
+export type GetMcpCatalogSourceConfig = (
+  opts: APIOptions,
+  sourceId: string,
+) => Promise<McpCatalogSourceConfig>;
+export type UpdateMcpCatalogSourceConfig = (
+  opts: APIOptions,
+  sourceId: string,
+  data: Partial<McpCatalogSourceConfigPayload>,
+) => Promise<McpCatalogSourceConfig>;
+export type DeleteMcpCatalogSourceConfig = (opts: APIOptions, sourceId: string) => Promise<void>;
+
+export type McpCatalogSourcePreviewRequest = {
+  type: string;
+  includedServers?: string[];
+  excludedServers?: string[];
+  properties?: Record<string, unknown>;
+};
+
+export type PreviewMcpCatalogSource = (
+  opts: APIOptions,
+  data: McpCatalogSourcePreviewRequest,
+  queryParams?: PreviewCatalogSourceQueryParams,
+) => Promise<CatalogSourcePreviewResult>;
+
+export type McpCatalogSettingsAPIs = {
+  getMcpCatalogSourceConfigs: GetMcpCatalogSourceConfigs;
+  createMcpCatalogSourceConfig: CreateMcpCatalogSourceConfig;
+  getMcpCatalogSourceConfig: GetMcpCatalogSourceConfig;
+  updateMcpCatalogSourceConfig: UpdateMcpCatalogSourceConfig;
+  deleteMcpCatalogSourceConfig: DeleteMcpCatalogSourceConfig;
+  previewMcpCatalogSource: PreviewMcpCatalogSource;
 };

--- a/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
@@ -1,9 +1,6 @@
 import { APIOptions } from 'mod-arch-core';
 import { PaginationParams } from '~/app/shared/types/catalogTypes';
-import {
-  CatalogSourcePreviewResult,
-  PreviewCatalogSourceQueryParams,
-} from '~/app/modelCatalogTypes';
+import { PreviewCatalogSourceQueryParams } from '~/app/modelCatalogTypes';
 
 export type McpDeploymentMode = 'local' | 'remote';
 
@@ -179,10 +176,14 @@ export type McpServerListParams = {
   q?: string;
 };
 
+export enum McpCatalogSourceType {
+  YAML = 'YAML',
+}
+
 export type McpCatalogSourceConfig = {
   id: string;
   name: string;
-  type: string;
+  type: McpCatalogSourceType;
   enabled?: boolean;
   labels?: string[];
   isDefault?: boolean;
@@ -216,17 +217,36 @@ export type UpdateMcpCatalogSourceConfig = (
 export type DeleteMcpCatalogSourceConfig = (opts: APIOptions, sourceId: string) => Promise<void>;
 
 export type McpCatalogSourcePreviewRequest = {
-  type: string;
+  type: McpCatalogSourceType;
   includedServers?: string[];
   excludedServers?: string[];
   properties?: Record<string, unknown>;
+};
+
+export type McpCatalogSourcePreviewAsset = {
+  name: string;
+  included: boolean;
+};
+
+export type McpCatalogSourcePreviewSummary = {
+  totalAssets: number;
+  includedAssets: number;
+  excludedAssets: number;
+};
+
+export type McpCatalogSourcePreviewResult = {
+  items: McpCatalogSourcePreviewAsset[];
+  summary: McpCatalogSourcePreviewSummary;
+  nextPageToken: string;
+  pageSize: number;
+  size: number;
 };
 
 export type PreviewMcpCatalogSource = (
   opts: APIOptions,
   data: McpCatalogSourcePreviewRequest,
   queryParams?: PreviewCatalogSourceQueryParams,
-) => Promise<CatalogSourcePreviewResult>;
+) => Promise<McpCatalogSourcePreviewResult>;
 
 export type McpCatalogSettingsAPIs = {
   getMcpCatalogSourceConfigs: GetMcpCatalogSourceConfigs;

--- a/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
@@ -177,7 +177,7 @@ export type McpServerListParams = {
 };
 
 export enum McpCatalogSourceType {
-  YAML = 'YAML',
+  YAML = 'yaml',
 }
 
 export type McpCatalogSourceConfig = {
@@ -254,5 +254,4 @@ export type McpCatalogSettingsAPIs = {
   getMcpCatalogSourceConfig: GetMcpCatalogSourceConfig;
   updateMcpCatalogSourceConfig: UpdateMcpCatalogSourceConfig;
   deleteMcpCatalogSourceConfig: DeleteMcpCatalogSourceConfig;
-  previewMcpCatalogSource: PreviewMcpCatalogSource;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Implements the data consumption layer for MCP Catalog Settings, following the same patterns established by the Model Catalog Settings feature.

This PR depends PR #2890 adds the BFF CRUD endpoints that this frontend data layer consumes. Without it, the MCP catalog settings page shows an empty state (expected behavior). Once #2890 is merged, the hooks will automatically start returning data from the backend.

No ui changes made, this is just preparing to receive the changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
