### PR TITLE
feat: Surface MCP server displayName in catalog UI

### DIFF
--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -2715,6 +2715,7 @@ func GetMcpServerMocks() []models.McpServer {
 	prometheusMcp := models.McpServer{
 		ID:          "1",
 		Name:        "Prometheus MCP Server",
+		DisplayName: stringToPointer("Prometheus Monitoring"),
 		SourceID:    stringToPointer("community-mcp-source"),
 		Description: stringToPointer("Query Prometheus metrics and alerts directly from your agent"),
 		Provider:    stringToPointer("Prometheus Community"),
@@ -2798,6 +2799,7 @@ func GetMcpServerMocks() []models.McpServer {
 	elasticMcp := models.McpServer{
 		ID:          "3",
 		Name:        "Elasticsearch MCP Server",
+		DisplayName: stringToPointer("Elastic Search"),
 		SourceID:    stringToPointer("organization-mcp-source"),
 		Description: stringToPointer("Search and analyze data in Elasticsearch clusters"),
 		Provider:    stringToPointer("Elastic"),
@@ -2851,6 +2853,7 @@ func GetMcpServerMocks() []models.McpServer {
 	grafanaMcp := models.McpServer{
 		ID:          "5",
 		Name:        "Grafana MCP Server",
+		DisplayName: stringToPointer("Grafana"),
 		SourceID:    stringToPointer("community-mcp-source"),
 		Description: stringToPointer("Query Grafana dashboards, data sources and annotations via natural language"),
 		Provider:    stringToPointer("Grafana Labs"),
@@ -2921,6 +2924,7 @@ func GetMcpServerMocks() []models.McpServer {
 	redisMcp := models.McpServer{
 		ID:          "8",
 		Name:        "Redis MCP Server",
+		DisplayName: stringToPointer("Redis Cache Manager"),
 		SourceID:    stringToPointer("organization-mcp-source"),
 		Description: stringToPointer("Manage Redis key-value stores, caches and pub/sub channels"),
 		Provider:    stringToPointer("Redis Ltd"),

--- a/clients/ui/bff/internal/models/mcp_server_catalog.go
+++ b/clients/ui/bff/internal/models/mcp_server_catalog.go
@@ -151,6 +151,7 @@ type McpTool struct {
 type McpServer struct {
 	ID                 string                            `json:"id"`
 	Name               string                            `json:"name"`
+	DisplayName        *string                           `json:"displayName,omitempty"`
 	SourceID           *string                           `json:"source_id,omitempty"`
 	Description        *string                           `json:"description,omitempty"`
 	Logo               *string                           `json:"logo,omitempty"`

--- a/clients/ui/frontend/src/__mocks__/mockMcpCatalogTestData.ts
+++ b/clients/ui/frontend/src/__mocks__/mockMcpCatalogTestData.ts
@@ -10,6 +10,7 @@ import type { McpCatalogFilterOptionsList } from '~/app/pages/mcpCatalog/types/m
 export const mockMcpServer = (partial?: Partial<McpServer>): McpServer => ({
   id: '1',
   name: 'Kubernetes',
+  displayName: 'Kubernetes MCP',
   description: 'Control and inspect Kubernetes clusters.',
   deploymentMode: 'local',
   securityIndicators: { verifiedSource: true, sast: true },

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/mcpCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/mcpCatalog.ts
@@ -90,6 +90,10 @@ class McpServerDetails {
     cy.testA11y();
   }
 
+  findPageTitle() {
+    return cy.findByTestId('app-page-title');
+  }
+
   findBreadcrumbCatalogLink() {
     return cy.get('.pf-v6-c-breadcrumb').contains('MCP Catalog');
   }

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalog/mcpServerDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalog/mcpServerDetails.cy.ts
@@ -67,7 +67,7 @@ describe('MCP Server Details Page', () => {
     it('should display server name and description', () => {
       mcpServerDetails.visit(kubernetesServer.id);
 
-      cy.findByTestId('app-page-title').should('contain.text', kubernetesServer.displayName);
+      mcpServerDetails.findPageTitle().should('contain.text', kubernetesServer.displayName);
 
       mcpServerDetails.findDescription().should('contain.text', kubernetesServer.description);
     });
@@ -91,19 +91,6 @@ describe('MCP Server Details Page', () => {
   });
 
   describe('displayName fallback', () => {
-    it('should display displayName in breadcrumb and title when provided', () => {
-      const serverWithDisplayName = mockMcpServer({
-        id: 'dn-test-1',
-        name: 'internal-server-id',
-        displayName: 'Friendly Server Name',
-      });
-      initServerDetailIntercept(serverWithDisplayName);
-      mcpServerDetails.visit(serverWithDisplayName.id);
-      mcpServerDetails.findBreadcrumbServerName().should('contain.text', 'Friendly Server Name');
-      cy.findByTestId('app-page-title').should('contain.text', 'Friendly Server Name');
-      cy.findByTestId('app-page-title').should('not.contain.text', 'internal-server-id');
-    });
-
     it('should fall back to name in breadcrumb and title when displayName is absent', () => {
       const serverWithoutDisplayName = mockMcpServer({
         id: 'dn-test-2',
@@ -113,7 +100,7 @@ describe('MCP Server Details Page', () => {
       initServerDetailIntercept(serverWithoutDisplayName);
       mcpServerDetails.visit(serverWithoutDisplayName.id);
       mcpServerDetails.findBreadcrumbServerName().should('contain.text', 'Fallback Server');
-      cy.findByTestId('app-page-title').should('contain.text', 'Fallback Server');
+      mcpServerDetails.findPageTitle().should('contain.text', 'Fallback Server');
     });
   });
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalog/mcpServerDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalog/mcpServerDetails.cy.ts
@@ -46,7 +46,9 @@ describe('MCP Server Details Page', () => {
     it('should display breadcrumb with MCP Catalog link and server name', () => {
       mcpServerDetails.visit(kubernetesServer.id);
       mcpServerDetails.findBreadcrumbCatalogLink().should('be.visible');
-      mcpServerDetails.findBreadcrumbServerName().should('contain.text', kubernetesServer.name);
+      mcpServerDetails
+        .findBreadcrumbServerName()
+        .should('contain.text', kubernetesServer.displayName);
     });
 
     it('should navigate back to catalog when clicking breadcrumb link', () => {
@@ -65,7 +67,7 @@ describe('MCP Server Details Page', () => {
     it('should display server name and description', () => {
       mcpServerDetails.visit(kubernetesServer.id);
 
-      cy.findByTestId('app-page-title').should('contain.text', kubernetesServer.name);
+      cy.findByTestId('app-page-title').should('contain.text', kubernetesServer.displayName);
 
       mcpServerDetails.findDescription().should('contain.text', kubernetesServer.description);
     });
@@ -85,6 +87,33 @@ describe('MCP Server Details Page', () => {
       mcpServerDetails.visit(remoteServer.id);
       mcpServerDetails.findRemoteTitleLabel().should('be.visible');
       mcpServerDetails.findRemoteTitleLabel().should('contain.text', 'Remote');
+    });
+  });
+
+  describe('displayName fallback', () => {
+    it('should display displayName in breadcrumb and title when provided', () => {
+      const serverWithDisplayName = mockMcpServer({
+        id: 'dn-test-1',
+        name: 'internal-server-id',
+        displayName: 'Friendly Server Name',
+      });
+      initServerDetailIntercept(serverWithDisplayName);
+      mcpServerDetails.visit(serverWithDisplayName.id);
+      mcpServerDetails.findBreadcrumbServerName().should('contain.text', 'Friendly Server Name');
+      cy.findByTestId('app-page-title').should('contain.text', 'Friendly Server Name');
+      cy.findByTestId('app-page-title').should('not.contain.text', 'internal-server-id');
+    });
+
+    it('should fall back to name in breadcrumb and title when displayName is absent', () => {
+      const serverWithoutDisplayName = mockMcpServer({
+        id: 'dn-test-2',
+        name: 'Fallback Server',
+        displayName: undefined,
+      });
+      initServerDetailIntercept(serverWithoutDisplayName);
+      mcpServerDetails.visit(serverWithoutDisplayName.id);
+      mcpServerDetails.findBreadcrumbServerName().should('contain.text', 'Fallback Server');
+      cy.findByTestId('app-page-title').should('contain.text', 'Fallback Server');
     });
   });
 

--- a/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
@@ -126,6 +126,7 @@ export type McpTool = {
 export type McpServer = {
   id: string;
   name: string;
+  displayName?: string;
   source_id?: string;
   description?: string;
   logo?: string;

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/components/McpCatalogCard.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/components/McpCatalogCard.tsx
@@ -88,7 +88,7 @@ const McpCatalogCard: React.FC<McpCatalogCardProps> = React.memo(({ server }) =>
             }}
           >
             <Truncate
-              content={server.name}
+              content={server.displayName || server.name}
               position="middle"
               tooltipPosition="top"
               data-testid={`mcp-catalog-card-name-${serverId}`}

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/components/__tests__/McpCatalogCard.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/components/__tests__/McpCatalogCard.spec.tsx
@@ -97,4 +97,16 @@ describe('McpCatalogCard', () => {
     render(<McpCatalogCard server={mockServer} />, { wrapper });
     expect(screen.queryByTestId('mcp-catalog-card-logo-1')).not.toBeInTheDocument();
   });
+
+  it('renders displayName when provided', () => {
+    render(<McpCatalogCard server={{ ...mockServer, displayName: 'My Display Name' }} />, {
+      wrapper,
+    });
+    expect(screen.getByTestId('mcp-catalog-card-name-1')).toHaveTextContent('My Display Name');
+  });
+
+  it('falls back to name when displayName is not provided', () => {
+    render(<McpCatalogCard server={{ ...mockServer, displayName: undefined }} />, { wrapper });
+    expect(screen.getByTestId('mcp-catalog-card-name-1')).toHaveTextContent('Test MCP Server');
+  });
 });

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/components/__tests__/McpCatalogCard.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/components/__tests__/McpCatalogCard.spec.tsx
@@ -104,9 +104,4 @@ describe('McpCatalogCard', () => {
     });
     expect(screen.getByTestId('mcp-catalog-card-name-1')).toHaveTextContent('My Display Name');
   });
-
-  it('falls back to name when displayName is not provided', () => {
-    render(<McpCatalogCard server={{ ...mockServer, displayName: undefined }} />, { wrapper });
-    expect(screen.getByTestId('mcp-catalog-card-name-1')).toHaveTextContent('Test MCP Server');
-  });
 });

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpServerDetailsPage.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpServerDetailsPage.tsx
@@ -46,7 +46,7 @@ const McpServerDetailsPage: React.FC = () => {
               <Link to={mcpCatalogUrl()}>MCP Catalog</Link>
             </BreadcrumbItem>
             <BreadcrumbItem isActive data-testid="breadcrumb-server-name">
-              {server?.name || 'Details'}
+              {server?.displayName || server?.name || 'Details'}
             </BreadcrumbItem>
           </Breadcrumb>
         }
@@ -75,7 +75,7 @@ const McpServerDetailsPage: React.FC = () => {
                     alignItems={{ default: 'alignItemsCenter' }}
                     flexWrap={{ default: 'wrap' }}
                   >
-                    <FlexItem>{server.name}</FlexItem>
+                    <FlexItem>{server.displayName || server.name}</FlexItem>
                     {isMcpRemoteDeploymentMode(server.deploymentMode) && (
                       <FlexItem>
                         <Label data-testid="mcp-server-details-remote-label">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Add `displayName` optional field to the `McpServer` frontend type and BFF model
- Update MCP catalog card title, details page breadcrumb, and page title to prefer `displayName` over `name` with automatic fallback
- Update Go mock data with a mix of servers with and without `displayName` to validate fallback behavior
<img width="1918" height="906" alt="image" src="https://github.com/user-attachments/assets/d7c31313-0018-4c89-95d8-2ac1253b55a1" />
Red: displayName
Blue: name(fallback in case displayName is not available)

Sample of MCP Details with displayName:
<img width="1918" height="771" alt="image" src="https://github.com/user-attachments/assets/0eaff058-f15f-4910-b7e4-88a15670c8e2" />

Sample of MCP Details without displayName:
<img width="1915" height="927" alt="image" src="https://github.com/user-attachments/assets/5f4e755f-2aaf-456c-bac8-8035e753e5f8" />
 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested and added some other cypress tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
