### PR TITLE
feat(tracking): add vendor-neutral userInteraction tracking abstraction

### DIFF
--- a/clients/ui/frontend/src/concepts/userInteraction/UserInteractionContext.ts
+++ b/clients/ui/frontend/src/concepts/userInteraction/UserInteractionContext.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { DEV_MODE } from '~/app/utilities/const';
+import type {
+  FormTrackingEventProperties,
+  LinkTrackingEventProperties,
+  SimpleTrackingEventProperties,
+} from './trackingTypes';
+
+export type UserInteractionAPI = {
+  trackFormEvent: (eventName: string, properties: FormTrackingEventProperties) => void;
+  trackLinkEvent: (eventName: string, properties: LinkTrackingEventProperties) => void;
+  trackSimpleEvent: (eventName: string, properties?: SimpleTrackingEventProperties) => void;
+  trackPageEvent: () => void;
+};
+
+const devLogger: UserInteractionAPI = {
+  trackFormEvent: (eventName, properties) => {
+    if (DEV_MODE) {
+      // eslint-disable-next-line no-console
+      console.log(`[UserInteraction] trackFormEvent: ${eventName}`, properties);
+    }
+  },
+  trackLinkEvent: (eventName, properties) => {
+    if (DEV_MODE) {
+      // eslint-disable-next-line no-console
+      console.log(`[UserInteraction] trackLinkEvent: ${eventName}`, properties);
+    }
+  },
+  trackSimpleEvent: (eventName, properties) => {
+    if (DEV_MODE) {
+      // eslint-disable-next-line no-console
+      console.log(`[UserInteraction] trackSimpleEvent: ${eventName}`, properties);
+    }
+  },
+  trackPageEvent: () => {
+    if (DEV_MODE) {
+      // eslint-disable-next-line no-console
+      console.log(`[UserInteraction] trackPageEvent: ${window.location.pathname}`);
+    }
+  },
+};
+
+export const UserInteractionContext = React.createContext<UserInteractionAPI>(devLogger);

--- a/clients/ui/frontend/src/concepts/userInteraction/UserInteractionProvider.tsx
+++ b/clients/ui/frontend/src/concepts/userInteraction/UserInteractionProvider.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { UserInteractionContext, type UserInteractionAPI } from './UserInteractionContext';
+
+type UserInteractionProviderProps = {
+  /** Custom tracking API implementation. When omitted, the default dev-mode logger is used. */
+  api?: UserInteractionAPI;
+  children: React.ReactNode;
+};
+
+/**
+ * Provider for user interaction tracking.
+ *
+ * Wrap your app (or a subtree) with this provider to inject a custom tracking implementation.
+ * When no `api` prop is provided, the default context value (dev-mode console logger) is used.
+ *
+ * Downstream integrations (e.g., ODH with Segment) can supply their own `api` implementation
+ * to route events to their analytics backend.
+ */
+const UserInteractionProvider: React.FC<UserInteractionProviderProps> = ({ api, children }) => {
+  const defaultApi = React.useContext(UserInteractionContext);
+  const value = api ?? defaultApi;
+
+  return (
+    <UserInteractionContext.Provider value={value}>{children}</UserInteractionContext.Provider>
+  );
+};
+
+export default UserInteractionProvider;

--- a/clients/ui/frontend/src/concepts/userInteraction/__tests__/useUserInteraction.spec.tsx
+++ b/clients/ui/frontend/src/concepts/userInteraction/__tests__/useUserInteraction.spec.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useUserInteraction } from '~/concepts/userInteraction/useUserInteraction';
+import UserInteractionProvider from '~/concepts/userInteraction/UserInteractionProvider';
+import { TrackingOutcome } from '~/concepts/userInteraction/trackingTypes';
+import type { UserInteractionAPI } from '~/concepts/userInteraction/UserInteractionContext';
+
+describe('useUserInteraction', () => {
+  it('calls the injected provider implementation instead of the default', () => {
+    const mockApi: UserInteractionAPI = {
+      trackFormEvent: jest.fn(),
+      trackLinkEvent: jest.fn(),
+      trackSimpleEvent: jest.fn(),
+      trackPageEvent: jest.fn(),
+    };
+
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <UserInteractionProvider api={mockApi}>{children}</UserInteractionProvider>
+    );
+
+    const { result } = renderHook(() => useUserInteraction(), { wrapper });
+
+    act(() => {
+      result.current.trackFormEvent('Model Registered', {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        registryName: 'production',
+      });
+    });
+
+    expect(mockApi.trackFormEvent).toHaveBeenCalledWith('Model Registered', {
+      outcome: 'submit',
+      success: true,
+      registryName: 'production',
+    });
+    expect(mockApi.trackLinkEvent).not.toHaveBeenCalled();
+  });
+
+  it('routes different event types to their respective handlers', () => {
+    const mockApi: UserInteractionAPI = {
+      trackFormEvent: jest.fn(),
+      trackLinkEvent: jest.fn(),
+      trackSimpleEvent: jest.fn(),
+      trackPageEvent: jest.fn(),
+    };
+
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <UserInteractionProvider api={mockApi}>{children}</UserInteractionProvider>
+    );
+
+    const { result } = renderHook(() => useUserInteraction(), { wrapper });
+
+    act(() => {
+      result.current.trackLinkEvent('Model Card Clicked', {
+        to: '/catalog/source1/granite-3b',
+        section: 'Model Catalog',
+      });
+      result.current.trackSimpleEvent('Performance View Toggled');
+      result.current.trackPageEvent();
+    });
+
+    expect(mockApi.trackLinkEvent).toHaveBeenCalledWith('Model Card Clicked', {
+      to: '/catalog/source1/granite-3b',
+      section: 'Model Catalog',
+    });
+    expect(mockApi.trackSimpleEvent).toHaveBeenCalledWith('Performance View Toggled');
+    expect(mockApi.trackPageEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('swaps implementation when provider is re-mounted with a different api', () => {
+    const firstApi: UserInteractionAPI = {
+      trackFormEvent: jest.fn(),
+      trackLinkEvent: jest.fn(),
+      trackSimpleEvent: jest.fn(),
+      trackPageEvent: jest.fn(),
+    };
+    const secondApi: UserInteractionAPI = {
+      trackFormEvent: jest.fn(),
+      trackLinkEvent: jest.fn(),
+      trackSimpleEvent: jest.fn(),
+      trackPageEvent: jest.fn(),
+    };
+
+    let currentApi = firstApi;
+
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <UserInteractionProvider api={currentApi}>{children}</UserInteractionProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useUserInteraction(), { wrapper });
+
+    act(() => {
+      result.current.trackSimpleEvent('Event One');
+    });
+    expect(firstApi.trackSimpleEvent).toHaveBeenCalledWith('Event One');
+    expect(secondApi.trackSimpleEvent).not.toHaveBeenCalled();
+
+    currentApi = secondApi;
+    rerender();
+
+    act(() => {
+      result.current.trackSimpleEvent('Event Two');
+    });
+    expect(secondApi.trackSimpleEvent).toHaveBeenCalledWith('Event Two');
+    expect(firstApi.trackSimpleEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/ui/frontend/src/concepts/userInteraction/__tests__/useUserInteraction.spec.tsx
+++ b/clients/ui/frontend/src/concepts/userInteraction/__tests__/useUserInteraction.spec.tsx
@@ -52,7 +52,7 @@ describe('useUserInteraction', () => {
 
     act(() => {
       result.current.trackLinkEvent('Model Card Clicked', {
-        to: '/catalog/source1/granite-3b',
+        href: '/catalog/source1/granite-3b',
         section: 'Model Catalog',
       });
       result.current.trackSimpleEvent('Performance View Toggled');
@@ -60,7 +60,7 @@ describe('useUserInteraction', () => {
     });
 
     expect(mockApi.trackLinkEvent).toHaveBeenCalledWith('Model Card Clicked', {
-      to: '/catalog/source1/granite-3b',
+      href: '/catalog/source1/granite-3b',
       section: 'Model Catalog',
     });
     expect(mockApi.trackSimpleEvent).toHaveBeenCalledWith('Performance View Toggled');

--- a/clients/ui/frontend/src/concepts/userInteraction/index.ts
+++ b/clients/ui/frontend/src/concepts/userInteraction/index.ts
@@ -1,0 +1,9 @@
+export { UserInteractionContext, type UserInteractionAPI } from './UserInteractionContext';
+export { useUserInteraction } from './useUserInteraction';
+export { default as UserInteractionProvider } from './UserInteractionProvider';
+export {
+  TrackingOutcome,
+  type FormTrackingEventProperties,
+  type LinkTrackingEventProperties,
+  type SimpleTrackingEventProperties,
+} from './trackingTypes';

--- a/clients/ui/frontend/src/concepts/userInteraction/trackingTypes.ts
+++ b/clients/ui/frontend/src/concepts/userInteraction/trackingTypes.ts
@@ -21,12 +21,15 @@ export type FormTrackingEventProperties = {
 };
 
 export type LinkTrackingEventProperties = {
-  from?: string;
+  /** Destination URL or route path. */
   href?: string;
-  to?: string;
+  /** Kind of element clicked (e.g., "project", "model", "external"). */
   type?: string;
+  /** UI region where the click occurred (e.g., "Model Catalog", "Sidebar"). */
   section?: string;
+  /** Display label of the clicked element. */
   name?: string;
+  [key: string]: string | number | boolean | undefined;
 };
 
 export type SimpleTrackingEventProperties = {

--- a/clients/ui/frontend/src/concepts/userInteraction/trackingTypes.ts
+++ b/clients/ui/frontend/src/concepts/userInteraction/trackingTypes.ts
@@ -1,0 +1,34 @@
+/**
+ * Vendor-neutral tracking event types.
+ *
+ * These mirror the main tracking methods available in downstream implementations
+ * (e.g., Segment) without introducing any vendor-specific dependency upstream.
+ *
+ * Event naming convention: "What-noun Past-Tensed-verb"
+ * Examples: "Model Deployed", "Pipeline Schedule Deleted", "Workbench Created"
+ */
+
+export const enum TrackingOutcome {
+  submit = 'submit',
+  cancel = 'cancel',
+}
+
+export type FormTrackingEventProperties = {
+  outcome: TrackingOutcome;
+  success?: boolean;
+  error?: string;
+  [key: string]: string | number | boolean | undefined;
+};
+
+export type LinkTrackingEventProperties = {
+  from?: string;
+  href?: string;
+  to?: string;
+  type?: string;
+  section?: string;
+  name?: string;
+};
+
+export type SimpleTrackingEventProperties = {
+  [key: string]: string | number | boolean | undefined;
+};

--- a/clients/ui/frontend/src/concepts/userInteraction/useUserInteraction.ts
+++ b/clients/ui/frontend/src/concepts/userInteraction/useUserInteraction.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { UserInteractionContext, type UserInteractionAPI } from './UserInteractionContext';
+
+/**
+ * Returns the user interaction tracking API from context.
+ *
+ * In standalone mode this is a dev-mode console logger.
+ * When a downstream provider is mounted (e.g., ODH Segment), returns that implementation.
+ */
+export const useUserInteraction = (): UserInteractionAPI =>
+  React.useContext(UserInteractionContext);


### PR DESCRIPTION
## Description

Add a `concepts/userInteraction` module that provides a non-opinionated tracking API via React context. This enables downstream integrations (e.g., ODH with Segment) to inject their own analytics implementation without introducing vendor-specific dependencies upstream.

### What's included

| File | Purpose |
|------|---------|
| `trackingTypes.ts` | Event property types + `TrackingOutcome` enum |
| `UserInteractionContext.ts` | React context with dev-mode console logger default |
| `useUserInteraction.ts` | Consumer hook |
| `UserInteractionProvider.tsx` | Provider for downstream to inject custom `api` |
| `index.ts` | Barrel export |

### API

| Method | Purpose |
|--------|---------|
| `trackFormEvent(name, props)` | Form submit/cancel (outcome, success, error) |
| `trackLinkEvent(name, props)` | Navigation/link clicks (from, href, to, section) |
| `trackSimpleEvent(name, props?)` | Simple named events |
| `trackPageEvent()` | Page view tracking |

### How downstream uses it

```tsx
import { useUserInteraction, TrackingOutcome } from '~/concepts/userInteraction';

const { trackFormEvent } = useUserInteraction();

// In a handler:
trackFormEvent('Model Registered', {
  outcome: TrackingOutcome.submit,
  success: true,
});
```

Downstream (e.g., ODH) injects a Segment-backed implementation via `UserInteractionProvider`:

```tsx
<UserInteractionProvider api={segmentImpl}>
  <App />
</UserInteractionProvider>
```

### Design decisions

- **No App.tsx change**: The context default (dev-mode logger) works without a provider mounted. No dead wrapper needed.
- **Reuses existing `DEV_MODE`**: Imports from `~/app/utilities/const` rather than redefining.
- **Purely additive**: 6 new files, zero modifications to existing code. No breaking changes.

## Testing

- Unit tests verify provider injection, event routing, and hot-swap behavior
- Type check passes (`npx tsc --noEmit`)
- Lint passes (`npx eslint`)

```
PASS src/concepts/userInteraction/__tests__/useUserInteraction.spec.tsx
  useUserInteraction
    ✓ calls the injected provider implementation instead of the default
    ✓ routes different event types to their respective handlers
    ✓ swaps implementation when provider is re-mounted with a different api
```