### PR TITLE
fix(csi): reject malformed model-registry URIs

### DIFF
--- a/cmd/csi/internal/storage/modelregistry_provider.go
+++ b/cmd/csi/internal/storage/modelregistry_provider.go
@@ -141,8 +141,14 @@ func (p *ModelRegistryProvider) parseModelVersion(storageUri string) (string, *s
 	}
 
 	registeredModelName := tokens[0]
+	if registeredModelName == "" {
+		return "", nil, ErrInvalidMRURI
+	}
 
 	if len(tokens) == 2 {
+		if tokens[1] == "" {
+			return "", nil, ErrInvalidMRURI
+		}
 		versionName = &tokens[1]
 	}
 

--- a/cmd/csi/internal/storage/modelregistry_provider_test.go
+++ b/cmd/csi/internal/storage/modelregistry_provider_test.go
@@ -72,6 +72,31 @@ func TestParseModelVersion(t *testing.T) {
 			expectedVersion: stringPtr("v1"),
 			expectError:     false,
 		},
+		{
+			name:        "missing model name",
+			storageUri:  "model-registry://",
+			expectError: true,
+		},
+		{
+			name:        "empty model name after slash",
+			storageUri:  "model-registry:///iris",
+			expectError: true,
+		},
+		{
+			name:        "embedded host without model name",
+			storageUri:  "model-registry://localhost:8080/",
+			expectError: true,
+		},
+		{
+			name:        "empty version name",
+			storageUri:  "model-registry://iris/",
+			expectError: true,
+		},
+		{
+			name:        "embedded host with empty version name",
+			storageUri:  "model-registry://localhost:8080/iris/",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -79,6 +104,7 @@ func TestParseModelVersion(t *testing.T) {
 			model, version, err := provider.parseModelVersion(tt.storageUri)
 			if tt.expectError {
 				assert.Error(t, err)
+				assert.ErrorIs(t, err, ErrInvalidMRURI)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedModel, model)


### PR DESCRIPTION
Bad `storageUri` values like `model-registry://`, `model-registry:///iris`, and `model-registry://iris/` slipped through CSI parsing and failed later in the flow. Kinda annoying to debug.

This patch rejects empty model and empty version path segments up front, so the CSI returns `ErrInvalidMRURI` right away.

Repro:
1. `cd cmd/csi`
2. `go test ./internal/storage -run TestParseModelVersion -v -count=1`
3. Check the malformed URI cases in the test table:
   `model-registry://`
   `model-registry:///iris`
   `model-registry://localhost:8080/`
   `model-registry://iris/`

Testing:
`go test ./... -count=1`
