### PR TITLE
fix: upgrade cosign to v3.0.4 and handle signing config conflict with explicit URLs

### DIFF
--- a/clients/python/src/model_registry/signing/image_signer.py
+++ b/clients/python/src/model_registry/signing/image_signer.py
@@ -250,7 +250,7 @@ class ImageSigner:
                 token_content = f.read().strip()
             env["COSIGN_IDENTITY_TOKEN"] = token_content
 
-        if fulcio_url is not None or rekor_url is not None:
+        if fulcio_url is not None and rekor_url is not None:
             # cosign v3+ defaults --use-signing-config=true which conflicts
             # with explicit service URLs; disable it when URLs are provided
             cmd.extend(["--use-signing-config=false"])

--- a/clients/python/src/model_registry/signing/image_signer.py
+++ b/clients/python/src/model_registry/signing/image_signer.py
@@ -250,9 +250,9 @@ class ImageSigner:
                 token_content = f.read().strip()
             env["COSIGN_IDENTITY_TOKEN"] = token_content
 
-        if fulcio_url is not None and rekor_url is not None:
+        if fulcio_url is not None or rekor_url is not None:
             # cosign v3+ defaults --use-signing-config=true which conflicts
-            # with explicit service URLs; disable it when URLs are provided
+            # with any explicit service URL; disable it when URLs are provided
             cmd.extend(["--use-signing-config=false"])
 
         if fulcio_url is not None:

--- a/clients/python/src/model_registry/signing/image_signer.py
+++ b/clients/python/src/model_registry/signing/image_signer.py
@@ -250,6 +250,11 @@ class ImageSigner:
                 token_content = f.read().strip()
             env["COSIGN_IDENTITY_TOKEN"] = token_content
 
+        if fulcio_url is not None or rekor_url is not None:
+            # cosign v3+ defaults --use-signing-config=true which conflicts
+            # with explicit service URLs; disable it when URLs are provided
+            cmd.extend(["--use-signing-config=false"])
+
         if fulcio_url is not None:
             cmd.extend(["--fulcio-url", fulcio_url])
 

--- a/clients/python/tests/test_signing.py
+++ b/clients/python/tests/test_signing.py
@@ -178,6 +178,7 @@ class TestImageSigner:
         cmd = mock_runner.run.call_args[0][0]
         assert cmd == [
             "cosign", "sign", "-y",
+            "--use-signing-config=false",
             "--fulcio-url", FULCIO_URL,
             "--rekor-url", REKOR_URL,
             "quay.io/example/image@sha256:abc123"
@@ -204,6 +205,7 @@ class TestImageSigner:
         cmd = mock_runner.run.call_args[0][0]
         env = mock_runner.run.call_args[1]["env"]
         assert env["COSIGN_IDENTITY_TOKEN"] == "test-token"  # noqa: S105
+        assert "--use-signing-config=false" in cmd
         assert cmd.count("https://default-fulcio.example.com") == 1
         assert cmd.count("https://default-rekor.example.com") == 1
 
@@ -319,6 +321,40 @@ class TestImageSigner:
 
         cmd = mock_runner.run.call_args[0][0]
         assert cmd[-1] == "quay.io/example/image@sha256:abc123"
+        assert "--use-signing-config=false" not in cmd
+
+    @pytest.mark.parametrize(
+        "fulcio_url, rekor_url, expect_flag",
+        [
+            pytest.param(FULCIO_URL, REKOR_URL, True, id="both_urls_disables_signing_config"),
+            pytest.param(FULCIO_URL, None, False, id="only_fulcio_keeps_signing_config"),
+            pytest.param(None, REKOR_URL, False, id="only_rekor_keeps_signing_config"),
+            pytest.param(None, None, False, id="no_urls_keeps_signing_config"),
+        ],
+    )
+    def test_sign_use_signing_config_flag(self, tmp_path, mocker, fulcio_url, rekor_url, expect_flag):
+        """Test --use-signing-config=false is only added when both fulcio and rekor URLs are set."""
+        token_file = tmp_path / "token"
+        token_file.write_text("test-token")
+
+        signer = ImageSigner()
+        mock_runner = mocker.MagicMock()
+        signer.runner = mock_runner
+        sigstore_dir = tmp_path / ".sigstore"
+        sigstore_dir.mkdir()
+        mocker.patch.object(signer, "_get_sigstore_dir", return_value=sigstore_dir)
+
+        signer.sign(
+            image="quay.io/example/image@sha256:abc123",
+            identity_token_path=str(token_file),
+            fulcio_url=fulcio_url,
+            rekor_url=rekor_url,
+        )
+        cmd = mock_runner.run.call_args[0][0]
+        if expect_flag:
+            assert "--use-signing-config=false" in cmd
+        else:
+            assert "--use-signing-config=false" not in cmd
 
     def test_verify_image_is_last_argument(self, mocker):
         """Test that image reference is always the last argument for verify."""

--- a/clients/python/tests/test_signing.py
+++ b/clients/python/tests/test_signing.py
@@ -327,13 +327,13 @@ class TestImageSigner:
         ("fulcio_url", "rekor_url", "expect_flag"),
         [
             pytest.param(FULCIO_URL, REKOR_URL, True, id="both_urls_disables_signing_config"),
-            pytest.param(FULCIO_URL, None, False, id="only_fulcio_keeps_signing_config"),
-            pytest.param(None, REKOR_URL, False, id="only_rekor_keeps_signing_config"),
+            pytest.param(FULCIO_URL, None, True, id="only_fulcio_disables_signing_config"),
+            pytest.param(None, REKOR_URL, True, id="only_rekor_disables_signing_config"),
             pytest.param(None, None, False, id="no_urls_keeps_signing_config"),
         ],
     )
     def test_sign_use_signing_config_flag(self, tmp_path, mocker, fulcio_url, rekor_url, expect_flag):
-        """Test --use-signing-config=false is only added when both fulcio and rekor URLs are set."""
+        """Test --use-signing-config=false is added when any explicit service URL is set."""
         token_file = tmp_path / "token"
         token_file.write_text("test-token")
 

--- a/clients/python/tests/test_signing.py
+++ b/clients/python/tests/test_signing.py
@@ -324,7 +324,7 @@ class TestImageSigner:
         assert "--use-signing-config=false" not in cmd
 
     @pytest.mark.parametrize(
-        "fulcio_url, rekor_url, expect_flag",
+        ("fulcio_url", "rekor_url", "expect_flag"),
         [
             pytest.param(FULCIO_URL, REKOR_URL, True, id="both_urls_disables_signing_config"),
             pytest.param(FULCIO_URL, None, False, id="only_fulcio_keeps_signing_config"),

--- a/jobs/async-upload/Dockerfile
+++ b/jobs/async-upload/Dockerfile
@@ -2,7 +2,8 @@
 #  Asynchronous Model-Sync Job image for Kubeflow Model Registry (https://github.com/kubeflow/hub/issues/1108)
 ###############################################################################
 
-FROM quay.io/securesign/cli-cosign@sha256:a8289d488491991d454a32784de19476f2c984917eb7a33b4544e55512f2747c AS cosign
+# cosign v3.0.4 (multi-arch, no expiration)
+FROM quay.io/securesign/cli-cosign@sha256:3df09cd1b4915e61d4de9c67416827b94e5900763e936e2909fd4d78e1ead8e8 AS cosign
 
 FROM registry.access.redhat.com/ubi9/python-312-minimal AS base
 


### PR DESCRIPTION
Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
 Update cosign from v2.0.0 to v3.0.4 in the async-upload Dockerfile. Cosign v3+ defaults --use-signing-config=true which conflicts with explicit --fulcio-url/--rekor-url flags. Auto-disable signing config when explicit service URLs are provided.

<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
