### PR TITLE
fix: make CORS configurable and disabled by default

### DIFF
--- a/catalog/cmd/catalog.go
+++ b/catalog/cmd/catalog.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -30,6 +31,7 @@ var catalogCfg = struct {
 	ListenAddress          string
 	ConfigPath             []string
 	PerformanceMetricsPath []string
+	CORSAllowedOrigins     []string
 }{
 	ListenAddress:          "0.0.0.0:8080",
 	ConfigPath:             []string{"sources.yaml"},
@@ -89,9 +91,21 @@ func init() {
 	fs.StringVarP(&catalogCfg.ListenAddress, "listen", "l", catalogCfg.ListenAddress, "Address to listen on")
 	fs.StringSliceVar(&catalogCfg.ConfigPath, "catalogs-path", catalogCfg.ConfigPath, "Path to catalog source configuration file")
 	fs.StringSliceVar(&catalogCfg.PerformanceMetricsPath, "performance-metrics", catalogCfg.PerformanceMetricsPath, "Path to performance metrics data directory")
+	fs.StringSliceVar(&catalogCfg.CORSAllowedOrigins, "cors-allowed-origins", nil,
+		"Comma-separated list of allowed CORS origins. If empty (default), CORS is disabled. Can also be set via CATALOG_CORS_ALLOWED_ORIGINS environment variable.")
 }
 
-func runCatalogServer(_ *cobra.Command, _ []string) error {
+func runCatalogServer(cmd *cobra.Command, _ []string) error {
+	if !cmd.Flags().Changed("cors-allowed-origins") {
+		if envVal := os.Getenv("CATALOG_CORS_ALLOWED_ORIGINS"); envVal != "" {
+			for _, origin := range strings.Split(envVal, ",") {
+				if o := strings.TrimSpace(origin); o != "" {
+					catalogCfg.CORSAllowedOrigins = append(catalogCfg.CORSAllowedOrigins, o)
+				}
+			}
+		}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -168,6 +182,7 @@ func runCatalogServer(_ *cobra.Command, _ []string) error {
 		ConfigPaths:            catalogCfg.ConfigPath,
 		PerformanceMetricsPath: catalogCfg.PerformanceMetricsPath,
 		RepoSet:                repoSet,
+		CORSAllowedOrigins:     catalogCfg.CORSAllowedOrigins,
 	})
 
 	pluginServer.AddReadinessCheck("leader_election", elector.Healthy)

--- a/catalog/internal/plugin/server.go
+++ b/catalog/internal/plugin/server.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/go-chi/cors"
 	"gorm.io/gorm"
 
 	"github.com/kubeflow/hub/internal/platform/datastore"
+	platformmw "github.com/kubeflow/hub/internal/platform/server/middleware"
 )
 
 // ServerConfig holds the dependencies needed to create a plugin Server.
@@ -24,6 +24,7 @@ type ServerConfig struct {
 	PerformanceMetricsPath []string
 	RepoSet                datastore.RepoSet
 	Logger                 *slog.Logger
+	CORSAllowedOrigins     []string
 }
 
 // readinessCheck is a named readiness check evaluated by the /readyz handler.
@@ -103,14 +104,7 @@ func (s *Server) MountRoutes() (chi.Router, error) {
 
 	s.router = chi.NewRouter()
 	s.router.Use(middleware.Logger)
-	s.router.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*", "http://*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-PINGOTHER"},
-		ExposedHeaders:   []string{"Link"},
-		AllowCredentials: false,
-		MaxAge:           300,
-	}))
+	s.router.Use(platformmw.CORSMiddleware(s.cfg.CORSAllowedOrigins))
 
 	for _, p := range s.plugins {
 		s.cfg.Logger.Info("mounting plugin routes", "plugin", p.Name())

--- a/catalog/internal/server/openapi/routers.go
+++ b/catalog/internal/server/openapi/routers.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/cors"
 )
 
 //lint:file-ignore U1000 Ignore all unused code, it's generated
@@ -40,14 +39,6 @@ type Router interface {
 func NewRouter(routers ...Router) chi.Router {
 	router := chi.NewRouter()
 	router.Use(Logger)
-	router.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*", "http://*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-PINGOTHER"},
-		ExposedHeaders:   []string{"Link"},
-		AllowCredentials: false,
-		MaxAge:           300, // Maximum value not ignored by any of major browsers
-	}))
 	for _, api := range routers {
 		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc

--- a/catalog/plugins/agent/scripts/gen_openapi_server.sh
+++ b/catalog/plugins/agent/scripts/gen_openapi_server.sh
@@ -21,7 +21,7 @@ trap 'rm -rf "$SPEC" "$GENDIR"' EXIT
 # No .openapi-generator-ignore cross-plugin entries needed.
 "$OPENAPI_GENERATOR" generate \
     -i "$SPEC" -g go-server -o "$GENDIR" --package-name openapi \
-    --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true,featureCORS=true \
+    --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true \
     --template-dir "$REPO_ROOT/templates/go-server"
 
 # Python-based regex replace function

--- a/catalog/plugins/mcp/scripts/gen_openapi_server.sh
+++ b/catalog/plugins/mcp/scripts/gen_openapi_server.sh
@@ -23,7 +23,7 @@ MCP_MODEL_MAPPINGS="MCPArtifact=MCPArtifact,MCPConfigMapKey=MCPConfigMapKey,MCPC
 # Generate into an isolated temp directory so we never touch other plugins' files.
 "$OPENAPI_GENERATOR" generate \
     -i "$SPEC" -g go-server -o "$GENDIR" --package-name openapi \
-    --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true,featureCORS=true \
+    --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true \
     --model-name-mappings="$MCP_MODEL_MAPPINGS" \
     --template-dir "$REPO_ROOT/templates/go-server"
 

--- a/catalog/plugins/model/scripts/gen_openapi_server.sh
+++ b/catalog/plugins/model/scripts/gen_openapi_server.sh
@@ -20,7 +20,7 @@ trap 'rm -rf "$SPEC" "$GENDIR"' EXIT
 # Generate into an isolated temp directory so we never touch other plugins' files.
 "$OPENAPI_GENERATOR" generate \
     -i "$SPEC" -g go-server -o "$GENDIR" --package-name openapi \
-    --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true,featureCORS=true \
+    --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true \
     --template-dir "$REPO_ROOT/templates/go-server"
 
 # Python-based regex replace function

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,10 +1,11 @@
 package cmd
 
 type Config struct {
-	DbFile      string   `mapstructure:"db-file" yaml:"db-file"`
-	Hostname    string   `mapstructure:"hostname" yaml:"hostname"`
-	Port        int      `mapstructure:"port" yaml:"port"`
-	LibraryDirs []string `mapstructure:"metadata-library-dir" yaml:"metadata-library-dir"`
+	DbFile             string   `mapstructure:"db-file" yaml:"db-file"`
+	Hostname           string   `mapstructure:"hostname" yaml:"hostname"`
+	Port               int      `mapstructure:"port" yaml:"port"`
+	LibraryDirs        []string `mapstructure:"metadata-library-dir" yaml:"metadata-library-dir"`
+	CORSAllowedOrigins []string `mapstructure:"cors-allowed-origins" yaml:"cors-allowed-origins"`
 }
 
 var cfg = Config{DbFile: "metadata.sqlite.db", Hostname: "localhost", Port: 8080, LibraryDirs: []string(nil)}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -171,7 +171,7 @@ func runProxyServer(cmd *cobra.Command, args []string) error {
 		ModelRegistryServiceAPIService := openapi.NewModelRegistryServiceAPIService(conn)
 		ModelRegistryServiceAPIController := openapi.NewModelRegistryServiceAPIController(ModelRegistryServiceAPIService)
 
-		router.SetRouter(middleware.WrapWithValidation(ModelRegistryServiceAPIController))
+		router.SetRouter(middleware.WrapWithValidation(cfg.CORSAllowedOrigins, ModelRegistryServiceAPIController))
 
 		// Set the model registry service in the holder for health checks AFTER router is ready
 		// This ensures the readiness probe only passes when the router can serve actual requests
@@ -250,4 +250,7 @@ func init() {
 	proxyCmd.Flags().BoolVar(&proxyCfg.EmbedMD.TLSConfig.VerifyServerCert, "embedmd-database-ssl-verify-server-cert", false, "EmbedMD SSL verify server cert")
 
 	proxyCmd.Flags().StringVar(&proxyCfg.DatastoreType, "datastore-type", proxyCfg.DatastoreType, "Datastore type")
+
+	proxyCmd.Flags().StringSliceVar(&cfg.CORSAllowedOrigins, "cors-allowed-origins", nil,
+		"Comma-separated list of allowed CORS origins. If empty (default), CORS is disabled.")
 }

--- a/internal/platform/server/middleware/cors.go
+++ b/internal/platform/server/middleware/cors.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/go-chi/cors"
+)
+
+// CORSMiddleware returns a CORS middleware handler. If allowedOrigins is empty,
+// the returned middleware is a no-op, making CORS effectively disabled.
+// This is the secure default: deployments that do not explicitly configure
+// allowed origins will not accept cross-origin requests.
+func CORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	if len(allowedOrigins) == 0 {
+		return func(next http.Handler) http.Handler {
+			return next
+		}
+	}
+
+	return cors.Handler(cors.Options{
+		AllowedOrigins:   allowedOrigins,
+		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+		ExposedHeaders:   []string{"Link"},
+		AllowCredentials: false,
+		MaxAge:           300,
+	})
+}

--- a/internal/platform/server/middleware/cors_test.go
+++ b/internal/platform/server/middleware/cors_test.go
@@ -1,0 +1,156 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func dummyHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+}
+
+func TestCORSMiddleware_Disabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		origins []string
+	}{
+		{"nil origins", nil},
+		{"empty slice", []string{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := CORSMiddleware(tc.origins)(dummyHandler())
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("Origin", "https://evil.com")
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+func TestCORSMiddleware_AllowsConfiguredOrigin(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "https://dashboard.example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_RejectsUnconfiguredOrigin(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_PreflightAllowed(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "https://dashboard.example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, rr.Header().Get("Access-Control-Allow-Methods"), "POST")
+}
+
+func TestCORSMiddleware_PreflightDisabled(t *testing.T) {
+	handler := CORSMiddleware(nil)(dummyHandler())
+
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_WildcardOrigin(t *testing.T) {
+	handler := CORSMiddleware([]string{"*"})(dummyHandler())
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://any-site.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_MultipleOrigins(t *testing.T) {
+	origins := []string{"https://dashboard.example.com", "https://admin.example.com"}
+	handler := CORSMiddleware(origins)(dummyHandler())
+
+	for _, origin := range origins {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Origin", origin)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, origin, rr.Header().Get("Access-Control-Allow-Origin"),
+			"expected origin %s to be allowed", origin)
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://other.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSMiddleware_CredentialsDisabled(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Credentials"))
+}
+
+func TestCORSMiddleware_PreflightPATCH(t *testing.T) {
+	handler := CORSMiddleware([]string{"https://dashboard.example.com"})(dummyHandler())
+
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	req.Header.Set("Access-Control-Request-Method", "PATCH")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "https://dashboard.example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, rr.Header().Get("Access-Control-Allow-Methods"), "PATCH")
+}

--- a/internal/server/middleware/router.go
+++ b/internal/server/middleware/router.go
@@ -7,11 +7,12 @@ import (
 	"github.com/kubeflow/hub/internal/server/openapi"
 )
 
-// WrapWithValidation wraps the auto-generated router with custom validation middleware
-func WrapWithValidation(routers ...openapi.Router) http.Handler {
-	// Create the auto-generated router
+// WrapWithValidation wraps the auto-generated router with CORS and validation middleware.
+// If corsAllowedOrigins is empty, CORS is disabled (no cross-origin headers are added).
+func WrapWithValidation(corsAllowedOrigins []string, routers ...openapi.Router) http.Handler {
 	baseRouter := openapi.NewRouter(routers...)
 
-	// Wrap it with our custom validation middleware
-	return platformmw.ValidationMiddleware(baseRouter)
+	handler := platformmw.CORSMiddleware(corsAllowedOrigins)(baseRouter)
+
+	return platformmw.ValidationMiddleware(handler)
 }

--- a/internal/server/middleware/router_test.go
+++ b/internal/server/middleware/router_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubeflow/hub/internal/server/openapi"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubRouter struct{}
+
+func (s *stubRouter) Routes() openapi.Routes {
+	return openapi.Routes{
+		"test": {Name: "test", Method: "GET", Pattern: "/test", HandlerFunc: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		}},
+	}
+}
+
+func (s *stubRouter) OrderedRoutes() []openapi.Route {
+	routes := s.Routes()
+	result := make([]openapi.Route, 0, len(routes))
+	for _, r := range routes {
+		result = append(result, r)
+	}
+	return result
+}
+
+func TestWrapWithValidation_CORSDisabled(t *testing.T) {
+	handler := WrapWithValidation(nil, &stubRouter{})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestWrapWithValidation_CORSEnabled(t *testing.T) {
+	handler := WrapWithValidation([]string{"https://dashboard.example.com"}, &stubRouter{})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "https://dashboard.example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestWrapWithValidation_CORSAndValidation(t *testing.T) {
+	handler := WrapWithValidation([]string{"https://dashboard.example.com"}, &stubRouter{})
+
+	req := httptest.NewRequest("GET", "/test?name=test%00invalid", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/internal/server/openapi/routers.go
+++ b/internal/server/openapi/routers.go
@@ -12,7 +12,6 @@ package openapi
 
 import (
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/cors"
 	"net/http"
 )
 
@@ -39,14 +38,6 @@ type Router interface {
 func NewRouter(routers ...Router) chi.Router {
 	router := chi.NewRouter()
 	router.Use(Logger)
-	router.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*", "http://*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-PINGOTHER"},
-		ExposedHeaders:   []string{"Link"},
-		AllowCredentials: false,
-		MaxAge:           300, // Maximum value not ignored by any of major browsers
-	}))
 	for _, api := range routers {
 		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc

--- a/scripts/gen_openapi_server.sh
+++ b/scripts/gen_openapi_server.sh
@@ -9,7 +9,7 @@ OPENAPI_GENERATOR=${OPENAPI_GENERATOR:-"$PROJECT_ROOT"/bin/openapi-generator-cli
 
 $OPENAPI_GENERATOR generate \
     -i "$PROJECT_ROOT"/api/openapi/model-registry.yaml -g go-server -o "$PROJECT_ROOT"/internal/server/openapi --package-name openapi \
-    --ignore-file-override "$PROJECT_ROOT"/.openapi-generator-ignore --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true,featureCORS=true \
+    --ignore-file-override "$PROJECT_ROOT"/.openapi-generator-ignore --additional-properties=outputAsLibrary=true,enumClassPrefix=true,router=chi,sourceFolder=,onlyInterfaces=true,isGoSubmodule=true,enumClassPrefix=true,useOneOfDiscriminatorLookup=true \
     --template-dir "$PROJECT_ROOT"/templates/go-server
 
 echo "Assembling type_assert Go file"

--- a/templates/go-server/routers.mustache
+++ b/templates/go-server/routers.mustache
@@ -6,15 +6,9 @@ import (
 {{#routers}}
 	{{#mux}}
 	"github.com/gorilla/mux"
-	{{#featureCORS}}
-	"github.com/gorilla/handlers"
-	{{/featureCORS}}
 	{{/mux}}
 	{{#chi}}
 	"github.com/go-chi/chi/v5"
-	{{#featureCORS}}
-	"github.com/go-chi/cors"
-	{{/featureCORS}}
 	{{/chi}}
 {{/routers}}
 )
@@ -47,16 +41,6 @@ func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}
 	{{#chi}}
 	router := chi.NewRouter()
 	router.Use(Logger)
-	{{#featureCORS}}
-	router.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*", "http://*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-PINGOTHER"},
-		ExposedHeaders:   []string{"Link"},
-		AllowCredentials: false,
-		MaxAge:           300, // Maximum value not ignored by any of major browsers
-	}))
-	{{/featureCORS}}
 	{{/chi}}
 {{/routers}}
 	for _, api := range routers {
@@ -65,9 +49,6 @@ func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}
 {{#routers}}
 	{{#mux}}
 			handler = Logger(handler, route.Name)
-			{{#featureCORS}}
-			handler = handlers.CORS()(handler)
-			{{/featureCORS}}
 
 			router.
 				Methods(route.Method).


### PR DESCRIPTION
## Description
The REST proxy and catalog server hardcoded permissive CORS wildcards (https://* and http://*) in generated code, allowing any origin to make cross-origin requests including state-changing methods. This replaces the hardcoded wildcards with a configurable --cors-allowed-origins flag (env: MR_CORS_ALLOWED_ORIGINS / CATALOG_CORS_ALLOWED_ORIGINS) that defaults to empty (CORS disabled), following the secure-by-default principle.

Key changes:
- Remove featureCORS from OpenAPI templates and generation scripts
- Add shared CORSMiddleware helper with explicit no-op when unconfigured to guard against go-chi/cors allowing all origins on empty config
- Add --cors-allowed-origins CLI flag to both proxy and catalog servers
- Include PATCH in allowed methods for partial-update API support

## How Has This Been Tested?
Unit testing

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
