### PR TITLE
fix(bff): authorize job namespace via SAR instead of requiring namespace equality

### DIFF
--- a/clients/ui/bff/internal/api/model_transfer_job_authz_test.go
+++ b/clients/ui/bff/internal/api/model_transfer_job_authz_test.go
@@ -1,47 +1,87 @@
 package api
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
 
-// TestEnsureNamespaceMatch guards the model-transfer-job BOLA fix: the namespace
-// a handler operates on (jobNamespace query parameter or request-body namespace)
-// must not differ from the namespace authorized by the SubjectAccessReview in
-// RequireAccessToMRService.
-func TestEnsureNamespaceMatch(t *testing.T) {
+	"github.com/kubeflow/hub/ui/bff/internal/constants"
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+)
+
+type stubKubernetesClientForAuthz struct {
+	k8s.KubernetesClientInterface
+	allowedNamespaces map[string]bool
+}
+
+func (s *stubKubernetesClientForAuthz) CanListServicesInNamespace(_ context.Context, _ *k8s.RequestIdentity, namespace string) (bool, error) {
+	return s.allowedNamespaces[namespace], nil
+}
+
+func TestAuthorizeJobNamespace(t *testing.T) {
+	app := &App{logger: slog.Default()}
+	identity := &k8s.RequestIdentity{UserID: "testuser"}
+
 	tests := []struct {
-		name       string
-		authorized string
-		operated   string
-		wantErr    bool
+		name              string
+		jobNamespace      string
+		allowedNamespaces map[string]bool
+		wantErr           bool
 	}{
 		{
-			name:       "same namespace is allowed",
-			authorized: "kubeflow",
-			operated:   "kubeflow",
-			wantErr:    false,
+			name:              "empty namespace defers to existing handling",
+			jobNamespace:      "",
+			allowedNamespaces: map[string]bool{},
+			wantErr:           false,
 		},
 		{
-			name:       "empty operated namespace defers to existing handling",
-			authorized: "kubeflow",
-			operated:   "",
-			wantErr:    false,
+			name:              "user has access to job namespace",
+			jobNamespace:      "user-project",
+			allowedNamespaces: map[string]bool{"user-project": true},
+			wantErr:           false,
 		},
 		{
-			name:       "cross-namespace operation is rejected",
-			authorized: "mr-attacker",
-			operated:   "mr-victim",
-			wantErr:    true,
+			name:              "cross-namespace without access is rejected",
+			jobNamespace:      "victim-namespace",
+			allowedNamespaces: map[string]bool{"attacker-namespace": true},
+			wantErr:           true,
+		},
+		{
+			name:              "same as registry namespace with access is allowed",
+			jobNamespace:      "rhoai-model-registries",
+			allowedNamespaces: map[string]bool{"rhoai-model-registries": true},
+			wantErr:           false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ensureNamespaceMatch(tc.authorized, tc.operated)
+			client := &stubKubernetesClientForAuthz{allowedNamespaces: tc.allowedNamespaces}
+			ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, identity)
+
+			err := app.authorizeJobNamespace(ctx, client, tc.jobNamespace)
 			if tc.wantErr && err == nil {
-				t.Fatalf("ensureNamespaceMatch(%q, %q): expected error, got nil", tc.authorized, tc.operated)
+				t.Fatalf("authorizeJobNamespace(%q): expected error, got nil", tc.jobNamespace)
 			}
 			if !tc.wantErr && err != nil {
-				t.Fatalf("ensureNamespaceMatch(%q, %q): unexpected error %v", tc.authorized, tc.operated, err)
+				t.Fatalf("authorizeJobNamespace(%q): unexpected error: %v", tc.jobNamespace, err)
 			}
 		})
+	}
+}
+
+func TestAuthorizeJobNamespaceMissingIdentity(t *testing.T) {
+	app := &App{logger: slog.Default()}
+	client := &stubKubernetesClientForAuthz{allowedNamespaces: map[string]bool{"ns": true}}
+	ctx := context.Background()
+
+	err := app.authorizeJobNamespace(ctx, client, "ns")
+	if err == nil {
+		t.Fatal("expected error for missing identity, got nil")
+	}
+	expected := "missing request identity"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, fmt.Sprint(err))
 	}
 }

--- a/clients/ui/bff/internal/api/model_transfer_job_handler.go
+++ b/clients/ui/bff/internal/api/model_transfer_job_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/kubeflow/hub/ui/bff/internal/constants"
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
 	"github.com/kubeflow/hub/ui/bff/internal/models"
 	"github.com/kubeflow/hub/ui/bff/internal/repositories"
 )
@@ -38,7 +40,7 @@ func (app *App) GetAllModelTransferJobsHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	jobNamespace := r.URL.Query().Get("jobNamespace")
-	if err := ensureNamespaceMatch(namespace, jobNamespace); err != nil {
+	if err := app.authorizeJobNamespace(ctx, client, jobNamespace); err != nil {
 		app.forbiddenResponse(w, r, err.Error())
 		return
 	}
@@ -89,7 +91,7 @@ func (app *App) GetModelTransferJobHandler(w http.ResponseWriter, r *http.Reques
 		app.badRequestResponse(w, r, err)
 		return
 	}
-	if err := ensureNamespaceMatch(namespace, jobNamespace); err != nil {
+	if err := app.authorizeJobNamespace(ctx, client, jobNamespace); err != nil {
 		app.forbiddenResponse(w, r, err.Error())
 		return
 	}
@@ -150,13 +152,10 @@ func (app *App) CreateModelTransferJobHandler(w http.ResponseWriter, r *http.Req
 
 	payload := *envelope.Data
 
-	// The transfer-job resources are created in payload.Namespace, so it must
-	// stay inside the namespace authorized by RequireAccessToMRService. Default
-	// an unset namespace to the authorized one and reject any other.
 	if payload.Namespace == "" {
 		payload.Namespace = namespace
 	}
-	if err := ensureNamespaceMatch(namespace, payload.Namespace); err != nil {
+	if err := app.authorizeJobNamespace(ctx, client, payload.Namespace); err != nil {
 		app.forbiddenResponse(w, r, err.Error())
 		return
 	}
@@ -218,12 +217,10 @@ func (app *App) UpdateModelTransferJobHandler(w http.ResponseWriter, r *http.Req
 	}
 	payload := *envelope.Data
 
-	// Keep the update inside the authorized namespace: the destination Secret and
-	// Job the repository reads and writes use payload.Namespace.
 	if payload.Namespace == "" {
 		payload.Namespace = namespace
 	}
-	if err := ensureNamespaceMatch(namespace, payload.Namespace); err != nil {
+	if err := app.authorizeJobNamespace(ctx, client, payload.Namespace); err != nil {
 		app.forbiddenResponse(w, r, err.Error())
 		return
 	}
@@ -292,7 +289,7 @@ func (app *App) DeleteModelTransferJobHandler(w http.ResponseWriter, r *http.Req
 		app.badRequestResponse(w, r, err)
 		return
 	}
-	if err := ensureNamespaceMatch(namespace, jobNamespace); err != nil {
+	if err := app.authorizeJobNamespace(ctx, client, jobNamespace); err != nil {
 		app.forbiddenResponse(w, r, err.Error())
 		return
 	}
@@ -353,7 +350,7 @@ func (app *App) GetModelTransferJobEventsHandler(w http.ResponseWriter, r *http.
 		app.badRequestResponse(w, r, err)
 		return
 	}
-	if err := ensureNamespaceMatch(namespace, jobNamespace); err != nil {
+	if err := app.authorizeJobNamespace(ctx, client, jobNamespace); err != nil {
 		app.forbiddenResponse(w, r, err.Error())
 		return
 	}
@@ -387,16 +384,26 @@ func getRequiredJobNamespace(r *http.Request) (string, error) {
 	return jobNamespace, nil
 }
 
-// ensureNamespaceMatch closes the model-transfer-job BOLA. RequireAccessToMRService
-// runs the SubjectAccessReview against the `namespace` query parameter, but the
-// handlers operate on a namespace taken from `jobNamespace` (read/list/events/delete)
-// or the request body (create/update). If that operated namespace differs from the
-// authorized one, the caller could act on another tenant's namespace. Requiring the
-// two to match keeps every operation inside the namespace the caller was authorized
-// for. An empty operated namespace is left to the caller's existing handling.
-func ensureNamespaceMatch(authorized, operated string) error {
-	if operated != "" && operated != authorized {
-		return fmt.Errorf("namespace %q does not match the authorized namespace %q", operated, authorized)
+// authorizeJobNamespace verifies the caller has service-level access in the
+// namespace where the transfer-job handler will operate. The middleware
+// (RequireAccessToMRService) authorizes the model-registry service namespace,
+// but jobs legitimately run in a different namespace (the user's project), so
+// a separate access check is required for that namespace. An empty namespace
+// is left to the caller's existing handling (e.g. cluster-wide list).
+func (app *App) authorizeJobNamespace(ctx context.Context, client kubernetes.KubernetesClientInterface, jobNamespace string) error {
+	if jobNamespace == "" {
+		return nil
+	}
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*kubernetes.RequestIdentity)
+	if !ok || identity == nil {
+		return fmt.Errorf("missing request identity")
+	}
+	allowed, err := client.CanListServicesInNamespace(ctx, identity, jobNamespace)
+	if err != nil {
+		return fmt.Errorf("authorization check failed for namespace %q: %w", jobNamespace, err)
+	}
+	if !allowed {
+		return fmt.Errorf("access denied to namespace %q", jobNamespace)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

The `ensureNamespaceMatch` check on model-transfer-job routes required `jobNamespace` to equal the model registry service namespace. This broke the legitimate cross-namespace flow where the registry lives in one namespace (e.g. `rhoai-model-registries`) and transfer jobs run in a user's project namespace.

This PR replaces `ensureNamespaceMatch` with `authorizeJobNamespace`, which performs a proper SubjectAccessReview (internal mode) or SelfSubjectAccessReview (user_token mode) against the job namespace. The caller must prove they have service-level access in the namespace they want to operate in, without requiring it to be the same as the registry namespace.

## What changed

**`clients/ui/bff/internal/api/model_transfer_job_handler.go`:**
- Removed `ensureNamespaceMatch` (static namespace equality check)
- Added `authorizeJobNamespace` method on `App` that performs a SAR/SSAR via `client.CanListServicesInNamespace` against the operated-on namespace
- All 6 handlers (list, get, create, update, delete, events) now call `authorizeJobNamespace` instead of `ensureNamespaceMatch`
- Added `context` and `kubernetes` imports for the SAR call

**`clients/ui/bff/internal/api/model_transfer_job_authz_test.go`:**
- Replaced `TestEnsureNamespaceMatch` with `TestAuthorizeJobNamespace` covering: empty namespace (defers), user has access (allowed), cross-namespace without access (rejected), same namespace with access (allowed)
- Added `TestAuthorizeJobNamespaceMissingIdentity` for the missing-identity edge case

## Security

The authorization bypass (BOLA) is still closed: in `internal` auth mode, a caller who can only `get services` in their own namespace cannot operate on jobs in another tenant's namespace because the SAR will deny it. In `user_token` mode, K8s RBAC already enforces this via the caller's own bearer token.

## Verification

- `go build ./...`: clean
- `go test ./internal/api/ -run TestAuthorizeJobNamespace -v`: all pass
- `go vet ./internal/api/`: clean

Made with [Cursor](https://cursor.com)