### PR TITLE
fix(catalog): strip qualified name prefix from template artifact API response

### DIFF
--- a/catalog/internal/catalog/agentcatalog/db_agent.go
+++ b/catalog/internal/catalog/agentcatalog/db_agent.go
@@ -226,7 +226,8 @@ func mapDBTemplateArtifactToAPI(dbArtifact models.AgentTemplateArtifact) openapi
 	attrs := dbArtifact.GetAttributes()
 	if attrs != nil {
 		if attrs.Name != nil {
-			tmpl.Name = attrs.Name
+			baseName := templateBaseNameFromStoredName(*attrs.Name)
+			tmpl.Name = &baseName
 		}
 		if attrs.Content != nil {
 			tmpl.Content = *attrs.Content
@@ -248,6 +249,13 @@ func mapDBTemplateArtifactToAPI(dbArtifact models.AgentTemplateArtifact) openapi
 func displayNameFromStoredName(storedName string) string {
 	if _, after, ok := strings.Cut(storedName, ":"); ok {
 		return after
+	}
+	return storedName
+}
+
+func templateBaseNameFromStoredName(storedName string) string {
+	if idx := strings.LastIndex(storedName, ":"); idx != -1 {
+		return storedName[idx+1:]
 	}
 	return storedName
 }

--- a/catalog/internal/catalog/agentcatalog/db_agent_test.go
+++ b/catalog/internal/catalog/agentcatalog/db_agent_test.go
@@ -125,7 +125,7 @@ func TestGetAgentArtifacts_NoFilterFetchesTemplates(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Items, 1)
 	require.NotNil(t, result.Items[0].Name)
-	assert.Equal(t, "agent.yaml", *result.Items[0].Name)
+	assert.Equal(t, "agent.yaml", *result.Items[0].Name, "template name should be the base name, not the qualified stored name")
 
 	require.NotNil(t, templateRepo.capturedListOptions, "List should be called on the template repo")
 	require.NotNil(t, templateRepo.capturedListOptions.ParentResourceID)
@@ -246,7 +246,7 @@ func TestMapDBTemplateArtifactToAPI_AllFieldsPresent(t *testing.T) {
 	require.NotNil(t, result.Id)
 	assert.Equal(t, "42", *result.Id)
 	require.NotNil(t, result.Name)
-	assert.Equal(t, name, *result.Name)
+	assert.Equal(t, "agent.yaml", *result.Name, "should return base name, not qualified stored name")
 	assert.Equal(t, content, result.Content)
 	require.NotNil(t, result.CreateTimeSinceEpoch)
 	assert.Equal(t, "1000", *result.CreateTimeSinceEpoch)
@@ -292,4 +292,39 @@ func TestMapDBTemplateArtifactToAPI_NilContentPointer(t *testing.T) {
 	assert.Equal(t, "", result.Content)
 	require.NotNil(t, result.Name)
 	assert.Equal(t, name, *result.Name)
+}
+
+func TestTemplateBaseNameFromStoredName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "qualified name", input: "source:agent:deploy.yaml", expected: "deploy.yaml"},
+		{name: "no prefix", input: "agent.yaml", expected: "agent.yaml"},
+		{name: "single prefix", input: "source:agent.yaml", expected: "agent.yaml"},
+		{name: "empty string", input: "", expected: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, templateBaseNameFromStoredName(tc.input))
+		})
+	}
+}
+
+func TestDisplayNameFromStoredName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "qualified name", input: "source:agent-name", expected: "agent-name"},
+		{name: "no prefix", input: "agent-name", expected: "agent-name"},
+		{name: "empty string", input: "", expected: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, displayNameFromStoredName(tc.input))
+		})
+	}
 }

--- a/catalog/internal/catalog/agentcatalog/service/agent_template_artifact_test.go
+++ b/catalog/internal/catalog/agentcatalog/service/agent_template_artifact_test.go
@@ -72,6 +72,47 @@ func TestAgentTemplateArtifactRepository(t *testing.T) {
 		require.NoError(t, err, "an artifact of a different type attached to the same parent should not be deleted")
 	})
 
+	t.Run("TestSave_StoresQualifiedName", func(t *testing.T) {
+		parentID := saveAgent("test-source:qualified-name-agent")
+		qualifiedName := "test-source:qualified-name-agent:deploy.yaml"
+		content := "apiVersion: apps/v1"
+
+		saved := saveTemplate(qualifiedName, content, parentID)
+		require.NotNil(t, saved.GetAttributes().Name)
+		assert.Equal(t, qualifiedName, *saved.GetAttributes().Name,
+			"repository should store the fully qualified name")
+
+		// Verify the DB has the qualified name
+		var dbArtifact schema.Artifact
+		err := sharedDB.Where("id = ?", *saved.GetID()).First(&dbArtifact).Error
+		require.NoError(t, err)
+		require.NotNil(t, dbArtifact.Name)
+		assert.Equal(t, qualifiedName, *dbArtifact.Name,
+			"DB should store the fully qualified name source_id:agent_name:template_name")
+
+		// Verify list returns the artifact with the qualified name
+		list, err := templateRepo.List(models.AgentTemplateArtifactListOptions{ParentResourceID: &parentID})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		assert.Equal(t, qualifiedName, *list.Items[0].GetAttributes().Name,
+			"repository List should return the fully qualified name")
+	})
+
+	t.Run("TestList_FilterByName", func(t *testing.T) {
+		parentID := saveAgent("test-source:name-filter-agent")
+		saveTemplate("test-source:name-filter-agent:agent.yaml", "content-a", parentID)
+		saveTemplate("test-source:name-filter-agent:deploy.yaml", "content-b", parentID)
+
+		nameFilter := "agent.yaml"
+		list, err := templateRepo.List(models.AgentTemplateArtifactListOptions{
+			ParentResourceID: &parentID,
+			Name:             &nameFilter,
+		})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		assert.Contains(t, *list.Items[0].GetAttributes().Name, "agent.yaml")
+	})
+
 	t.Run("TestDeleteByParentID_NoArtifacts", func(t *testing.T) {
 		agentID := saveAgent("source:agent-empty")
 


### PR DESCRIPTION
Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Template artifacts stored in the DB use a qualified name format (source_id:agent_name:template_name) but the API was returning it as-is. The agent endpoint already strips its prefix via displayNameFromStoredName, but the template artifact mapping did not.

Add templateBaseNameFromStoredName to extract the base template name, and add repository-level tests verifying the DB stores the qualified name while the API returns only the base name.

<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
