### PR TITLE
Tech debt: remove unused cold-start sub type metrics

### DIFF
--- a/catalog/README.md
+++ b/catalog/README.md
@@ -272,87 +272,16 @@ customProperties:
   modelcar_image_size:
     metadataType: MetadataDoubleValue
     double_value: 405.19
-  modelcar_image_size_bytes:
-    metadataType: MetadataDoubleValue
-    double_value: 405186009411
 ```
 
-##### Cold-Start and VRAM Metrics
+##### VRAM and Container Size Metrics
 
 The catalog supports specialized performance metrics for model deployment planning:
 
 **Model-Level Metrics** (stored as custom properties on the model):
 
 - **Minimum VRAM** (`min_vram_gb`): The minimum GPU memory required to run the model, in gigabytes.
-- **Container Image Size**: Model container image size in both GB (`modelcar_image_size`) and exact bytes (`modelcar_image_size_bytes`).
-
-**Artifact-Level Metrics** (stored as separate Performance Artifacts):
-
-Cold-start load times are stored as individual artifacts, one per GPU configuration. Each artifact contains:
-- `performance_sub_type`: `"cold-start"`
-- `gpu_type`: GPU hardware type (e.g., "A100-80", "H100", "H200")
-- `gpu_count`: Number of GPUs required
-- `cold_start_time_to_load_seconds`: Time to load the model in seconds
-- `runtime_command`: Deployment command (optional)
-
-**Example metadata.json with cold-start data:**
-
-```json
-{
-  "id": "vendor/model-name",
-  "size": "229B",
-  "tensor_type": "FP8",
-  "min_vram_gb": 265.0,
-  "modelcar_image_size": 405.19,
-  "modelcar_image_size_bytes": 405186009411,
-  "cold_start_matrix": [
-    {
-      "gpu_type": "A100-80",
-      "gpu_count": 4,
-      "cold_start_time_to_load_seconds": 587.3,
-      "runtime_command": "vllm serve vendor/model-name --tensor-parallel-size 4"
-    },
-    {
-      "gpu_type": "H200",
-      "gpu_count": 4,
-      "cold_start_time_to_load_seconds": 806.7,
-      "runtime_command": "vllm serve vendor/model-name --tensor-parallel-size 4"
-    }
-  ]
-}
-```
-
-The `cold_start_matrix` array in the source metadata is processed by the catalog service and converted into separate Performance Artifacts (one per GPU configuration). These artifacts are queryable and filterable through the catalog API.
-
-**Use Cases:**
-- Filter models by available GPU memory constraints
-- Compare cold-start performance across different GPU types
-- Estimate deployment startup times
-- Plan infrastructure capacity and storage requirements
-- Copy runtime commands for deployment
-
-**UI Features:**
-
-The Model Catalog UI provides:
-- **Filters** for cold-start load time, minimum VRAM, and container size
-- **Sorting** by cold-start load time
-- **Performance View** toggle to access metrics
-- **Filter persistence** when navigating between catalog and performance insights
-- **Runtime command** display and copy functionality in model details
-
-**Artifact Storage:**
-
-Cold-start metrics are stored as Performance Artifacts in the Model Registry:
-- Each GPU configuration creates a separate artifact
-- Artifact naming: `cold-start-model-{model_id}-{gpu_type}-{gpu_count}`
-- Metrics type: `performance-metrics`
-- Performance sub-type: `cold-start`
-
-**Validation:**
-- GPU count must be > 0
-- GPU type must be non-empty
-- Duplicate configurations (same GPU type and count) are automatically deduplicated
-- Zero `cold_start_time_to_load_seconds` values are omitted from artifacts
+- **Container Image Size**: Model container image size in GB (`modelcar_image_size`).
 
 #### Deployment Metadata
 

--- a/catalog/internal/catalog/modelcatalog/performance_artifact_service.go
+++ b/catalog/internal/catalog/modelcatalog/performance_artifact_service.go
@@ -82,41 +82,14 @@ func (s *PerformanceArtifactService) GetArtifacts(params PerformanceArtifactPara
 		artifacts = append(artifacts, dbResult.Items[i].CatalogMetricsArtifact)
 	}
 
-	// Partition into benchmark vs cold-start artifacts. They share the same
-	// metricsType but have different property schemas; validation and
-	// processing (targetRPS, recommendations) only apply to benchmarks.
-	benchmarks, _ := s.partitionBySubType(artifacts)
-
-	// Validate custom properties only on benchmark artifacts
-	if err := s.validateCustomProperties(benchmarks, params.RPSProperty, params.LatencyProperty, params.HardwareCountProperty, params.HardwareTypeProperty); err != nil {
+	if err := s.validateCustomProperties(artifacts, params.RPSProperty, params.LatencyProperty, params.HardwareCountProperty, params.HardwareTypeProperty); err != nil {
 		return nil, fmt.Errorf("invalid custom properties: %w", err)
 	}
 
-	// Apply performance-specific processing to benchmark artifacts only
-	benchmarks = s.processArtifacts(benchmarks, params)
-
-	// Rebuild the output in the original repository order: cold-start artifacts
-	// stay in-place, benchmark artifacts are replaced by the processed/filtered
-	// subset (which may be smaller after recommendation filtering).
-	keptBenchmarks := s.buildIDSet(benchmarks)
-	result := make([]sharedmodels.CatalogMetricsArtifact, 0, len(artifacts))
-	for _, artifact := range artifacts {
-		if s.isColdStartArtifact(artifact) {
-			result = append(result, artifact)
-		} else {
-			id := artifact.GetID()
-			if id == nil {
-				if !params.Recommendations {
-					result = append(result, artifact)
-				}
-			} else if processed, kept := keptBenchmarks[*id]; kept {
-				result = append(result, processed)
-			}
-		}
-	}
+	artifacts = s.processArtifacts(artifacts, params)
 
 	list := &dbmodels.ListWrapper[sharedmodels.CatalogMetricsArtifact]{
-		Items:         result,
+		Items:         artifacts,
 		PageSize:      dbResult.PageSize,
 		Size:          dbResult.Size,
 		NextPageToken: dbResult.NextPageToken,
@@ -136,37 +109,6 @@ func (s *PerformanceArtifactService) buildPerformanceFilterQuery(userFilter stri
 		return performanceFilter
 	}
 	return fmt.Sprintf("(%s) AND (%s)", userFilter, performanceFilter)
-}
-
-// partitionBySubType splits artifacts into benchmark artifacts and cold-start artifacts.
-// Cold-start artifacts carry performance_sub_type='cold-start' and use a different
-// property schema (gpu_type, gpu_count, cold_start_time_to_load_seconds) than the
-// benchmark artifacts (requests_per_second, ttft_p90, hardware_count, hardware_type).
-func (s *PerformanceArtifactService) partitionBySubType(artifacts []sharedmodels.CatalogMetricsArtifact) (benchmarks, coldStarts []sharedmodels.CatalogMetricsArtifact) {
-	for _, artifact := range artifacts {
-		if s.isColdStartArtifact(artifact) {
-			coldStarts = append(coldStarts, artifact)
-		} else {
-			benchmarks = append(benchmarks, artifact)
-		}
-	}
-	return benchmarks, coldStarts
-}
-
-func (s *PerformanceArtifactService) isColdStartArtifact(artifact sharedmodels.CatalogMetricsArtifact) bool {
-	return s.extractCustomPropertiesStringValue(artifact.GetCustomProperties(), "performance_sub_type") == "cold-start"
-}
-
-// buildIDSet indexes processed benchmark artifacts by their ID so that the
-// caller can look up the processed version while iterating in repo order.
-func (s *PerformanceArtifactService) buildIDSet(artifacts []sharedmodels.CatalogMetricsArtifact) map[int32]sharedmodels.CatalogMetricsArtifact {
-	m := make(map[int32]sharedmodels.CatalogMetricsArtifact, len(artifacts))
-	for _, a := range artifacts {
-		if id := a.GetID(); id != nil {
-			m[*id] = a
-		}
-	}
-	return m
 }
 
 func (s *PerformanceArtifactService) processArtifacts(artifacts []sharedmodels.CatalogMetricsArtifact, params PerformanceArtifactParams) []sharedmodels.CatalogMetricsArtifact {

--- a/catalog/internal/catalog/modelcatalog/performance_artifact_service_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_artifact_service_test.go
@@ -639,6 +639,168 @@ func TestGetMinimumRecommendedLatency(t *testing.T) {
 	assert.Equal(t, 150.0, *minLatency) // Expected minimum from test data
 }
 
+func TestGetArtifacts_WithColdStartAndRuntimeCommand(t *testing.T) {
+	mockArtifactRepo := &mockPerfArtifactRepo{}
+	service := NewPerformanceArtifactService(mockArtifactRepo, nil)
+
+	id1 := int32(1)
+	id2 := int32(2)
+
+	runtimeCmd := "python3 -m vllm.entrypoints.openai.api_server --model provider1-granite/granite-3.1-8b-instruct --tensor-parallel-size 8"
+	testArtifacts := []sharedmodels.CatalogArtifact{
+		{
+			CatalogMetricsArtifact: &dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
+				Attributes: &models.CatalogMetricsArtifactAttributes{
+					Name:        new("perf-with-coldstart"),
+					MetricsType: models.MetricsTypePerformance,
+				},
+				Properties: &[]dbmodels.Properties{},
+				CustomProperties: &[]dbmodels.Properties{
+					dbmodels.NewDoubleProperty("requests_per_second", 150.0, true),
+					dbmodels.NewDoubleProperty("ttft_p90", 40.0, true),
+					dbmodels.NewIntProperty("hardware_count", 8, true),
+					dbmodels.NewStringProperty("hardware_type", "A100", true),
+					dbmodels.NewDoubleProperty("cold_start_time_to_load_seconds", 85.2, true),
+					dbmodels.NewStringProperty("runtime_command", runtimeCmd, true),
+				},
+			},
+		},
+		{
+			CatalogMetricsArtifact: &dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
+				Attributes: &models.CatalogMetricsArtifactAttributes{
+					Name:        new("perf-without-coldstart"),
+					MetricsType: models.MetricsTypePerformance,
+				},
+				Properties: &[]dbmodels.Properties{},
+				CustomProperties: &[]dbmodels.Properties{
+					dbmodels.NewDoubleProperty("requests_per_second", 200.0, true),
+					dbmodels.NewDoubleProperty("ttft_p90", 55.0, true),
+					dbmodels.NewIntProperty("hardware_count", 4, true),
+					dbmodels.NewStringProperty("hardware_type", "H100", true),
+				},
+			},
+		},
+	}
+	testArtifacts[0].CatalogMetricsArtifact.SetID(id1)
+	testArtifacts[1].CatalogMetricsArtifact.SetID(id2)
+
+	mockArtifactRepo.On("List", mock.AnythingOfType("models.CatalogArtifactListOptions")).
+		Return(&dbmodels.ListWrapper[sharedmodels.CatalogArtifact]{Items: testArtifacts}, nil)
+
+	params := PerformanceArtifactParams{
+		ModelID:         123,
+		TargetRPS:       300,
+		Recommendations: false,
+		PageSize:        10,
+	}
+
+	result, err := service.GetArtifacts(params)
+
+	require.NoError(t, err)
+	require.Len(t, result.Items, 2)
+
+	// Verify cold_start and runtime_command are preserved on the first artifact
+	props := result.Items[0].GetCustomProperties()
+	var foundColdStart, foundRuntimeCmd bool
+	for _, prop := range *props {
+		if prop.Name == "cold_start_time_to_load_seconds" {
+			foundColdStart = true
+			require.NotNil(t, prop.DoubleValue)
+			assert.Equal(t, 85.2, *prop.DoubleValue)
+		}
+		if prop.Name == "runtime_command" {
+			foundRuntimeCmd = true
+			require.NotNil(t, prop.StringValue)
+			assert.Equal(t, runtimeCmd, *prop.StringValue)
+		}
+	}
+	assert.True(t, foundColdStart, "cold_start_time_to_load_seconds should be preserved")
+	assert.True(t, foundRuntimeCmd, "runtime_command should be preserved")
+
+	// Verify replicas are calculated correctly for both artifacts
+	replicas1 := service.extractCustomPropertiesIntValue(result.Items[0].GetCustomProperties(), "replicas", 0)
+	assert.Equal(t, int32(2), replicas1) // ceil(300/150) = 2
+
+	replicas2 := service.extractCustomPropertiesIntValue(result.Items[1].GetCustomProperties(), "replicas", 0)
+	assert.Equal(t, int32(2), replicas2) // ceil(300/200) = 2
+}
+
+func TestProcessArtifacts_ColdStartPreservedWithRecommendations(t *testing.T) {
+	service := NewPerformanceArtifactService(nil, nil)
+
+	id1 := int32(1)
+	id2 := int32(2)
+	id3 := int32(3)
+
+	runtimeCmd1 := "vllm serve provider1-granite/granite-3.1-8b-instruct --tensor-parallel-size 2"
+	runtimeCmd2 := "vllm serve provider1-granite/granite-3.1-8b-instruct --tensor-parallel-size 8"
+	artifacts := []sharedmodels.CatalogMetricsArtifact{
+		&dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
+			Attributes: &models.CatalogMetricsArtifactAttributes{
+				Name: new("config-a100-80-2gpu"),
+			},
+			CustomProperties: &[]dbmodels.Properties{
+				dbmodels.NewStringProperty("hardware_type", "A100-80", true),
+				dbmodels.NewIntProperty("hardware_count", 2, true),
+				dbmodels.NewDoubleProperty("requests_per_second", 25.0, true),
+				dbmodels.NewDoubleProperty("ttft_p90", 38.7, true),
+				dbmodels.NewDoubleProperty("cold_start_time_to_load_seconds", 73.6, true),
+				dbmodels.NewStringProperty("runtime_command", runtimeCmd1, true),
+			},
+		},
+		&dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
+			Attributes: &models.CatalogMetricsArtifactAttributes{
+				Name: new("config-a100-8gpu"),
+			},
+			CustomProperties: &[]dbmodels.Properties{
+				dbmodels.NewStringProperty("hardware_type", "A100", true),
+				dbmodels.NewIntProperty("hardware_count", 8, true),
+				dbmodels.NewDoubleProperty("requests_per_second", 15.0, true),
+				dbmodels.NewDoubleProperty("ttft_p90", 58.5, true),
+				dbmodels.NewDoubleProperty("cold_start_time_to_load_seconds", 85.2, true),
+				dbmodels.NewStringProperty("runtime_command", runtimeCmd2, true),
+			},
+		},
+		// Dominated: slower latency AND higher cost than config-a100-80-2gpu
+		&dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
+			Attributes: &models.CatalogMetricsArtifactAttributes{
+				Name: new("config-dominated"),
+			},
+			CustomProperties: &[]dbmodels.Properties{
+				dbmodels.NewStringProperty("hardware_type", "A100-80", true),
+				dbmodels.NewIntProperty("hardware_count", 4, true),
+				dbmodels.NewDoubleProperty("requests_per_second", 25.0, true),
+				dbmodels.NewDoubleProperty("ttft_p90", 45.0, true),
+				dbmodels.NewDoubleProperty("cold_start_time_to_load_seconds", 95.0, true),
+				dbmodels.NewStringProperty("runtime_command", runtimeCmd1, true),
+			},
+		},
+	}
+
+	artifacts[0].SetID(id1)
+	artifacts[1].SetID(id2)
+	artifacts[2].SetID(id3)
+
+	params := PerformanceArtifactParams{
+		TargetRPS:       50,
+		Recommendations: true,
+	}
+
+	result := service.processArtifacts(artifacts, params)
+
+	// With recommendations, dominated artifacts are filtered out
+	require.Less(t, len(result), 3, "dominated artifact should be filtered")
+
+	// Verify cold_start and runtime_command survive on remaining artifacts
+	for _, artifact := range result {
+		coldStart := service.extractCustomPropertiesDoubleValue(artifact.GetCustomProperties(), "cold_start_time_to_load_seconds", 0)
+		assert.Greater(t, coldStart, 0.0, "cold_start_time_to_load_seconds should be preserved")
+
+		rtCmd := service.extractCustomPropertiesStringValue(artifact.GetCustomProperties(), "runtime_command")
+		assert.NotEmpty(t, rtCmd, "runtime_command should be preserved")
+	}
+}
+
 func TestGetMinimumRecommendedLatency_NoArtifacts(t *testing.T) {
 	// Mock repositories for testing
 	mockArtifactRepo := &mockPerfArtifactRepo{}
@@ -669,226 +831,4 @@ func TestGetMinimumRecommendedLatency_NoArtifacts(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Nil(t, minLatency) // Should return nil for models without data
-}
-
-func TestPartitionBySubType(t *testing.T) {
-	service := NewPerformanceArtifactService(nil, nil)
-
-	id1 := int32(1)
-	id2 := int32(2)
-	id3 := int32(3)
-
-	coldStart := "cold-start"
-	artifacts := []sharedmodels.CatalogMetricsArtifact{
-		&dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
-			Attributes: &models.CatalogMetricsArtifactAttributes{
-				Name: new("perf-benchmark"),
-			},
-			CustomProperties: &[]dbmodels.Properties{
-				dbmodels.NewDoubleProperty("requests_per_second", 100.0, true),
-				dbmodels.NewDoubleProperty("ttft_p90", 50.0, true),
-				dbmodels.NewIntProperty("hardware_count", 2, true),
-				dbmodels.NewStringProperty("hardware_type", "A100", true),
-			},
-		},
-		&dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
-			Attributes: &models.CatalogMetricsArtifactAttributes{
-				Name: new("cold-start-entry"),
-			},
-			CustomProperties: &[]dbmodels.Properties{
-				{Name: "performance_sub_type", StringValue: &coldStart},
-				dbmodels.NewStringProperty("gpu_type", "A100", true),
-				dbmodels.NewIntProperty("gpu_count", 2, true),
-			},
-		},
-		&dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
-			Attributes: &models.CatalogMetricsArtifactAttributes{
-				Name: new("another-benchmark"),
-			},
-			CustomProperties: &[]dbmodels.Properties{
-				dbmodels.NewDoubleProperty("requests_per_second", 200.0, true),
-				dbmodels.NewDoubleProperty("ttft_p90", 30.0, true),
-				dbmodels.NewIntProperty("hardware_count", 4, true),
-				dbmodels.NewStringProperty("hardware_type", "H100", true),
-			},
-		},
-	}
-	artifacts[0].SetID(id1)
-	artifacts[1].SetID(id2)
-	artifacts[2].SetID(id3)
-
-	benchmarks, coldStarts := service.partitionBySubType(artifacts)
-
-	require.Len(t, benchmarks, 2)
-	require.Len(t, coldStarts, 1)
-	assert.Equal(t, id1, *benchmarks[0].GetID())
-	assert.Equal(t, id3, *benchmarks[1].GetID())
-	assert.Equal(t, id2, *coldStarts[0].GetID())
-}
-
-func TestPartitionBySubType_AllColdStart(t *testing.T) {
-	service := NewPerformanceArtifactService(nil, nil)
-
-	coldStart := "cold-start"
-	id1 := int32(1)
-	artifacts := []sharedmodels.CatalogMetricsArtifact{
-		&dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
-			Attributes: &models.CatalogMetricsArtifactAttributes{
-				Name: new("cold-start-only"),
-			},
-			CustomProperties: &[]dbmodels.Properties{
-				{Name: "performance_sub_type", StringValue: &coldStart},
-				dbmodels.NewStringProperty("gpu_type", "A100", true),
-				dbmodels.NewIntProperty("gpu_count", 1, true),
-			},
-		},
-	}
-	artifacts[0].SetID(id1)
-
-	benchmarks, coldStarts := service.partitionBySubType(artifacts)
-	require.Empty(t, benchmarks)
-	require.Len(t, coldStarts, 1)
-}
-
-func TestGetArtifacts_OnlyColdStartArtifacts(t *testing.T) {
-	mockArtifactRepo := &mockPerfArtifactRepo{}
-	service := NewPerformanceArtifactService(mockArtifactRepo, nil)
-
-	coldStart := "cold-start"
-	id1 := int32(1)
-	testArtifacts := []sharedmodels.CatalogArtifact{
-		{
-			CatalogMetricsArtifact: &dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
-				Attributes: &models.CatalogMetricsArtifactAttributes{
-					Name:        new("cold-start-artifact"),
-					MetricsType: models.MetricsTypePerformance,
-				},
-				Properties: &[]dbmodels.Properties{},
-				CustomProperties: &[]dbmodels.Properties{
-					{Name: "performance_sub_type", StringValue: &coldStart},
-					dbmodels.NewStringProperty("gpu_type", "A100", true),
-					dbmodels.NewIntProperty("gpu_count", 2, true),
-				},
-			},
-		},
-	}
-	testArtifacts[0].CatalogMetricsArtifact.SetID(id1)
-
-	mockArtifactRepo.On("List", mock.AnythingOfType("models.CatalogArtifactListOptions")).
-		Return(&dbmodels.ListWrapper[sharedmodels.CatalogArtifact]{
-			Items: testArtifacts,
-		}, nil)
-
-	params := PerformanceArtifactParams{
-		ModelID:         123,
-		TargetRPS:       100,
-		Recommendations: false,
-		PageSize:        10,
-	}
-
-	result, err := service.GetArtifacts(params)
-
-	require.NoError(t, err, "should not error when only cold-start artifacts are present")
-	require.Len(t, result.Items, 1, "cold-start artifacts should be included in results")
-	assert.Equal(t, id1, *result.Items[0].GetID())
-}
-
-func TestGetArtifacts_MixedBenchmarkAndColdStart(t *testing.T) {
-	mockArtifactRepo := &mockPerfArtifactRepo{}
-	service := NewPerformanceArtifactService(mockArtifactRepo, nil)
-
-	coldStart := "cold-start"
-	id1 := int32(1)
-	id2 := int32(2)
-	id3 := int32(3)
-
-	// Repository returns: benchmark, cold-start, benchmark (interleaved)
-	testArtifacts := []sharedmodels.CatalogArtifact{
-		{
-			CatalogMetricsArtifact: &dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
-				Attributes: &models.CatalogMetricsArtifactAttributes{
-					Name:        new("benchmark-1"),
-					MetricsType: models.MetricsTypePerformance,
-				},
-				Properties: &[]dbmodels.Properties{},
-				CustomProperties: &[]dbmodels.Properties{
-					dbmodels.NewDoubleProperty("requests_per_second", 150.0, true),
-					dbmodels.NewDoubleProperty("ttft_p90", 40.0, true),
-					dbmodels.NewIntProperty("hardware_count", 2, true),
-					dbmodels.NewStringProperty("hardware_type", "A100", true),
-				},
-			},
-		},
-		{
-			CatalogMetricsArtifact: &dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
-				Attributes: &models.CatalogMetricsArtifactAttributes{
-					Name:        new("cold-start-artifact"),
-					MetricsType: models.MetricsTypePerformance,
-				},
-				Properties: &[]dbmodels.Properties{},
-				CustomProperties: &[]dbmodels.Properties{
-					{Name: "performance_sub_type", StringValue: &coldStart},
-					dbmodels.NewStringProperty("gpu_type", "A100", true),
-					dbmodels.NewIntProperty("gpu_count", 2, true),
-				},
-			},
-		},
-		{
-			CatalogMetricsArtifact: &dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
-				Attributes: &models.CatalogMetricsArtifactAttributes{
-					Name:        new("benchmark-2"),
-					MetricsType: models.MetricsTypePerformance,
-				},
-				Properties: &[]dbmodels.Properties{},
-				CustomProperties: &[]dbmodels.Properties{
-					dbmodels.NewDoubleProperty("requests_per_second", 300.0, true),
-					dbmodels.NewDoubleProperty("ttft_p90", 80.0, true),
-					dbmodels.NewIntProperty("hardware_count", 4, true),
-					dbmodels.NewStringProperty("hardware_type", "A100", true),
-				},
-			},
-		},
-	}
-	testArtifacts[0].CatalogMetricsArtifact.SetID(id1)
-	testArtifacts[1].CatalogMetricsArtifact.SetID(id2)
-	testArtifacts[2].CatalogMetricsArtifact.SetID(id3)
-
-	mockArtifactRepo.On("List", mock.AnythingOfType("models.CatalogArtifactListOptions")).
-		Return(&dbmodels.ListWrapper[sharedmodels.CatalogArtifact]{
-			Items: testArtifacts,
-		}, nil)
-
-	params := PerformanceArtifactParams{
-		ModelID:         123,
-		TargetRPS:       300,
-		Recommendations: false,
-		PageSize:        10,
-	}
-
-	result, err := service.GetArtifacts(params)
-
-	require.NoError(t, err, "should handle mixed artifact types without error")
-	require.Len(t, result.Items, 3, "all artifacts should be returned")
-
-	// Verify order matches repository order: benchmark-1, cold-start, benchmark-2
-	assert.Equal(t, id1, *result.Items[0].GetID())
-	assert.Equal(t, id2, *result.Items[1].GetID())
-	assert.Equal(t, id3, *result.Items[2].GetID())
-
-	// Benchmark artifact should have targetRPS calculations added
-	benchProps := result.Items[0].GetCustomProperties()
-	var hasReplicas bool
-	for _, prop := range *benchProps {
-		if prop.Name == "replicas" {
-			hasReplicas = true
-			require.Equal(t, int32(2), *prop.IntValue) // ceil(300/150) = 2
-		}
-	}
-	assert.True(t, hasReplicas, "benchmark artifact should have replicas calculated")
-
-	// Cold-start artifact should NOT have replicas added
-	coldProps := result.Items[1].GetCustomProperties()
-	for _, prop := range *coldProps {
-		assert.NotEqual(t, "replicas", prop.Name, "cold-start artifact should not have replicas")
-	}
 }

--- a/catalog/internal/catalog/modelcatalog/performance_metrics.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics.go
@@ -21,22 +21,13 @@ import (
 // metadataJSON represents the minimal structure needed from metadata.json files
 // Only the ID field is needed to look up existing models
 type metadataJSON struct {
-	ID                     string           `json:"id"`                        // Maps to model name for lookup
-	OverallAccuracy        *float64         `json:"overall_accuracy"`          // Overall accuracy score for the model
-	Size                   *string          `json:"size"`                      // Model parameter count (e.g., "8B params")
-	TensorType             *string          `json:"tensor_type"`               // Data precision (e.g., "FP16", "INT4")
-	VariantGroupID         *string          `json:"variant_group_id"`          // UUID linking model variants together
-	MinVRAMGB              *float64         `json:"min_vram_gb"`               // Minimum VRAM required in GB (e.g., 466.0)
-	ModelcarImageSize      *float64         `json:"modelcar_image_size"`       // Modelcar image size in GB (e.g., 405.19)
-	ModelcarImageSizeBytes *int64           `json:"modelcar_image_size_bytes"` // Modelcar image size in bytes (e.g., 405186009411)
-	ColdStartMatrix        []coldStartEntry `json:"cold_start_matrix"`         // Cold start times per GPU configuration
-}
-
-type coldStartEntry struct {
-	GPUType                    string  `json:"gpu_type"`
-	GPUCount                   int     `json:"gpu_count"`
-	ColdStartTimeToLoadSeconds float64 `json:"cold_start_time_to_load_seconds"`
-	RuntimeCommand             string  `json:"runtime_command"`
+	ID                string   `json:"id"`                  // Maps to model name for lookup
+	OverallAccuracy   *float64 `json:"overall_accuracy"`    // Overall accuracy score for the model
+	Size              *string  `json:"size"`                // Model parameter count (e.g., "8B params")
+	TensorType        *string  `json:"tensor_type"`         // Data precision (e.g., "FP16", "INT4")
+	VariantGroupID    *string  `json:"variant_group_id"`    // UUID linking model variants together
+	MinVRAMGB         *float64 `json:"min_vram_gb"`         // Minimum VRAM required in GB (e.g., 466.0)
+	ModelcarImageSize *float64 `json:"modelcar_image_size"` // Modelcar image size in GB (e.g., 405.19)
 }
 
 // parseMetadataJSON parses JSON data into metadataJSON struct, extracting only the ID field
@@ -380,12 +371,12 @@ func processModelDirectory(dirPath string, modelRepo dbmodels.CatalogModelReposi
 	glog.V(2).Infof("Found existing model %s with ID %d, processing metrics", namespacedModelName, modelID)
 
 	// Use batch processing for all artifacts
-	return processModelArtifactsBatch(dirPath, modelID, metadata.ID, metadata.OverallAccuracy, metadata.ColdStartMatrix, metricsArtifactRepo, metricsArtifactTypeID)
+	return processModelArtifactsBatch(dirPath, modelID, metadata.ID, metadata.OverallAccuracy, metricsArtifactRepo, metricsArtifactTypeID)
 }
 
 // processModelArtifactsBatch processes all metric artifacts for a model in batch
 // This reduces DB overhead by parsing, checking, and inserting in optimized phases
-func processModelArtifactsBatch(dirPath string, modelID int32, modelName string, overallAccuracy *float64, coldStartMatrix []coldStartEntry, metricsArtifactRepo dbmodels.CatalogMetricsArtifactRepository, metricsArtifactTypeID int32) (int, error) {
+func processModelArtifactsBatch(dirPath string, modelID int32, modelName string, overallAccuracy *float64, metricsArtifactRepo dbmodels.CatalogMetricsArtifactRepository, metricsArtifactTypeID int32) (int, error) {
 	// Parse all metrics files
 	var evaluationRecords []evaluationRecord
 	var performanceRecords []performanceRecord
@@ -424,7 +415,7 @@ func processModelArtifactsBatch(dirPath string, modelID int32, modelName string,
 		}
 	}
 
-	totalRecords := len(evaluationRecords) + len(performanceRecords) + len(securityRecords) + len(coldStartMatrix)
+	totalRecords := len(evaluationRecords) + len(performanceRecords) + len(securityRecords)
 	if totalRecords == 0 {
 		return 0, nil
 	}
@@ -467,21 +458,6 @@ func processModelArtifactsBatch(dirPath string, modelID int32, modelName string,
 			artifactsToInsert = append(artifactsToInsert, artifact)
 		} else {
 			glog.V(2).Infof("Performance artifact %s already exists, skipping", perfRecord.ID)
-		}
-	}
-
-	// Check cold-start artifacts (one per GPU configuration from metadata.json)
-	for i, csEntry := range coldStartMatrix {
-		if csEntry.GPUType == "" || csEntry.GPUCount <= 0 {
-			glog.Warningf("Skipping cold-start entry %d for model %s: gpu_type and gpu_count (positive) are required", i, modelName)
-			continue
-		}
-		externalID := coldStartExternalID(modelID, csEntry)
-		if !existingArtifactsMap[externalID] {
-			artifact := createColdStartArtifact(csEntry, externalID, modelID, metricsArtifactTypeID)
-			artifactsToInsert = append(artifactsToInsert, artifact)
-		} else {
-			glog.V(2).Infof("Cold-start artifact %s already exists, skipping", externalID)
 		}
 	}
 
@@ -763,56 +739,6 @@ func createPerformanceArtifact(perfRecord performanceRecord, modelID int32, type
 	return metricsArtifact
 }
 
-func coldStartExternalID(modelID int32, entry coldStartEntry) string {
-	return fmt.Sprintf("cold-start-model-%d-%s-%d", modelID, entry.GPUType, entry.GPUCount)
-}
-
-// createColdStartArtifact creates a metrics artifact from a single cold-start matrix entry.
-// Each GPU configuration becomes its own artifact with discrete, filterable custom properties.
-func createColdStartArtifact(entry coldStartEntry, externalID string, modelID int32, typeID int32) *dbmodels.CatalogMetricsArtifactImpl {
-	artifactName := fmt.Sprintf("cold-start-model-%d-%s-%d", modelID, entry.GPUType, entry.GPUCount)
-
-	now := time.Now().UnixMilli()
-
-	gpuCount := int32(entry.GPUCount)
-	subType := "cold-start"
-	customProperties := []models.Properties{
-		{Name: "performance_sub_type", StringValue: &subType},
-		{Name: "gpu_type", StringValue: &entry.GPUType},
-		{Name: "gpu_count", IntValue: &gpuCount},
-	}
-
-	if entry.RuntimeCommand != "" {
-		customProperties = append(customProperties, models.Properties{
-			Name:        "runtime_command",
-			StringValue: &entry.RuntimeCommand,
-		})
-	}
-
-	if entry.ColdStartTimeToLoadSeconds != 0 {
-		seconds := entry.ColdStartTimeToLoadSeconds
-		customProperties = append(customProperties, models.Properties{
-			Name:        "cold_start_time_to_load_seconds",
-			DoubleValue: &seconds,
-		})
-	}
-
-	properties := []models.Properties{}
-
-	return &dbmodels.CatalogMetricsArtifactImpl{
-		TypeID: &typeID,
-		Attributes: &dbmodels.CatalogMetricsArtifactAttributes{
-			Name:                     &artifactName,
-			ExternalID:               &externalID,
-			CreateTimeSinceEpoch:     &now,
-			LastUpdateTimeSinceEpoch: &now,
-			MetricsType:              dbmodels.MetricsTypePerformance,
-		},
-		Properties:       &properties,
-		CustomProperties: &customProperties,
-	}
-}
-
 // parseSecurityEvaluationFile reads and parses a security-evaluations.ndjson file
 func parseSecurityEvaluationFile(filePath string) ([]securityEvaluationRecord, error) {
 	file, err := os.Open(filePath)
@@ -976,29 +902,6 @@ func enrichCatalogModelFromMetadata(existingModel dbmodels.CatalogModel, metadat
 			DoubleValue:      metadata.ModelcarImageSize,
 			IsCustomProperty: true,
 		})
-	}
-
-	if metadata.ModelcarImageSizeBytes != nil {
-		bytesAsDouble := float64(*metadata.ModelcarImageSizeBytes)
-		customProperties = append(customProperties, models.Properties{
-			Name:             "modelcar_image_size_bytes",
-			DoubleValue:      &bytesAsDouble,
-			IsCustomProperty: true,
-		})
-	}
-
-	if len(metadata.ColdStartMatrix) > 0 {
-		csJSON, err := json.Marshal(metadata.ColdStartMatrix)
-		if err != nil {
-			glog.Warningf("Failed to marshal cold_start_matrix for model: %v", err)
-		} else {
-			csStr := string(csJSON)
-			customProperties = append(customProperties, models.Properties{
-				Name:             "cold_start_matrix",
-				StringValue:      &csStr,
-				IsCustomProperty: true,
-			})
-		}
 	}
 
 	if len(customProperties) == 0 {

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -1301,7 +1301,7 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 				"size": "405B params",
 				"tensor_type": "FP8",
 				"min_vram_gb": 265.0,
-				"modelcar_image_size": 405.19,
+				"modelcar_image_size": 405.19
 			}`,
 			wantID:                "sample-model/test-405b-instruct",
 			wantSize:              &[]string{"405B params"}[0],

--- a/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_metrics_test.go
@@ -2,14 +2,12 @@ package modelcatalog
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/models"
-	dbmodels "github.com/kubeflow/hub/internal/platform/db/entity"
 )
 
 func TestParseMetadataJSON(t *testing.T) {
@@ -766,6 +764,58 @@ func TestPerformanceRecordUnmarshalJSON(t *testing.T) {
 			checkCustomProps: true,
 		},
 		{
+			name: "performance record with cold_start and runtime_command",
+			jsonData: `{
+				"id": "perf-coldstart-001",
+				"model_id": "certified/production-llm-8b",
+				"requests_per_second": 4.0,
+				"ttft_p90": 45.8,
+				"hardware_type": "H100",
+				"hardware_count": 2,
+				"cold_start_time_to_load_seconds": 38.1,
+				"runtime_command": "python3 -m vllm.entrypoints.openai.api_server --model certified/production-llm-8b --tensor-parallel-size 2"
+			}`,
+			wantID:      "perf-coldstart-001",
+			wantModelID: "certified/production-llm-8b",
+			wantCustomProps: map[string]any{
+				"id":                              "perf-coldstart-001",
+				"model_id":                        "certified/production-llm-8b",
+				"requests_per_second":             4.0,
+				"ttft_p90":                        45.8,
+				"hardware_type":                   "H100",
+				"hardware_count":                  float64(2),
+				"cold_start_time_to_load_seconds": 38.1,
+				"runtime_command":                 "python3 -m vllm.entrypoints.openai.api_server --model certified/production-llm-8b --tensor-parallel-size 2",
+			},
+			wantErr:          false,
+			checkCustomProps: true,
+		},
+		{
+			name: "performance record with cold_start zero value",
+			jsonData: `{
+				"id": "perf-coldstart-zero",
+				"model_id": "test/model",
+				"requests_per_second": 2.0,
+				"hardware_type": "A100-80",
+				"hardware_count": 1,
+				"cold_start_time_to_load_seconds": 0,
+				"runtime_command": ""
+			}`,
+			wantID:      "perf-coldstart-zero",
+			wantModelID: "test/model",
+			wantCustomProps: map[string]any{
+				"id":                              "perf-coldstart-zero",
+				"model_id":                        "test/model",
+				"requests_per_second":             2.0,
+				"hardware_type":                   "A100-80",
+				"hardware_count":                  float64(1),
+				"cold_start_time_to_load_seconds": float64(0),
+				"runtime_command":                 "",
+			},
+			wantErr:          false,
+			checkCustomProps: true,
+		},
+		{
 			name:             "empty JSON object",
 			jsonData:         `{}`,
 			wantID:           "",
@@ -896,6 +946,108 @@ func TestPerformanceRecordUnmarshalJSON_CoreFieldsInCustomProperties(t *testing.
 	}
 }
 
+func TestPerformanceRecordUnmarshalJSON_ColdStartAndRuntimeCommand(t *testing.T) {
+	jsonData := `{
+		"id": "a1b2c3d4-1111-4aaa-bbbb-000000000004",
+		"model_id": "certified/production-llm-8b",
+		"config_id": "cfg-h100-2gpu-chatbot",
+		"use_case": "chatbot",
+		"ttft_p90": 45.8,
+		"requests_per_second": 4.0,
+		"hardware_type": "H100",
+		"hardware_count": 2,
+		"runtime_command": "python3 -m vllm.entrypoints.openai.api_server \\\n  --model certified/production-llm-8b \\\n  --max-model-len 8192 \\\n  --tensor-parallel-size 2 \\\n  --trust-remote-code",
+		"cold_start_time_to_load_seconds": 38.1
+	}`
+
+	var pr performanceRecord
+	err := pr.UnmarshalJSON([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if pr.ID != "a1b2c3d4-1111-4aaa-bbbb-000000000004" {
+		t.Errorf("ID = %v, want a1b2c3d4-1111-4aaa-bbbb-000000000004", pr.ID)
+	}
+	if pr.ModelID != "certified/production-llm-8b" {
+		t.Errorf("ModelID = %v, want certified/production-llm-8b", pr.ModelID)
+	}
+
+	// Verify cold_start_time_to_load_seconds is captured as a custom property
+	csValue, ok := pr.CustomProperties["cold_start_time_to_load_seconds"]
+	if !ok {
+		t.Fatal("cold_start_time_to_load_seconds not found in CustomProperties")
+	}
+	csFloat, err := csValue.(json.Number).Float64()
+	if err != nil {
+		t.Fatalf("cold_start_time_to_load_seconds is not a number: %v", err)
+	}
+	if csFloat != 38.1 {
+		t.Errorf("cold_start_time_to_load_seconds = %v, want 38.1", csFloat)
+	}
+
+	// Verify runtime_command is captured as a custom property
+	rtValue, ok := pr.CustomProperties["runtime_command"]
+	if !ok {
+		t.Fatal("runtime_command not found in CustomProperties")
+	}
+	rtStr, ok := rtValue.(string)
+	if !ok {
+		t.Fatalf("runtime_command is not a string: %T", rtValue)
+	}
+	if !strings.Contains(rtStr, "--tensor-parallel-size 2") {
+		t.Errorf("runtime_command missing tensor-parallel-size: %v", rtStr)
+	}
+	if !strings.Contains(rtStr, "certified/production-llm-8b") {
+		t.Errorf("runtime_command missing model name: %v", rtStr)
+	}
+}
+
+func TestParsePerformanceFile_ColdStartFields(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ndjsonContent := `{"id": "perf-001", "model_id": "test/model-8b", "requests_per_second": 4.0, "ttft_p90": 45.8, "hardware_type": "H100", "hardware_count": 2, "cold_start_time_to_load_seconds": 38.1, "runtime_command": "vllm serve test/model-8b --tensor-parallel-size 2"}
+{"id": "perf-002", "model_id": "test/model-8b", "requests_per_second": 2.0, "ttft_p90": 65.3, "hardware_type": "A100-80", "hardware_count": 1, "cold_start_time_to_load_seconds": 52.7, "runtime_command": "vllm serve test/model-8b --tensor-parallel-size 1"}
+`
+	filePath := filepath.Join(tmpDir, "performance.ndjson")
+	if err := os.WriteFile(filePath, []byte(ndjsonContent), 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	records, err := parsePerformanceFile(filePath)
+	if err != nil {
+		t.Fatalf("parsePerformanceFile() error = %v", err)
+	}
+
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+
+	// Verify first record
+	cs1, err := records[0].CustomProperties["cold_start_time_to_load_seconds"].(json.Number).Float64()
+	if err != nil {
+		t.Fatalf("record[0] cold_start_time_to_load_seconds not a number: %v", err)
+	}
+	if cs1 != 38.1 {
+		t.Errorf("record[0] cold_start_time_to_load_seconds = %v, want 38.1", cs1)
+	}
+	if records[0].CustomProperties["runtime_command"] != "vllm serve test/model-8b --tensor-parallel-size 2" {
+		t.Errorf("record[0] runtime_command = %v", records[0].CustomProperties["runtime_command"])
+	}
+
+	// Verify second record
+	cs2, err := records[1].CustomProperties["cold_start_time_to_load_seconds"].(json.Number).Float64()
+	if err != nil {
+		t.Fatalf("record[1] cold_start_time_to_load_seconds not a number: %v", err)
+	}
+	if cs2 != 52.7 {
+		t.Errorf("record[1] cold_start_time_to_load_seconds = %v, want 52.7", cs2)
+	}
+	if records[1].CustomProperties["runtime_command"] != "vllm serve test/model-8b --tensor-parallel-size 1" {
+		t.Errorf("record[1] runtime_command = %v", records[1].CustomProperties["runtime_command"])
+	}
+}
+
 func TestUnmarshalJSON_EdgeCases(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -966,17 +1118,15 @@ func TestUnmarshalJSON_EdgeCases(t *testing.T) {
 
 func TestParseMetadataJSON_NewFields(t *testing.T) {
 	tests := []struct {
-		name                       string
-		jsonData                   string
-		wantID                     string
-		wantSize                   *string
-		wantTensorType             *string
-		wantVariantID              *string
-		wantMinVRAMGB              *float64
-		wantModelcarImageSize      *float64
-		wantModelcarImageSizeBytes *int64
-		wantColdStartMatrix        []coldStartEntry
-		wantErr                    bool
+		name                  string
+		jsonData              string
+		wantID                string
+		wantSize              *string
+		wantTensorType        *string
+		wantVariantID         *string
+		wantMinVRAMGB         *float64
+		wantModelcarImageSize *float64
+		wantErr               bool
 	}{
 		{
 			name: "complete metadata with all new fields",
@@ -1129,36 +1279,20 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "metadata with vRAM and cold-start matrix fields",
+			name: "metadata with vRAM field",
 			jsonData: `{
 				"id": "sample-model/test-405b-instruct",
 				"size": "405B params",
 				"tensor_type": "FP8",
 				"variant_group_id": "vwx234mn-5678-901v-wx23-456789abcdef",
-				"min_vram_gb": 265.0,
-				"cold_start_matrix": [
-					{
-						"gpu_type": "A100-80",
-						"gpu_count": 4,
-						"cold_start_time_to_load_seconds": 587.3
-					},
-					{
-						"gpu_type": "B200",
-						"gpu_count": 2,
-						"cold_start_time_to_load_seconds": 559.9
-					}
-				]
+				"min_vram_gb": 265.0
 			}`,
 			wantID:         "sample-model/test-405b-instruct",
 			wantSize:       &[]string{"405B params"}[0],
 			wantTensorType: &[]string{"FP8"}[0],
 			wantVariantID:  &[]string{"vwx234mn-5678-901v-wx23-456789abcdef"}[0],
 			wantMinVRAMGB:  &[]float64{265.0}[0],
-			wantColdStartMatrix: []coldStartEntry{
-				{GPUType: "A100-80", GPUCount: 4, ColdStartTimeToLoadSeconds: 587.3},
-				{GPUType: "B200", GPUCount: 2, ColdStartTimeToLoadSeconds: 559.9},
-			},
-			wantErr: false,
+			wantErr:        false,
 		},
 		{
 			name: "metadata with modelcar image size fields",
@@ -1168,47 +1302,13 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 				"tensor_type": "FP8",
 				"min_vram_gb": 265.0,
 				"modelcar_image_size": 405.19,
-				"modelcar_image_size_bytes": 405186009411
 			}`,
-			wantID:                     "sample-model/test-405b-instruct",
-			wantSize:                   &[]string{"405B params"}[0],
-			wantTensorType:             &[]string{"FP8"}[0],
-			wantMinVRAMGB:              &[]float64{265.0}[0],
-			wantModelcarImageSize:      &[]float64{405.19}[0],
-			wantModelcarImageSizeBytes: &[]int64{405186009411}[0],
-			wantErr:                    false,
-		},
-		{
-			name: "metadata with runtime_command in cold-start matrix",
-			jsonData: `{
-				"id": "RedHatAI/MiniMax-M2.5",
-				"size": "229B",
-				"tensor_type": "FP8",
-				"min_vram_gb": 265.0,
-				"cold_start_matrix": [
-					{
-						"gpu_type": "A100-80",
-						"gpu_count": 4,
-						"cold_start_time_to_load_seconds": 587.3,
-						"runtime_command": "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"
-					},
-					{
-						"gpu_type": "H200",
-						"gpu_count": 4,
-						"cold_start_time_to_load_seconds": 806.7,
-						"runtime_command": "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"
-					}
-				]
-			}`,
-			wantID:         "RedHatAI/MiniMax-M2.5",
-			wantSize:       &[]string{"229B"}[0],
-			wantTensorType: &[]string{"FP8"}[0],
-			wantMinVRAMGB:  &[]float64{265.0}[0],
-			wantColdStartMatrix: []coldStartEntry{
-				{GPUType: "A100-80", GPUCount: 4, ColdStartTimeToLoadSeconds: 587.3, RuntimeCommand: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"},
-				{GPUType: "H200", GPUCount: 4, ColdStartTimeToLoadSeconds: 806.7, RuntimeCommand: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --tensor-parallel-size 4"},
-			},
-			wantErr: false,
+			wantID:                "sample-model/test-405b-instruct",
+			wantSize:              &[]string{"405B params"}[0],
+			wantTensorType:        &[]string{"FP8"}[0],
+			wantMinVRAMGB:         &[]float64{265.0}[0],
+			wantModelcarImageSize: &[]float64{405.19}[0],
+			wantErr:               false,
 		},
 	}
 
@@ -1259,24 +1359,6 @@ func TestParseMetadataJSON_NewFields(t *testing.T) {
 				t.Errorf("parseMetadataJSON() ModelcarImageSize = %v, want %v", *got.ModelcarImageSize, *tt.wantModelcarImageSize)
 			}
 
-			// Test ModelcarImageSizeBytes field
-			if (got.ModelcarImageSizeBytes == nil) != (tt.wantModelcarImageSizeBytes == nil) {
-				t.Errorf("parseMetadataJSON() ModelcarImageSizeBytes nil mismatch: got %v, want %v", got.ModelcarImageSizeBytes, tt.wantModelcarImageSizeBytes)
-			} else if got.ModelcarImageSizeBytes != nil && *got.ModelcarImageSizeBytes != *tt.wantModelcarImageSizeBytes {
-				t.Errorf("parseMetadataJSON() ModelcarImageSizeBytes = %v, want %v", *got.ModelcarImageSizeBytes, *tt.wantModelcarImageSizeBytes)
-			}
-
-			// Test ColdStartMatrix field
-			if len(got.ColdStartMatrix) != len(tt.wantColdStartMatrix) {
-				t.Errorf("parseMetadataJSON() ColdStartMatrix length = %d, want %d", len(got.ColdStartMatrix), len(tt.wantColdStartMatrix))
-			} else {
-				for i, entry := range got.ColdStartMatrix {
-					want := tt.wantColdStartMatrix[i]
-					if entry.GPUType != want.GPUType || entry.GPUCount != want.GPUCount || entry.ColdStartTimeToLoadSeconds != want.ColdStartTimeToLoadSeconds || entry.RuntimeCommand != want.RuntimeCommand {
-						t.Errorf("parseMetadataJSON() ColdStartMatrix[%d] = %+v, want %+v", i, entry, want)
-					}
-				}
-			}
 		})
 	}
 }
@@ -1526,10 +1608,6 @@ func TestEnrichCatalogModelFromMetadata_NewFields(t *testing.T) {
 	metadata := metadataJSON{
 		ID:        modelName,
 		MinVRAMGB: &minVRAM,
-		ColdStartMatrix: []coldStartEntry{
-			{GPUType: "A100", GPUCount: 2, ColdStartTimeToLoadSeconds: 127.3},
-			{GPUType: "H100", GPUCount: 1, ColdStartTimeToLoadSeconds: 68.9},
-		},
 	}
 
 	mockRepo := &mockPerfModelRepo{}
@@ -1557,408 +1635,6 @@ func TestEnrichCatalogModelFromMetadata_NewFields(t *testing.T) {
 		t.Errorf("min_vram_gb = %v, want %v", v, 80.0)
 	}
 
-	// Verify cold_start_matrix is set as a JSON string custom property
-	stringPropMap := make(map[string]string)
-	for _, p := range *props {
-		if p.StringValue != nil {
-			stringPropMap[p.Name] = *p.StringValue
-		}
-	}
-	csJSON, ok := stringPropMap["cold_start_matrix"]
-	if !ok {
-		t.Fatal("expected custom property 'cold_start_matrix' to be set")
-	}
-	var csMatrix []coldStartEntry
-	if err := json.Unmarshal([]byte(csJSON), &csMatrix); err != nil {
-		t.Fatalf("cold_start_matrix is not valid JSON: %v", err)
-	}
-	if len(csMatrix) != 2 {
-		t.Fatalf("cold_start_matrix length = %d, want 2", len(csMatrix))
-	}
-	if csMatrix[0].GPUType != "A100" || csMatrix[0].GPUCount != 2 || csMatrix[0].ColdStartTimeToLoadSeconds != 127.3 {
-		t.Errorf("cold_start_matrix[0] = %+v, want {A100, 2, 127.3}", csMatrix[0])
-	}
-	if csMatrix[1].GPUType != "H100" || csMatrix[1].GPUCount != 1 || csMatrix[1].ColdStartTimeToLoadSeconds != 68.9 {
-		t.Errorf("cold_start_matrix[1] = %+v, want {H100, 1, 68.9}", csMatrix[1])
-	}
-}
-
-func TestEnrichCatalogModelFromMetadata_EmptyColdStartMatrix(t *testing.T) {
-	modelName := "test-vendor/test-model"
-	modelID := int32(2)
-
-	existingModel := &models.CatalogModelImpl{
-		ID: &modelID,
-		Attributes: &models.CatalogModelAttributes{
-			Name: &modelName,
-		},
-	}
-
-	size := "8B params"
-	metadata := metadataJSON{
-		ID:              modelName,
-		Size:            &size,
-		ColdStartMatrix: []coldStartEntry{},
-	}
-
-	mockRepo := &mockPerfModelRepo{}
-
-	err := enrichCatalogModelFromMetadata(existingModel, metadata, mockRepo)
-	if err != nil {
-		t.Fatalf("enrichCatalogModelFromMetadata() error = %v", err)
-	}
-
-	props := existingModel.GetCustomProperties()
-	if props == nil {
-		t.Fatal("expected custom properties to be set, got nil")
-	}
-
-	for _, p := range *props {
-		if p.Name == "cold_start_matrix" {
-			t.Error("cold_start_matrix should not be set when matrix is empty")
-		}
-	}
-}
-
-func TestCreateColdStartArtifact(t *testing.T) {
-	modelID := int32(42)
-	typeID := int32(7)
-
-	tests := []struct {
-		name           string
-		entry          coldStartEntry
-		wantGPUType    string
-		wantGPUCount   int
-		wantSeconds    *float64
-		wantExtID      string
-		wantArtName    string
-		wantRuntimeCmd string
-	}{
-		{
-			name: "valid entry with float seconds",
-			entry: coldStartEntry{
-				GPUType:                    "A100-80",
-				GPUCount:                   4,
-				ColdStartTimeToLoadSeconds: 587.3,
-				RuntimeCommand:             "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 4 --trust-remote-code",
-			},
-			wantGPUType:    "A100-80",
-			wantGPUCount:   4,
-			wantSeconds:    &[]float64{587.3}[0],
-			wantExtID:      "cold-start-model-42-A100-80-4",
-			wantArtName:    "cold-start-model-42-A100-80-4",
-			wantRuntimeCmd: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 4 --trust-remote-code",
-		},
-		{
-			name: "valid entry with integer-like seconds",
-			entry: coldStartEntry{
-				GPUType:                    "H100",
-				GPUCount:                   1,
-				ColdStartTimeToLoadSeconds: 68.0,
-				RuntimeCommand:             "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 1 --trust-remote-code",
-			},
-			wantGPUType:    "H100",
-			wantGPUCount:   1,
-			wantSeconds:    &[]float64{68.0}[0],
-			wantExtID:      "cold-start-model-42-H100-1",
-			wantArtName:    "cold-start-model-42-H100-1",
-			wantRuntimeCmd: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 1 --trust-remote-code",
-		},
-		{
-			name: "zero seconds value omits seconds property",
-			entry: coldStartEntry{
-				GPUType:                    "B200",
-				GPUCount:                   2,
-				ColdStartTimeToLoadSeconds: 0,
-				RuntimeCommand:             "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 2 --trust-remote-code",
-			},
-			wantGPUType:    "B200",
-			wantGPUCount:   2,
-			wantSeconds:    nil,
-			wantExtID:      "cold-start-model-42-B200-2",
-			wantArtName:    "cold-start-model-42-B200-2",
-			wantRuntimeCmd: "python3 -m vllm.entrypoints.openai.api_server --model RedHatAI/MiniMax-M2.5 --max-model-len -1 --tensor-parallel-size 2 --trust-remote-code",
-		},
-		{
-			name: "empty runtime_command omits property",
-			entry: coldStartEntry{
-				GPUType:                    "H200",
-				GPUCount:                   4,
-				ColdStartTimeToLoadSeconds: 806.7,
-			},
-			wantGPUType:    "H200",
-			wantGPUCount:   4,
-			wantSeconds:    &[]float64{806.7}[0],
-			wantExtID:      "cold-start-model-42-H200-4",
-			wantArtName:    "cold-start-model-42-H200-4",
-			wantRuntimeCmd: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			externalID := coldStartExternalID(modelID, tt.entry)
-			artifact := createColdStartArtifact(tt.entry, externalID, modelID, typeID)
-
-			if artifact == nil {
-				t.Fatal("expected non-nil artifact")
-			}
-
-			// Verify type and metrics type
-			if *artifact.TypeID != typeID {
-				t.Errorf("TypeID = %d, want %d", *artifact.TypeID, typeID)
-			}
-			attrs := artifact.GetAttributes()
-			if attrs.MetricsType != models.MetricsTypePerformance {
-				t.Errorf("MetricsType = %q, want %q", attrs.MetricsType, models.MetricsTypePerformance)
-			}
-
-			// Verify naming
-			if *attrs.ExternalID != tt.wantExtID {
-				t.Errorf("ExternalID = %q, want %q", *attrs.ExternalID, tt.wantExtID)
-			}
-			if *attrs.Name != tt.wantArtName {
-				t.Errorf("Name = %q, want %q", *attrs.Name, tt.wantArtName)
-			}
-
-			// Verify timestamps are set
-			if attrs.CreateTimeSinceEpoch == nil || *attrs.CreateTimeSinceEpoch <= 0 {
-				t.Error("expected CreateTimeSinceEpoch to be set")
-			}
-			if attrs.LastUpdateTimeSinceEpoch == nil || *attrs.LastUpdateTimeSinceEpoch <= 0 {
-				t.Error("expected LastUpdateTimeSinceEpoch to be set")
-			}
-
-			// Verify custom properties
-			customProps := artifact.GetCustomProperties()
-			if customProps == nil {
-				t.Fatal("expected custom properties to be set")
-			}
-			stringPropMap := make(map[string]string)
-			doublePropMap := make(map[string]float64)
-			intPropMap := make(map[string]int32)
-			for _, p := range *customProps {
-				if p.StringValue != nil {
-					stringPropMap[p.Name] = *p.StringValue
-				}
-				if p.DoubleValue != nil {
-					doublePropMap[p.Name] = *p.DoubleValue
-				}
-				if p.IntValue != nil {
-					intPropMap[p.Name] = *p.IntValue
-				}
-			}
-
-			if stringPropMap["performance_sub_type"] != "cold-start" {
-				t.Errorf("performance_sub_type = %v, want %q", stringPropMap["performance_sub_type"], "cold-start")
-			}
-			if stringPropMap["gpu_type"] != tt.wantGPUType {
-				t.Errorf("gpu_type = %v, want %q", stringPropMap["gpu_type"], tt.wantGPUType)
-			}
-			if intPropMap["gpu_count"] != int32(tt.wantGPUCount) {
-				t.Errorf("gpu_count = %v, want %d", intPropMap["gpu_count"], tt.wantGPUCount)
-			}
-			if tt.wantRuntimeCmd != "" {
-				if stringPropMap["runtime_command"] != tt.wantRuntimeCmd {
-					t.Errorf("runtime_command = %v, want %q", stringPropMap["runtime_command"], tt.wantRuntimeCmd)
-				}
-			} else {
-				if _, exists := stringPropMap["runtime_command"]; exists {
-					t.Error("expected runtime_command to be absent when not provided")
-				}
-			}
-			if tt.wantSeconds != nil {
-				if doublePropMap["cold_start_time_to_load_seconds"] != *tt.wantSeconds {
-					t.Errorf("cold_start_time_to_load_seconds = %v, want %v", doublePropMap["cold_start_time_to_load_seconds"], *tt.wantSeconds)
-				}
-			} else {
-				if _, exists := doublePropMap["cold_start_time_to_load_seconds"]; exists {
-					t.Error("expected cold_start_time_to_load_seconds to be absent for zero value")
-				}
-			}
-		})
-	}
-}
-
-func TestProcessModelArtifactsBatch_ColdStartOnly(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	coldStartMatrix := []coldStartEntry{
-		{GPUType: "A100", GPUCount: 2, ColdStartTimeToLoadSeconds: 127.3},
-		{GPUType: "H100", GPUCount: 1, ColdStartTimeToLoadSeconds: 68.9},
-	}
-
-	modelID := int32(1)
-	typeID := int32(7)
-
-	var savedArtifacts []models.CatalogMetricsArtifact
-	mockRepo := &mockMetricsArtifactRepo{
-		listResult: &dbmodels.ListWrapper[models.CatalogMetricsArtifact]{},
-		batchSaveFunc: func(artifacts []models.CatalogMetricsArtifact, parentID *int32) ([]models.CatalogMetricsArtifact, error) {
-			savedArtifacts = artifacts
-			return artifacts, nil
-		},
-	}
-
-	count, err := processModelArtifactsBatch(tmpDir, modelID, "test-model", nil, coldStartMatrix, mockRepo, typeID)
-	if err != nil {
-		t.Fatalf("processModelArtifactsBatch() error = %v", err)
-	}
-
-	if count != 2 {
-		t.Errorf("processModelArtifactsBatch() returned count = %d, want 2", count)
-	}
-
-	if len(savedArtifacts) != 2 {
-		t.Fatalf("expected 2 saved artifacts, got %d", len(savedArtifacts))
-	}
-
-	// Verify both artifacts have performance metrics type
-	for _, a := range savedArtifacts {
-		if a.GetAttributes().MetricsType != models.MetricsTypePerformance {
-			t.Errorf("expected MetricsType %q, got %q", models.MetricsTypePerformance, a.GetAttributes().MetricsType)
-		}
-	}
-}
-
-func TestProcessModelArtifactsBatch_ColdStartDedup(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	coldStartMatrix := []coldStartEntry{
-		{GPUType: "A100", GPUCount: 2, ColdStartTimeToLoadSeconds: 127.3},
-	}
-
-	modelID := int32(1)
-	typeID := int32(7)
-	existingExternalID := "cold-start-model-1-A100-2"
-
-	mockRepo := &mockMetricsArtifactRepo{
-		listResult: &dbmodels.ListWrapper[models.CatalogMetricsArtifact]{
-			Items: []models.CatalogMetricsArtifact{
-				&models.CatalogMetricsArtifactImpl{
-					Attributes: &models.CatalogMetricsArtifactAttributes{
-						ExternalID: &existingExternalID,
-					},
-				},
-			},
-			Size: 1,
-		},
-	}
-
-	count, err := processModelArtifactsBatch(tmpDir, modelID, "test-model", nil, coldStartMatrix, mockRepo, typeID)
-	if err != nil {
-		t.Fatalf("processModelArtifactsBatch() error = %v", err)
-	}
-
-	if count != 0 {
-		t.Errorf("processModelArtifactsBatch() returned count = %d, want 0 (all duplicates)", count)
-	}
-}
-
-func TestProcessModelArtifactsBatch_ColdStartInvalidGPUCount(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	coldStartMatrix := []coldStartEntry{
-		{GPUType: "A100", GPUCount: -1, ColdStartTimeToLoadSeconds: 100.0},
-		{GPUType: "H100", GPUCount: 0, ColdStartTimeToLoadSeconds: 50.0},
-		{GPUType: "", GPUCount: 4, ColdStartTimeToLoadSeconds: 200.0},
-		{GPUType: "H200", GPUCount: 2, ColdStartTimeToLoadSeconds: 75.5},
-	}
-
-	modelID := int32(1)
-	typeID := int32(7)
-
-	var savedArtifacts []models.CatalogMetricsArtifact
-	mockRepo := &mockMetricsArtifactRepo{
-		listResult: &dbmodels.ListWrapper[models.CatalogMetricsArtifact]{},
-		batchSaveFunc: func(artifacts []models.CatalogMetricsArtifact, parentID *int32) ([]models.CatalogMetricsArtifact, error) {
-			savedArtifacts = artifacts
-			return artifacts, nil
-		},
-	}
-
-	count, err := processModelArtifactsBatch(tmpDir, modelID, "test-model", nil, coldStartMatrix, mockRepo, typeID)
-	if err != nil {
-		t.Fatalf("processModelArtifactsBatch() error = %v", err)
-	}
-
-	if count != 1 {
-		t.Errorf("processModelArtifactsBatch() returned count = %d, want 1 (only H200 entry is valid)", count)
-	}
-
-	if len(savedArtifacts) != 1 {
-		t.Fatalf("expected 1 saved artifact, got %d", len(savedArtifacts))
-	}
-
-	attrs := savedArtifacts[0].GetAttributes()
-	wantExtID := "cold-start-model-1-H200-2"
-	if *attrs.ExternalID != wantExtID {
-		t.Errorf("expected saved artifact ExternalID = %q, got %q", wantExtID, *attrs.ExternalID)
-	}
-}
-
-func TestProcessModelArtifactsBatch_ColdStartNamesUniqueAcrossModels(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	coldStartMatrix := []coldStartEntry{
-		{GPUType: "H100", GPUCount: 4, ColdStartTimeToLoadSeconds: 105.7},
-		{GPUType: "H200", GPUCount: 2, ColdStartTimeToLoadSeconds: 98.5},
-	}
-
-	typeID := int32(7)
-
-	// Collect all artifact names across both models to check uniqueness
-	allNames := map[string]int32{}
-
-	for _, modelID := range []int32{1, 2} {
-		mockRepo := &mockMetricsArtifactRepo{
-			listResult: &dbmodels.ListWrapper[models.CatalogMetricsArtifact]{},
-			batchSaveFunc: func(artifacts []models.CatalogMetricsArtifact, parentID *int32) ([]models.CatalogMetricsArtifact, error) {
-				for _, a := range artifacts {
-					name := *a.GetAttributes().Name
-					if prev, exists := allNames[name]; exists {
-						t.Errorf("artifact name %q from model %d collides with model %d — would violate UNIQUE(type_id, name) constraint", name, modelID, prev)
-					}
-					allNames[name] = modelID
-				}
-				return artifacts, nil
-			},
-		}
-
-		_, err := processModelArtifactsBatch(tmpDir, modelID, fmt.Sprintf("test-model-%d", modelID), nil, coldStartMatrix, mockRepo, typeID)
-		if err != nil {
-			t.Fatalf("processModelArtifactsBatch() model %d error = %v", modelID, err)
-		}
-	}
-
-	if len(allNames) != 4 {
-		t.Errorf("expected 4 unique artifact names (2 GPU configs x 2 models), got %d", len(allNames))
-	}
-}
-
-// mockMetricsArtifactRepo is a minimal mock for CatalogMetricsArtifactRepository used in batch tests
-type mockMetricsArtifactRepo struct {
-	listResult    *dbmodels.ListWrapper[models.CatalogMetricsArtifact]
-	batchSaveFunc func([]models.CatalogMetricsArtifact, *int32) ([]models.CatalogMetricsArtifact, error)
-}
-
-func (m *mockMetricsArtifactRepo) GetByID(id int32) (models.CatalogMetricsArtifact, error) {
-	return nil, nil
-}
-
-func (m *mockMetricsArtifactRepo) List(opts models.CatalogMetricsArtifactListOptions) (*dbmodels.ListWrapper[models.CatalogMetricsArtifact], error) {
-	return m.listResult, nil
-}
-
-func (m *mockMetricsArtifactRepo) Save(artifact models.CatalogMetricsArtifact, parentID *int32) (models.CatalogMetricsArtifact, error) {
-	return artifact, nil
-}
-
-func (m *mockMetricsArtifactRepo) BatchSave(artifacts []models.CatalogMetricsArtifact, parentID *int32) ([]models.CatalogMetricsArtifact, error) {
-	if m.batchSaveFunc != nil {
-		return m.batchSaveFunc(artifacts, parentID)
-	}
-	return artifacts, nil
 }
 
 // cacheKeys returns all keys from a map for diagnostic output.

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -1449,6 +1449,18 @@ func GetCatalogPerformanceMetricsArtifactMock(itemCount int32) []models.CatalogA
 						MetadataType: "MetadataStringValue",
 					},
 				},
+				"cold_start_time_to_load_seconds": {
+					MetadataDoubleValue: &openapi.MetadataDoubleValue{
+						DoubleValue:  45.2,
+						MetadataType: "MetadataDoubleValue",
+					},
+				},
+				"runtime_command": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "python3 -m vllm.entrypoints.openai.api_server \\\n  --model provider1-granite/granite-3.1-8b-instruct \\\n  --max-model-len 8192 \\\n  --tensor-parallel-size 1 \\\n  --trust-remote-code",
+						MetadataType: "MetadataStringValue",
+					},
+				},
 			}),
 		},
 		{
@@ -1559,6 +1571,18 @@ func GetCatalogPerformanceMetricsArtifactMock(itemCount int32) []models.CatalogA
 						MetadataType: "MetadataStringValue",
 					},
 				},
+				"cold_start_time_to_load_seconds": {
+					MetadataDoubleValue: &openapi.MetadataDoubleValue{
+						DoubleValue:  85.2,
+						MetadataType: "MetadataDoubleValue",
+					},
+				},
+				"runtime_command": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "python3 -m vllm.entrypoints.openai.api_server \\\n  --model provider1-granite/granite-3.1-8b-instruct \\\n  --max-model-len 8192 \\\n  --tensor-parallel-size 8 \\\n  --trust-remote-code",
+						MetadataType: "MetadataStringValue",
+					},
+				},
 			}),
 		},
 		{
@@ -1666,6 +1690,18 @@ func GetCatalogPerformanceMetricsArtifactMock(itemCount int32) []models.CatalogA
 				"use_case": {
 					MetadataStringValue: &openapi.MetadataStringValue{
 						StringValue:  "long_rag",
+						MetadataType: "MetadataStringValue",
+					},
+				},
+				"cold_start_time_to_load_seconds": {
+					MetadataDoubleValue: &openapi.MetadataDoubleValue{
+						DoubleValue:  73.6,
+						MetadataType: "MetadataDoubleValue",
+					},
+				},
+				"runtime_command": {
+					MetadataStringValue: &openapi.MetadataStringValue{
+						StringValue:  "python3 -m vllm.entrypoints.openai.api_server \\\n  --model provider1-granite/granite-3.1-8b-instruct \\\n  --max-model-len 8192 \\\n  --tensor-parallel-size 2 \\\n  --trust-remote-code",
 						MetadataType: "MetadataStringValue",
 					},
 				},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR removes unused cold-start sub-type for the model catalog performance artifacts. This is no longer needed as any related data is now able to go straight into the existing performance artifacts.

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested using a local performance benchmark file with cold start and runtime commands. I confirmed that the metrics load and show up in the UI appropriately. Additionally, the filtering aspect works as expected for the cold start metrics.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
