### PR TITLE
test(catalog): add coverage for agent template artifact lifecycle

### DIFF
--- a/catalog/internal/catalog/agentcatalog/db_agent_test.go
+++ b/catalog/internal/catalog/agentcatalog/db_agent_test.go
@@ -1,0 +1,295 @@
+package agentcatalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/models"
+	agentservice "github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/service"
+	openapi "github.com/kubeflow/hub/catalog/pkg/openapi"
+	dbmodels "github.com/kubeflow/hub/internal/platform/db/entity"
+	"github.com/kubeflow/hub/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mock repositories ---
+
+type mockAgentRepo struct {
+	getResult models.Agent
+	getErr    error
+}
+
+func (m *mockAgentRepo) GetByID(_ int32) (models.Agent, error) {
+	if m.getResult != nil || m.getErr != nil {
+		return m.getResult, m.getErr
+	}
+	return nil, errors.New("not implemented")
+}
+func (m *mockAgentRepo) GetByName(_ string) (models.Agent, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockAgentRepo) List(_ *models.AgentListOptions) (*dbmodels.ListWrapper[models.Agent], error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockAgentRepo) Save(_ models.Agent) (models.Agent, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockAgentRepo) DeleteBySource(_ string) error { return errors.New("not implemented") }
+func (m *mockAgentRepo) DeleteByID(_ int32) error      { return errors.New("not implemented") }
+func (m *mockAgentRepo) GetDistinctSourceIDs() ([]string, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockAgentRepo) GetTypeID() int32 { return 0 }
+
+type mockAgentTemplateArtifactRepo struct {
+	listResult *dbmodels.ListWrapper[models.AgentTemplateArtifact]
+	listErr    error
+	// capturedListOptions stores the last options passed to List, nil if List was never called.
+	capturedListOptions *models.AgentTemplateArtifactListOptions
+}
+
+func (m *mockAgentTemplateArtifactRepo) GetByID(_ int32) (models.AgentTemplateArtifact, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockAgentTemplateArtifactRepo) List(opts models.AgentTemplateArtifactListOptions) (*dbmodels.ListWrapper[models.AgentTemplateArtifact], error) {
+	m.capturedListOptions = &opts
+	return m.listResult, m.listErr
+}
+func (m *mockAgentTemplateArtifactRepo) Save(_ models.AgentTemplateArtifact, _ *int32) (models.AgentTemplateArtifact, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockAgentTemplateArtifactRepo) DeleteByParentID(_ int32) error {
+	return errors.New("not implemented")
+}
+
+// --- helpers ---
+
+func newTestAgentCatalog(agentRepo models.AgentRepository, templateRepo models.AgentTemplateArtifactRepository) *DBAgentCatalog {
+	return &DBAgentCatalog{
+		agentRepo:                 agentRepo,
+		agentTemplateArtifactRepo: templateRepo,
+	}
+}
+
+func agentEntity(id int32) models.Agent {
+	name := "test-source:test-agent"
+	return &models.AgentImpl{
+		ID:         &id,
+		Attributes: &models.AgentAttributes{Name: &name},
+	}
+}
+
+func makeTemplateArtifact(id int32, name string, content string) models.AgentTemplateArtifact {
+	return &models.AgentTemplateArtifactImpl{
+		ID: &id,
+		Attributes: &models.AgentTemplateArtifactAttributes{
+			Name:    &name,
+			Content: &content,
+		},
+	}
+}
+
+func templateArtifactList(items ...models.AgentTemplateArtifact) *dbmodels.ListWrapper[models.AgentTemplateArtifact] {
+	return &dbmodels.ListWrapper[models.AgentTemplateArtifact]{Items: items}
+}
+
+// --- GetAgentArtifacts tests ---
+
+func TestGetAgentArtifacts_InvalidAgentID(t *testing.T) {
+	cat := newTestAgentCatalog(&mockAgentRepo{}, &mockAgentTemplateArtifactRepo{})
+
+	_, err := cat.GetAgentArtifacts(context.Background(), "not-a-number", nil, 10, "", "", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrBadRequest)
+}
+
+func TestGetAgentArtifacts_AgentNotFound(t *testing.T) {
+	agentRepo := &mockAgentRepo{getErr: agentservice.ErrAgentNotFound}
+	cat := newTestAgentCatalog(agentRepo, &mockAgentTemplateArtifactRepo{})
+
+	_, err := cat.GetAgentArtifacts(context.Background(), "1", nil, 10, "", "", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestGetAgentArtifacts_NoFilterFetchesTemplates(t *testing.T) {
+	agentRepo := &mockAgentRepo{getResult: agentEntity(1)}
+	templateRepo := &mockAgentTemplateArtifactRepo{
+		listResult: templateArtifactList(makeTemplateArtifact(1, "agent.yaml", "content-a")),
+	}
+	cat := newTestAgentCatalog(agentRepo, templateRepo)
+
+	result, err := cat.GetAgentArtifacts(context.Background(), "1", nil, 10, "", "", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.NotNil(t, result.Items[0].Name)
+	assert.Equal(t, "agent.yaml", *result.Items[0].Name)
+
+	require.NotNil(t, templateRepo.capturedListOptions, "List should be called on the template repo")
+	require.NotNil(t, templateRepo.capturedListOptions.ParentResourceID)
+	assert.Equal(t, int32(1), *templateRepo.capturedListOptions.ParentResourceID)
+}
+
+func TestGetAgentArtifacts_ExplicitTemplateArtifactFilterFetchesTemplates(t *testing.T) {
+	agentRepo := &mockAgentRepo{getResult: agentEntity(1)}
+	templateRepo := &mockAgentTemplateArtifactRepo{
+		listResult: templateArtifactList(makeTemplateArtifact(1, "agent.yaml", "content-a")),
+	}
+	cat := newTestAgentCatalog(agentRepo, templateRepo)
+
+	result, err := cat.GetAgentArtifacts(context.Background(), "1",
+		[]openapi.AgentArtifactTypeQueryParam{openapi.AGENTARTIFACTTYPEQUERYPARAM_TEMPLATE_ARTIFACT}, 10, "", "", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.NotNil(t, templateRepo.capturedListOptions, "List should be called when filter explicitly includes template-artifact")
+}
+
+func TestGetAgentArtifacts_NonTemplateFilterSkipsFetch(t *testing.T) {
+	agentRepo := &mockAgentRepo{getResult: agentEntity(1)}
+	templateRepo := &mockAgentTemplateArtifactRepo{
+		listResult: templateArtifactList(makeTemplateArtifact(1, "agent.yaml", "content-a")),
+	}
+	cat := newTestAgentCatalog(agentRepo, templateRepo)
+
+	result, err := cat.GetAgentArtifacts(context.Background(), "1",
+		[]openapi.AgentArtifactTypeQueryParam{"image-artifact"}, 10, "", "", nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Items)
+	assert.Nil(t, templateRepo.capturedListOptions, "template repo List should not be called when the filter excludes template-artifact")
+}
+
+func TestGetAgentArtifacts_MixedFilterTypesIncludesTemplates(t *testing.T) {
+	agentRepo := &mockAgentRepo{getResult: agentEntity(1)}
+	templateRepo := &mockAgentTemplateArtifactRepo{
+		listResult: templateArtifactList(makeTemplateArtifact(1, "agent.yaml", "content-a")),
+	}
+	cat := newTestAgentCatalog(agentRepo, templateRepo)
+
+	result, err := cat.GetAgentArtifacts(context.Background(), "1",
+		[]openapi.AgentArtifactTypeQueryParam{"image-artifact", openapi.AGENTARTIFACTTYPEQUERYPARAM_TEMPLATE_ARTIFACT}, 10, "", "", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+}
+
+func TestGetAgentArtifacts_EmptyResultReturnsEmptySliceNotNil(t *testing.T) {
+	agentRepo := &mockAgentRepo{getResult: agentEntity(1)}
+	templateRepo := &mockAgentTemplateArtifactRepo{listResult: templateArtifactList()}
+	cat := newTestAgentCatalog(agentRepo, templateRepo)
+
+	result, err := cat.GetAgentArtifacts(context.Background(), "1", nil, 10, "", "", nil)
+	require.NoError(t, err)
+	assert.NotNil(t, result.Items)
+	assert.Empty(t, result.Items)
+	assert.Equal(t, int32(0), result.Size)
+}
+
+func TestGetAgentArtifacts_NilTemplateRepoSkipsFetch(t *testing.T) {
+	agentRepo := &mockAgentRepo{getResult: agentEntity(1)}
+	cat := newTestAgentCatalog(agentRepo, nil)
+
+	result, err := cat.GetAgentArtifacts(context.Background(), "1", nil, 10, "", "", nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Items)
+}
+
+func TestGetAgentArtifacts_RepoErrorPropagates(t *testing.T) {
+	agentRepo := &mockAgentRepo{getResult: agentEntity(1)}
+	templateRepo := &mockAgentTemplateArtifactRepo{listErr: errors.New("db error")}
+	cat := newTestAgentCatalog(agentRepo, templateRepo)
+
+	_, err := cat.GetAgentArtifacts(context.Background(), "1", nil, 10, "", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+func TestGetAgentArtifacts_NextPageTokenPassthrough(t *testing.T) {
+	agentRepo := &mockAgentRepo{getResult: agentEntity(1)}
+	templateRepo := &mockAgentTemplateArtifactRepo{
+		listResult: &dbmodels.ListWrapper[models.AgentTemplateArtifact]{
+			Items:         []models.AgentTemplateArtifact{makeTemplateArtifact(1, "agent.yaml", "content-a")},
+			NextPageToken: "next-token",
+		},
+	}
+	cat := newTestAgentCatalog(agentRepo, templateRepo)
+
+	result, err := cat.GetAgentArtifacts(context.Background(), "1", nil, 10, "", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "next-token", result.NextPageToken)
+}
+
+// --- mapDBTemplateArtifactToAPI tests ---
+
+func TestMapDBTemplateArtifactToAPI_AllFieldsPresent(t *testing.T) {
+	id := int32(42)
+	name := "src:agent:agent.yaml"
+	content := "template content here"
+	createTime := int64(1000)
+	updateTime := int64(2000)
+	externalID := "ext-123"
+
+	dbArtifact := &models.AgentTemplateArtifactImpl{
+		ID: &id,
+		Attributes: &models.AgentTemplateArtifactAttributes{
+			Name:                     &name,
+			Content:                  &content,
+			CreateTimeSinceEpoch:     &createTime,
+			LastUpdateTimeSinceEpoch: &updateTime,
+			ExternalID:               &externalID,
+		},
+	}
+
+	result := mapDBTemplateArtifactToAPI(dbArtifact)
+
+	assert.Equal(t, "template-artifact", result.ArtifactType)
+	require.NotNil(t, result.Id)
+	assert.Equal(t, "42", *result.Id)
+	require.NotNil(t, result.Name)
+	assert.Equal(t, name, *result.Name)
+	assert.Equal(t, content, result.Content)
+	require.NotNil(t, result.CreateTimeSinceEpoch)
+	assert.Equal(t, "1000", *result.CreateTimeSinceEpoch)
+	require.NotNil(t, result.LastUpdateTimeSinceEpoch)
+	assert.Equal(t, "2000", *result.LastUpdateTimeSinceEpoch)
+	require.NotNil(t, result.ExternalId)
+	assert.Equal(t, externalID, *result.ExternalId)
+}
+
+func TestMapDBTemplateArtifactToAPI_NilID(t *testing.T) {
+	name := "agent.yaml"
+	content := "x"
+	dbArtifact := &models.AgentTemplateArtifactImpl{
+		Attributes: &models.AgentTemplateArtifactAttributes{Name: &name, Content: &content},
+	}
+
+	result := mapDBTemplateArtifactToAPI(dbArtifact)
+	assert.Nil(t, result.Id)
+}
+
+func TestMapDBTemplateArtifactToAPI_NilAttributes(t *testing.T) {
+	dbArtifact := &models.AgentTemplateArtifactImpl{}
+
+	result := mapDBTemplateArtifactToAPI(dbArtifact)
+
+	assert.Equal(t, "template-artifact", result.ArtifactType)
+	assert.Nil(t, result.Id)
+	assert.Nil(t, result.Name)
+	assert.Equal(t, "", result.Content)
+	assert.Nil(t, result.CreateTimeSinceEpoch)
+	assert.Nil(t, result.LastUpdateTimeSinceEpoch)
+	assert.Nil(t, result.ExternalId)
+}
+
+func TestMapDBTemplateArtifactToAPI_NilContentPointer(t *testing.T) {
+	name := "agent.yaml"
+	dbArtifact := &models.AgentTemplateArtifactImpl{
+		Attributes: &models.AgentTemplateArtifactAttributes{Name: &name},
+	}
+
+	result := mapDBTemplateArtifactToAPI(dbArtifact)
+
+	assert.Equal(t, "", result.Content)
+	require.NotNil(t, result.Name)
+	assert.Equal(t, name, *result.Name)
+}

--- a/catalog/internal/catalog/agentcatalog/loader.go
+++ b/catalog/internal/catalog/agentcatalog/loader.go
@@ -142,7 +142,7 @@ func (l *AgentLoader) loadFromYAML(ctx context.Context, sourceID string, source 
 				return
 			}
 
-			if l.services.AgentTemplateArtifactRepository != nil && len(ya.Templates) > 0 {
+			if l.services.AgentTemplateArtifactRepository != nil {
 				if err := l.services.AgentTemplateArtifactRepository.DeleteByParentID(*agentID); err != nil {
 					glog.Errorf("error deleting existing template artifacts for agent %s: %v", ya.Name, err)
 				}

--- a/catalog/internal/catalog/agentcatalog/loader_test.go
+++ b/catalog/internal/catalog/agentcatalog/loader_test.go
@@ -1,0 +1,225 @@
+package agentcatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/models"
+	agentservice "github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/service"
+	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
+	"github.com/kubeflow/hub/catalog/internal/db/service"
+	"github.com/kubeflow/hub/catalog/internal/testhelpers"
+	"github.com/kubeflow/hub/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutils.TestMainPostgresHelper(m))
+}
+
+func setupAgentLoaderTest(t *testing.T) (*gorm.DB, Services, func()) {
+	sharedDB, cleanup := testutils.SetupPostgresWithMigrations(t, testhelpers.MustDatastoreSpec(t))
+
+	catalogSourceTypeID := testhelpers.GetCatalogSourceTypeIDForDBTest(t, sharedDB)
+	agentTypeID := testhelpers.GetAgentTypeIDForDBTest(t, sharedDB)
+	agentTemplateArtifactTypeID := testhelpers.GetAgentTemplateArtifactTypeIDForDBTest(t, sharedDB)
+
+	services := Services{
+		AgentRepository:                 agentservice.NewAgentRepository(sharedDB, agentTypeID),
+		AgentTemplateArtifactRepository: agentservice.NewAgentTemplateArtifactRepository(sharedDB, agentTemplateArtifactTypeID),
+		CatalogSourceRepository:         service.NewCatalogSourceRepository(sharedDB, catalogSourceTypeID),
+		PropertyOptionsRepository:       service.NewPropertyOptionsRepository(sharedDB),
+	}
+
+	return sharedDB, services, cleanup
+}
+
+func runAgentLeaderOperations(t *testing.T, baseLoader *basecatalog.BaseLoader, loader *AgentLoader) {
+	t.Helper()
+
+	require.NoError(t, loader.ParseAllConfigs())
+
+	baseLoader.SetLeader(true)
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- loader.PerformLeaderOperations(context.Background(), mapset.NewSet[string]())
+	}()
+
+	select {
+	case err := <-leaderDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for leader operations")
+	}
+
+	baseLoader.WaitForInflightWrites(5 * time.Second)
+}
+
+func writeAgentSourceFiles(t *testing.T, dir string, agentsYAML string) (agentsFile, sourcesFile string) {
+	t.Helper()
+
+	agentsFile = filepath.Join(dir, "agents.yaml")
+	require.NoError(t, os.WriteFile(agentsFile, []byte(agentsYAML), 0644))
+
+	sourcesFile = filepath.Join(dir, "sources.yaml")
+	require.NoError(t, os.WriteFile(sourcesFile, []byte(`agent_catalogs:
+  - name: "Test Agent Catalog"
+    id: test_agent_catalog
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: `+agentsFile+`
+`), 0644))
+
+	return agentsFile, sourcesFile
+}
+
+func listTemplatesForParent(t *testing.T, services Services, parentID int32) []models.AgentTemplateArtifact {
+	t.Helper()
+	result, err := services.AgentTemplateArtifactRepository.List(models.AgentTemplateArtifactListOptions{ParentResourceID: &parentID})
+	require.NoError(t, err)
+	return result.Items
+}
+
+// TestAgentLoaderTemplateSaveFlow_InitialLoad verifies that on first load the
+// loader saves the parent agent and persists all of its template artifacts,
+// qualified with source/agent/name.
+func TestAgentLoaderTemplateSaveFlow_InitialLoad(t *testing.T) {
+	_, services, cleanup := setupAgentLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+	_, sourcesFile := writeAgentSourceFiles(t, tmpDir, `agents:
+  - name: "test-agent"
+    description: "Test agent"
+    templates:
+      - name: "template-a.yaml"
+        content: "content-a"
+      - name: "template-b.yaml"
+        content: "content-b"
+`)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewAgentLoader(services, baseLoader)
+	runAgentLeaderOperations(t, baseLoader, loader)
+
+	agent, err := services.AgentRepository.GetByName("test_agent_catalog:test-agent")
+	require.NoError(t, err)
+	require.NotNil(t, agent.GetID())
+
+	templates := listTemplatesForParent(t, services, *agent.GetID())
+	require.Len(t, templates, 2)
+
+	byName := map[string]string{}
+	for _, tmpl := range templates {
+		attrs := tmpl.GetAttributes()
+		require.NotNil(t, attrs.Name)
+		require.NotNil(t, attrs.Content)
+		byName[*attrs.Name] = *attrs.Content
+	}
+	assert.Equal(t, "content-a", byName["test_agent_catalog:test-agent:template-a.yaml"])
+	assert.Equal(t, "content-b", byName["test_agent_catalog:test-agent:template-b.yaml"])
+}
+
+// TestAgentLoaderTemplateSaveFlow_ReloadReplacesTemplates verifies the
+// loader's save-parent -> delete-children -> save-new-children flow: after a
+// reload with a different set of templates, the old template artifacts must
+// be gone and only the new ones remain, while the parent agent's identity
+// (its ID) is preserved via upsert.
+func TestAgentLoaderTemplateSaveFlow_ReloadReplacesTemplates(t *testing.T) {
+	_, services, cleanup := setupAgentLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+	agentsFile, sourcesFile := writeAgentSourceFiles(t, tmpDir, `agents:
+  - name: "test-agent"
+    description: "Test agent"
+    templates:
+      - name: "template-a.yaml"
+        content: "content-a"
+      - name: "template-b.yaml"
+        content: "content-b"
+`)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewAgentLoader(services, baseLoader)
+	runAgentLeaderOperations(t, baseLoader, loader)
+
+	agentBefore, err := services.AgentRepository.GetByName("test_agent_catalog:test-agent")
+	require.NoError(t, err)
+	agentIDBefore := *agentBefore.GetID()
+
+	// Reload with a completely different template set for the same agent.
+	require.NoError(t, os.WriteFile(agentsFile, []byte(`agents:
+  - name: "test-agent"
+    description: "Test agent"
+    templates:
+      - name: "template-c.yaml"
+        content: "content-c"
+`), 0644))
+
+	baseLoader2 := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader2 := NewAgentLoader(services, baseLoader2)
+	runAgentLeaderOperations(t, baseLoader2, loader2)
+
+	agentAfter, err := services.AgentRepository.GetByName("test_agent_catalog:test-agent")
+	require.NoError(t, err)
+	assert.Equal(t, agentIDBefore, *agentAfter.GetID(), "reloading should upsert the same agent, not create a new one")
+
+	templates := listTemplatesForParent(t, services, *agentAfter.GetID())
+	require.Len(t, templates, 1, "stale template artifacts from the previous load must be deleted")
+
+	attrs := templates[0].GetAttributes()
+	require.NotNil(t, attrs.Name)
+	assert.Equal(t, "test_agent_catalog:test-agent:template-c.yaml", *attrs.Name)
+	require.NotNil(t, attrs.Content)
+	assert.Equal(t, "content-c", *attrs.Content)
+}
+
+// TestAgentLoaderTemplateSaveFlow_ReloadWithNoTemplatesRemovesAll verifies
+// that dropping the "templates" key entirely on reload clears previously
+// saved template artifacts instead of leaving them orphaned.
+func TestAgentLoaderTemplateSaveFlow_ReloadWithNoTemplatesRemovesAll(t *testing.T) {
+	_, services, cleanup := setupAgentLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+	agentsFile, sourcesFile := writeAgentSourceFiles(t, tmpDir, `agents:
+  - name: "test-agent"
+    description: "Test agent"
+    templates:
+      - name: "template-a.yaml"
+        content: "content-a"
+`)
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewAgentLoader(services, baseLoader)
+	runAgentLeaderOperations(t, baseLoader, loader)
+
+	agent, err := services.AgentRepository.GetByName("test_agent_catalog:test-agent")
+	require.NoError(t, err)
+	agentID := *agent.GetID()
+
+	templatesBefore := listTemplatesForParent(t, services, agentID)
+	require.Len(t, templatesBefore, 1)
+
+	// Reload the same agent with its templates list removed entirely.
+	require.NoError(t, os.WriteFile(agentsFile, []byte(`agents:
+  - name: "test-agent"
+    description: "Test agent"
+`), 0644))
+
+	baseLoader2 := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader2 := NewAgentLoader(services, baseLoader2)
+	runAgentLeaderOperations(t, baseLoader2, loader2)
+
+	templatesAfter := listTemplatesForParent(t, services, agentID)
+	assert.Empty(t, templatesAfter, "stale template artifacts must be cleared when the reloaded agent declares no templates")
+}

--- a/catalog/internal/catalog/agentcatalog/service/agent.go
+++ b/catalog/internal/catalog/agentcatalog/service/agent.go
@@ -16,6 +16,8 @@ import (
 	"gorm.io/gorm"
 )
 
+const AgentTypeName = "kf.Agent"
+
 var ErrAgentNotFound = errors.New("agent not found")
 
 // AgentRepositoryImpl implements AgentRepository using GORM.

--- a/catalog/internal/catalog/agentcatalog/service/agent_template_artifact_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/agent_template_artifact_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAgentTemplateArtifactRepository_DeleteByParentID(t *testing.T) {
+func TestAgentTemplateArtifactRepository(t *testing.T) {
 	sharedDB, cleanup := testutils.SetupPostgresWithMigrations(t, testDatastoreSpec())
 	defer cleanup()
 
@@ -20,82 +20,62 @@ func TestAgentTemplateArtifactRepository_DeleteByParentID(t *testing.T) {
 	agentRepo := NewAgentRepository(sharedDB, agentTypeID)
 	templateRepo := NewAgentTemplateArtifactRepository(sharedDB, templateTypeID)
 
-	// Create two parent agents.
-	parent1Name := "source:agent-one"
-	parent1, err := agentRepo.Save(&models.AgentImpl{
-		Attributes: &models.AgentAttributes{Name: &parent1Name},
-	})
-	require.NoError(t, err)
-	parent1ID := *parent1.GetID()
+	saveAgent := func(name string) int32 {
+		saved, err := agentRepo.Save(&models.AgentImpl{Attributes: &models.AgentAttributes{Name: &name}})
+		require.NoError(t, err)
+		return *saved.GetID()
+	}
 
-	parent2Name := "source:agent-two"
-	parent2, err := agentRepo.Save(&models.AgentImpl{
-		Attributes: &models.AgentAttributes{Name: &parent2Name},
-	})
-	require.NoError(t, err)
-	parent2ID := *parent2.GetID()
-
-	saveTemplate := func(name, content string, parentID int32) {
-		_, err := templateRepo.Save(&models.AgentTemplateArtifactImpl{
+	saveTemplate := func(name, content string, parentID int32) models.AgentTemplateArtifact {
+		saved, err := templateRepo.Save(&models.AgentTemplateArtifactImpl{
 			Attributes: &models.AgentTemplateArtifactAttributes{
 				Name:    &name,
 				Content: &content,
 			},
 		}, &parentID)
 		require.NoError(t, err)
+		return saved
 	}
 
-	// Two template artifacts under parent1, one under parent2.
-	saveTemplate("source:agent-one:agent.yaml", "content-1", parent1ID)
-	saveTemplate("source:agent-one:extra.yaml", "content-2", parent1ID)
-	parent2TemplateName := "source:agent-two:agent.yaml"
-	saveTemplate(parent2TemplateName, "content-3", parent2ID)
+	t.Run("TestDeleteByParentID_RemovesOnlyOwnParentAndType", func(t *testing.T) {
+		parent1ID := saveAgent("source:agent-one")
+		parent2ID := saveAgent("source:agent-two")
 
-	// Attach an artifact of a different type to parent1, to confirm
-	// DeleteByParentID scopes its deletion to its own artifact type.
-	otherTypeID := getTypeIDByName(t, sharedDB, "kf.OtherArtifact")
-	otherArtifact := schema.Artifact{TypeID: otherTypeID, Name: new("unrelated-artifact")}
-	require.NoError(t, sharedDB.Create(&otherArtifact).Error)
-	require.NoError(t, sharedDB.Create(&schema.Attribution{ContextID: parent1ID, ArtifactID: otherArtifact.ID}).Error)
+		saveTemplate("source:agent-one:agent.yaml", "content-1", parent1ID)
+		tmpl2 := saveTemplate("source:agent-one:extra.yaml", "content-2", parent1ID)
+		parent2Template := saveTemplate("source:agent-two:agent.yaml", "content-3", parent2ID)
 
-	impl, ok := templateRepo.(*AgentTemplateArtifactRepositoryImpl)
-	require.True(t, ok)
+		// Attach an artifact of a different type to parent1, to confirm
+		// DeleteByParentID scopes its deletion to its own artifact type.
+		otherTypeID := getTypeIDByName(t, sharedDB, "kf.OtherArtifact")
+		otherArtifact := schema.Artifact{TypeID: otherTypeID, Name: new("unrelated-artifact")}
+		require.NoError(t, sharedDB.Create(&otherArtifact).Error)
+		require.NoError(t, sharedDB.Create(&schema.Attribution{ContextID: parent1ID, ArtifactID: otherArtifact.ID}).Error)
 
-	require.NoError(t, impl.DeleteByParentID(parent1ID))
+		require.NoError(t, templateRepo.DeleteByParentID(parent1ID))
 
-	list1, err := templateRepo.List(models.AgentTemplateArtifactListOptions{ParentResourceID: &parent1ID})
-	require.NoError(t, err)
-	assert.Empty(t, list1.Items, "parent1's template artifacts should be deleted")
+		list1, err := templateRepo.List(models.AgentTemplateArtifactListOptions{ParentResourceID: &parent1ID})
+		require.NoError(t, err)
+		assert.Empty(t, list1.Items, "parent1's template artifacts should be deleted")
 
-	list2, err := templateRepo.List(models.AgentTemplateArtifactListOptions{ParentResourceID: &parent2ID})
-	require.NoError(t, err)
-	require.Len(t, list2.Items, 1, "parent2's template artifact should be untouched")
-	require.NotNil(t, list2.Items[0].GetAttributes().Name)
-	assert.Equal(t, parent2TemplateName, *list2.Items[0].GetAttributes().Name)
+		_, err = templateRepo.GetByID(*tmpl2.GetID())
+		assert.ErrorIs(t, err, ErrAgentTemplateArtifactNotFound)
 
-	var remaining schema.Artifact
-	err = sharedDB.Where("id = ?", otherArtifact.ID).First(&remaining).Error
-	require.NoError(t, err, "an artifact of a different type attached to the same parent should not be deleted")
-}
+		list2, err := templateRepo.List(models.AgentTemplateArtifactListOptions{ParentResourceID: &parent2ID})
+		require.NoError(t, err)
+		require.Len(t, list2.Items, 1, "parent2's template artifact should be untouched")
+		require.NotNil(t, list2.Items[0].GetAttributes().Name)
+		assert.Equal(t, *parent2Template.GetAttributes().Name, *list2.Items[0].GetAttributes().Name)
 
-func TestAgentTemplateArtifactRepository_DeleteByParentID_NoArtifacts(t *testing.T) {
-	sharedDB, cleanup := testutils.SetupPostgresWithMigrations(t, testDatastoreSpec())
-	defer cleanup()
+		var remaining schema.Artifact
+		err = sharedDB.Where("id = ?", otherArtifact.ID).First(&remaining).Error
+		require.NoError(t, err, "an artifact of a different type attached to the same parent should not be deleted")
+	})
 
-	agentTypeID := getAgentTypeID(t, sharedDB)
-	templateTypeID := getAgentTemplateArtifactTypeID(t, sharedDB)
+	t.Run("TestDeleteByParentID_NoArtifacts", func(t *testing.T) {
+		agentID := saveAgent("source:agent-empty")
 
-	agentRepo := NewAgentRepository(sharedDB, agentTypeID)
-	templateRepo := NewAgentTemplateArtifactRepository(sharedDB, templateTypeID)
-
-	name := "source:agent-empty"
-	agent, err := agentRepo.Save(&models.AgentImpl{Attributes: &models.AgentAttributes{Name: &name}})
-	require.NoError(t, err)
-	agentID := *agent.GetID()
-
-	impl, ok := templateRepo.(*AgentTemplateArtifactRepositoryImpl)
-	require.True(t, ok)
-
-	// A parent with no template artifacts should be a no-op, not an error.
-	require.NoError(t, impl.DeleteByParentID(agentID))
+		// A parent with no template artifacts should be idempotent, not an error.
+		require.NoError(t, templateRepo.DeleteByParentID(agentID))
+	})
 }

--- a/catalog/internal/catalog/agentcatalog/service/agent_template_artifact_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/agent_template_artifact_test.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/models"
+	"github.com/kubeflow/hub/internal/platform/db/schema"
+	"github.com/kubeflow/hub/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentTemplateArtifactRepository_DeleteByParentID(t *testing.T) {
+	sharedDB, cleanup := testutils.SetupPostgresWithMigrations(t, testDatastoreSpec())
+	defer cleanup()
+
+	agentTypeID := getAgentTypeID(t, sharedDB)
+	templateTypeID := getAgentTemplateArtifactTypeID(t, sharedDB)
+
+	agentRepo := NewAgentRepository(sharedDB, agentTypeID)
+	templateRepo := NewAgentTemplateArtifactRepository(sharedDB, templateTypeID)
+
+	// Create two parent agents.
+	parent1Name := "source:agent-one"
+	parent1, err := agentRepo.Save(&models.AgentImpl{
+		Attributes: &models.AgentAttributes{Name: &parent1Name},
+	})
+	require.NoError(t, err)
+	parent1ID := *parent1.GetID()
+
+	parent2Name := "source:agent-two"
+	parent2, err := agentRepo.Save(&models.AgentImpl{
+		Attributes: &models.AgentAttributes{Name: &parent2Name},
+	})
+	require.NoError(t, err)
+	parent2ID := *parent2.GetID()
+
+	saveTemplate := func(name, content string, parentID int32) {
+		_, err := templateRepo.Save(&models.AgentTemplateArtifactImpl{
+			Attributes: &models.AgentTemplateArtifactAttributes{
+				Name:    &name,
+				Content: &content,
+			},
+		}, &parentID)
+		require.NoError(t, err)
+	}
+
+	// Two template artifacts under parent1, one under parent2.
+	saveTemplate("source:agent-one:agent.yaml", "content-1", parent1ID)
+	saveTemplate("source:agent-one:extra.yaml", "content-2", parent1ID)
+	parent2TemplateName := "source:agent-two:agent.yaml"
+	saveTemplate(parent2TemplateName, "content-3", parent2ID)
+
+	// Attach an artifact of a different type to parent1, to confirm
+	// DeleteByParentID scopes its deletion to its own artifact type.
+	otherTypeID := getTypeIDByName(t, sharedDB, "kf.OtherArtifact")
+	otherArtifact := schema.Artifact{TypeID: otherTypeID, Name: new("unrelated-artifact")}
+	require.NoError(t, sharedDB.Create(&otherArtifact).Error)
+	require.NoError(t, sharedDB.Create(&schema.Attribution{ContextID: parent1ID, ArtifactID: otherArtifact.ID}).Error)
+
+	impl, ok := templateRepo.(*AgentTemplateArtifactRepositoryImpl)
+	require.True(t, ok)
+
+	require.NoError(t, impl.DeleteByParentID(parent1ID))
+
+	list1, err := templateRepo.List(models.AgentTemplateArtifactListOptions{ParentResourceID: &parent1ID})
+	require.NoError(t, err)
+	assert.Empty(t, list1.Items, "parent1's template artifacts should be deleted")
+
+	list2, err := templateRepo.List(models.AgentTemplateArtifactListOptions{ParentResourceID: &parent2ID})
+	require.NoError(t, err)
+	require.Len(t, list2.Items, 1, "parent2's template artifact should be untouched")
+	require.NotNil(t, list2.Items[0].GetAttributes().Name)
+	assert.Equal(t, parent2TemplateName, *list2.Items[0].GetAttributes().Name)
+
+	var remaining schema.Artifact
+	err = sharedDB.Where("id = ?", otherArtifact.ID).First(&remaining).Error
+	require.NoError(t, err, "an artifact of a different type attached to the same parent should not be deleted")
+}
+
+func TestAgentTemplateArtifactRepository_DeleteByParentID_NoArtifacts(t *testing.T) {
+	sharedDB, cleanup := testutils.SetupPostgresWithMigrations(t, testDatastoreSpec())
+	defer cleanup()
+
+	agentTypeID := getAgentTypeID(t, sharedDB)
+	templateTypeID := getAgentTemplateArtifactTypeID(t, sharedDB)
+
+	agentRepo := NewAgentRepository(sharedDB, agentTypeID)
+	templateRepo := NewAgentTemplateArtifactRepository(sharedDB, templateTypeID)
+
+	name := "source:agent-empty"
+	agent, err := agentRepo.Save(&models.AgentImpl{Attributes: &models.AgentAttributes{Name: &name}})
+	require.NoError(t, err)
+	agentID := *agent.GetID()
+
+	impl, ok := templateRepo.(*AgentTemplateArtifactRepositoryImpl)
+	require.True(t, ok)
+
+	// A parent with no template artifacts should be a no-op, not an error.
+	require.NoError(t, impl.DeleteByParentID(agentID))
+}

--- a/catalog/internal/catalog/agentcatalog/service/test_helpers_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/test_helpers_test.go
@@ -31,16 +31,27 @@ func testDatastoreSpec() *datastore.Spec {
 			AddString("repositoryUrl").
 			AddStruct("env").
 			AddStruct("artifacts"),
+		).
+		AddArtifact(AgentTemplateArtifactTypeName, datastore.NewSpecType(NewAgentTemplateArtifactRepository).
+			AddString("content"),
 		)
 }
 
 func getAgentTypeID(t *testing.T, db *gorm.DB) int32 {
+	return getTypeIDByName(t, db, testAgentTypeName)
+}
+
+func getAgentTemplateArtifactTypeID(t *testing.T, db *gorm.DB) int32 {
+	return getTypeIDByName(t, db, AgentTemplateArtifactTypeName)
+}
+
+func getTypeIDByName(t *testing.T, db *gorm.DB, name string) int32 {
 	var typeRecord schema.Type
-	err := db.Where("name = ?", testAgentTypeName).First(&typeRecord).Error
+	err := db.Where("name = ?", name).First(&typeRecord).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			typeRecord = schema.Type{
-				Name: testAgentTypeName,
+				Name: name,
 			}
 			err = db.Create(&typeRecord).Error
 			require.NoError(t, err)

--- a/catalog/internal/catalog/agentcatalog/service/test_helpers_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/test_helpers_test.go
@@ -16,11 +16,9 @@ func TestMain(m *testing.M) {
 	os.Exit(testutils.TestMainPostgresHelper(m))
 }
 
-const testAgentTypeName = "kf.Agent"
-
 func testDatastoreSpec() *datastore.Spec {
 	return datastore.NewSpec().
-		AddContext(testAgentTypeName, datastore.NewSpecType(NewAgentRepository).
+		AddContext(AgentTypeName, datastore.NewSpecType(NewAgentRepository).
 			AddString("source_id").
 			AddString("displayName").
 			AddString("description").
@@ -38,7 +36,7 @@ func testDatastoreSpec() *datastore.Spec {
 }
 
 func getAgentTypeID(t *testing.T, db *gorm.DB) int32 {
-	return getTypeIDByName(t, db, testAgentTypeName)
+	return getTypeIDByName(t, db, AgentTypeName)
 }
 
 func getAgentTemplateArtifactTypeID(t *testing.T, db *gorm.DB) int32 {

--- a/catalog/internal/catalog/agentcatalog/yaml_provider_test.go
+++ b/catalog/internal/catalog/agentcatalog/yaml_provider_test.go
@@ -1,0 +1,92 @@
+package agentcatalog
+
+import (
+	"testing"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYamlTemplateToEntity_DefaultNameWhenNil(t *testing.T) {
+	tmpl := yamlAgentTemplate{
+		Name:    nil,
+		Content: "template body",
+	}
+
+	entity := yamlTemplateToEntity(tmpl, "my-agent", "my-source")
+
+	attrs := entity.GetAttributes()
+	require.NotNil(t, attrs)
+	require.NotNil(t, attrs.Name)
+	assert.Equal(t, "my-source:my-agent:agent.yaml", *attrs.Name)
+}
+
+func TestYamlTemplateToEntity_DefaultNameWhenEmptyString(t *testing.T) {
+	emptyName := ""
+	tmpl := yamlAgentTemplate{
+		Name:    &emptyName,
+		Content: "template body",
+	}
+
+	entity := yamlTemplateToEntity(tmpl, "my-agent", "my-source")
+
+	attrs := entity.GetAttributes()
+	require.NotNil(t, attrs)
+	require.NotNil(t, attrs.Name)
+	assert.Equal(t, "my-source:my-agent:agent.yaml", *attrs.Name)
+}
+
+func TestYamlTemplateToEntity_CustomNameUsed(t *testing.T) {
+	customName := "deployment.yaml"
+	tmpl := yamlAgentTemplate{
+		Name:    &customName,
+		Content: "template body",
+	}
+
+	entity := yamlTemplateToEntity(tmpl, "my-agent", "my-source")
+
+	attrs := entity.GetAttributes()
+	require.NotNil(t, attrs)
+	require.NotNil(t, attrs.Name)
+	assert.Equal(t, "my-source:my-agent:deployment.yaml", *attrs.Name)
+}
+
+func TestYamlTemplateToEntity_QualifiedNameOrdering(t *testing.T) {
+	customName := "config.yaml"
+	tmpl := yamlAgentTemplate{Name: &customName, Content: "x"}
+
+	entity := yamlTemplateToEntity(tmpl, "agent-b", "source-a")
+
+	attrs := entity.GetAttributes()
+	require.NotNil(t, attrs.Name)
+	assert.Equal(t, "source-a:agent-b:config.yaml", *attrs.Name)
+}
+
+func TestYamlTemplateToEntity_ContentAndArtifactTypeSet(t *testing.T) {
+	tmpl := yamlAgentTemplate{Content: "some yaml content"}
+
+	entity := yamlTemplateToEntity(tmpl, "agent", "source")
+
+	attrs := entity.GetAttributes()
+	require.NotNil(t, attrs.Content)
+	assert.Equal(t, "some yaml content", *attrs.Content)
+	require.NotNil(t, attrs.ArtifactType)
+	assert.Equal(t, models.AgentTemplateArtifactType, *attrs.ArtifactType)
+
+	props := entity.GetProperties()
+	require.NotNil(t, props)
+	require.Len(t, *props, 1)
+	assert.Equal(t, "content", (*props)[0].Name)
+	require.NotNil(t, (*props)[0].StringValue)
+	assert.Equal(t, "some yaml content", *(*props)[0].StringValue)
+	assert.False(t, (*props)[0].IsCustomProperty)
+}
+
+func TestYamlTemplateToEntity_IDNotSet(t *testing.T) {
+	tmpl := yamlAgentTemplate{Content: "x"}
+
+	entity := yamlTemplateToEntity(tmpl, "agent", "source")
+
+	assert.Nil(t, entity.GetID())
+}

--- a/catalog/internal/plugins/agent/plugin.go
+++ b/catalog/internal/plugins/agent/plugin.go
@@ -32,7 +32,7 @@ func (p *Plugin) Migrations() []plugin.Migration { return nil }
 func (p *Plugin) DatastoreEntries() []plugin.DatastoreEntry {
 	return []plugin.DatastoreEntry{
 		{
-			TypeName: "kf.Agent",
+			TypeName: agentservice.AgentTypeName,
 			Category: "context",
 			Spec: datastore.NewSpecType(agentservice.NewAgentRepository).
 				AddString("source_id").

--- a/catalog/internal/testhelpers/spec_bootstrap.go
+++ b/catalog/internal/testhelpers/spec_bootstrap.go
@@ -60,6 +60,12 @@ func init() {
 				AddStruct("artifacts"),
 		},
 		plugin.DatastoreEntry{
+			TypeName: agentcatalogservice.AgentTemplateArtifactTypeName,
+			Category: "artifact",
+			Spec: datastore.NewSpecType(agentcatalogservice.NewAgentTemplateArtifactRepository).
+				AddString("content"),
+		},
+		plugin.DatastoreEntry{
 			TypeName: service.MCPServerTypeName,
 			Category: "context",
 			Spec: datastore.NewSpecType(mcpcatalogservice.NewMCPServerRepository).

--- a/catalog/internal/testhelpers/spec_bootstrap.go
+++ b/catalog/internal/testhelpers/spec_bootstrap.go
@@ -45,7 +45,7 @@ func init() {
 				AddString("metricsType"),
 		},
 		plugin.DatastoreEntry{
-			TypeName: "kf.Agent",
+			TypeName: agentcatalogservice.AgentTypeName,
 			Category: "context",
 			Spec: datastore.NewSpecType(agentcatalogservice.NewAgentRepository).
 				AddString("source_id").

--- a/catalog/internal/testhelpers/type_helpers.go
+++ b/catalog/internal/testhelpers/type_helpers.go
@@ -3,12 +3,16 @@ package testhelpers
 import (
 	"testing"
 
+	agentcatalogservice "github.com/kubeflow/hub/catalog/internal/catalog/agentcatalog/service"
 	"github.com/kubeflow/hub/catalog/internal/db/service"
 	"github.com/kubeflow/hub/internal/platform/datastore"
 	"github.com/kubeflow/hub/internal/platform/db/schema"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
+
+// AgentTypeName is the context type name used for agents in the catalog.
+const AgentTypeName = "kf.Agent"
 
 // MustDatastoreSpec calls service.DatastoreSpec and fails the test on error.
 func MustDatastoreSpec(t *testing.T) *datastore.Spec {
@@ -63,5 +67,21 @@ func GetMCPServerToolTypeIDForDBTest(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
 	err := db.Where("name = ?", service.MCPServerToolTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to query MCPServerTool type")
+	return typeRecord.ID
+}
+
+// GetAgentTypeIDForDBTest retrieves the Agent type ID for testing
+func GetAgentTypeIDForDBTest(t *testing.T, db *gorm.DB) int32 {
+	var typeRecord schema.Type
+	err := db.Where("name = ?", AgentTypeName).First(&typeRecord).Error
+	require.NoError(t, err, "Failed to query Agent type")
+	return typeRecord.ID
+}
+
+// GetAgentTemplateArtifactTypeIDForDBTest retrieves the AgentTemplateArtifact type ID for testing
+func GetAgentTemplateArtifactTypeIDForDBTest(t *testing.T, db *gorm.DB) int32 {
+	var typeRecord schema.Type
+	err := db.Where("name = ?", agentcatalogservice.AgentTemplateArtifactTypeName).First(&typeRecord).Error
+	require.NoError(t, err, "Failed to query AgentTemplateArtifact type")
 	return typeRecord.ID
 }

--- a/catalog/internal/testhelpers/type_helpers.go
+++ b/catalog/internal/testhelpers/type_helpers.go
@@ -11,9 +11,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// AgentTypeName is the context type name used for agents in the catalog.
-const AgentTypeName = "kf.Agent"
-
 // MustDatastoreSpec calls service.DatastoreSpec and fails the test on error.
 func MustDatastoreSpec(t *testing.T) *datastore.Spec {
 	t.Helper()
@@ -73,7 +70,7 @@ func GetMCPServerToolTypeIDForDBTest(t *testing.T, db *gorm.DB) int32 {
 // GetAgentTypeIDForDBTest retrieves the Agent type ID for testing
 func GetAgentTypeIDForDBTest(t *testing.T, db *gorm.DB) int32 {
 	var typeRecord schema.Type
-	err := db.Where("name = ?", AgentTypeName).First(&typeRecord).Error
+	err := db.Where("name = ?", agentcatalogservice.AgentTypeName).First(&typeRecord).Error
 	require.NoError(t, err, "Failed to query Agent type")
 	return typeRecord.ID
 }


### PR DESCRIPTION
## Description
Adds test coverage for the agent catalog plugin:
- `GetAgentArtifacts` filtering logic (empty results, mixed artifact types)
- `mapDBTemplateArtifactToAPI` field mapping correctness
- `yamlTemplateToEntity` default name and qualified-name construction
- `DeleteByParentID` cascading-delete correctness
- The loader's template-saving flow (save parent -> delete children -> save new)

While adding the loader test coverage, found and fixed a real bug in `AgentLoader.loadFromYAML`: `DeleteByParentID` was only called when the reloaded agent declared at least one template (`len(ya.Templates) > 0`). This meant removing all templates from an agent's YAML left the old template artifacts orphaned in the database instead of being cleared. The delete now always runs when the template repo is configured; only the save-new-templates loop stays conditional on there being templates to save.

Also registers the `kf.AgentTemplateArtifact` datastore entry in the shared test bootstrap (`catalog/internal/testhelpers`), which was missing even though it's registered in the real plugin (`catalog/internal/plugins/agent/plugin.go`), and adds matching type-ID test helpers so DB-backed tests for this type can run.

Finally, centralizes the `"kf.Agent"` type name (previously a raw string literal duplicated across `plugin.go`, `testhelpers/spec_bootstrap.go`, and a locally-scoped test constant) into a single exported `AgentTypeName` constant in `agentcatalog/service`, matching the existing convention for `MCPServerTypeName` / `CatalogModelTypeName` and the sibling `AgentTemplateArtifactTypeName`.

## How Has This Been Tested?
- `make build/compile`
- `go vet ./...` (catalog module)
- `golangci-lint run ./...` (catalog module) — no new findings
- `go test ./...` (catalog module) — all passing, including new Postgres-testcontainer-backed tests for the repository (`agent_template_artifact_test.go`) and loader (`loader_test.go`)

## Merge criteria:
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

Not a UI change — no UI checklist items apply.