### PR TITLE
Fix preview for default sources

### DIFF
--- a/clients/ui/frontend/src/app/pages/mcpCatalogSettings/useMcpSourcePreview.ts
+++ b/clients/ui/frontend/src/app/pages/mcpCatalogSettings/useMcpSourcePreview.ts
@@ -96,6 +96,7 @@ export const useMcpSourcePreview = ({
       excludedServers: config.excludedServers,
       properties: {
         yaml: config.yaml,
+        yamlCatalogPath: config.yamlCatalogPath,
       },
     };
   }, [formData, existingSourceConfig]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to fix the preview for the default sources
we are seeing 500 internal server error for preview of default MCP sources- now fixed

## How Has This Been Tested?
Test this change against kind cluster and see the preview for the default MCP sources

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
