### PR TITLE
mount mcp-catalog-sources ConfigMap in catalog server deployment

### DIFF
--- a/manifests/kustomize/options/catalog/base/deployment.yaml
+++ b/manifests/kustomize/options/catalog/base/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       - name: sources
         configMap:
           name: model-catalog-sources
+      - name: mcp-sources
+        configMap:
+          name: mcp-catalog-sources
       containers:
         - name: catalog
           env:
@@ -56,6 +59,7 @@ spec:
           args:
             - --listen=0.0.0.0:8080
             - --catalogs-path=/catalog/sources.yaml
+            - --catalogs-path=/mcp-catalog/sources.yaml
           image: ghcr.io/kubeflow/hub/server:latest
           ports:
             - name: http-api
@@ -80,3 +84,5 @@ spec:
           volumeMounts:
           - name: sources
             mountPath: /catalog
+          - name: mcp-sources
+            mountPath: /mcp-catalog

--- a/manifests/kustomize/options/catalog/base/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/base/kustomization.yaml
@@ -14,6 +14,12 @@ configMapGenerator:
   name: model-catalog-sources
   options:
     disableNameSuffixHash: true
+- behavior: create
+  files:
+  - sources.yaml=mcp-sources.yaml
+  name: mcp-catalog-sources
+  options:
+    disableNameSuffixHash: true
 
 secretGenerator:
 - name: model-catalog-postgres

--- a/manifests/kustomize/options/catalog/base/mcp-sources.yaml
+++ b/manifests/kustomize/options/catalog/base/mcp-sources.yaml
@@ -1,0 +1,1 @@
+mcp_catalogs: []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The catalog server only watches ConfigMaps that are mounted as volumes, and `mcp-catalog-sources ` wasn't mounted

## How Has This Been Tested?
```
kubectl kustomize manifests/kustomize/options/catalog/base/
kubectl kustomize manifests/kustomize/options/catalog/overlays/demo/
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
