### PR TITLE
fix(catalog): query source-prefixed Context.name for agent name filter

### DIFF
--- a/catalog/internal/catalog/agentcatalog/service/agent.go
+++ b/catalog/internal/catalog/agentcatalog/service/agent.go
@@ -154,7 +154,7 @@ func applyAgentListFilters(query *gorm.DB, listOptions *models.AgentListOptions)
 	contextTable := utils.GetTableName(query.Statement.DB, &schema.Context{})
 
 	if listOptions.Name != nil {
-		query = query.Where(fmt.Sprintf("%s.name LIKE ?", contextTable), listOptions.Name)
+		query = query.Where(fmt.Sprintf("%s.name LIKE ?", contextTable), fmt.Sprintf("%%:%s", *listOptions.Name))
 	}
 
 	if listOptions.Query != nil && *listOptions.Query != "" {

--- a/catalog/internal/catalog/agentcatalog/service/agent_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/agent_test.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/models"
+	dbmodels "github.com/kubeflow/hub/internal/platform/db/entity"
+	"github.com/kubeflow/hub/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentRepository(t *testing.T) {
+	sharedDB, cleanup := testutils.SetupPostgresWithMigrations(t, testDatastoreSpec())
+	defer cleanup()
+
+	typeID := getAgentTypeID(t, sharedDB)
+	repo := NewAgentRepository(sharedDB, typeID)
+
+	t.Run("TestList_FilterByName", func(t *testing.T) {
+		// Create agents with source-prefixed names (as the loader does: sourceID:agentName)
+		agents := []struct {
+			contextName string
+			framework   string
+		}{
+			{"test-source:langgraph-react-agent", "langgraph"},
+			{"test-source:langgraph-agentic-rag", "langgraph"},
+			{"test-source:crewai-websearch-agent", "crewai"},
+		}
+
+		for _, agent := range agents {
+			_, err := repo.Save(&models.AgentImpl{
+				Attributes: &models.AgentAttributes{
+					Name: &agent.contextName,
+				},
+				Properties: &[]dbmodels.Properties{
+					{
+						Name:        "source_id",
+						StringValue: new("test-source"),
+					},
+					{
+						Name:        "framework",
+						StringValue: &agent.framework,
+					},
+				},
+			})
+			require.NoError(t, err)
+		}
+
+		// Filter by name with wildcard — should match via %:pattern
+		nameFilter := "langgraph%"
+		result, err := repo.List(&models.AgentListOptions{
+			Name: &nameFilter,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(result.Items), "Expected 2 langgraph agents")
+		for _, item := range result.Items {
+			assert.Contains(t, *item.GetAttributes().Name, "langgraph")
+		}
+
+		// Exact name match
+		exactFilter := "crewai-websearch-agent"
+		exactResult, err := repo.List(&models.AgentListOptions{
+			Name: &exactFilter,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(exactResult.Items), "Expected 1 crewai agent")
+
+		// No match
+		noMatchFilter := "nonexistent%"
+		noMatchResult, err := repo.List(&models.AgentListOptions{
+			Name: &noMatchFilter,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(noMatchResult.Items), "Expected 0 agents for nonexistent name")
+	})
+}

--- a/catalog/internal/catalog/agentcatalog/service/test_helpers_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/test_helpers_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/kubeflow/hub/internal/platform/datastore"
+	"github.com/kubeflow/hub/internal/platform/db/schema"
+	"github.com/kubeflow/hub/internal/testutils"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutils.TestMainPostgresHelper(m))
+}
+
+const testAgentTypeName = "kf.Agent"
+
+func testDatastoreSpec() *datastore.Spec {
+	return datastore.NewSpec().
+		AddContext(testAgentTypeName, datastore.NewSpecType(NewAgentRepository).
+			AddString("source_id").
+			AddString("displayName").
+			AddString("description").
+			AddString("readme").
+			AddString("framework").
+			AddStruct("labels").
+			AddString("logo").
+			AddString("repositoryUrl").
+			AddStruct("env").
+			AddStruct("artifacts"),
+		)
+}
+
+func getAgentTypeID(t *testing.T, db *gorm.DB) int32 {
+	var typeRecord schema.Type
+	err := db.Where("name = ?", testAgentTypeName).First(&typeRecord).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			typeRecord = schema.Type{
+				Name: testAgentTypeName,
+			}
+			err = db.Create(&typeRecord).Error
+			require.NoError(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+	return typeRecord.ID
+}


### PR DESCRIPTION
Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
  The name query parameter on GET /agents used Context.name directly,
  but agent names are stored with a source ID prefix (e.g. rh_agents:name).
  Prepend %: to the LIKE pattern to match the prefix, following the same
  approach used by agent template artifacts.
  
  Ref: RHOAIENG-75725

<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
