### PR TITLE
fix(client): infer default port from URL scheme

### DIFF
--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -80,7 +80,7 @@ class ModelRegistry:
     def __init__(  # noqa: C901
         self,
         server_address: str,
-        port: int = 443,
+        port: int | None = None,
         *,
         author: str,
         is_secure: bool | None = None,
@@ -95,7 +95,8 @@ class ModelRegistry:
 
         Args:
             server_address: Server address.
-            port: Server port. Defaults to 443.
+            port: Server port. Inferred from URL scheme if not provided;
+                defaults to 8080 for http:// URLs and 443 otherwise.
 
         Keyword Args:
             author: Name of the author.
@@ -128,22 +129,23 @@ class ModelRegistry:
             if not user_token:
                 warn("User access token is missing", stacklevel=2)
 
-        self.hint_server_address_port(server_address, port)
-
-        # --- START OF URL SANITIZATION BLOCK ---
         from urllib.parse import urlparse
 
         parsed = urlparse(server_address)
         if parsed.scheme in ("http", "https"):
             if parsed.port:
                 port = parsed.port
+            elif port is None:
+                port = 8080 if parsed.scheme == "http" else 443
             # Infer is_secure from scheme only if user didn't explicitly pass it
             if is_secure is None:
                 is_secure = parsed.scheme == "https"
+        elif port is None:
+            port = 443
         # Fall back to secure by default if still unset
         if is_secure is None:
             is_secure = True
-        # --- END OF URL SANITIZATION BLOCK ---
+        self.hint_server_address_port(server_address, port)
         if is_secure:
             if not custom_ca and custom_ca_envvar and (cert := os.getenv(custom_ca_envvar)):
                 logger.info(

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -23,6 +23,48 @@ def test_secure_client(monkeypatch):
     assert "user token" in str(e.value).lower()
 
 
+def test_http_server_address_defaults_to_port_8080(mock_get_registered_models):
+    client = ModelRegistry(server_address="http://localhost", author="test_author")
+
+    assert client._api.config.host == "http://localhost:8080"
+    assert client._api.config.verify_ssl is False
+
+
+def test_https_server_address_defaults_to_port_443(mock_get_registered_models):
+    test_token = "test-token"  # noqa: S105
+    client = ModelRegistry(
+        server_address="https://localhost",
+        author="test_author",
+        user_token=test_token,
+    )
+
+    assert client._api.config.host == "https://localhost:443"
+
+
+def test_hint_server_address_port_http_url_uses_embedded_port(mock_get_registered_models, caplog):
+    with caplog.at_level(logging.WARNING):
+        client = ModelRegistry(server_address="http://example.com:8080", author="test")
+
+    assert client._api.config.host == "http://example.com:8080"
+    assert client._api.config.verify_ssl is False
+    assert len(caplog.records) == 0
+
+
+def test_hint_server_address_port_https_url_uses_embedded_port(mock_get_registered_models, caplog):
+    test_token = "test-token"  # noqa: S105
+    with caplog.at_level(logging.WARNING):
+        client = ModelRegistry(
+            server_address="https://example.com:8080",
+            author="test",
+            user_token=test_token,
+        )
+
+    assert client._api.config.host == "https://example.com:8080"
+    assert client._api.config.access_token == test_token
+    assert len(caplog.records) == 1
+    assert "Server address protocol is https://, but port is not 443 or ending with 443" in caplog.records[0].message
+
+
 @pytest.mark.e2e
 async def test_register_new(
     client: ModelRegistry,


### PR DESCRIPTION
Infer the Python client's default port from the server URL scheme so http:// addresses use the local development default while preserving the PR's scheme-based is_secure inference and corrected hint logging.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
