### PR TITLE
fix(readme): make build checks status badge a clickable link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubeflow Hub
 
-![build checks status](https://github.com/kubeflow/hub/actions/workflows/build.yml/badge.svg?branch=main)
+[![build checks status](https://github.com/kubeflow/hub/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/kubeflow/hub/actions/workflows/build.yml)
 [![codecov](https://codecov.io/github/kubeflow/hub/graph/badge.svg?token=61URLQA3VS)](https://codecov.io/github/kubeflow/hub)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry?ref=badge_shield&issueType=license)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9937/badge)](https://www.bestpractices.dev/projects/9937)


### PR DESCRIPTION
## What

The "build checks status" badge in `README.md` is a bare image and not wrapped in a link, unlike the other badges next to it (codecov, FOSSA, OpenSSF). This means clicking it doesn't take you to the GitHub Actions workflow page — it just opens the raw `badge.svg` asset instead.

## Fix

Wrapped the badge image in a link to the Actions workflow page, matching the `[![alt](img-url)](target-url)` pattern already used by the other badges in the same line.

-![build checks status](https://github.com/kubeflow/hub/actions/workflows/build.yml/badge.svg?branch=main)
+[![build checks status](https://github.com/kubeflow/hub/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/kubeflow/hub/actions/workflows/build.yml)

## Verification

Checked all other badges in the README (codecov, FOSSA, OpenSSF) — they all use the linked badge pattern, so this brings the build status badge in line with the existing convention.


