### PR TITLE
feat(ui/bff): implement ConfigMap-backed CRUD for MCP catalog source configs

### DIFF
--- a/clients/ui/bff/internal/api/catalog_source_preview_handler_test.go
+++ b/clients/ui/bff/internal/api/catalog_source_preview_handler_test.go
@@ -58,11 +58,11 @@ var _ = Describe("CreateCatalogSourcePreviewHandler", func() {
 				Data models.CatalogSourcePreviewRequest `json:"data"`
 			}{
 				Data: models.CatalogSourcePreviewRequest{
-					Type:           "yaml",
-					IncludedModels: []string{},
-					ExcludedModels: []string{},
+					Type:            "yaml",
+					IncludedServers: []string{"*"},
+					ExcludedServers: []string{},
 					Properties: map[string]interface{}{
-						"yaml": "servers:\n  - name: test-server",
+						"yaml": "mcp_servers:\n  - name: test-server",
 					},
 				},
 			}

--- a/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
+++ b/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
@@ -204,7 +204,7 @@ func (app *App) DeleteMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 
 	sourceID := ps.ByName(CatalogSourceId)
 
-	_, err = app.repositories.McpCatalogSettingsRepository.DeleteMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
+	deletedConfig, err := app.repositories.McpCatalogSettingsRepository.DeleteMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
 	if err != nil {
 		if errors.Is(err, repositories.ErrMcpCatalogCannotDeleteDefault) {
 			app.forbiddenResponse(w, r, err.Error())
@@ -218,5 +218,11 @@ func (app *App) DeleteMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	result := McpCatalogSettingsSourceConfigEnvelope{
+		Data: deletedConfig,
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
 }

--- a/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
+++ b/clients/ui/bff/internal/api/mcp_catalog_settings_handler.go
@@ -111,7 +111,8 @@ func (app *App) CreateMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 	created, err := app.repositories.McpCatalogSettingsRepository.CreateMcpCatalogSourceConfig(ctx, client, namespace, *envelope.Data)
 	if err != nil {
 		if errors.Is(err, repositories.ErrMcpCatalogSourceAlreadyExist) ||
-			errors.Is(err, repositories.ErrMcpCatalogSourceIdRequired) {
+			errors.Is(err, repositories.ErrMcpCatalogSourceIdRequired) ||
+			errors.Is(err, repositories.ErrMcpCatalogValidationFailed) {
 			app.badRequestResponse(w, r, err)
 		} else if errors.Is(err, repositories.ErrMcpCatalogSourceConflict) {
 			app.conflictResponse(w, r, err.Error())
@@ -166,6 +167,9 @@ func (app *App) UpdateMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 	if err != nil {
 		if errors.Is(err, repositories.ErrMcpCatalogSourceNotFound) {
 			app.notFoundResponse(w, r)
+		} else if errors.Is(err, repositories.ErrMcpCatalogCannotChangeDefault) ||
+			errors.Is(err, repositories.ErrMcpCatalogCannotChangeType) {
+			app.forbiddenResponse(w, r, err.Error())
 		} else if errors.Is(err, repositories.ErrMcpCatalogSourceConflict) {
 			app.conflictResponse(w, r, err.Error())
 		} else {
@@ -202,7 +206,9 @@ func (app *App) DeleteMcpCatalogSourceConfigHandler(w http.ResponseWriter, r *ht
 
 	_, err = app.repositories.McpCatalogSettingsRepository.DeleteMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
 	if err != nil {
-		if errors.Is(err, repositories.ErrMcpCatalogSourceNotFound) {
+		if errors.Is(err, repositories.ErrMcpCatalogCannotDeleteDefault) {
+			app.forbiddenResponse(w, r, err.Error())
+		} else if errors.Is(err, repositories.ErrMcpCatalogSourceNotFound) {
 			app.notFoundResponse(w, r)
 		} else if errors.Is(err, repositories.ErrMcpCatalogSourceConflict) {
 			app.conflictResponse(w, r, err.Error())

--- a/clients/ui/bff/internal/api/mcp_catalog_settings_handler_test.go
+++ b/clients/ui/bff/internal/api/mcp_catalog_settings_handler_test.go
@@ -1,0 +1,339 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestMcpCatalogSettings", func() {
+	var requestIdentity kubernetes.RequestIdentity
+
+	BeforeEach(func() {
+		requestIdentity = kubernetes.RequestIdentity{
+			UserID: "user@example.com",
+		}
+	})
+
+	Context("fetching MCP catalog source config", func() {
+		It("GET ALL returns 200", func() {
+			_, rs, err := setupApiTest[McpCatalogSettingsSourceConfigListEnvelope](
+				http.MethodGet,
+				"/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("GET SINGLE returns 200", func() {
+			_, rs, err := setupApiTest[McpCatalogSettingsSourceConfigEnvelope](
+				http.MethodGet,
+				"/api/v1/settings/mcp_catalog/source_configs/community_mcp_servers?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("GET returns 404 for non-existent source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodGet,
+				"/api/v1/settings/mcp_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("GET returns 400 when namespace is missing", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodGet,
+				"/api/v1/settings/mcp_catalog/source_configs",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("creating MCP source config", func() {
+		It("POST returns 201 on success", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{
+					Id:      "mcp_handler_test_create",
+					Name:    "MCP Handler Test",
+					Type:    "yaml",
+					Enabled: mcpHandlerBoolPtr(true),
+					Yaml:    mcpHandlerStringPtr("servers: []"),
+				},
+			}
+			_, rs, err := setupApiTest[McpCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+		})
+
+		It("POST returns 400 for validation error (missing required field)", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{
+					Name:    "Test",
+					Type:    "yaml",
+					Enabled: mcpHandlerBoolPtr(true),
+					Yaml:    mcpHandlerStringPtr("servers: []"),
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 for duplicate source", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{
+					Id:      "community_mcp_servers",
+					Name:    "Duplicate",
+					Type:    "yaml",
+					Enabled: mcpHandlerBoolPtr(true),
+					Yaml:    mcpHandlerStringPtr("servers: []"),
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 when type is missing", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{
+					Id:      "test_mcp_missing_type",
+					Name:    "Test Missing Type",
+					Enabled: mcpHandlerBoolPtr(true),
+					Yaml:    mcpHandlerStringPtr("servers: []"),
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 when yaml is missing for yaml type", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{
+					Id:      "test_mcp_yaml_no_content",
+					Name:    "Test YAML No Content",
+					Type:    "yaml",
+					Enabled: mcpHandlerBoolPtr(true),
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 for unsupported catalog type", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{
+					Id:      "test_mcp_invalid_type",
+					Name:    "Test Invalid Type",
+					Type:    "invalid_type",
+					Enabled: mcpHandlerBoolPtr(true),
+					Yaml:    mcpHandlerStringPtr("servers: []"),
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("patching an MCP source config", func() {
+		It("PATCH returns 200 on success", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{Enabled: mcpHandlerBoolPtr(false)},
+			}
+			_, rs, err := setupApiTest[McpCatalogSettingsSourceConfigEnvelope](
+				http.MethodPatch,
+				"/api/v1/settings/mcp_catalog/source_configs/community_mcp_servers?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("PATCH returns 404 for non-existent source", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{Enabled: mcpHandlerBoolPtr(false)},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/mcp_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("PATCH returns 403 when changing type", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{Type: "hf"},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/mcp_catalog/source_configs/community_mcp_servers?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("PATCH returns 403 when updating forbidden field on default", func() {
+			payload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{Name: "Changed Name"},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/mcp_catalog/source_configs/community_mcp_servers?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+	})
+
+	Context("deleting an MCP source config", func() {
+		It("DELETE returns 200 on success", func() {
+			createPayload := McpCatalogSourcePayloadEnvelope{
+				Data: &models.McpCatalogSourceConfigPayload{
+					Id:      "mcp_delete_handler_test",
+					Name:    "MCP Delete Test",
+					Type:    "yaml",
+					Enabled: mcpHandlerBoolPtr(true),
+					Yaml:    mcpHandlerStringPtr("servers: []"),
+				},
+			}
+			_, _, err := setupApiTest[McpCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/mcp_catalog/source_configs?namespace=kubeflow",
+				createPayload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, rs, err := setupApiTest[McpCatalogSettingsSourceConfigEnvelope](
+				http.MethodDelete,
+				"/api/v1/settings/mcp_catalog/source_configs/mcp_delete_handler_test?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("DELETE returns 404 for non-existent source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodDelete,
+				"/api/v1/settings/mcp_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("DELETE returns 403 for default source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodDelete,
+				"/api/v1/settings/mcp_catalog/source_configs/community_mcp_servers?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+	})
+})
+
+func mcpHandlerBoolPtr(b bool) *bool {
+	return &b
+}
+
+func mcpHandlerStringPtr(s string) *string {
+	return &s
+}

--- a/clients/ui/bff/internal/integrations/kubernetes/client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/client.go
@@ -16,7 +16,7 @@ const CatalogSourceDefaultConfigMapName = "default-catalog-sources"
 const CatalogSourceUserConfigMapName = "model-catalog-sources"
 
 const McpCatalogSourceKey = "sources.yaml"
-const McpCatalogSourceDefaultConfigMapName = "default-mcp-catalog-sources"
+const McpCatalogSourceDefaultConfigMapName = CatalogSourceDefaultConfigMapName
 const McpCatalogSourceUserConfigMapName = "mcp-catalog-sources"
 
 type KubernetesClientInterface interface {

--- a/clients/ui/bff/internal/integrations/kubernetes/client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/client.go
@@ -15,6 +15,10 @@ const CatalogSourceKey = "sources.yaml"
 const CatalogSourceDefaultConfigMapName = "default-catalog-sources"
 const CatalogSourceUserConfigMapName = "model-catalog-sources"
 
+const McpCatalogSourceKey = "sources.yaml"
+const McpCatalogSourceDefaultConfigMapName = "default-mcp-catalog-sources"
+const McpCatalogSourceUserConfigMapName = "mcp-catalog-sources"
+
 type KubernetesClientInterface interface {
 	// Service discovery
 	GetServiceNames(ctx context.Context, namespace string) ([]string, error)
@@ -47,6 +51,10 @@ type KubernetesClientInterface interface {
 	CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret) (*corev1.Secret, error)
 	PatchSecret(ctx context.Context, namespace string, secretName string, data map[string]string) error
 	DeleteSecret(ctx context.Context, namespace string, secretName string) error
+
+	// MCP Catalog Settings
+	GetAllMcpCatalogSourceConfigs(ctx context.Context, namespace string) (corev1.ConfigMap, corev1.ConfigMap, error)
+	UpdateMcpCatalogSourceConfig(ctx context.Context, namespace string, configMap *corev1.ConfigMap) error
 
 	// Model transfer jobs
 	CanListJobsClusterWide(ctx context.Context, identity *RequestIdentity) (bool, error)

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -1469,7 +1469,7 @@ catalogs:
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			k8s.McpCatalogSourceKey:       raw,
+			k8s.McpCatalogSourceKey:      raw,
 			"community_mcp_servers.yaml": "servers:\n - name: community_server_1",
 		},
 	}
@@ -1517,7 +1517,7 @@ catalogs:
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			k8s.McpCatalogSourceKey:    raw,
+			k8s.McpCatalogSourceKey:   raw,
 			"custom_mcp_servers.yaml": "servers:\n - name: custom_server_1",
 			"org_mcp_servers.yaml":    "servers:\n - name: org_server_1",
 		},

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -266,6 +266,26 @@ func setupMock(mockK8sClient kubernetes.Interface, ctx context.Context) error {
 		return err
 	}
 
+	err = createMcpCatalogDefaultSourcesConfigMap(mockK8sClient, ctx, "kubeflow")
+	if err != nil {
+		return err
+	}
+
+	err = createMcpCatalogSourcesConfigMap(mockK8sClient, ctx, "kubeflow")
+	if err != nil {
+		return err
+	}
+
+	err = createMcpCatalogDefaultSourcesConfigMap(mockK8sClient, ctx, "bella-namespace")
+	if err != nil {
+		return err
+	}
+
+	err = createMcpCatalogSourcesConfigMap(mockK8sClient, ctx, "bella-namespace")
+	if err != nil {
+		return err
+	}
+
 	err = createHuggingFaceSecret(mockK8sClient, ctx, "kubeflow")
 	if err != nil {
 		return err
@@ -1412,6 +1432,99 @@ func createTransferJobPodEvents(k8sClient kubernetes.Interface, ctx context.Cont
 				return fmt.Errorf("failed to create event for pod %s: %w", pe.podName, err)
 			}
 		}
+	}
+
+	return nil
+}
+
+func createMcpCatalogDefaultSourcesConfigMap(
+	k8sClient kubernetes.Interface,
+	ctx context.Context,
+	namespace string,
+) error {
+	raw := strings.TrimSpace(`
+catalogs:
+  - name: Community MCP Servers
+    id: community_mcp_servers
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: community_mcp_servers.yaml
+    labels:
+      - Community
+
+  - name: Verified MCP Servers
+    id: verified_mcp_servers
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: verified_mcp_servers.yaml
+    labels:
+      - Verified
+`)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8s.McpCatalogSourceDefaultConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			k8s.McpCatalogSourceKey:       raw,
+			"community_mcp_servers.yaml": "servers:\n - name: community_server_1",
+		},
+	}
+
+	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create default-mcp-catalog-sources configmap: %w", err)
+	}
+
+	return nil
+}
+
+func createMcpCatalogSourcesConfigMap(
+	k8sClient kubernetes.Interface,
+	ctx context.Context,
+	namespace string,
+) error {
+	raw := strings.TrimSpace(`
+catalogs:
+  - name: Custom MCP Servers
+    id: custom_mcp_servers
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: custom_mcp_servers.yaml
+    includedServers:
+      - server-*
+    excludedServers:
+      - test-server-*
+    labels:
+      - Custom
+
+  - name: Organization MCP
+    id: org_mcp_servers
+    type: yaml
+    enabled: false
+    properties:
+      yamlCatalogPath: org_mcp_servers.yaml
+    labels:
+      - Organization
+`)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8s.McpCatalogSourceUserConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			k8s.McpCatalogSourceKey:    raw,
+			"custom_mcp_servers.yaml": "servers:\n - name: custom_server_1",
+			"org_mcp_servers.yaml":    "servers:\n - name: org_server_1",
+		},
+	}
+
+	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create mcp-catalog-sources configmap: %w", err)
 	}
 
 	return nil

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -266,7 +266,7 @@ func setupMock(mockK8sClient kubernetes.Interface, ctx context.Context) error {
 		return err
 	}
 
-	err = createMcpCatalogDefaultSourcesConfigMap(mockK8sClient, ctx, "kubeflow")
+	err = addMcpDataToDefaultCatalogSourcesConfigMap(mockK8sClient, ctx, "kubeflow")
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func setupMock(mockK8sClient kubernetes.Interface, ctx context.Context) error {
 		return err
 	}
 
-	err = createMcpCatalogDefaultSourcesConfigMap(mockK8sClient, ctx, "bella-namespace")
+	err = addMcpDataToDefaultCatalogSourcesConfigMap(mockK8sClient, ctx, "bella-namespace")
 	if err != nil {
 		return err
 	}
@@ -1437,13 +1437,18 @@ func createTransferJobPodEvents(k8sClient kubernetes.Interface, ctx context.Cont
 	return nil
 }
 
-func createMcpCatalogDefaultSourcesConfigMap(
+func addMcpDataToDefaultCatalogSourcesConfigMap(
 	k8sClient kubernetes.Interface,
 	ctx context.Context,
 	namespace string,
 ) error {
-	raw := strings.TrimSpace(`
-catalogs:
+	cm, err := k8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, k8s.CatalogSourceDefaultConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get default-catalog-sources configmap for MCP data: %w", err)
+	}
+
+	mcpRaw := strings.TrimSpace(`
+mcp_catalogs:
   - name: Community MCP Servers
     id: community_mcp_servers
     type: yaml
@@ -1463,19 +1468,12 @@ catalogs:
       - Verified
 `)
 
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      k8s.McpCatalogSourceDefaultConfigMapName,
-			Namespace: namespace,
-		},
-		Data: map[string]string{
-			k8s.McpCatalogSourceKey:      raw,
-			"community_mcp_servers.yaml": "servers:\n - name: community_server_1",
-		},
-	}
+	existingSources := cm.Data[k8s.McpCatalogSourceKey]
+	cm.Data[k8s.McpCatalogSourceKey] = existingSources + "\n" + mcpRaw
+	cm.Data["community_mcp_servers.yaml"] = "servers:\n - name: community_server_1"
 
-	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
-		return fmt.Errorf("failed to create default-mcp-catalog-sources configmap: %w", err)
+	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update default-catalog-sources configmap with MCP data: %w", err)
 	}
 
 	return nil
@@ -1487,7 +1485,7 @@ func createMcpCatalogSourcesConfigMap(
 	namespace string,
 ) error {
 	raw := strings.TrimSpace(`
-catalogs:
+mcp_catalogs:
   - name: Custom MCP Servers
     id: custom_mcp_servers
     type: yaml

--- a/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
@@ -362,6 +362,73 @@ func (kc *SharedClientLogic) UpdateCatalogSourceConfig(
 	return nil
 }
 
+func (kc *SharedClientLogic) GetAllMcpCatalogSourceConfigs(
+	sessionCtx context.Context,
+	namespace string,
+) (corev1.ConfigMap, corev1.ConfigMap, error) {
+	if namespace == "" {
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, fmt.Errorf("namespace cannot be empty")
+	}
+
+	sessionLogger := sessionCtx.Value(constants.TraceLoggerKey).(*slog.Logger)
+
+	defaultCM, err := kc.Client.CoreV1().
+		ConfigMaps(namespace).
+		Get(sessionCtx, McpCatalogSourceDefaultConfigMapName, metav1.GetOptions{})
+
+	if err != nil {
+		sessionLogger.Error("failed to fetch default MCP catalog source configmap",
+			"namespace", namespace,
+			"name", McpCatalogSourceDefaultConfigMapName,
+			"error", err,
+		)
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, fmt.Errorf("failed to get %s: %w", McpCatalogSourceDefaultConfigMapName, err)
+	}
+
+	userCM, err := kc.Client.CoreV1().ConfigMaps(namespace).Get(sessionCtx, McpCatalogSourceUserConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return *defaultCM, corev1.ConfigMap{}, nil
+		}
+		sessionLogger.Error("failed to fetch MCP catalog source configmap",
+			"namespace", namespace,
+			"name", McpCatalogSourceUserConfigMapName,
+			"error", err,
+		)
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, fmt.Errorf("failed to get %s: %w", McpCatalogSourceUserConfigMapName, err)
+	}
+
+	return *defaultCM, *userCM, nil
+}
+
+func (kc *SharedClientLogic) UpdateMcpCatalogSourceConfig(
+	ctx context.Context,
+	namespace string,
+	configMap *corev1.ConfigMap,
+) error {
+	sessionLogger := ctx.Value(constants.TraceLoggerKey).(*slog.Logger)
+
+	_, err := kc.Client.CoreV1().
+		ConfigMaps(namespace).
+		Update(ctx, configMap, metav1.UpdateOptions{})
+
+	if err != nil {
+		sessionLogger.Error("failed to update MCP catalog sources configmap",
+			"namespace", namespace,
+			"name", configMap.Name,
+			"error", err,
+		)
+		return fmt.Errorf("failed to update configmap %s: %w", configMap.Name, err)
+	}
+
+	sessionLogger.Info("successfully updated MCP catalog sources configmap",
+		"namespace", namespace,
+		"name", configMap.Name,
+	)
+
+	return nil
+}
+
 // GetAllModelTransferJobs lists model transfer jobs. If jobNamespace is non-empty,
 // jobs are listed only in that namespace. Otherwise jobs are listed across all namespaces.
 func (kc *SharedClientLogic) GetAllModelTransferJobs(

--- a/clients/ui/bff/internal/models/catalog_source_preview.go
+++ b/clients/ui/bff/internal/models/catalog_source_preview.go
@@ -1,10 +1,12 @@
 package models
 
 type CatalogSourcePreviewRequest struct {
-	Type           string                 `json:"type"`
-	IncludedModels []string               `json:"includedModels,omitempty"`
-	ExcludedModels []string               `json:"excludedModels,omitempty"`
-	Properties     map[string]interface{} `json:"properties,omitempty"`
+	Type            string                 `json:"type"`
+	IncludedModels  []string               `json:"includedModels,omitempty"`
+	ExcludedModels  []string               `json:"excludedModels,omitempty"`
+	IncludedServers []string               `json:"includedServers,omitempty"`
+	ExcludedServers []string               `json:"excludedServers,omitempty"`
+	Properties      map[string]interface{} `json:"properties,omitempty"`
 }
 
 type CatalogSourcePreviewModel struct {

--- a/clients/ui/bff/internal/repositories/catalog_source_preview.go
+++ b/clients/ui/bff/internal/repositories/catalog_source_preview.go
@@ -37,6 +37,10 @@ func (a CatalogSourcePreview) CreateCatalogSourcePreview(client httpclient.HTTPC
 		"type": sourcePreviewPayload.Type,
 	}
 
+	if assetType := pageValues.Get("assetType"); assetType != "" {
+		configData["assetType"] = assetType
+	}
+
 	if len(sourcePreviewPayload.IncludedModels) > 0 {
 		configData["includedModels"] = sourcePreviewPayload.IncludedModels
 	}

--- a/clients/ui/bff/internal/repositories/catalog_source_preview.go
+++ b/clients/ui/bff/internal/repositories/catalog_source_preview.go
@@ -34,9 +34,20 @@ func (a CatalogSourcePreview) CreateCatalogSourcePreview(client httpclient.HTTPC
 	}
 
 	configData := map[string]interface{}{
-		"type":           sourcePreviewPayload.Type,
-		"includedModels": sourcePreviewPayload.IncludedModels,
-		"excludedModels": sourcePreviewPayload.ExcludedModels,
+		"type": sourcePreviewPayload.Type,
+	}
+
+	if len(sourcePreviewPayload.IncludedModels) > 0 {
+		configData["includedModels"] = sourcePreviewPayload.IncludedModels
+	}
+	if len(sourcePreviewPayload.ExcludedModels) > 0 {
+		configData["excludedModels"] = sourcePreviewPayload.ExcludedModels
+	}
+	if len(sourcePreviewPayload.IncludedServers) > 0 {
+		configData["includedServers"] = sourcePreviewPayload.IncludedServers
+	}
+	if len(sourcePreviewPayload.ExcludedServers) > 0 {
+		configData["excludedServers"] = sourcePreviewPayload.ExcludedServers
 	}
 
 	properties := make(map[string]interface{})

--- a/clients/ui/bff/internal/repositories/catalog_source_preview_test.go
+++ b/clients/ui/bff/internal/repositories/catalog_source_preview_test.go
@@ -213,3 +213,80 @@ func TestCreateCatalogSourcePreview_EmptyYamlFallsBackToPath(t *testing.T) {
 	assert.Equal(t, int32(3), result.Size)
 	mockClient.AssertExpectations(t)
 }
+
+func TestCreateCatalogSourcePreview_MCPServerPreview(t *testing.T) {
+	mockClient := &mocks.MockHTTPClient{}
+
+	responseJSON := `{"size": 5, "pageSize": 10, "nextPageToken": "", "items": []}`
+	mockClient.On("POSTWithContentType", mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte(responseJSON), nil)
+
+	repo := CatalogSourcePreview{}
+	payload := models.CatalogSourcePreviewRequest{
+		Type:            "yaml",
+		IncludedServers: []string{"kubernetes*"},
+		ExcludedServers: []string{"*-internal"},
+		Properties: map[string]interface{}{
+			"yaml": "mcp_servers:\n  - name: kubernetes-mcp",
+		},
+	}
+
+	pageValues := url.Values{}
+	pageValues.Set("assetType", "mcp_servers")
+
+	result, err := repo.CreateCatalogSourcePreview(mockClient, payload, pageValues)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int32(5), result.Size)
+	mockClient.AssertExpectations(t)
+}
+
+func TestCreateCatalogSourcePreview_MCPServerWithYamlCatalogPath(t *testing.T) {
+	mockClient := &mocks.MockHTTPClient{}
+
+	responseJSON := `{"size": 3, "pageSize": 10, "nextPageToken": "", "items": []}`
+	mockClient.On("POSTWithContentType", mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte(responseJSON), nil)
+
+	repo := CatalogSourcePreview{}
+	payload := models.CatalogSourcePreviewRequest{
+		Type: "yaml",
+		Properties: map[string]interface{}{
+			"yamlCatalogPath": "mcp-servers.yaml",
+		},
+	}
+
+	pageValues := url.Values{}
+	pageValues.Set("assetType", "mcp_servers")
+
+	result, err := repo.CreateCatalogSourcePreview(mockClient, payload, pageValues)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int32(3), result.Size)
+	mockClient.AssertExpectations(t)
+}
+
+func TestCreateCatalogSourcePreview_AssetTypeNotSetForModels(t *testing.T) {
+	mockClient := &mocks.MockHTTPClient{}
+
+	responseJSON := `{"size": 10, "pageSize": 10, "nextPageToken": "", "items": []}`
+	mockClient.On("POSTWithContentType", mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte(responseJSON), nil)
+
+	repo := CatalogSourcePreview{}
+	payload := models.CatalogSourcePreviewRequest{
+		Type:           "yaml",
+		IncludedModels: []string{"model-*"},
+		Properties: map[string]interface{}{
+			"yaml": "models:\n  - name: test",
+		},
+	}
+
+	result, err := repo.CreateCatalogSourcePreview(mockClient, payload, url.Values{})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	mockClient.AssertExpectations(t)
+}

--- a/clients/ui/bff/internal/repositories/mcp_catalog_helpers.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_helpers.go
@@ -22,7 +22,7 @@ func ParseMcpCatalogYaml(raw string, isDefault bool) ([]models.McpCatalogSourceC
 			Labels          []string               `yaml:"labels"`
 			IncludedServers []string               `yaml:"includedServers"`
 			ExcludedServers []string               `yaml:"excludedServers"`
-		} `yaml:"catalogs"`
+		} `yaml:"mcp_catalogs"`
 	}
 
 	if err := yaml.Unmarshal([]byte(raw), &parsed); err != nil {
@@ -61,7 +61,7 @@ func FindMcpCatalogSourceById(sourceYAML string, catalogId string, isDefault boo
 			Labels          []string `yaml:"labels"`
 			IncludedServers []string `yaml:"includedServers"`
 			ExcludedServers []string `yaml:"excludedServers"`
-		} `yaml:"catalogs"`
+		} `yaml:"mcp_catalogs"`
 	}
 
 	if err := yaml.Unmarshal([]byte(sourceYAML), &parsed); err != nil {
@@ -92,7 +92,7 @@ func FindMcpCatalogSourceProperties(sourceYAML string, sourceId string) (yamlPat
 		Catalogs []struct {
 			Id         string                 `yaml:"id"`
 			Properties map[string]interface{} `yaml:"properties"`
-		} `yaml:"catalogs"`
+		} `yaml:"mcp_catalogs"`
 	}
 
 	if err := yaml.Unmarshal([]byte(sourceYAML), &parsed); err != nil {
@@ -106,6 +106,53 @@ func FindMcpCatalogSourceProperties(sourceYAML string, sourceId string) (yamlPat
 		}
 	}
 	return ""
+}
+
+func AppendMcpCatalogSourceToYaml(existingConfigMapEntry string, newEntry map[string]interface{}) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"mcp_catalogs"`
+	}
+
+	if existingConfigMapEntry != "" {
+		if err := yaml.Unmarshal([]byte(existingConfigMapEntry), &parsed); err != nil {
+			return "", fmt.Errorf("failed to parse existing MCP sources.yaml: %w", err)
+		}
+	} else {
+		parsed.Catalogs = []map[string]interface{}{}
+	}
+	parsed.Catalogs = append(parsed.Catalogs, newEntry)
+
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated MCP sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
+}
+
+func RemoveMcpCatalogSourceFromYAML(existingYAML string, sourceId string) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"mcp_catalogs"`
+	}
+
+	if err := yaml.Unmarshal([]byte(existingYAML), &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse MCP sources.yaml: %w", err)
+	}
+
+	filteredCatalogs := make([]map[string]interface{}, 0)
+	for _, catalogSource := range parsed.Catalogs {
+		if id, ok := catalogSource["id"].(string); ok && id != sourceId {
+			filteredCatalogs = append(filteredCatalogs, catalogSource)
+		}
+	}
+
+	parsed.Catalogs = filteredCatalogs
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated MCP sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
 }
 
 func ConvertMcpSourceConfigToYamlEntry(payload models.McpCatalogSourceConfigPayload, yamlFileName string) map[string]interface{} {
@@ -145,7 +192,7 @@ func UpdateMcpCatalogSourceInYAML(
 	yamlFilePath string,
 ) (string, error) {
 	var parsed struct {
-		Catalogs []map[string]interface{} `yaml:"catalogs"`
+		Catalogs []map[string]interface{} `yaml:"mcp_catalogs"`
 	}
 
 	if existingYAML == "" {

--- a/clients/ui/bff/internal/repositories/mcp_catalog_helpers.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_helpers.go
@@ -1,0 +1,308 @@
+package repositories
+
+import (
+	"fmt"
+
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	McpCatalogTypeYaml = "yaml"
+)
+
+func ParseMcpCatalogYaml(raw string, isDefault bool) ([]models.McpCatalogSourceConfig, error) {
+	var parsed struct {
+		Catalogs []struct {
+			Name            string                 `yaml:"name"`
+			Id              string                 `yaml:"id"`
+			Type            string                 `yaml:"type"`
+			Enabled         *bool                  `yaml:"enabled"`
+			Properties      map[string]interface{} `yaml:"properties"`
+			Labels          []string               `yaml:"labels"`
+			IncludedServers []string               `yaml:"includedServers"`
+			ExcludedServers []string               `yaml:"excludedServers"`
+		} `yaml:"catalogs"`
+	}
+
+	if err := yaml.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse MCP catalogs yaml: %w", err)
+	}
+
+	catalogs := make([]models.McpCatalogSourceConfig, 0, len(parsed.Catalogs))
+	for _, c := range parsed.Catalogs {
+		entry := models.McpCatalogSourceConfig{
+			Id:              c.Id,
+			Name:            c.Name,
+			Type:            c.Type,
+			Enabled:         c.Enabled,
+			Labels:          c.Labels,
+			IsDefault:       &isDefault,
+			IncludedServers: c.IncludedServers,
+			ExcludedServers: c.ExcludedServers,
+		}
+		catalogs = append(catalogs, entry)
+	}
+
+	return catalogs, nil
+}
+
+func FindMcpCatalogSourceById(sourceYAML string, catalogId string, isDefault bool) *models.McpCatalogSourceConfig {
+	if sourceYAML == "" {
+		return nil
+	}
+
+	var parsed struct {
+		Catalogs []struct {
+			Id              string   `yaml:"id"`
+			Name            string   `yaml:"name"`
+			Type            string   `yaml:"type"`
+			Enabled         *bool    `yaml:"enabled"`
+			Labels          []string `yaml:"labels"`
+			IncludedServers []string `yaml:"includedServers"`
+			ExcludedServers []string `yaml:"excludedServers"`
+		} `yaml:"catalogs"`
+	}
+
+	if err := yaml.Unmarshal([]byte(sourceYAML), &parsed); err != nil {
+		return nil
+	}
+
+	for _, catalog := range parsed.Catalogs {
+		if catalog.Id == catalogId {
+			isDefaultVal := isDefault
+			return &models.McpCatalogSourceConfig{
+				Id:              catalog.Id,
+				Name:            catalog.Name,
+				Type:            catalog.Type,
+				Enabled:         catalog.Enabled,
+				Labels:          catalog.Labels,
+				IsDefault:       &isDefaultVal,
+				IncludedServers: catalog.IncludedServers,
+				ExcludedServers: catalog.ExcludedServers,
+			}
+		}
+	}
+
+	return nil
+}
+
+func FindMcpCatalogSourceProperties(sourceYAML string, sourceId string) (yamlPath string) {
+	var parsed struct {
+		Catalogs []struct {
+			Id         string                 `yaml:"id"`
+			Properties map[string]interface{} `yaml:"properties"`
+		} `yaml:"catalogs"`
+	}
+
+	if err := yaml.Unmarshal([]byte(sourceYAML), &parsed); err != nil {
+		return ""
+	}
+
+	for _, catalogSource := range parsed.Catalogs {
+		if catalogSource.Id == sourceId && catalogSource.Properties != nil {
+			yamlPath, _ = catalogSource.Properties["yamlCatalogPath"].(string)
+			return
+		}
+	}
+	return ""
+}
+
+func ConvertMcpSourceConfigToYamlEntry(payload models.McpCatalogSourceConfigPayload, yamlFileName string) map[string]interface{} {
+	entry := map[string]interface{}{
+		"id":      payload.Id,
+		"name":    payload.Name,
+		"type":    payload.Type,
+		"enabled": payload.Enabled,
+	}
+
+	if len(payload.Labels) > 0 {
+		entry["labels"] = payload.Labels
+	}
+
+	properties := make(map[string]interface{})
+	if yamlFileName != "" {
+		properties["yamlCatalogPath"] = yamlFileName
+	}
+	if len(properties) > 0 {
+		entry["properties"] = properties
+	}
+
+	if len(payload.IncludedServers) > 0 {
+		entry["includedServers"] = payload.IncludedServers
+	}
+	if len(payload.ExcludedServers) > 0 {
+		entry["excludedServers"] = payload.ExcludedServers
+	}
+
+	return entry
+}
+
+func UpdateMcpCatalogSourceInYAML(
+	existingYAML string,
+	catalogId string,
+	payload models.McpCatalogSourceConfigPayload,
+	yamlFilePath string,
+) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"catalogs"`
+	}
+
+	if existingYAML == "" {
+		return "", fmt.Errorf("no existing yaml to update")
+	}
+
+	if err := yaml.Unmarshal([]byte(existingYAML), &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse sources.yaml: %w", err)
+	}
+
+	found := false
+	for i, catalogSource := range parsed.Catalogs {
+		if id, ok := catalogSource["id"].(string); ok && id == catalogId {
+			found = true
+
+			if payload.Name != "" {
+				catalogSource["name"] = payload.Name
+			}
+			if len(payload.Labels) > 0 {
+				catalogSource["labels"] = payload.Labels
+			}
+			if payload.Enabled != nil {
+				catalogSource["enabled"] = *payload.Enabled
+			}
+
+			if payload.IncludedServers != nil {
+				if len(payload.IncludedServers) > 0 {
+					catalogSource["includedServers"] = payload.IncludedServers
+				} else {
+					delete(catalogSource, "includedServers")
+				}
+			}
+			if payload.ExcludedServers != nil {
+				if len(payload.ExcludedServers) > 0 {
+					catalogSource["excludedServers"] = payload.ExcludedServers
+				} else {
+					delete(catalogSource, "excludedServers")
+				}
+			}
+
+			properties, _ := catalogSource["properties"].(map[string]interface{})
+			if properties == nil {
+				properties = make(map[string]interface{})
+			}
+			if yamlFilePath != "" && payload.Yaml != nil {
+				properties["yamlCatalogPath"] = yamlFilePath
+			}
+			if len(properties) > 0 {
+				catalogSource["properties"] = properties
+			}
+
+			parsed.Catalogs[i] = catalogSource
+			break
+		}
+	}
+
+	if !found {
+		return "", fmt.Errorf("MCP catalog '%s' not found in yaml", catalogId)
+	}
+
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
+}
+
+func BuildOverrideEntryForDefaultMcpSource(catalogId string, payload models.McpCatalogSourceConfigPayload) map[string]interface{} {
+	entry := map[string]interface{}{
+		"id": catalogId,
+	}
+
+	if payload.Enabled != nil {
+		entry["enabled"] = *payload.Enabled
+	}
+
+	if len(payload.IncludedServers) > 0 {
+		entry["includedServers"] = payload.IncludedServers
+	}
+	if len(payload.ExcludedServers) > 0 {
+		entry["excludedServers"] = payload.ExcludedServers
+	}
+
+	return entry
+}
+
+func mergeMcpCatalogSourceConfigs(defaultCatalog models.McpCatalogSourceConfig, userCatalog models.McpCatalogSourceConfig) models.McpCatalogSourceConfig {
+	mergedSource := defaultCatalog
+
+	if userCatalog.Name != "" {
+		mergedSource.Name = userCatalog.Name
+	}
+
+	if userCatalog.Type != "" {
+		mergedSource.Type = userCatalog.Type
+	}
+
+	if userCatalog.Enabled != nil {
+		mergedSource.Enabled = userCatalog.Enabled
+	}
+
+	if userCatalog.IncludedServers != nil {
+		mergedSource.IncludedServers = userCatalog.IncludedServers
+	}
+
+	if userCatalog.ExcludedServers != nil {
+		mergedSource.ExcludedServers = userCatalog.ExcludedServers
+	}
+
+	if userCatalog.Yaml != nil {
+		mergedSource.Yaml = userCatalog.Yaml
+	}
+
+	return mergedSource
+}
+
+func validateMcpCatalogSourceConfigPayload(payload models.McpCatalogSourceConfigPayload) error {
+	if payload.Id == "" {
+		return fmt.Errorf("%w", ErrMcpCatalogSourceIdRequired)
+	}
+
+	if err := validateCatalogId(payload.Id); err != nil {
+		return err
+	}
+
+	if payload.Name == "" {
+		return fmt.Errorf("%w: name is required", ErrMcpCatalogValidationFailed)
+	}
+
+	if payload.Type == "" {
+		return fmt.Errorf("%w: type is required", ErrMcpCatalogValidationFailed)
+	}
+
+	if payload.Type != McpCatalogTypeYaml {
+		return fmt.Errorf("%w: unsupported MCP catalog type: %s (supported: yaml)", ErrMcpCatalogValidationFailed, payload.Type)
+	}
+
+	if payload.Yaml == nil || *payload.Yaml == "" {
+		return fmt.Errorf("%w: yaml field is required for yaml-type sources", ErrMcpCatalogValidationFailed)
+	}
+
+	return nil
+}
+
+func validateMcpUpdatePayloadForDefaultOverride(payload models.McpCatalogSourceConfigPayload) error {
+	if payload.Name != "" {
+		return fmt.Errorf("%w: cannot change 'name'", ErrMcpCatalogCannotChangeDefault)
+	}
+
+	if len(payload.Labels) > 0 {
+		return fmt.Errorf("%w: cannot change 'labels'", ErrMcpCatalogCannotChangeDefault)
+	}
+
+	if payload.Yaml != nil && *payload.Yaml != "" {
+		return fmt.Errorf("%w: cannot change 'yaml' content", ErrMcpCatalogCannotChangeDefault)
+	}
+
+	return nil
+}

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
@@ -154,7 +154,7 @@ func (r *McpCatalogSettingsRepository) CreateMcpCatalogSourceConfig(
 
 	existingConfigMapEntry := userCM.Data[k8s.McpCatalogSourceKey]
 
-	updatedConfigMapEntry, err := AppendCatalogSourceToYaml(existingConfigMapEntry, newEntry)
+	updatedConfigMapEntry, err := AppendMcpCatalogSourceToYaml(existingConfigMapEntry, newEntry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to append MCP catalog to yaml: %w", err)
 	}
@@ -256,7 +256,7 @@ func (r *McpCatalogSettingsRepository) UpdateMcpCatalogSourceConfig(
 		userCM.Data[k8s.McpCatalogSourceKey] = updatedYAML
 	} else {
 		overrideEntry := BuildOverrideEntryForDefaultMcpSource(sourceID, payload)
-		updatedYAML, err := AppendCatalogSourceToYaml(userCM.Data[k8s.McpCatalogSourceKey], overrideEntry)
+		updatedYAML, err := AppendMcpCatalogSourceToYaml(userCM.Data[k8s.McpCatalogSourceKey], overrideEntry)
 		if err != nil {
 			return nil, fmt.Errorf("failed to append override entry: %w", err)
 		}
@@ -299,7 +299,7 @@ func (r *McpCatalogSettingsRepository) DeleteMcpCatalogSourceConfig(
 		delete(userCM.Data, yamlFilePath)
 	}
 
-	updatedYAML, err := RemoveCatalogSourceFromYAML(userCM.Data[k8s.McpCatalogSourceKey], sourceID)
+	updatedYAML, err := RemoveMcpCatalogSourceFromYAML(userCM.Data[k8s.McpCatalogSourceKey], sourceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to remove MCP catalog from sources.yaml: %w", err)
 	}

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
@@ -4,17 +4,23 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
+	"github.com/kubeflow/hub/ui/bff/internal/constants"
 	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
 	"github.com/kubeflow/hub/ui/bff/internal/models"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
-	ErrMcpCatalogSourceNotFound     = errors.New("mcp catalog source not found")
-	ErrMcpCatalogSourceAlreadyExist = errors.New("mcp catalog source already exists")
-	ErrMcpCatalogSourceIdRequired   = errors.New("mcp catalog source ID is required")
-	ErrMcpCatalogSourceConflict     = errors.New("mcp catalog source was modified by another request")
-	ErrMcpCatalogNotImplemented     = errors.New("mcp catalog settings not implemented yet")
+	ErrMcpCatalogSourceNotFound       = errors.New("mcp catalog source not found")
+	ErrMcpCatalogSourceAlreadyExist   = errors.New("mcp catalog source already exists")
+	ErrMcpCatalogSourceIdRequired     = errors.New("mcp catalog source ID is required")
+	ErrMcpCatalogSourceConflict       = errors.New("mcp catalog source was modified by another request")
+	ErrMcpCatalogCannotChangeDefault  = errors.New("cannot change the default MCP source")
+	ErrMcpCatalogCannotDeleteDefault  = errors.New("cannot delete the default MCP source")
+	ErrMcpCatalogValidationFailed     = errors.New("validation failed")
+	ErrMcpCatalogCannotChangeType     = errors.New("cannot change MCP catalog source type")
 )
 
 type McpCatalogSettingsRepository struct {
@@ -24,91 +30,288 @@ func NewMcpCatalogSettingsRepository() *McpCatalogSettingsRepository {
 	return &McpCatalogSettingsRepository{}
 }
 
-func (r *McpCatalogSettingsRepository) GetAllMcpCatalogSourceConfigs(_ context.Context, _ k8s.KubernetesClientInterface, _ string) (*models.McpCatalogSourceConfigList, error) {
-	enabled := true
-	disabled := false
-	isDefault := true
-	communityYamlPath := "community-mcp-servers.yaml"
-	orgYaml := "source: organization_mcp_servers\nmcp_servers:\n  - name: Elasticsearch MCP Server\n    description: Search and analyze data in Elasticsearch clusters\n  - name: Dynatrace MCP Server\n    description: Access Dynatrace observability data and perform actions\n  - name: PostgreSQL MCP Server\n    description: Query and manage PostgreSQL databases\n  - name: Redis MCP Server\n    description: Manage Redis key-value stores, caches and pub/sub channels\n"
-	standaloneYaml := "source: other\nmcp_servers:\n  - name: Standalone MCP Server\n    description: MCP server with no category, available for use\n"
-	disabledYaml := "source: disabled_servers\nmcp_servers:\n  - name: Experimental MCP Server\n    description: Experimental server for testing\n"
-	return &models.McpCatalogSourceConfigList{
-		Catalogs: []models.McpCatalogSourceConfig{
-			{
-				Id:              "community-mcp-source",
-				Name:            "Community MCP Servers",
-				Type:            "yaml",
-				Enabled:         &enabled,
-				Labels:          []string{"community_mcp_servers"},
-				IsDefault:       &isDefault,
-				YamlCatalogPath: &communityYamlPath,
-			},
-			{
-				Id:      "organization-mcp-source",
-				Name:    "Organization MCP Servers",
-				Type:    "yaml",
-				Enabled: &enabled,
-				Labels:  []string{"organization_mcp_servers"},
-				Yaml:    &orgYaml,
-			},
-			{
-				Id:      "standalone-mcp-source",
-				Name:    "Other MCP Servers",
-				Type:    "yaml",
-				Enabled: &enabled,
-				Labels:  []string{},
-				Yaml:    &standaloneYaml,
-			},
-			{
-				Id:      "disabled-mcp-source",
-				Name:    "Disabled MCP source",
-				Type:    "yaml",
-				Enabled: &disabled,
-				Labels:  []string{"disabled_servers"},
-				Yaml:    &disabledYaml,
-			},
-		},
-	}, nil
+func (r *McpCatalogSettingsRepository) GetAllMcpCatalogSourceConfigs(ctx context.Context, client k8s.KubernetesClientInterface, namespace string) (*models.McpCatalogSourceConfigList, error) {
+	defaultCM, userCM, err := client.GetAllMcpCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch MCP catalog source configmaps: %w", err)
+	}
+
+	catalogMap := make(map[string]models.McpCatalogSourceConfig)
+
+	if raw, ok := defaultCM.Data[k8s.McpCatalogSourceKey]; ok {
+		defaultCatalogSources, err := ParseMcpCatalogYaml(raw, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse default MCP catalogs: %w", err)
+		}
+		for _, catalog := range defaultCatalogSources {
+			catalogMap[catalog.Id] = catalog
+		}
+	}
+
+	if raw, ok := userCM.Data[k8s.McpCatalogSourceKey]; ok {
+		userManagedSources, err := ParseMcpCatalogYaml(raw, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse user managed MCP catalogs: %w", err)
+		}
+		for _, userCatalogSource := range userManagedSources {
+			if existingSource, exist := catalogMap[userCatalogSource.Id]; exist {
+				mergedCatalogSources := mergeMcpCatalogSourceConfigs(existingSource, userCatalogSource)
+				catalogMap[userCatalogSource.Id] = mergedCatalogSources
+			} else {
+				catalogMap[userCatalogSource.Id] = userCatalogSource
+			}
+		}
+	}
+
+	catalogSources := &models.McpCatalogSourceConfigList{
+		Catalogs: make([]models.McpCatalogSourceConfig, 0),
+	}
+
+	for _, c := range catalogMap {
+		catalogSources.Catalogs = append(catalogSources.Catalogs, c)
+	}
+
+	return catalogSources, nil
 }
 
 func (r *McpCatalogSettingsRepository) GetMcpCatalogSourceConfig(ctx context.Context, client k8s.KubernetesClientInterface, namespace string, sourceID string) (*models.McpCatalogSourceConfig, error) {
-	all, err := r.GetAllMcpCatalogSourceConfigs(ctx, client, namespace)
+	defaultCM, userCM, err := client.GetAllMcpCatalogSourceConfigs(ctx, namespace)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fetch MCP catalog source configmaps: %w", err)
 	}
-	for i := range all.Catalogs {
-		if all.Catalogs[i].Id == sourceID {
-			return &all.Catalogs[i], nil
+
+	defaultSource := FindMcpCatalogSourceById(defaultCM.Data[k8s.McpCatalogSourceKey], sourceID, true)
+	userSource := FindMcpCatalogSourceById(userCM.Data[k8s.McpCatalogSourceKey], sourceID, false)
+
+	var result *models.McpCatalogSourceConfig
+
+	if userSource != nil {
+		if defaultSource != nil {
+			merged := mergeMcpCatalogSourceConfigs(*defaultSource, *userSource)
+			result = &merged
+		} else {
+			result = userSource
+		}
+	} else if defaultSource != nil {
+		result = defaultSource
+	} else {
+		return nil, fmt.Errorf("%w, %s", ErrMcpCatalogSourceNotFound, sourceID)
+	}
+
+	yamlFilePath := FindMcpCatalogSourceProperties(userCM.Data[k8s.McpCatalogSourceKey], sourceID)
+	if yamlFilePath == "" {
+		yamlFilePath = FindMcpCatalogSourceProperties(defaultCM.Data[k8s.McpCatalogSourceKey], sourceID)
+	}
+
+	if result.Type == McpCatalogTypeYaml {
+		if yamlFilePath != "" {
+			result.YamlCatalogPath = &yamlFilePath
+			if yamlContent, ok := userCM.Data[yamlFilePath]; ok {
+				result.Yaml = &yamlContent
+			} else if yamlContent, ok := defaultCM.Data[yamlFilePath]; ok {
+				result.Yaml = &yamlContent
+			} else if result.IsDefault == nil || !*result.IsDefault {
+				sessionLogger := ctx.Value(constants.TraceLoggerKey).(*slog.Logger)
+				sessionLogger.Warn("MCP yaml catalog content missing from configmap",
+					"catalogId", sourceID,
+					"expectedPath", yamlFilePath,
+				)
+			}
 		}
 	}
-	return nil, fmt.Errorf("%w: %s", ErrMcpCatalogSourceNotFound, sourceID)
+
+	return result, nil
 }
 
-func (r *McpCatalogSettingsRepository) CreateMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, payload models.McpCatalogSourceConfigPayload) (*models.McpCatalogSourceConfig, error) {
-	if payload.Id == "" {
-		return nil, ErrMcpCatalogSourceIdRequired
+func (r *McpCatalogSettingsRepository) CreateMcpCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	payload models.McpCatalogSourceConfigPayload,
+) (*models.McpCatalogSourceConfig, error) {
+	if err := validateMcpCatalogSourceConfigPayload(payload); err != nil {
+		return nil, err
 	}
-	enabled := true
-	return &models.McpCatalogSourceConfig{
-		Id:      payload.Id,
-		Name:    payload.Name,
-		Type:    payload.Type,
-		Enabled: &enabled,
-		Labels:  payload.Labels,
-	}, nil
+
+	defaultCM, userCM, err := client.GetAllMcpCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch MCP catalog source configmaps: %w", err)
+	}
+
+	if FindMcpCatalogSourceById(defaultCM.Data[k8s.McpCatalogSourceKey], payload.Id, true) != nil {
+		return nil, fmt.Errorf("%w: '%s' already exists in default sources", ErrMcpCatalogSourceAlreadyExist, payload.Id)
+	}
+
+	if FindMcpCatalogSourceById(userCM.Data[k8s.McpCatalogSourceKey], payload.Id, false) != nil {
+		return nil, fmt.Errorf("%w: '%s' already exists in user managed sources", ErrMcpCatalogSourceAlreadyExist, payload.Id)
+	}
+
+	yamlFileName := fmt.Sprintf("%s.yaml", payload.Id)
+	yamlContent := make(map[string]string)
+	yamlContent[yamlFileName] = *payload.Yaml
+
+	newEntry := ConvertMcpSourceConfigToYamlEntry(payload, yamlFileName)
+
+	existingConfigMapEntry := userCM.Data[k8s.McpCatalogSourceKey]
+
+	updatedConfigMapEntry, err := AppendCatalogSourceToYaml(existingConfigMapEntry, newEntry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to append MCP catalog to yaml: %w", err)
+	}
+
+	if userCM.Data == nil {
+		userCM.Data = make(map[string]string)
+	}
+	userCM.Data[k8s.McpCatalogSourceKey] = updatedConfigMapEntry
+
+	for key, value := range yamlContent {
+		userCM.Data[key] = value
+	}
+
+	err = client.UpdateMcpCatalogSourceConfig(ctx, namespace, &userCM)
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrMcpCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update user MCP configmap: %w", err)
+	}
+
+	return r.GetMcpCatalogSourceConfig(ctx, client, namespace, payload.Id)
 }
 
-func (r *McpCatalogSettingsRepository) UpdateMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, sourceID string, payload models.McpCatalogSourceConfigPayload) (*models.McpCatalogSourceConfig, error) {
-	enabled := true
-	return &models.McpCatalogSourceConfig{
-		Id:      sourceID,
-		Name:    payload.Name,
-		Type:    payload.Type,
-		Enabled: &enabled,
-		Labels:  payload.Labels,
-	}, nil
+func (r *McpCatalogSettingsRepository) UpdateMcpCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	sourceID string,
+	payload models.McpCatalogSourceConfigPayload,
+) (*models.McpCatalogSourceConfig, error) {
+	defaultCM, userCM, err := client.GetAllMcpCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch MCP catalog source configmaps: %w", err)
+	}
+
+	existingUserSource := FindMcpCatalogSourceById(userCM.Data[k8s.McpCatalogSourceKey], sourceID, false)
+	existingDefaultSource := FindMcpCatalogSourceById(defaultCM.Data[k8s.McpCatalogSourceKey], sourceID, true)
+
+	var existingCatalog *models.McpCatalogSourceConfig
+	var isOverridingDefault bool
+
+	if existingUserSource != nil {
+		existingCatalog = existingUserSource
+		isOverridingDefault = existingDefaultSource != nil
+	} else if existingDefaultSource != nil {
+		existingCatalog = existingDefaultSource
+		isOverridingDefault = true
+	} else {
+		return nil, fmt.Errorf("%w: '%s'", ErrMcpCatalogSourceNotFound, sourceID)
+	}
+
+	if payload.Type != "" && payload.Type != existingCatalog.Type {
+		return nil, fmt.Errorf(
+			"%w: cannot change from '%s' to '%s'",
+			ErrMcpCatalogCannotChangeType,
+			existingCatalog.Type,
+			payload.Type,
+		)
+	}
+
+	if isOverridingDefault {
+		if err := validateMcpUpdatePayloadForDefaultOverride(payload); err != nil {
+			return nil, err
+		}
+	}
+
+	var yamlFilePath string
+	if !isOverridingDefault || existingUserSource != nil {
+		yamlFilePath = FindMcpCatalogSourceProperties(userCM.Data[k8s.McpCatalogSourceKey], sourceID)
+		if yamlFilePath == "" {
+			yamlFilePath = FindMcpCatalogSourceProperties(defaultCM.Data[k8s.McpCatalogSourceKey], sourceID)
+		}
+	}
+
+	if userCM.Data == nil {
+		userCM.Data = make(map[string]string)
+	}
+
+	if !isOverridingDefault || existingUserSource != nil {
+		if payload.Yaml != nil && *payload.Yaml != "" {
+			if yamlFilePath == "" {
+				yamlFilePath = fmt.Sprintf("%s.yaml", sourceID)
+			}
+			userCM.Data[yamlFilePath] = *payload.Yaml
+		}
+	}
+
+	if existingUserSource != nil {
+		updatedYAML, err := UpdateMcpCatalogSourceInYAML(
+			userCM.Data[k8s.McpCatalogSourceKey],
+			sourceID,
+			payload,
+			yamlFilePath,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update MCP catalog in yaml: %w", err)
+		}
+		userCM.Data[k8s.McpCatalogSourceKey] = updatedYAML
+	} else {
+		overrideEntry := BuildOverrideEntryForDefaultMcpSource(sourceID, payload)
+		updatedYAML, err := AppendCatalogSourceToYaml(userCM.Data[k8s.McpCatalogSourceKey], overrideEntry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to append override entry: %w", err)
+		}
+		userCM.Data[k8s.McpCatalogSourceKey] = updatedYAML
+	}
+
+	err = client.UpdateMcpCatalogSourceConfig(ctx, namespace, &userCM)
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrMcpCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update user MCP configmap: %w", err)
+	}
+
+	return r.GetMcpCatalogSourceConfig(ctx, client, namespace, sourceID)
 }
 
-func (r *McpCatalogSettingsRepository) DeleteMcpCatalogSourceConfig(_ context.Context, _ k8s.KubernetesClientInterface, _ string, _ string) (*models.McpCatalogSourceConfig, error) {
-	return nil, nil
+func (r *McpCatalogSettingsRepository) DeleteMcpCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	sourceID string,
+) (*models.McpCatalogSourceConfig, error) {
+	defaultCM, userCM, err := client.GetAllMcpCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch MCP catalog source configmaps: %w", err)
+	}
+
+	if FindMcpCatalogSourceById(defaultCM.Data[k8s.McpCatalogSourceKey], sourceID, true) != nil {
+		return nil, fmt.Errorf("%w: '%s' is a default source", ErrMcpCatalogCannotDeleteDefault, sourceID)
+	}
+
+	catalogSourceToDelete := FindMcpCatalogSourceById(userCM.Data[k8s.McpCatalogSourceKey], sourceID, false)
+	if catalogSourceToDelete == nil {
+		return nil, fmt.Errorf("%w: '%s' not found in user sources", ErrMcpCatalogSourceNotFound, sourceID)
+	}
+
+	yamlFilePath := FindMcpCatalogSourceProperties(userCM.Data[k8s.McpCatalogSourceKey], sourceID)
+	if catalogSourceToDelete.Type == McpCatalogTypeYaml && yamlFilePath != "" {
+		delete(userCM.Data, yamlFilePath)
+	}
+
+	updatedYAML, err := RemoveCatalogSourceFromYAML(userCM.Data[k8s.McpCatalogSourceKey], sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove MCP catalog from sources.yaml: %w", err)
+	}
+	userCM.Data[k8s.McpCatalogSourceKey] = updatedYAML
+
+	err = client.UpdateMcpCatalogSourceConfig(ctx, namespace, &userCM)
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrMcpCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update configmap after deletion: %w", err)
+	}
+
+	return catalogSourceToDelete, nil
 }

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings.go
@@ -13,14 +13,14 @@ import (
 )
 
 var (
-	ErrMcpCatalogSourceNotFound       = errors.New("mcp catalog source not found")
-	ErrMcpCatalogSourceAlreadyExist   = errors.New("mcp catalog source already exists")
-	ErrMcpCatalogSourceIdRequired     = errors.New("mcp catalog source ID is required")
-	ErrMcpCatalogSourceConflict       = errors.New("mcp catalog source was modified by another request")
-	ErrMcpCatalogCannotChangeDefault  = errors.New("cannot change the default MCP source")
-	ErrMcpCatalogCannotDeleteDefault  = errors.New("cannot delete the default MCP source")
-	ErrMcpCatalogValidationFailed     = errors.New("validation failed")
-	ErrMcpCatalogCannotChangeType     = errors.New("cannot change MCP catalog source type")
+	ErrMcpCatalogSourceNotFound      = errors.New("mcp catalog source not found")
+	ErrMcpCatalogSourceAlreadyExist  = errors.New("mcp catalog source already exists")
+	ErrMcpCatalogSourceIdRequired    = errors.New("mcp catalog source ID is required")
+	ErrMcpCatalogSourceConflict      = errors.New("mcp catalog source was modified by another request")
+	ErrMcpCatalogCannotChangeDefault = errors.New("cannot change the default MCP source")
+	ErrMcpCatalogCannotDeleteDefault = errors.New("cannot delete the default MCP source")
+	ErrMcpCatalogValidationFailed    = errors.New("validation failed")
+	ErrMcpCatalogCannotChangeType    = errors.New("cannot change MCP catalog source type")
 )
 
 type McpCatalogSettingsRepository struct {

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings_test.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings_test.go
@@ -46,6 +46,27 @@ var _ = Describe("McpCatalogSettingsRepository", func() {
 			Expect(defaultCatalog).NotTo(BeNil())
 			Expect(*defaultCatalog.IsDefault).To(BeTrue())
 		})
+
+		It("should merge, if user overrides the default source", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Enabled: mcpBoolPtr(false),
+			}
+			_, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			catalogs, err := repo.GetAllMcpCatalogSourceConfigs(ctx, k8sClient, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			var mergedCatalog *models.McpCatalogSourceConfig
+			for _, c := range catalogs.Catalogs {
+				if c.Id == "community_mcp_servers" {
+					mergedCatalog = &c
+					break
+				}
+			}
+			Expect(mergedCatalog).NotTo(BeNil())
+			Expect(*mergedCatalog.Enabled).To(BeFalse())
+			Expect(mergedCatalog.Name).To(Equal("Community MCP Servers"))
+		})
 	})
 
 	Describe("GetMcpCatalogSourceConfig", func() {
@@ -69,6 +90,20 @@ var _ = Describe("McpCatalogSettingsRepository", func() {
 			catalog, err := repo.GetMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_mcp_servers")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*catalog.IsDefault).To(BeFalse())
+		})
+
+		It("should return merged data for user override default source config", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Enabled: mcpBoolPtr(false),
+			}
+			_, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			catalog, err := repo.GetMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(catalog.Name).To(Equal("Community MCP Servers"))
+			Expect(*catalog.IsDefault).To(BeTrue())
+			Expect(*catalog.Enabled).To(BeFalse())
 		})
 	})
 
@@ -202,6 +237,30 @@ var _ = Describe("McpCatalogSettingsRepository", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid catalog ID"))
 		})
+
+		It("should reject catalog ID with path traversal attempt", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:   "../../../etc/passwd",
+				Name: "Malicious",
+				Type: "yaml",
+				Yaml: mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid catalog ID"))
+		})
+
+		It("should reject catalog ID with forward slash", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:   "test/malicious",
+				Name: "Malicious",
+				Type: "yaml",
+				Yaml: mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid catalog ID"))
+		})
 	})
 
 	Describe("UpdateMcpCatalogSourceConfig", func() {
@@ -278,6 +337,15 @@ var _ = Describe("McpCatalogSettingsRepository", func() {
 			Expect(result.IncludedServers).To(ConsistOf("server-a", "server-b"))
 		})
 
+		It("should allow updating excludedServers on default catalog", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				ExcludedServers: []string{"blocked-*"},
+			}
+			result, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers", payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.ExcludedServers).To(ConsistOf("blocked-*"))
+		})
+
 		It("should allow updating default twice", func() {
 			payload1 := models.McpCatalogSourceConfigPayload{
 				Enabled: mcpBoolPtr(false),
@@ -293,6 +361,54 @@ var _ = Describe("McpCatalogSettingsRepository", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*result.Enabled).To(BeTrue())
 			Expect(result.IncludedServers).To(ConsistOf("updated-server"))
+		})
+
+		It("should clear includedServers when empty array is provided", func() {
+			initialPayload := models.McpCatalogSourceConfigPayload{
+				Id:              "test_clear_mcp_servers",
+				Name:            "Test Clear MCP Servers",
+				Type:            "yaml",
+				IncludedServers: []string{"server-*"},
+				ExcludedServers: []string{"old-*"},
+				Yaml:            mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", initialPayload)
+			Expect(err).NotTo(HaveOccurred())
+
+			emptyServers := []string{}
+			updatePayload := models.McpCatalogSourceConfigPayload{
+				IncludedServers: emptyServers,
+				ExcludedServers: []string{"*"},
+			}
+
+			result, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "test_clear_mcp_servers", updatePayload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IncludedServers).To(BeEmpty())
+			Expect(result.ExcludedServers).To(Equal([]string{"*"}))
+		})
+
+		It("should clear excludedServers when empty array is provided", func() {
+			initialPayload := models.McpCatalogSourceConfigPayload{
+				Id:              "test_clear_excluded_mcp_servers",
+				Name:            "Test Clear Excluded MCP Servers",
+				Type:            "yaml",
+				IncludedServers: []string{"server-*"},
+				ExcludedServers: []string{"old-*"},
+				Yaml:            mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", initialPayload)
+			Expect(err).NotTo(HaveOccurred())
+
+			emptyServers := []string{}
+			updatePayload := models.McpCatalogSourceConfigPayload{
+				IncludedServers: []string{"*"},
+				ExcludedServers: emptyServers,
+			}
+
+			result, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "test_clear_excluded_mcp_servers", updatePayload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.ExcludedServers).To(BeEmpty())
+			Expect(result.IncludedServers).To(Equal([]string{"*"}))
 		})
 
 		It("should return conflict error when concurrent updates occur with stale resourceVersion", func() {

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings_test.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings_test.go
@@ -441,7 +441,7 @@ var _ = Describe("McpCatalogSettingsRepository", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cmAfterA.ResourceVersion).NotTo(Equal(resourceVersionA))
 
-			cmB.Data[k8s.McpCatalogSourceKey] = "catalogs:\n  - id: mcp_concurrency_test\n    name: Updated by Request B\n    type: yaml\n    enabled: true"
+			cmB.Data[k8s.McpCatalogSourceKey] = "mcp_catalogs:\n  - id: mcp_concurrency_test\n    name: Updated by Request B\n    type: yaml\n    enabled: true"
 			err = k8sClient.UpdateMcpCatalogSourceConfig(ctx, "kubeflow", &cmB)
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsConflict(err)).To(BeTrue(), "Expected conflict error due to stale resourceVersion, got: %v", err)

--- a/clients/ui/bff/internal/repositories/mcp_catalog_settings_test.go
+++ b/clients/ui/bff/internal/repositories/mcp_catalog_settings_test.go
@@ -1,0 +1,372 @@
+package repositories
+
+import (
+	"context"
+
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/mocks"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var _ = Describe("McpCatalogSettingsRepository", func() {
+	var (
+		repo      *McpCatalogSettingsRepository
+		k8sClient k8s.KubernetesClientInterface
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		repo = NewMcpCatalogSettingsRepository()
+		var err error
+		k8sClient, err = kubernetesMockedStaticClientFactory.GetClient(mocks.NewMockSessionContextNoParent())
+		Expect(err).NotTo(HaveOccurred())
+		ctx = mocks.NewMockSessionContextNoParent()
+	})
+
+	Describe("GetAllMcpCatalogSourceConfigs", func() {
+		It("should return merged source config from both default and user managed configMap", func() {
+			catalogs, err := repo.GetAllMcpCatalogSourceConfigs(ctx, k8sClient, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(catalogs.Catalogs).NotTo(BeEmpty())
+		})
+
+		It("default catalog should have isDefault=true", func() {
+			catalogs, err := repo.GetAllMcpCatalogSourceConfigs(ctx, k8sClient, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			var defaultCatalog *models.McpCatalogSourceConfig
+			for _, c := range catalogs.Catalogs {
+				if c.Id == "community_mcp_servers" {
+					defaultCatalog = &c
+					break
+				}
+			}
+			Expect(defaultCatalog).NotTo(BeNil())
+			Expect(*defaultCatalog.IsDefault).To(BeTrue())
+		})
+	})
+
+	Describe("GetMcpCatalogSourceConfig", func() {
+		It("should return Yaml content and YamlCatalogPath for yaml type source config", func() {
+			catalog, err := repo.GetMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(catalog.Type).To(Equal("yaml"))
+			Expect(catalog.Yaml).NotTo(BeNil())
+			Expect(*catalog.Yaml).NotTo(BeEmpty())
+			Expect(catalog.YamlCatalogPath).NotTo(BeNil())
+			Expect(*catalog.YamlCatalogPath).To(Equal("community_mcp_servers.yaml"))
+		})
+
+		It("should return error if the source config doesn't exist", func() {
+			_, err := repo.GetMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "does_not_exist")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("should return isDefault=false for user managed source", func() {
+			catalog, err := repo.GetMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_mcp_servers")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*catalog.IsDefault).To(BeFalse())
+		})
+	})
+
+	Describe("CreateMcpCatalogSourceConfig", func() {
+		It("should fail when id is missing", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Name:    "Test",
+				Type:    "yaml",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mcp catalog source ID is required"))
+		})
+
+		It("should fail when name is missing", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:      "test",
+				Type:    "yaml",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("name is required"))
+		})
+
+		It("should fail when type is missing", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:      "test_id",
+				Name:    "Test",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("type is required"))
+		})
+
+		It("should fail when yaml is missing for yaml type source config", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:      "test_id",
+				Name:    "Test",
+				Type:    "yaml",
+				Enabled: mcpBoolPtr(true),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("yaml field is required"))
+		})
+
+		It("should fail for unsupported type", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:      "test_id",
+				Name:    "Test",
+				Type:    "invalid-type",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported MCP catalog type"))
+		})
+
+		It("should fail when id already exists in user sources", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:      "custom_mcp_servers",
+				Name:    "Duplicate",
+				Type:    "yaml",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already exists"))
+		})
+
+		It("should fail when id matches a default source", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:      "community_mcp_servers",
+				Name:    "Duplicate Default",
+				Type:    "yaml",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already exists in default"))
+		})
+
+		It("should create yaml type source successfully", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:      "test_mcp_yaml_create",
+				Name:    "Test MCP YAML Create",
+				Type:    "yaml",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers:\n  - name: test"),
+				Labels:  []string{"test"},
+			}
+			result, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Id).To(Equal("test_mcp_yaml_create"))
+			Expect(*result.IsDefault).To(BeFalse())
+		})
+
+		It("should create source with includedServers and excludedServers", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:              "test_mcp_with_filters",
+				Name:            "Test MCP With Filters",
+				Type:            "yaml",
+				Enabled:         mcpBoolPtr(true),
+				Yaml:            mcpStringPtr("servers: []"),
+				IncludedServers: []string{"server-*"},
+				ExcludedServers: []string{"test-*"},
+			}
+			result, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IncludedServers).To(ConsistOf("server-*"))
+			Expect(result.ExcludedServers).To(ConsistOf("test-*"))
+		})
+
+		It("should reject catalog ID with special characters", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Id:   "test@#$%",
+				Name: "Special",
+				Type: "yaml",
+				Yaml: mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid catalog ID"))
+		})
+	})
+
+	Describe("UpdateMcpCatalogSourceConfig", func() {
+		It("should fail if source does not exist", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Enabled: mcpBoolPtr(false),
+			}
+			_, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "does_not_exist", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("should fail when trying to update the source type", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Type: "hf",
+			}
+			_, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_mcp_servers", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot change"))
+		})
+
+		It("should fail when updating the name of the default source config", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Name: "Changed Name",
+			}
+			_, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot change"))
+		})
+
+		It("should fail when updating the labels of default source config", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Labels: []string{"new-label"},
+			}
+			_, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot change"))
+		})
+
+		It("should fail when updating the yaml of the default source config", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Yaml: mcpStringPtr("new content"),
+			}
+			_, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers", payload)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot change"))
+		})
+
+		It("should update the user managed source config successfully", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Name:    "Updated Name",
+				Enabled: mcpBoolPtr(false),
+			}
+			result, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_mcp_servers", payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Name).To(Equal("Updated Name"))
+		})
+
+		It("should override the enabled property of default source config in user managed configMap", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				Enabled: mcpBoolPtr(false),
+			}
+			result, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers", payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*result.Enabled).To(BeFalse())
+		})
+
+		It("should allow updating includedServers on default catalog", func() {
+			payload := models.McpCatalogSourceConfigPayload{
+				IncludedServers: []string{"server-a", "server-b"},
+			}
+			result, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers", payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IncludedServers).To(ConsistOf("server-a", "server-b"))
+		})
+
+		It("should allow updating default twice", func() {
+			payload1 := models.McpCatalogSourceConfigPayload{
+				Enabled: mcpBoolPtr(false),
+			}
+			_, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "verified_mcp_servers", payload1)
+			Expect(err).NotTo(HaveOccurred())
+
+			payload2 := models.McpCatalogSourceConfigPayload{
+				Enabled:         mcpBoolPtr(true),
+				IncludedServers: []string{"updated-server"},
+			}
+			result, err := repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "verified_mcp_servers", payload2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*result.Enabled).To(BeTrue())
+			Expect(result.IncludedServers).To(ConsistOf("updated-server"))
+		})
+
+		It("should return conflict error when concurrent updates occur with stale resourceVersion", func() {
+			createPayload := models.McpCatalogSourceConfigPayload{
+				Id:      "mcp_concurrency_test",
+				Name:    "MCP Concurrency Test",
+				Type:    "yaml",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", createPayload)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, cmA, err := k8sClient.GetAllMcpCatalogSourceConfigs(ctx, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			resourceVersionA := cmA.ResourceVersion
+			Expect(resourceVersionA).NotTo(BeEmpty())
+
+			_, cmB, err := k8sClient.GetAllMcpCatalogSourceConfigs(ctx, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cmB.ResourceVersion).To(Equal(resourceVersionA))
+
+			payloadA := models.McpCatalogSourceConfigPayload{
+				Name: "Updated by Request A",
+			}
+			_, err = repo.UpdateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "mcp_concurrency_test", payloadA)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, cmAfterA, err := k8sClient.GetAllMcpCatalogSourceConfigs(ctx, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cmAfterA.ResourceVersion).NotTo(Equal(resourceVersionA))
+
+			cmB.Data[k8s.McpCatalogSourceKey] = "catalogs:\n  - id: mcp_concurrency_test\n    name: Updated by Request B\n    type: yaml\n    enabled: true"
+			err = k8sClient.UpdateMcpCatalogSourceConfig(ctx, "kubeflow", &cmB)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsConflict(err)).To(BeTrue(), "Expected conflict error due to stale resourceVersion, got: %v", err)
+		})
+	})
+
+	Describe("DeleteMcpCatalogSourceConfig", func() {
+		It("should fail when deleting default catalog", func() {
+			_, err := repo.DeleteMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_mcp_servers")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot delete the default MCP source: 'community_mcp_servers' is a default source"))
+		})
+
+		It("should fail when the source config does not exist in catalog", func() {
+			_, err := repo.DeleteMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "totally_fake_id")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("should delete user yaml source successfully", func() {
+			createPayload := models.McpCatalogSourceConfigPayload{
+				Id:      "delete_test_mcp",
+				Name:    "Delete MCP Test",
+				Type:    "yaml",
+				Enabled: mcpBoolPtr(true),
+				Yaml:    mcpStringPtr("servers: []"),
+			}
+			_, err := repo.CreateMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", createPayload)
+			Expect(err).NotTo(HaveOccurred())
+
+			deleted, err := repo.DeleteMcpCatalogSourceConfig(ctx, k8sClient, "kubeflow", "delete_test_mcp")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted.Id).To(Equal("delete_test_mcp"))
+		})
+	})
+})
+
+func mcpBoolPtr(b bool) *bool {
+	return &b
+}
+
+func mcpStringPtr(s string) *string {
+	return &s
+}

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
@@ -168,6 +168,14 @@ func (f *fakeKubernetesClient) UpdateCatalogSourceConfig(ctx context.Context, na
 	return nil
 }
 
+func (f *fakeKubernetesClient) GetAllMcpCatalogSourceConfigs(ctx context.Context, namespace string) (corev1.ConfigMap, corev1.ConfigMap, error) {
+	return corev1.ConfigMap{}, corev1.ConfigMap{}, nil
+}
+
+func (f *fakeKubernetesClient) UpdateMcpCatalogSourceConfig(ctx context.Context, namespace string, configMap *corev1.ConfigMap) error {
+	return nil
+}
+
 func (f *fakeKubernetesClient) CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret) (*corev1.Secret, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Description

Replace the stub `McpCatalogSettingsRepository` with a real implementation that persists MCP catalog source configurations to Kubernetes ConfigMaps (`default-mcp-catalog-sources` / `mcp-catalog-sources`), mirroring the existing model catalog settings pattern.

### Changes

- Add MCP-specific ConfigMap constants (`McpCatalogSourceDefaultConfigMapName`, `McpCatalogSourceUserConfigMapName`) and K8s client interface methods (`GetAllMcpCatalogSourceConfigs`, `UpdateMcpCatalogSourceConfig`)
- Implement the new methods in `SharedClientLogic` (fetches default + user ConfigMaps, tolerates missing user CM)
- Create MCP YAML parsing helpers (`ParseMcpCatalogYaml`, `FindMcpCatalogSourceById`, `ConvertMcpSourceConfigToYamlEntry`, `UpdateMcpCatalogSourceInYAML`, etc.)
- Full repository CRUD with:
  - Merge logic for default + user sources
  - Payload validation (id format, required fields, yaml content)
  - Conflict detection via resourceVersion
  - Default source protection (cannot delete; restricted field updates)
- Update handler error mapping for new validation/forbidden/conflict errors
- Add envtest ConfigMap fixtures for MCP catalog sources
- Comprehensive Ginkgo test suite covering all CRUD operations and edge cases

## How Has This Been Tested?

- All 90 repository-level unit tests pass (`go test ./internal/repositories/ -count=1`)
- `go build ./...` and `go vet ./...` pass cleanly
- Tests use envtest with real K8s API server to verify ConfigMap CRUD, merge logic, conflict detection, and validation

## Test Impact

New test file `mcp_catalog_settings_test.go` covers:
- GetAll (merged default + user sources, isDefault flag)
- Get by ID (yaml content resolution, not-found error, isDefault)
- Create (validation: missing id/name/type/yaml, unsupported type, duplicate id, special characters; success with labels and server filters)
- Update (not-found, type change rejected, default source protections for name/labels/yaml, user source update, default override, concurrent conflict detection)
- Delete (default source protection, not-found, successful delete with yaml cleanup)

## Merge criteria:

- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

- [x] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.