### PR TITLE
refactor(catalog): rationalize agent schema — typed fields vs customProperties

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -818,6 +818,11 @@ components:
             framework:
               type: string
               description: Agent framework (e.g., langgraph, crewai, autogen).
+            labels:
+              type: array
+              items:
+                type: string
+              description: Labels for categorization and filtering.
             logo:
               type: string
               description: URL or path to the agent logo image.

--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -818,19 +818,6 @@ components:
             framework:
               type: string
               description: Agent framework (e.g., langgraph, crewai, autogen).
-            agentType:
-              type: string
-              description: Catalog classification (e.g., starter_kit).
-            tags:
-              type: array
-              items:
-                type: string
-              description: Tags for categorization and filtering.
-            models:
-              type: array
-              items:
-                type: string
-              description: Compatible model identifiers.
             logo:
               type: string
               description: URL or path to the agent logo image.
@@ -838,10 +825,6 @@ components:
               type: string
               format: uri
               description: URL to the agent source code repository.
-            publishedDate:
-              type: string
-              format: date-time
-              description: Date when the agent was published.
             env:
               type: array
               items:

--- a/api/openapi/src/plugins/agent.yaml
+++ b/api/openapi/src/plugins/agent.yaml
@@ -129,6 +129,11 @@ components:
             framework:
               type: string
               description: Agent framework (e.g., langgraph, crewai, autogen).
+            labels:
+              type: array
+              items:
+                type: string
+              description: Labels for categorization and filtering.
             logo:
               type: string
               description: URL or path to the agent logo image.

--- a/api/openapi/src/plugins/agent.yaml
+++ b/api/openapi/src/plugins/agent.yaml
@@ -129,19 +129,6 @@ components:
             framework:
               type: string
               description: Agent framework (e.g., langgraph, crewai, autogen).
-            agentType:
-              type: string
-              description: Catalog classification (e.g., starter_kit).
-            tags:
-              type: array
-              items:
-                type: string
-              description: Tags for categorization and filtering.
-            models:
-              type: array
-              items:
-                type: string
-              description: Compatible model identifiers.
             logo:
               type: string
               description: URL or path to the agent logo image.
@@ -149,10 +136,6 @@ components:
               type: string
               format: uri
               description: URL to the agent source code repository.
-            publishedDate:
-              type: string
-              format: date-time
-              description: Date when the agent was published.
             env:
               type: array
               items:

--- a/catalog/internal/catalog/agentcatalog/db_agent.go
+++ b/catalog/internal/catalog/agentcatalog/db_agent.go
@@ -199,6 +199,11 @@ func mapDBAgentToAPI(dbAgent models.Agent) openapi.Agent {
 				res.Logo = prop.StringValue
 			case "repositoryUrl":
 				res.RepositoryUrl = prop.StringValue
+			case "labels":
+				var labels []string
+				if err := json.Unmarshal([]byte(*prop.StringValue), &labels); err == nil {
+					res.Labels = labels
+				}
 			case "env":
 				var envVars []openapi.AgentEnvVar
 				if err := json.Unmarshal([]byte(*prop.StringValue), &envVars); err == nil {

--- a/catalog/internal/catalog/agentcatalog/db_agent.go
+++ b/catalog/internal/catalog/agentcatalog/db_agent.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/models"
 	agentservice "github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/service"
@@ -67,8 +66,14 @@ func (d *DBAgentCatalog) GetFilterOptions(ctx context.Context) (*openapi.FilterO
 		}
 	}
 
+	var namedQueriesPtr *map[string]map[string]openapi.FieldFilter
+	if d.sources != nil {
+		namedQueriesPtr = basecatalog.ConvertNamedQueries(d.sources.GetNamedQueries(), options)
+	}
+
 	return &openapi.FilterOptionsList{
-		Filters: &options,
+		Filters:      &options,
+		NamedQueries: namedQueriesPtr,
 	}, nil
 }
 
@@ -190,26 +195,10 @@ func mapDBAgentToAPI(dbAgent models.Agent) openapi.Agent {
 				res.Readme = prop.StringValue
 			case "framework":
 				res.Framework = prop.StringValue
-			case "agentType":
-				res.AgentType = prop.StringValue
 			case "logo":
 				res.Logo = prop.StringValue
 			case "repositoryUrl":
 				res.RepositoryUrl = prop.StringValue
-			case "publishedDate":
-				if t, err := time.Parse(time.RFC3339, *prop.StringValue); err == nil {
-					res.PublishedDate = &t
-				}
-			case "tags":
-				var tags []string
-				if err := json.Unmarshal([]byte(*prop.StringValue), &tags); err == nil {
-					res.Tags = tags
-				}
-			case "models":
-				var models []string
-				if err := json.Unmarshal([]byte(*prop.StringValue), &models); err == nil {
-					res.Models = models
-				}
 			case "env":
 				var envVars []openapi.AgentEnvVar
 				if err := json.Unmarshal([]byte(*prop.StringValue), &envVars); err == nil {

--- a/catalog/internal/catalog/agentcatalog/loader.go
+++ b/catalog/internal/catalog/agentcatalog/loader.go
@@ -186,6 +186,13 @@ func (l *AgentLoader) updateSources(path string, config *basecatalog.SourceConfi
 		glog.Infof("loaded agent source %s of type %s", source.GetId(), source.Type)
 	}
 
+	if config.NamedQueries != nil {
+		filtered := basecatalog.FilterNamedQueriesByAssetType(config.NamedQueries, basecatalog.AssetTypeAgents)
+		if len(filtered) > 0 {
+			return l.Sources.MergeWithNamedQueries(path, sources, filtered)
+		}
+	}
+
 	return l.Sources.Merge(path, sources)
 }
 

--- a/catalog/internal/catalog/agentcatalog/service/entity_mappings_agent.go
+++ b/catalog/internal/catalog/agentcatalog/service/entity_mappings_agent.go
@@ -38,9 +38,7 @@ var agentProperties = map[string]filter.PropertyDefinition{
 	"displayName":              {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "displayName"},
 	"description":              {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "description"},
 	"framework":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "framework"},
-	"agentType":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "agentType"},
-	"tags":                     {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "tags"},
-	"models":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "models"},
 	"repositoryUrl":            {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "repositoryUrl"},
-	"publishedDate":            {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "publishedDate"},
+	"labels":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "labels"},
+	"models":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "models"},
 }

--- a/catalog/internal/catalog/agentcatalog/service/entity_mappings_agent.go
+++ b/catalog/internal/catalog/agentcatalog/service/entity_mappings_agent.go
@@ -40,5 +40,4 @@ var agentProperties = map[string]filter.PropertyDefinition{
 	"framework":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "framework"},
 	"repositoryUrl":            {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "repositoryUrl"},
 	"labels":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "labels"},
-	"models":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "models"},
 }

--- a/catalog/internal/catalog/agentcatalog/service/entity_mappings_agent_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/entity_mappings_agent_test.go
@@ -18,7 +18,6 @@ var expectedAgentProperties = map[string]filter.PropertyDefinition{
 	"framework":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "framework"},
 	"repositoryUrl":            {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "repositoryUrl"},
 	"labels":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "labels"},
-	"models":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "models"},
 }
 
 func TestAgentEntityMappings(t *testing.T) {

--- a/catalog/internal/catalog/agentcatalog/service/entity_mappings_agent_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/entity_mappings_agent_test.go
@@ -16,11 +16,9 @@ var expectedAgentProperties = map[string]filter.PropertyDefinition{
 	"displayName":              {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "displayName"},
 	"description":              {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "description"},
 	"framework":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "framework"},
-	"agentType":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "agentType"},
-	"tags":                     {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "tags"},
-	"models":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "models"},
 	"repositoryUrl":            {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "repositoryUrl"},
-	"publishedDate":            {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "publishedDate"},
+	"labels":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "labels"},
+	"models":                   {Location: filter.PropertyTable, ValueType: filter.ArrayValueType, Column: "models"},
 }
 
 func TestAgentEntityMappings(t *testing.T) {

--- a/catalog/internal/catalog/agentcatalog/sources.go
+++ b/catalog/internal/catalog/agentcatalog/sources.go
@@ -17,8 +17,9 @@ type agentOriginEntry struct {
 
 // AgentSourceCollection manages agent catalog sources from multiple origins with priority-based merging.
 type AgentSourceCollection struct {
-	mu      sync.RWMutex
-	entries []agentOriginEntry
+	mu           sync.RWMutex
+	entries      []agentOriginEntry
+	namedQueries map[string]map[string]basecatalog.FieldFilter
 }
 
 func NewAgentSourceCollection(originOrder ...string) *AgentSourceCollection {
@@ -27,7 +28,8 @@ func NewAgentSourceCollection(originOrder ...string) *AgentSourceCollection {
 		entries[i] = agentOriginEntry{origin: origin, sources: nil}
 	}
 	return &AgentSourceCollection{
-		entries: entries,
+		entries:      entries,
+		namedQueries: make(map[string]map[string]basecatalog.FieldFilter),
 	}
 }
 
@@ -44,6 +46,34 @@ func (sc *AgentSourceCollection) Merge(origin string, sources map[string]basecat
 
 	sc.entries = append(sc.entries, agentOriginEntry{origin: origin, sources: sources})
 	return nil
+}
+
+func (sc *AgentSourceCollection) MergeWithNamedQueries(origin string, sources map[string]basecatalog.PluginSource, namedQueries map[string]map[string]basecatalog.FieldFilter) error {
+	if err := sc.Merge(origin, sources); err != nil {
+		return err
+	}
+
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	for queryName, fieldFilters := range namedQueries {
+		if sc.namedQueries[queryName] == nil {
+			sc.namedQueries[queryName] = make(map[string]basecatalog.FieldFilter)
+		}
+		maps.Copy(sc.namedQueries[queryName], fieldFilters)
+	}
+	return nil
+}
+
+func (sc *AgentSourceCollection) GetNamedQueries() map[string]map[string]basecatalog.FieldFilter {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	result := make(map[string]map[string]basecatalog.FieldFilter, len(sc.namedQueries))
+	for queryName, fieldFilters := range sc.namedQueries {
+		result[queryName] = make(map[string]basecatalog.FieldFilter, len(fieldFilters))
+		maps.Copy(result[queryName], fieldFilters)
+	}
+	return result
 }
 
 func (sc *AgentSourceCollection) merged() map[string]basecatalog.PluginSource {

--- a/catalog/internal/catalog/agentcatalog/yaml_provider.go
+++ b/catalog/internal/catalog/agentcatalog/yaml_provider.go
@@ -31,8 +31,7 @@ type yamlAgent struct {
 	Description      *string                             `yaml:"description,omitempty" json:"description,omitempty"`
 	Readme           *string                             `yaml:"readme,omitempty" json:"readme,omitempty"`
 	Framework        *string                             `yaml:"framework,omitempty" json:"framework,omitempty"`
-	AgentType        *string                             `yaml:"agentType,omitempty" json:"agentType,omitempty"`
-	Tags             []string                            `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Labels           []string                            `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Models           []string                            `yaml:"models,omitempty" json:"models,omitempty"`
 	Logo             *string                             `yaml:"logo,omitempty" json:"logo,omitempty"`
 	RepositoryUrl    *string                             `yaml:"repositoryUrl,omitempty" json:"repositoryUrl,omitempty"`
@@ -100,28 +99,11 @@ func yamlAgentToEntity(ya yamlAgent, sourceID string) models.Agent {
 	if ya.Framework != nil {
 		properties = append(properties, dbmodels.NewStringProperty("framework", *ya.Framework, false))
 	}
-	if ya.AgentType != nil {
-		properties = append(properties, dbmodels.NewStringProperty("agentType", *ya.AgentType, false))
-	}
 	if ya.Logo != nil {
 		properties = append(properties, dbmodels.NewStringProperty("logo", *ya.Logo, false))
 	}
 	if ya.RepositoryUrl != nil {
 		properties = append(properties, dbmodels.NewStringProperty("repositoryUrl", *ya.RepositoryUrl, false))
-	}
-	if ya.PublishedDate != nil {
-		properties = append(properties, dbmodels.NewStringProperty("publishedDate", *ya.PublishedDate, false))
-	}
-
-	if len(ya.Tags) > 0 {
-		if jsonBytes, err := json.Marshal(ya.Tags); err == nil {
-			properties = append(properties, dbmodels.NewStringProperty("tags", string(jsonBytes), false))
-		}
-	}
-	if len(ya.Models) > 0 {
-		if jsonBytes, err := json.Marshal(ya.Models); err == nil {
-			properties = append(properties, dbmodels.NewStringProperty("models", string(jsonBytes), false))
-		}
 	}
 	if len(ya.Env) > 0 {
 		if jsonBytes, err := json.Marshal(ya.Env); err == nil {
@@ -141,11 +123,29 @@ func yamlAgentToEntity(ya yamlAgent, sourceID string) models.Agent {
 
 	agent.Properties = &properties
 
+	customProps := []dbmodels.Properties{}
+
+	if ya.PublishedDate != nil {
+		customProps = append(customProps, dbmodels.NewStringProperty("publishedDate", *ya.PublishedDate, true))
+	}
+	if len(ya.Labels) > 0 {
+		if jsonBytes, err := json.Marshal(ya.Labels); err == nil {
+			customProps = append(customProps, dbmodels.NewStringProperty("labels", string(jsonBytes), true))
+		}
+	}
+	if len(ya.Models) > 0 {
+		if jsonBytes, err := json.Marshal(ya.Models); err == nil {
+			customProps = append(customProps, dbmodels.NewStringProperty("models", string(jsonBytes), true))
+		}
+	}
+
 	if ya.CustomProperties != nil {
-		customProps := []dbmodels.Properties{}
 		for key, value := range *ya.CustomProperties {
 			customProps = append(customProps, convertAgentMetadataToProperty(key, value))
 		}
+	}
+
+	if len(customProps) > 0 {
 		agent.CustomProperties = &customProps
 	}
 

--- a/catalog/internal/catalog/agentcatalog/yaml_provider.go
+++ b/catalog/internal/catalog/agentcatalog/yaml_provider.go
@@ -31,6 +31,7 @@ type yamlAgent struct {
 	Description      *string                             `yaml:"description,omitempty" json:"description,omitempty"`
 	Readme           *string                             `yaml:"readme,omitempty" json:"readme,omitempty"`
 	Framework        *string                             `yaml:"framework,omitempty" json:"framework,omitempty"`
+	Labels           []string                            `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Logo             *string                             `yaml:"logo,omitempty" json:"logo,omitempty"`
 	RepositoryUrl    *string                             `yaml:"repositoryUrl,omitempty" json:"repositoryUrl,omitempty"`
 	Env              []yamlAgentEnvVar                   `yaml:"env,omitempty" json:"env,omitempty"`
@@ -95,6 +96,11 @@ func yamlAgentToEntity(ya yamlAgent, sourceID string) models.Agent {
 	}
 	if ya.Framework != nil {
 		properties = append(properties, dbmodels.NewStringProperty("framework", *ya.Framework, false))
+	}
+	if len(ya.Labels) > 0 {
+		if jsonBytes, err := json.Marshal(ya.Labels); err == nil {
+			properties = append(properties, dbmodels.NewStringProperty("labels", string(jsonBytes), false))
+		}
 	}
 	if ya.Logo != nil {
 		properties = append(properties, dbmodels.NewStringProperty("logo", *ya.Logo, false))

--- a/catalog/internal/catalog/agentcatalog/yaml_provider.go
+++ b/catalog/internal/catalog/agentcatalog/yaml_provider.go
@@ -31,11 +31,8 @@ type yamlAgent struct {
 	Description      *string                             `yaml:"description,omitempty" json:"description,omitempty"`
 	Readme           *string                             `yaml:"readme,omitempty" json:"readme,omitempty"`
 	Framework        *string                             `yaml:"framework,omitempty" json:"framework,omitempty"`
-	Labels           []string                            `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Models           []string                            `yaml:"models,omitempty" json:"models,omitempty"`
 	Logo             *string                             `yaml:"logo,omitempty" json:"logo,omitempty"`
 	RepositoryUrl    *string                             `yaml:"repositoryUrl,omitempty" json:"repositoryUrl,omitempty"`
-	PublishedDate    *string                             `yaml:"publishedDate,omitempty" json:"publishedDate,omitempty"`
 	Env              []yamlAgentEnvVar                   `yaml:"env,omitempty" json:"env,omitempty"`
 	Artifacts        []yamlAgentArtifact                 `yaml:"artifacts,omitempty" json:"artifacts,omitempty"`
 	CustomProperties *map[string]openapi.MetadataValue   `yaml:"customProperties,omitempty" json:"customProperties,omitempty"`
@@ -123,29 +120,11 @@ func yamlAgentToEntity(ya yamlAgent, sourceID string) models.Agent {
 
 	agent.Properties = &properties
 
-	customProps := []dbmodels.Properties{}
-
-	if ya.PublishedDate != nil {
-		customProps = append(customProps, dbmodels.NewStringProperty("publishedDate", *ya.PublishedDate, true))
-	}
-	if len(ya.Labels) > 0 {
-		if jsonBytes, err := json.Marshal(ya.Labels); err == nil {
-			customProps = append(customProps, dbmodels.NewStringProperty("labels", string(jsonBytes), true))
-		}
-	}
-	if len(ya.Models) > 0 {
-		if jsonBytes, err := json.Marshal(ya.Models); err == nil {
-			customProps = append(customProps, dbmodels.NewStringProperty("models", string(jsonBytes), true))
-		}
-	}
-
 	if ya.CustomProperties != nil {
+		customProps := []dbmodels.Properties{}
 		for key, value := range *ya.CustomProperties {
 			customProps = append(customProps, convertAgentMetadataToProperty(key, value))
 		}
-	}
-
-	if len(customProps) > 0 {
 		agent.CustomProperties = &customProps
 	}
 

--- a/catalog/internal/plugins/agent/plugin.go
+++ b/catalog/internal/plugins/agent/plugin.go
@@ -40,12 +40,9 @@ func (p *Plugin) DatastoreEntries() []plugin.DatastoreEntry {
 				AddString("description").
 				AddString("readme").
 				AddString("framework").
-				AddString("agentType").
-				AddStruct("tags").
-				AddStruct("models").
+				AddStruct("labels").
 				AddString("logo").
 				AddString("repositoryUrl").
-				AddString("publishedDate").
 				AddStruct("env").
 				AddStruct("artifacts"),
 		},

--- a/catalog/internal/testhelpers/spec_bootstrap.go
+++ b/catalog/internal/testhelpers/spec_bootstrap.go
@@ -4,6 +4,7 @@
 package testhelpers
 
 import (
+	agentcatalogservice "github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/service"
 	mcpcatalogservice "github.com/kubeflow/hub/catalog/internal/catalog/mcpcatalog/service"
 	modelcatalogservice "github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/service"
 	"github.com/kubeflow/hub/catalog/internal/db/service"
@@ -42,6 +43,21 @@ func init() {
 			Category: "artifact",
 			Spec: datastore.NewSpecType(modelcatalogservice.NewCatalogMetricsArtifactRepository).
 				AddString("metricsType"),
+		},
+		plugin.DatastoreEntry{
+			TypeName: "kf.Agent",
+			Category: "context",
+			Spec: datastore.NewSpecType(agentcatalogservice.NewAgentRepository).
+				AddString("source_id").
+				AddString("displayName").
+				AddString("description").
+				AddString("readme").
+				AddString("framework").
+				AddStruct("labels").
+				AddString("logo").
+				AddString("repositoryUrl").
+				AddStruct("env").
+				AddStruct("artifacts"),
 		},
 		plugin.DatastoreEntry{
 			TypeName: service.MCPServerTypeName,

--- a/catalog/pkg/openapi/model_agent.go
+++ b/catalog/pkg/openapi/model_agent.go
@@ -41,6 +41,8 @@ type Agent struct {
 	Readme *string `json:"readme,omitempty"`
 	// Agent framework (e.g., langgraph, crewai, autogen).
 	Framework *string `json:"framework,omitempty"`
+	// Labels for categorization and filtering.
+	Labels []string `json:"labels,omitempty"`
 	// URL or path to the agent logo image.
 	Logo *string `json:"logo,omitempty"`
 	// URL to the agent source code repository.
@@ -415,6 +417,38 @@ func (o *Agent) SetFramework(v string) {
 	o.Framework = &v
 }
 
+// GetLabels returns the Labels field value if set, zero value otherwise.
+func (o *Agent) GetLabels() []string {
+	if o == nil || IsNil(o.Labels) {
+		var ret []string
+		return ret
+	}
+	return o.Labels
+}
+
+// GetLabelsOk returns a tuple with the Labels field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Agent) GetLabelsOk() ([]string, bool) {
+	if o == nil || IsNil(o.Labels) {
+		return nil, false
+	}
+	return o.Labels, true
+}
+
+// HasLabels returns a boolean if a field has been set.
+func (o *Agent) HasLabels() bool {
+	if o != nil && !IsNil(o.Labels) {
+		return true
+	}
+
+	return false
+}
+
+// SetLabels gets a reference to the given []string and assigns it to the Labels field.
+func (o *Agent) SetLabels(v []string) {
+	o.Labels = v
+}
+
 // GetLogo returns the Logo field value if set, zero value otherwise.
 func (o *Agent) GetLogo() string {
 	if o == nil || IsNil(o.Logo) {
@@ -583,6 +617,9 @@ func (o Agent) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Framework) {
 		toSerialize["framework"] = o.Framework
+	}
+	if !IsNil(o.Labels) {
+		toSerialize["labels"] = o.Labels
 	}
 	if !IsNil(o.Logo) {
 		toSerialize["logo"] = o.Logo

--- a/catalog/pkg/openapi/model_agent.go
+++ b/catalog/pkg/openapi/model_agent.go
@@ -12,7 +12,6 @@ package openapi
 
 import (
 	"encoding/json"
-	"time"
 )
 
 // checks if the Agent type satisfies the MappedNullable interface at compile time
@@ -42,18 +41,10 @@ type Agent struct {
 	Readme *string `json:"readme,omitempty"`
 	// Agent framework (e.g., langgraph, crewai, autogen).
 	Framework *string `json:"framework,omitempty"`
-	// Catalog classification (e.g., starter_kit).
-	AgentType *string `json:"agentType,omitempty"`
-	// Tags for categorization and filtering.
-	Tags []string `json:"tags,omitempty"`
-	// Compatible model identifiers.
-	Models []string `json:"models,omitempty"`
 	// URL or path to the agent logo image.
 	Logo *string `json:"logo,omitempty"`
 	// URL to the agent source code repository.
 	RepositoryUrl *string `json:"repositoryUrl,omitempty"`
-	// Date when the agent was published.
-	PublishedDate *time.Time `json:"publishedDate,omitempty"`
 	// Environment variables required for deployment.
 	Env []AgentEnvVar `json:"env,omitempty"`
 	// OCI artifacts for agent deployment.
@@ -424,102 +415,6 @@ func (o *Agent) SetFramework(v string) {
 	o.Framework = &v
 }
 
-// GetAgentType returns the AgentType field value if set, zero value otherwise.
-func (o *Agent) GetAgentType() string {
-	if o == nil || IsNil(o.AgentType) {
-		var ret string
-		return ret
-	}
-	return *o.AgentType
-}
-
-// GetAgentTypeOk returns a tuple with the AgentType field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Agent) GetAgentTypeOk() (*string, bool) {
-	if o == nil || IsNil(o.AgentType) {
-		return nil, false
-	}
-	return o.AgentType, true
-}
-
-// HasAgentType returns a boolean if a field has been set.
-func (o *Agent) HasAgentType() bool {
-	if o != nil && !IsNil(o.AgentType) {
-		return true
-	}
-
-	return false
-}
-
-// SetAgentType gets a reference to the given string and assigns it to the AgentType field.
-func (o *Agent) SetAgentType(v string) {
-	o.AgentType = &v
-}
-
-// GetTags returns the Tags field value if set, zero value otherwise.
-func (o *Agent) GetTags() []string {
-	if o == nil || IsNil(o.Tags) {
-		var ret []string
-		return ret
-	}
-	return o.Tags
-}
-
-// GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Agent) GetTagsOk() ([]string, bool) {
-	if o == nil || IsNil(o.Tags) {
-		return nil, false
-	}
-	return o.Tags, true
-}
-
-// HasTags returns a boolean if a field has been set.
-func (o *Agent) HasTags() bool {
-	if o != nil && !IsNil(o.Tags) {
-		return true
-	}
-
-	return false
-}
-
-// SetTags gets a reference to the given []string and assigns it to the Tags field.
-func (o *Agent) SetTags(v []string) {
-	o.Tags = v
-}
-
-// GetModels returns the Models field value if set, zero value otherwise.
-func (o *Agent) GetModels() []string {
-	if o == nil || IsNil(o.Models) {
-		var ret []string
-		return ret
-	}
-	return o.Models
-}
-
-// GetModelsOk returns a tuple with the Models field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Agent) GetModelsOk() ([]string, bool) {
-	if o == nil || IsNil(o.Models) {
-		return nil, false
-	}
-	return o.Models, true
-}
-
-// HasModels returns a boolean if a field has been set.
-func (o *Agent) HasModels() bool {
-	if o != nil && !IsNil(o.Models) {
-		return true
-	}
-
-	return false
-}
-
-// SetModels gets a reference to the given []string and assigns it to the Models field.
-func (o *Agent) SetModels(v []string) {
-	o.Models = v
-}
-
 // GetLogo returns the Logo field value if set, zero value otherwise.
 func (o *Agent) GetLogo() string {
 	if o == nil || IsNil(o.Logo) {
@@ -582,38 +477,6 @@ func (o *Agent) HasRepositoryUrl() bool {
 // SetRepositoryUrl gets a reference to the given string and assigns it to the RepositoryUrl field.
 func (o *Agent) SetRepositoryUrl(v string) {
 	o.RepositoryUrl = &v
-}
-
-// GetPublishedDate returns the PublishedDate field value if set, zero value otherwise.
-func (o *Agent) GetPublishedDate() time.Time {
-	if o == nil || IsNil(o.PublishedDate) {
-		var ret time.Time
-		return ret
-	}
-	return *o.PublishedDate
-}
-
-// GetPublishedDateOk returns a tuple with the PublishedDate field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Agent) GetPublishedDateOk() (*time.Time, bool) {
-	if o == nil || IsNil(o.PublishedDate) {
-		return nil, false
-	}
-	return o.PublishedDate, true
-}
-
-// HasPublishedDate returns a boolean if a field has been set.
-func (o *Agent) HasPublishedDate() bool {
-	if o != nil && !IsNil(o.PublishedDate) {
-		return true
-	}
-
-	return false
-}
-
-// SetPublishedDate gets a reference to the given time.Time and assigns it to the PublishedDate field.
-func (o *Agent) SetPublishedDate(v time.Time) {
-	o.PublishedDate = &v
 }
 
 // GetEnv returns the Env field value if set, zero value otherwise.
@@ -721,23 +584,11 @@ func (o Agent) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Framework) {
 		toSerialize["framework"] = o.Framework
 	}
-	if !IsNil(o.AgentType) {
-		toSerialize["agentType"] = o.AgentType
-	}
-	if !IsNil(o.Tags) {
-		toSerialize["tags"] = o.Tags
-	}
-	if !IsNil(o.Models) {
-		toSerialize["models"] = o.Models
-	}
 	if !IsNil(o.Logo) {
 		toSerialize["logo"] = o.Logo
 	}
 	if !IsNil(o.RepositoryUrl) {
 		toSerialize["repositoryUrl"] = o.RepositoryUrl
-	}
-	if !IsNil(o.PublishedDate) {
-		toSerialize["publishedDate"] = o.PublishedDate
 	}
 	if !IsNil(o.Env) {
 		toSerialize["env"] = o.Env

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-enterprise-agents.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-enterprise-agents.yaml
@@ -3,6 +3,11 @@ agents:
     displayName: "Incident Response Agent"
     description: "Production incident response agent that triages alerts, queries observability systems, and suggests remediation steps based on runbooks."
     framework: langgraph
+    labels:
+      - incident-response
+      - observability
+      - sre
+      - production
     repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/incident-responder"
     readme: |
       # Incident Response Agent
@@ -33,15 +38,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/incident-responder:v2.1.0"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["incident-response","observability","sre","production"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-04-01T00:00:00Z"
     createTimeSinceEpoch: "1743465600000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -49,6 +48,11 @@ agents:
     displayName: "Compliance Auditor"
     description: "Automated compliance checking agent that validates infrastructure configurations against SOC2, HIPAA, and PCI-DSS requirements."
     framework: crewai
+    labels:
+      - compliance
+      - security
+      - audit
+      - governance
     repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/compliance-auditor"
     readme: |
       # Compliance Auditor
@@ -74,15 +78,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/compliance-auditor:v1.4.0"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["compliance","security","audit","governance"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-03-15T00:00:00Z"
     createTimeSinceEpoch: "1742083200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -90,6 +88,10 @@ agents:
     displayName: "Employee Onboarding Assistant"
     description: "Interactive onboarding agent that guides new employees through setup, training, and policy acknowledgment workflows."
     framework: langgraph
+    labels:
+      - hr
+      - onboarding
+      - workflow
     repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/onboarding-assistant"
     readme: |
       # Employee Onboarding Assistant
@@ -113,14 +115,8 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/onboarding-assistant:v1.0.0"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["hr","onboarding","workflow"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct","llama-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-05-01T00:00:00Z"
     createTimeSinceEpoch: "1746057600000"
     lastUpdateTimeSinceEpoch: "1750550400000"

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-enterprise-agents.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-enterprise-agents.yaml
@@ -3,15 +3,7 @@ agents:
     displayName: "Incident Response Agent"
     description: "Production incident response agent that triages alerts, queries observability systems, and suggests remediation steps based on runbooks."
     framework: langgraph
-    labels:
-      - incident-response
-      - observability
-      - sre
-      - production
-    models:
-      - granite-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/incident-responder"
-    publishedDate: "2025-04-01T00:00:00Z"
     readme: |
       # Incident Response Agent
 
@@ -40,6 +32,16 @@ agents:
         required: false
     artifacts:
       - uri: "oci://quay.io/example-org/incident-responder:v2.1.0"
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["incident-response","observability","sre","production"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-04-01T00:00:00Z"
     createTimeSinceEpoch: "1743465600000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -47,15 +49,7 @@ agents:
     displayName: "Compliance Auditor"
     description: "Automated compliance checking agent that validates infrastructure configurations against SOC2, HIPAA, and PCI-DSS requirements."
     framework: crewai
-    labels:
-      - compliance
-      - security
-      - audit
-      - governance
-    models:
-      - granite-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/compliance-auditor"
-    publishedDate: "2025-03-15T00:00:00Z"
     readme: |
       # Compliance Auditor
 
@@ -79,6 +73,16 @@ agents:
         required: true
     artifacts:
       - uri: "oci://quay.io/example-org/compliance-auditor:v1.4.0"
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["compliance","security","audit","governance"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-03-15T00:00:00Z"
     createTimeSinceEpoch: "1742083200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -86,15 +90,7 @@ agents:
     displayName: "Employee Onboarding Assistant"
     description: "Interactive onboarding agent that guides new employees through setup, training, and policy acknowledgment workflows."
     framework: langgraph
-    labels:
-      - hr
-      - onboarding
-      - workflow
-    models:
-      - granite-3.1-8b-instruct
-      - llama-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/onboarding-assistant"
-    publishedDate: "2025-05-01T00:00:00Z"
     readme: |
       # Employee Onboarding Assistant
 
@@ -116,5 +112,15 @@ agents:
         required: false
     artifacts:
       - uri: "oci://quay.io/example-org/onboarding-assistant:v1.0.0"
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["hr","onboarding","workflow"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct","llama-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-05-01T00:00:00Z"
     createTimeSinceEpoch: "1746057600000"
     lastUpdateTimeSinceEpoch: "1750550400000"

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-enterprise-agents.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-enterprise-agents.yaml
@@ -1,0 +1,120 @@
+agents:
+  - name: incident-responder
+    displayName: "Incident Response Agent"
+    description: "Production incident response agent that triages alerts, queries observability systems, and suggests remediation steps based on runbooks."
+    framework: langgraph
+    labels:
+      - incident-response
+      - observability
+      - sre
+      - production
+    models:
+      - granite-3.1-8b-instruct
+    repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/incident-responder"
+    publishedDate: "2025-04-01T00:00:00Z"
+    readme: |
+      # Incident Response Agent
+
+      An enterprise-grade incident response agent that integrates with
+      PagerDuty, Prometheus, Grafana, and internal runbooks to automate
+      the first 10 minutes of incident response.
+
+      ## Capabilities
+      - Triage incoming alerts by severity and blast radius
+      - Query Prometheus and Grafana for correlated metrics
+      - Search runbooks for matching remediation procedures
+      - Post status updates to Slack and incident channels
+      - Escalate to on-call engineers when human judgment is needed
+
+      ## Security
+      Runs with read-only access to observability systems. Remediation
+      actions require human approval via the incident channel.
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: PAGERDUTY_API_KEY
+        required: true
+      - name: PROMETHEUS_URL
+        required: true
+      - name: SLACK_WEBHOOK_URL
+        required: false
+    artifacts:
+      - uri: "oci://quay.io/example-org/incident-responder:v2.1.0"
+    createTimeSinceEpoch: "1743465600000"
+    lastUpdateTimeSinceEpoch: "1750550400000"
+
+  - name: compliance-auditor
+    displayName: "Compliance Auditor"
+    description: "Automated compliance checking agent that validates infrastructure configurations against SOC2, HIPAA, and PCI-DSS requirements."
+    framework: crewai
+    labels:
+      - compliance
+      - security
+      - audit
+      - governance
+    models:
+      - granite-3.1-8b-instruct
+    repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/compliance-auditor"
+    publishedDate: "2025-03-15T00:00:00Z"
+    readme: |
+      # Compliance Auditor
+
+      A CrewAI-powered compliance agent that continuously audits your
+      infrastructure against regulatory frameworks.
+
+      ## Supported Frameworks
+      - SOC2 Type II
+      - HIPAA
+      - PCI-DSS v4.0
+      - NIST 800-53
+
+      ## How It Works
+      The agent scans Kubernetes manifests, Terraform state, and cloud
+      provider configurations, then generates compliance reports with
+      specific remediation recommendations.
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: K8S_CLUSTER_CONTEXT
+        required: true
+    artifacts:
+      - uri: "oci://quay.io/example-org/compliance-auditor:v1.4.0"
+    createTimeSinceEpoch: "1742083200000"
+    lastUpdateTimeSinceEpoch: "1750550400000"
+
+  - name: onboarding-assistant
+    displayName: "Employee Onboarding Assistant"
+    description: "Interactive onboarding agent that guides new employees through setup, training, and policy acknowledgment workflows."
+    framework: langgraph
+    labels:
+      - hr
+      - onboarding
+      - workflow
+    models:
+      - granite-3.1-8b-instruct
+      - llama-3.1-8b-instruct
+    repositoryUrl: "https://github.com/example-org/enterprise-agents/tree/main/agents/onboarding-assistant"
+    publishedDate: "2025-05-01T00:00:00Z"
+    readme: |
+      # Employee Onboarding Assistant
+
+      A conversational agent that automates employee onboarding by guiding
+      new hires through account setup, training modules, and policy
+      acknowledgment — all via natural language chat.
+
+      ## Features
+      - Automated account provisioning (SSO, email, Slack)
+      - Interactive training module walkthroughs
+      - Policy acknowledgment tracking
+      - Manager notification and checklist sync
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: HR_SYSTEM_API_URL
+        required: true
+      - name: SLACK_BOT_TOKEN
+        required: false
+    artifacts:
+      - uri: "oci://quay.io/example-org/onboarding-assistant:v1.0.0"
+    createTimeSinceEpoch: "1746057600000"
+    lastUpdateTimeSinceEpoch: "1750550400000"

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-sample-agents.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-sample-agents.yaml
@@ -3,6 +3,11 @@ agents:
     displayName: "Travel Planner Agent"
     description: "Multi-step travel planning agent that researches destinations, compares flights and hotels, and builds complete itineraries using tool calling."
     framework: langgraph
+    labels:
+      - travel
+      - planning
+      - react
+      - tool-calling
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/travel-planner"
     readme: |
       # Travel Planner Agent
@@ -32,15 +37,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/travel-planner-agent:latest"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["travel","planning","react","tool-calling"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct","mistral-7b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-06-01T00:00:00Z"
     createTimeSinceEpoch: "1748736000000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -48,6 +47,10 @@ agents:
     displayName: "Code Review Agent"
     description: "Automated code review agent that analyzes pull requests for bugs, security issues, and style violations using a CrewAI multi-agent pipeline."
     framework: crewai
+    labels:
+      - code-review
+      - security
+      - developer-tools
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/code-reviewer"
     readme: |
       # Code Review Agent
@@ -72,15 +75,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/code-reviewer-agent:latest"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["code-review","security","developer-tools"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-05-15T00:00:00Z"
     createTimeSinceEpoch: "1747267200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -88,6 +85,10 @@ agents:
     displayName: "Customer Support Bot"
     description: "RAG-powered customer support agent that searches knowledge bases to provide context-aware responses to user queries."
     framework: llamaindex
+    labels:
+      - customer-support
+      - rag
+      - knowledge-base
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/customer-support"
     readme: |
       # Customer Support Bot
@@ -106,15 +107,9 @@ agents:
       - name: VECTOR_DB_URI
         required: true
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["customer-support","rag","knowledge-base"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct","llama-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-05-20T00:00:00Z"
     createTimeSinceEpoch: "1747699200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -122,6 +117,10 @@ agents:
     displayName: "Data Pipeline Builder"
     description: "Conversational agent that designs and generates Apache Airflow DAGs from natural language descriptions of data workflows."
     framework: langgraph
+    labels:
+      - data-engineering
+      - airflow
+      - code-generation
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/data-pipeline-builder"
     readme: |
       # Data Pipeline Builder
@@ -142,15 +141,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/data-pipeline-builder:latest"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["data-engineering","airflow","code-generation"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-06-10T00:00:00Z"
     createTimeSinceEpoch: "1749600000000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -158,6 +151,10 @@ agents:
     displayName: "Research Assistant"
     description: "Multi-tool research agent that searches academic papers, summarizes findings, and generates literature reviews with proper citations."
     framework: autogen
+    labels:
+      - research
+      - summarization
+      - academic
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/research-assistant"
     readme: |
       # Research Assistant
@@ -177,15 +174,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/research-assistant:latest"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["research","summarization","academic"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct","mistral-7b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-05-25T00:00:00Z"
     createTimeSinceEpoch: "1748131200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -193,6 +184,10 @@ agents:
     displayName: "Multi-Agent Orchestrator"
     description: "A2A-compatible orchestrator that coordinates multiple specialized agents over the Agent-to-Agent protocol, enabling complex multi-step workflows with validated container images."
     framework: langgraph
+    labels:
+      - orchestration
+      - a2a
+      - multi-agent
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/multi-agent-orchestrator"
     readme: |
       # Multi-Agent Orchestrator
@@ -212,15 +207,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/multi-agent-orchestrator:v0.1.0-validated"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["orchestration","a2a","multi-agent"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-06-15T00:00:00Z"
       protocol:
         metadataType: MetadataStringValue
         string_value: A2A

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-sample-agents.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-sample-agents.yaml
@@ -3,16 +3,7 @@ agents:
     displayName: "Travel Planner Agent"
     description: "Multi-step travel planning agent that researches destinations, compares flights and hotels, and builds complete itineraries using tool calling."
     framework: langgraph
-    labels:
-      - travel
-      - planning
-      - react
-      - tool-calling
-    models:
-      - granite-3.1-8b-instruct
-      - mistral-7b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/travel-planner"
-    publishedDate: "2025-06-01T00:00:00Z"
     readme: |
       # Travel Planner Agent
 
@@ -40,6 +31,16 @@ agents:
         required: true
     artifacts:
       - uri: "oci://quay.io/example-org/travel-planner-agent:latest"
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["travel","planning","react","tool-calling"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct","mistral-7b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-06-01T00:00:00Z"
     createTimeSinceEpoch: "1748736000000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -47,14 +48,7 @@ agents:
     displayName: "Code Review Agent"
     description: "Automated code review agent that analyzes pull requests for bugs, security issues, and style violations using a CrewAI multi-agent pipeline."
     framework: crewai
-    labels:
-      - code-review
-      - security
-      - developer-tools
-    models:
-      - granite-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/code-reviewer"
-    publishedDate: "2025-05-15T00:00:00Z"
     readme: |
       # Code Review Agent
 
@@ -77,6 +71,16 @@ agents:
         required: true
     artifacts:
       - uri: "oci://quay.io/example-org/code-reviewer-agent:latest"
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["code-review","security","developer-tools"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-05-15T00:00:00Z"
     createTimeSinceEpoch: "1747267200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -84,15 +88,7 @@ agents:
     displayName: "Customer Support Bot"
     description: "RAG-powered customer support agent that searches knowledge bases to provide context-aware responses to user queries."
     framework: llamaindex
-    labels:
-      - customer-support
-      - rag
-      - knowledge-base
-    models:
-      - granite-3.1-8b-instruct
-      - llama-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/customer-support"
-    publishedDate: "2025-05-20T00:00:00Z"
     readme: |
       # Customer Support Bot
 
@@ -109,6 +105,16 @@ agents:
         required: true
       - name: VECTOR_DB_URI
         required: true
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["customer-support","rag","knowledge-base"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct","llama-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-05-20T00:00:00Z"
     createTimeSinceEpoch: "1747699200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -116,14 +122,7 @@ agents:
     displayName: "Data Pipeline Builder"
     description: "Conversational agent that designs and generates Apache Airflow DAGs from natural language descriptions of data workflows."
     framework: langgraph
-    labels:
-      - data-engineering
-      - airflow
-      - code-generation
-    models:
-      - granite-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/data-pipeline-builder"
-    publishedDate: "2025-06-10T00:00:00Z"
     readme: |
       # Data Pipeline Builder
 
@@ -142,6 +141,16 @@ agents:
         required: false
     artifacts:
       - uri: "oci://quay.io/example-org/data-pipeline-builder:latest"
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["data-engineering","airflow","code-generation"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-06-10T00:00:00Z"
     createTimeSinceEpoch: "1749600000000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -149,15 +158,7 @@ agents:
     displayName: "Research Assistant"
     description: "Multi-tool research agent that searches academic papers, summarizes findings, and generates literature reviews with proper citations."
     framework: autogen
-    labels:
-      - research
-      - summarization
-      - academic
-    models:
-      - granite-3.1-8b-instruct
-      - mistral-7b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/research-assistant"
-    publishedDate: "2025-05-25T00:00:00Z"
     readme: |
       # Research Assistant
 
@@ -175,6 +176,16 @@ agents:
         required: false
     artifacts:
       - uri: "oci://quay.io/example-org/research-assistant:latest"
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["research","summarization","academic"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct","mistral-7b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-05-25T00:00:00Z"
     createTimeSinceEpoch: "1748131200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -182,14 +193,7 @@ agents:
     displayName: "Multi-Agent Orchestrator"
     description: "A2A-compatible orchestrator that coordinates multiple specialized agents over the Agent-to-Agent protocol, enabling complex multi-step workflows with validated container images."
     framework: langgraph
-    labels:
-      - orchestration
-      - a2a
-      - multi-agent
-    models:
-      - granite-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/multi-agent-orchestrator"
-    publishedDate: "2025-06-15T00:00:00Z"
     readme: |
       # Multi-Agent Orchestrator
 
@@ -208,6 +212,15 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/multi-agent-orchestrator:v0.1.0-validated"
     customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["orchestration","a2a","multi-agent"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-06-15T00:00:00Z"
       protocol:
         metadataType: MetadataStringValue
         string_value: A2A

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-sample-agents.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-sample-agents.yaml
@@ -1,0 +1,218 @@
+agents:
+  - name: travel-planner
+    displayName: "Travel Planner Agent"
+    description: "Multi-step travel planning agent that researches destinations, compares flights and hotels, and builds complete itineraries using tool calling."
+    framework: langgraph
+    labels:
+      - travel
+      - planning
+      - react
+      - tool-calling
+    models:
+      - granite-3.1-8b-instruct
+      - mistral-7b-instruct
+    repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/travel-planner"
+    publishedDate: "2025-06-01T00:00:00Z"
+    readme: |
+      # Travel Planner Agent
+
+      A multi-step travel planning agent built with LangGraph that uses ReAct-style
+      tool calling to research destinations, compare flights and hotels, and build
+      complete itineraries.
+
+      ## Features
+      - Destination research via web search tools
+      - Flight and hotel comparison
+      - Itinerary generation with day-by-day breakdown
+      - Budget tracking and optimization
+
+      ## Quick Start
+      ```bash
+      export MODEL_ENDPOINT=https://your-model-endpoint
+      export MODEL_NAME=granite-3.1-8b-instruct
+      podman run -e MODEL_ENDPOINT -e MODEL_NAME \
+        quay.io/example-org/travel-planner-agent:latest
+      ```
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: MODEL_NAME
+        required: true
+    artifacts:
+      - uri: "oci://quay.io/example-org/travel-planner-agent:latest"
+    createTimeSinceEpoch: "1748736000000"
+    lastUpdateTimeSinceEpoch: "1750550400000"
+
+  - name: code-reviewer
+    displayName: "Code Review Agent"
+    description: "Automated code review agent that analyzes pull requests for bugs, security issues, and style violations using a CrewAI multi-agent pipeline."
+    framework: crewai
+    labels:
+      - code-review
+      - security
+      - developer-tools
+    models:
+      - granite-3.1-8b-instruct
+    repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/code-reviewer"
+    publishedDate: "2025-05-15T00:00:00Z"
+    readme: |
+      # Code Review Agent
+
+      An automated code review agent using CrewAI to orchestrate multiple specialized
+      sub-agents: a bug detector, a security scanner, and a style checker.
+
+      ## Architecture
+      The agent uses a crew of three specialists:
+      1. **Bug Hunter** — identifies logic errors and edge cases
+      2. **Security Auditor** — checks for OWASP Top 10 vulnerabilities
+      3. **Style Enforcer** — validates coding standards and conventions
+
+      ## Usage
+      Connect to your GitHub repository and the agent will automatically review
+      new pull requests.
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: GITHUB_TOKEN
+        required: true
+    artifacts:
+      - uri: "oci://quay.io/example-org/code-reviewer-agent:latest"
+    createTimeSinceEpoch: "1747267200000"
+    lastUpdateTimeSinceEpoch: "1750550400000"
+
+  - name: customer-support-bot
+    displayName: "Customer Support Bot"
+    description: "RAG-powered customer support agent that searches knowledge bases to provide context-aware responses to user queries."
+    framework: llamaindex
+    labels:
+      - customer-support
+      - rag
+      - knowledge-base
+    models:
+      - granite-3.1-8b-instruct
+      - llama-3.1-8b-instruct
+    repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/customer-support"
+    publishedDate: "2025-05-20T00:00:00Z"
+    readme: |
+      # Customer Support Bot
+
+      A RAG-powered customer support agent built with LlamaIndex that searches
+      knowledge bases and documentation to provide accurate, context-aware responses.
+
+      ## Features
+      - Multi-source RAG over documentation, FAQs, and knowledge bases
+      - Conversation memory with context window management
+      - Escalation to human agents when confidence is low
+      - Citation tracking — every answer links to its source
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: VECTOR_DB_URI
+        required: true
+    createTimeSinceEpoch: "1747699200000"
+    lastUpdateTimeSinceEpoch: "1750550400000"
+
+  - name: data-pipeline-builder
+    displayName: "Data Pipeline Builder"
+    description: "Conversational agent that designs and generates Apache Airflow DAGs from natural language descriptions of data workflows."
+    framework: langgraph
+    labels:
+      - data-engineering
+      - airflow
+      - code-generation
+    models:
+      - granite-3.1-8b-instruct
+    repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/data-pipeline-builder"
+    publishedDate: "2025-06-10T00:00:00Z"
+    readme: |
+      # Data Pipeline Builder
+
+      Describe your data workflow in plain English, and this agent generates
+      production-ready Apache Airflow DAGs with proper error handling,
+      retries, and monitoring.
+
+      ## Supported Sources
+      - PostgreSQL, MySQL, MongoDB
+      - S3, GCS, Azure Blob Storage
+      - REST APIs and webhooks
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: AIRFLOW_API_URL
+        required: false
+    artifacts:
+      - uri: "oci://quay.io/example-org/data-pipeline-builder:latest"
+    createTimeSinceEpoch: "1749600000000"
+    lastUpdateTimeSinceEpoch: "1750550400000"
+
+  - name: research-assistant
+    displayName: "Research Assistant"
+    description: "Multi-tool research agent that searches academic papers, summarizes findings, and generates literature reviews with proper citations."
+    framework: autogen
+    labels:
+      - research
+      - summarization
+      - academic
+    models:
+      - granite-3.1-8b-instruct
+      - mistral-7b-instruct
+    repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/research-assistant"
+    publishedDate: "2025-05-25T00:00:00Z"
+    readme: |
+      # Research Assistant
+
+      An AutoGen-based multi-agent system for academic research. It coordinates
+      a searcher, a reader, and a writer to produce literature reviews.
+
+      ## Agents
+      - **Searcher** — queries arXiv, Semantic Scholar, and PubMed
+      - **Reader** — extracts key findings and methodology from papers
+      - **Writer** — synthesizes findings into structured literature reviews
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: SEMANTIC_SCHOLAR_API_KEY
+        required: false
+    artifacts:
+      - uri: "oci://quay.io/example-org/research-assistant:latest"
+    createTimeSinceEpoch: "1748131200000"
+    lastUpdateTimeSinceEpoch: "1750550400000"
+
+  - name: multi-agent-orchestrator
+    displayName: "Multi-Agent Orchestrator"
+    description: "A2A-compatible orchestrator that coordinates multiple specialized agents over the Agent-to-Agent protocol, enabling complex multi-step workflows with validated container images."
+    framework: langgraph
+    labels:
+      - orchestration
+      - a2a
+      - multi-agent
+    models:
+      - granite-3.1-8b-instruct
+    repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/multi-agent-orchestrator"
+    publishedDate: "2025-06-15T00:00:00Z"
+    readme: |
+      # Multi-Agent Orchestrator
+
+      An A2A protocol-based orchestrator built with LangGraph that coordinates
+      specialized sub-agents for complex workflows.
+
+      ## Features
+      - Agent-to-Agent (A2A) protocol support
+      - Dynamic agent discovery and delegation
+      - Validated container images for production deployment
+    env:
+      - name: MODEL_ENDPOINT
+        required: true
+      - name: A2A_DISCOVERY_URL
+        required: true
+    artifacts:
+      - uri: "oci://quay.io/example-org/multi-agent-orchestrator:v0.1.0-validated"
+    customProperties:
+      protocol:
+        metadataType: MetadataStringValue
+        string_value: A2A
+      imageVersion:
+        metadataType: MetadataStringValue
+        string_value: v0.1.0-validated
+    createTimeSinceEpoch: "1750032000000"
+    lastUpdateTimeSinceEpoch: "1750550400000"

--- a/manifests/kustomize/options/catalog/overlays/demo/dev-sources.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/dev-sources.yaml
@@ -38,6 +38,22 @@ mcp_catalogs:
     properties:
       yamlCatalogPath: dev-community-mcp-servers.yaml
 
+agent_catalogs:
+  - name: "Sample Agents"
+    id: sample_agents
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: dev-sample-agents.yaml
+  - name: "Enterprise Agents"
+    id: enterprise_agents
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: dev-enterprise-agents.yaml
+    labels:
+      - Enterprise
+
 # namedQueries define reusable server-side filter presets that clients can
 # reference by name via the `namedQuery` API parameter. Multiple config files
 # can contribute queries; later files override individual fields within a query

--- a/manifests/kustomize/options/catalog/overlays/demo/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/overlays/demo/kustomization.yaml
@@ -13,6 +13,8 @@ configMapGenerator:
   - dev-community-models.yaml=dev-community-models.yaml
   - dev-organization-mcp-servers.yaml=dev-organization-mcp-servers.yaml
   - dev-community-mcp-servers.yaml=dev-community-mcp-servers.yaml
+  - dev-sample-agents.yaml=dev-sample-agents.yaml
+  - dev-enterprise-agents.yaml=dev-enterprise-agents.yaml
   name: model-catalog-sources
   options:
     disableNameSuffixHash: true

--- a/manifests/kustomize/options/catalog/overlays/e2e/sample-agent-catalog.yaml
+++ b/manifests/kustomize/options/catalog/overlays/e2e/sample-agent-catalog.yaml
@@ -6,8 +6,7 @@ agents:
     description: "Multi-step travel planning agent that researches destinations, compares flights and hotels, and builds complete itineraries using tool calling."
     readme: "# Travel Planner Agent\n\nA starter kit for building a travel planning assistant. Uses ReAct-style reasoning to break down complex travel requests into research, comparison, and booking steps.\n\n## Features\n- Multi-city itinerary planning\n- Flight and hotel comparison via tool calls\n- Budget-aware recommendations"
     framework: langgraph
-    agentType: starter_kit
-    tags:
+    labels:
       - travel
       - planning
       - react
@@ -35,8 +34,7 @@ agents:
     displayName: "Code Review Agent"
     description: "Automated code review agent that analyzes pull requests for bugs, security issues, and style violations using static analysis tools and LLM reasoning."
     framework: crewai
-    agentType: starter_kit
-    tags:
+    labels:
       - code-review
       - security
       - developer-tools
@@ -61,8 +59,7 @@ agents:
     displayName: "Customer Support Bot"
     description: "RAG-powered customer support agent that searches knowledge bases and previous tickets to provide accurate, context-aware responses to customer inquiries."
     framework: llamaindex
-    agentType: starter_kit
-    tags:
+    labels:
       - customer-support
       - rag
       - knowledge-base
@@ -88,8 +85,7 @@ agents:
     displayName: "Data Pipeline Orchestrator"
     description: "Agent that designs and executes data transformation pipelines by composing SQL queries, API calls, and file operations through MCP tool servers."
     framework: autogen
-    agentType: starter_kit
-    tags:
+    labels:
       - data-engineering
       - mcp
       - pipeline
@@ -117,8 +113,7 @@ agents:
     displayName: "Research Assistant"
     description: "Web search and summarization agent that gathers information from multiple sources, cross-references findings, and produces structured research reports."
     framework: langgraph
-    agentType: starter_kit
-    tags:
+    labels:
       - research
       - web-search
       - summarization

--- a/manifests/kustomize/options/catalog/overlays/e2e/sample-agent-catalog.yaml
+++ b/manifests/kustomize/options/catalog/overlays/e2e/sample-agent-catalog.yaml
@@ -6,17 +6,8 @@ agents:
     description: "Multi-step travel planning agent that researches destinations, compares flights and hotels, and builds complete itineraries using tool calling."
     readme: "# Travel Planner Agent\n\nA starter kit for building a travel planning assistant. Uses ReAct-style reasoning to break down complex travel requests into research, comparison, and booking steps.\n\n## Features\n- Multi-city itinerary planning\n- Flight and hotel comparison via tool calls\n- Budget-aware recommendations"
     framework: langgraph
-    labels:
-      - travel
-      - planning
-      - react
-      - tool-calling
-    models:
-      - granite-3.1-8b-instruct
-      - mistral-7b-instruct
     logo: "https://example.com/logos/travel-planner.svg"
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/travel-planner"
-    publishedDate: "2025-06-01T00:00:00Z"
     env:
       - name: MODEL_ENDPOINT
         required: true
@@ -26,7 +17,16 @@ agents:
         required: false
     artifacts:
       - uri: "oci://quay.io/example-org/travel-planner-agent:latest"
-    customProperties: {}
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["travel","planning","react","tool-calling"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct","mistral-7b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-06-01T00:00:00Z"
     createTimeSinceEpoch: "1748736000000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -34,14 +34,7 @@ agents:
     displayName: "Code Review Agent"
     description: "Automated code review agent that analyzes pull requests for bugs, security issues, and style violations using static analysis tools and LLM reasoning."
     framework: crewai
-    labels:
-      - code-review
-      - security
-      - developer-tools
-    models:
-      - granite-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/code-reviewer"
-    publishedDate: "2025-05-15T00:00:00Z"
     env:
       - name: MODEL_ENDPOINT
         required: true
@@ -51,7 +44,16 @@ agents:
         required: true
     artifacts:
       - uri: "oci://quay.io/example-org/code-reviewer-agent:latest"
-    customProperties: {}
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["code-review","security","developer-tools"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-05-15T00:00:00Z"
     createTimeSinceEpoch: "1747267200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -59,15 +61,7 @@ agents:
     displayName: "Customer Support Bot"
     description: "RAG-powered customer support agent that searches knowledge bases and previous tickets to provide accurate, context-aware responses to customer inquiries."
     framework: llamaindex
-    labels:
-      - customer-support
-      - rag
-      - knowledge-base
-    models:
-      - granite-3.1-8b-instruct
-      - llama-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/customer-support"
-    publishedDate: "2025-05-20T00:00:00Z"
     env:
       - name: MODEL_ENDPOINT
         required: true
@@ -77,7 +71,16 @@ agents:
         required: true
       - name: VECTOR_DB_TOKEN
         required: false
-    customProperties: {}
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["customer-support","rag","knowledge-base"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct","llama-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-05-20T00:00:00Z"
     createTimeSinceEpoch: "1747699200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -85,15 +88,7 @@ agents:
     displayName: "Data Pipeline Orchestrator"
     description: "Agent that designs and executes data transformation pipelines by composing SQL queries, API calls, and file operations through MCP tool servers."
     framework: autogen
-    labels:
-      - data-engineering
-      - mcp
-      - pipeline
-      - sql
-    models:
-      - granite-3.1-8b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/data-pipeline"
-    publishedDate: "2025-04-28T00:00:00Z"
     env:
       - name: MODEL_ENDPOINT
         required: true
@@ -105,7 +100,16 @@ agents:
         required: true
     artifacts:
       - uri: "oci://quay.io/example-org/data-pipeline-agent:latest"
-    customProperties: {}
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["data-engineering","mcp","pipeline","sql"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-04-28T00:00:00Z"
     createTimeSinceEpoch: "1745798400000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -113,16 +117,7 @@ agents:
     displayName: "Research Assistant"
     description: "Web search and summarization agent that gathers information from multiple sources, cross-references findings, and produces structured research reports."
     framework: langgraph
-    labels:
-      - research
-      - web-search
-      - summarization
-      - report-generation
-    models:
-      - granite-3.1-8b-instruct
-      - mistral-7b-instruct
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/research-assistant"
-    publishedDate: "2025-05-10T00:00:00Z"
     env:
       - name: MODEL_ENDPOINT
         required: true
@@ -130,6 +125,15 @@ agents:
         required: true
       - name: SEARCH_API_KEY
         required: true
-    customProperties: {}
+    customProperties:
+      labels:
+        metadataType: MetadataStringValue
+        string_value: '["research","web-search","summarization","report-generation"]'
+      models:
+        metadataType: MetadataStringValue
+        string_value: '["granite-3.1-8b-instruct","mistral-7b-instruct"]'
+      publishedDate:
+        metadataType: MetadataStringValue
+        string_value: "2025-05-10T00:00:00Z"
     createTimeSinceEpoch: "1746835200000"
     lastUpdateTimeSinceEpoch: "1750550400000"

--- a/manifests/kustomize/options/catalog/overlays/e2e/sample-agent-catalog.yaml
+++ b/manifests/kustomize/options/catalog/overlays/e2e/sample-agent-catalog.yaml
@@ -6,6 +6,11 @@ agents:
     description: "Multi-step travel planning agent that researches destinations, compares flights and hotels, and builds complete itineraries using tool calling."
     readme: "# Travel Planner Agent\n\nA starter kit for building a travel planning assistant. Uses ReAct-style reasoning to break down complex travel requests into research, comparison, and booking steps.\n\n## Features\n- Multi-city itinerary planning\n- Flight and hotel comparison via tool calls\n- Budget-aware recommendations"
     framework: langgraph
+    labels:
+      - travel
+      - planning
+      - react
+      - tool-calling
     logo: "https://example.com/logos/travel-planner.svg"
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/travel-planner"
     env:
@@ -18,15 +23,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/travel-planner-agent:latest"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["travel","planning","react","tool-calling"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct","mistral-7b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-06-01T00:00:00Z"
     createTimeSinceEpoch: "1748736000000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -34,6 +33,10 @@ agents:
     displayName: "Code Review Agent"
     description: "Automated code review agent that analyzes pull requests for bugs, security issues, and style violations using static analysis tools and LLM reasoning."
     framework: crewai
+    labels:
+      - code-review
+      - security
+      - developer-tools
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/code-reviewer"
     env:
       - name: MODEL_ENDPOINT
@@ -45,15 +48,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/code-reviewer-agent:latest"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["code-review","security","developer-tools"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-05-15T00:00:00Z"
     createTimeSinceEpoch: "1747267200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -61,6 +58,10 @@ agents:
     displayName: "Customer Support Bot"
     description: "RAG-powered customer support agent that searches knowledge bases and previous tickets to provide accurate, context-aware responses to customer inquiries."
     framework: llamaindex
+    labels:
+      - customer-support
+      - rag
+      - knowledge-base
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/customer-support"
     env:
       - name: MODEL_ENDPOINT
@@ -72,15 +73,9 @@ agents:
       - name: VECTOR_DB_TOKEN
         required: false
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["customer-support","rag","knowledge-base"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct","llama-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-05-20T00:00:00Z"
     createTimeSinceEpoch: "1747699200000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -88,6 +83,11 @@ agents:
     displayName: "Data Pipeline Orchestrator"
     description: "Agent that designs and executes data transformation pipelines by composing SQL queries, API calls, and file operations through MCP tool servers."
     framework: autogen
+    labels:
+      - data-engineering
+      - mcp
+      - pipeline
+      - sql
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/data-pipeline"
     env:
       - name: MODEL_ENDPOINT
@@ -101,15 +101,9 @@ agents:
     artifacts:
       - uri: "oci://quay.io/example-org/data-pipeline-agent:latest"
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["data-engineering","mcp","pipeline","sql"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-04-28T00:00:00Z"
     createTimeSinceEpoch: "1745798400000"
     lastUpdateTimeSinceEpoch: "1750550400000"
 
@@ -117,6 +111,11 @@ agents:
     displayName: "Research Assistant"
     description: "Web search and summarization agent that gathers information from multiple sources, cross-references findings, and produces structured research reports."
     framework: langgraph
+    labels:
+      - research
+      - web-search
+      - summarization
+      - report-generation
     repositoryUrl: "https://github.com/example-org/agent-starter-kits/tree/main/agents/research-assistant"
     env:
       - name: MODEL_ENDPOINT
@@ -126,14 +125,8 @@ agents:
       - name: SEARCH_API_KEY
         required: true
     customProperties:
-      labels:
-        metadataType: MetadataStringValue
-        string_value: '["research","web-search","summarization","report-generation"]'
       models:
         metadataType: MetadataStringValue
         string_value: '["granite-3.1-8b-instruct","mistral-7b-instruct"]'
-      publishedDate:
-        metadataType: MetadataStringValue
-        string_value: "2025-05-10T00:00:00Z"
     createTimeSinceEpoch: "1746835200000"
     lastUpdateTimeSinceEpoch: "1750550400000"


### PR DESCRIPTION
## Description

Rationalize the agent plugin's OpenAPI schema by separating universal fields (typed, filterable) from optional/vendor-specific metadata (customProperties).

### Schema changes

**Typed schema fields** (kept on the Agent object):
`name`, `source_id`, `displayName`, `description`, `readme`, `framework`, `labels`, `logo`, `repositoryUrl`, `env`, `artifacts`

**Dropped entirely:**
- `agentType` — was always `starter_kit` on every entry; dead field

**Moved to `customProperties`:**
- `models` — optional, not every agent is model-specific; no longer server-side filterable
- Any vendor-specific metadata (e.g. `protocol`, `imageVersion` on the sample orchestrator agent)

**Removed:**
- `publishedDate` — unused, redundant with `createTimeSinceEpoch`/`lastUpdateTimeSinceEpoch`

### Other changes

- Add named query plumbing to the agent plugin (`AgentSourceCollection.GetNamedQueries`, loader filtering by `AssetTypeAgents`, `filter_options` response includes `namedQueries`). Returns empty for now — matches the MCP catalog pattern so the infrastructure is ready.
- Wire agent catalog sources and sample data into the demo kustomize overlay so agents load in the Tilt dev environment.
- Sample data uses `customProperties:` blocks with `MetadataValue` structure for `models`, matching the model/MCP catalog YAML conventions.

Assisted-by: Claude Code

## How Has This Been Tested?

- `make -C catalog test` — all catalog unit tests pass
- `make build/compile` — main project compiles
- Verified agent API response via `curl` against Tilt dev environment (9 agents, labels as typed array, models in customProperties, protocol/imageVersion on orchestrator agent)
- Verified filter_options endpoint returns correct keys (`labels` as ArrayValueType, `models` falls through to Custom)

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).