### PR TITLE
A proposal for Skills Catalog in Kubeflow

### DIFF
--- a/proposals/KEP-0005-skills-catalog/README.md
+++ b/proposals/KEP-0005-skills-catalog/README.md
@@ -13,10 +13,10 @@ Agent skills have an open specification, growing public repositories, and instal
 ### Goals
 
 - `skill` plugin; API base `/api/skill_catalog/v1alpha1`.
-- A `git-skills-plugin` source type - named after what it reads, following the existing convention (`yaml`, `hf`) - configured through a YAML file that lists repositories; SKILL.md files are parsed per the specification at sync time.
-- Versioned entries: a repository can list multiple refs (tags, releases, branches, or commits). Each ref becomes its own set of catalog entries, with the version shown in the UI.
+- A `git-skills-plugin` source type - a dedicated type for git-hosted skills, alongside the existing `yaml` and `hf` types - listing repositories whose SKILL.md files are parsed per the specification at sync time.
+- Versioned entries: a repository can list multiple refs (tags, releases, branches, or commits). Each ref becomes its own set of catalog entries, with the version shown in the UI. A branch is surfaced as `latest` (not the raw branch name), and every entry pins to the commit it resolved to, so installs are reproducible.
 - Custom metadata (trust tier, provider, category, labels) assigned in the source file; per-skill overrides; include/exclude filtering.
-- Catalog UI: gallery, detail with rendered SKILL.md, filters, install instructions; an admin settings page that manages sources (add/modify/delete source files and repo entries, with include/exclude preview before save) alongside sync status and manual sync.
+- Catalog UI: gallery, detail with rendered SKILL.md, filters, install instructions; an admin settings page that reuses the existing model/MCP catalog-settings mechanism to manage sources (add/edit/delete user-managed sources with include/exclude preview before save; shipped defaults read-only) alongside sync status and manual sync.
 - `marketplace.json` endpoint, with optional URL rewriting for deployments fronting repos with an internal git mirror.
 
 ### Non-Goals
@@ -36,28 +36,32 @@ A standard Hub catalog plugin, following the existing plugin architecture.
 
 ### 2. Skill sources
 
-Registered like any other catalog source, as `type: git-skills-plugin`; the source's configured file lists git repositories and their catalog metadata:
+Registered like any other catalog source, as `type: git-skills-plugin`. A source lists git repositories and their catalog metadata. The repository list can live in the source config **inline** (used by UI-added sources - written to the user-managed ConfigMap, editable like an `hf` source) or **via a file** (`yamlCatalogPath`, used by shipped defaults that bundle many repos). The loader accepts both.
 
 ```yaml
-source: Community Skills
-trustTier: communityContributed
-repositories:
-  - url: https://github.com/example/skills.git
-    refs: [main, v1.0]            # optional; tags/releases/branches/commits -
+# inline form (UI-added source in the user-managed ConfigMap)
+- name: Community Skills
+  id: community-skills
+  type: git-skills-plugin
+  enabled: true
+  trustTier: communityContributed
+  repositories:
+    - url: https://github.com/example/skills.git
+      refs: [main, v1.0]          # optional; tags/releases/branches/commits -
                                   #   each ref yields its own catalog entries.
                                   #   Also: scanPaths, authSecretName,
                                   #   canonicalUrl (when url is a mirror)
-    provider: Example Org
-    category: DevOps
-    labels: [community]
-    includedSkills: ["*"]
-    excludedSkills: ["*-draft"]
-    skillOverrides: [{name: deploy, category: SRE}]
+      provider: Example Org
+      category: DevOps
+      labels: [community]
+      includedSkills: ["*"]
+      excludedSkills: ["*-draft"]
+      skillOverrides: [{name: deploy, category: SRE}]
 ```
 
-Each time the catalog syncs, the plugin reads each listed repository at each listed ref (making a temporary, lightweight copy used only for parsing, then throwing it away), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref, and the exact commit it resolved to is recorded. Skills, refs, repositories, or sources that have been removed are cleaned up. Pulling from private git repositories with securely configured credentials will be supported.
+Each time the catalog syncs, the plugin reads each listed repository at each listed ref (making a temporary, lightweight copy used only for parsing, then throwing it away), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref (a branch is surfaced as `latest`, not the branch name), and the exact commit it resolved to is recorded as `resolvedCommit`. Skills, refs, repositories, or sources that have been removed are cleaned up. Pulling from private git repositories with securely configured credentials will be supported.
 
-Source files stored in a ConfigMap are picked up automatically whenever they change. Files that are mounted read-only appear as read-only in the UI.
+Source management reuses the same mechanism as the model and MCP catalogs: read-only defaults (shipped in a ConfigMap) merged with a user-managed ConfigMap that the settings UI writes via the BFF, with per-source auth stored as Secrets. Adding a skills git source through the UI works like adding a HuggingFace source for models. Editing the ConfigMap directly (kubectl/GitOps) works too; the file-watcher picks up either path.
 
 ### 3. Custom metadata
 
@@ -81,23 +85,26 @@ The `Skill` resource carries the SKILL.md fields (including the body as `readme`
 
 ### 6. Marketplace endpoint
 
-`GET .../marketplace.json` conforms to the [Claude Code plugin marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces):
+`GET .../claude/marketplace.json` serves the marketplace manifest in the [Claude Code plugin marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces). The `claude/` segment is a deliberate per-consumer-format namespace: this path is Claude Code's schema, and another agent's format would live at a sibling path under the same API version - the manifest is a rendered view of the one skill index, not a separate data source.
 
 ```
 /plugin marketplace add https://hub.example.com/api/skill_catalog/v1alpha1
 /plugin install deploy@example-skill-catalog
 ```
 
-Source URLs default to the repositories' own URLs. An optional `skill_content_mirror: {internalBaseUrl, externalBaseUrl}` setting rewrites them for deployments that put an internal mirror in front of the repositories (using the external base by default, and the internal base for `?audience=cluster`). When a skill has entries at multiple refs, the repository's first-listed ref is the one exposed. A note for user docs: `npx skills add` reads git repositories directly, never this endpoint.
+Every listed ref of a skill is exposed as its own plugin entry carrying its version (a branch appears as `latest`), so all versions are discoverable, and each entry's git source is pinned to the commit it resolved to (`resolvedCommit`) so `/plugin install` is reproducible even for `latest`. Source URLs default to the repositories' own URLs. An optional `skill_content_mirror: {internalBaseUrl, externalBaseUrl}` setting rewrites them for deployments that put an internal mirror in front of the repositories (using the external base by default, and the internal base for `?audience=cluster`). A note for user docs: `npx skills add` reads git repositories directly, never this endpoint.
 
 ### 7. UI
 
-Follows the MCP catalog UI, built on the shared catalog components, with a BFF (backend-for-frontend) proxy handler. It includes gallery cards (name, provider, tier badge, version label, description, category/license chips, labels); a detail page (rendered readme, metadata sidebar, supporting files linked to the repository, and install instructions with copy-paste marketplace/npx/manual commands); filters driven by `filter_options`; and an admin settings page (add, edit, or delete source files and repository entries with a preview before saving, plus sync status and manual sync).
+Follows the MCP catalog UI, built on the shared catalog components, with a BFF (backend-for-frontend) proxy handler. It includes gallery cards (name, provider, tier badge, version label, description, category/license chips, labels); a detail page (rendered readme, metadata sidebar, supporting files linked to the repository, and install instructions with copy-paste marketplace/npx/manual commands); filters driven by `filter_options`; and an admin settings page reusing the existing model/MCP catalog-settings pattern (list sources with status, add/edit/delete user-managed sources with a preview before saving, manual sync; shipped defaults read-only).
 
 ## Risks and Mitigations
 
-- **Hub fetches remote content at sync** → only temporary, lightweight copies are made (kept isolated and cleaned up afterward), with timeouts and size limits; content is only parsed, never executed; and private repositories authenticate through Kubernetes Secrets.
-- **Malicious or oversized configured repos** → changing sources requires configuration access; limits are enforced; a source in trouble shows a degraded status; and a scanning hook is planned for the future.
+Source URLs are treated as trusted: managing sources requires admin access (settings page) or configuration access (ConfigMap/GitOps edits), the same trust boundary as the other catalogs. The operational risk is resource exhaustion, not untrusted input.
+
+- **Hub fetches remote content at sync** → only temporary, lightweight copies are made (kept isolated and cleaned up afterward); content is only parsed, never executed; private repositories authenticate through Kubernetes Secrets. Concrete limits bound the blast radius: a per-clone timeout, a maximum repository size, a maximum number of refs per repository, and a global cap on in-flight clones so a large source set (many repositories × many refs) cannot saturate the pod.
+- **Sync storms from rapid config changes** → hot-reload is debounced, so a burst of ConfigMap edits (UI or GitOps) coalesces into a single sync rather than a fetch storm.
+- **A source in trouble** → shown as a degraded source status; a content-scanning hook is planned for the future.
 
 ## Alternatives
 

--- a/proposals/KEP-0005-skills-catalog/README.md
+++ b/proposals/KEP-0005-skills-catalog/README.md
@@ -1,0 +1,105 @@
+# KEP-0005: Skill Catalog Plugin
+
+## Summary
+
+Add a `skill` catalog plugin that indexes AI agent skills - directories containing a `SKILL.md` per the [Agent Skills specification](https://agentskills.io/specification) - serving them through the standard catalog API, a catalog UI alongside the model/MCP/agent catalogs, and a plugin-marketplace endpoint so compatible agents install skills with one `marketplace add`.
+
+Skill sources are git repositories, listed in a YAML source file (ConfigMap-mountable) together with their catalog metadata. At sync, the plugin reads the repos directly and rebuilds the ephemeral database index; repos are never stored.
+
+## Motivation
+
+Agent skills have an open specification, growing public repositories, and installation tooling (`npx skills add`, Claude Code marketplaces). Organizations need what Hub already provides for models, MCP servers, and agents: a curated, filterable catalog with provenance and a governed acquisition path. Skills complete the catalog family.
+
+### Goals
+
+- `skill` plugin; API base `/api/skill_catalog/v1alpha1`.
+- A `git` source type - named per the existing convention of naming source types for what they read (`yaml`, `hf`) - configured via a YAML file listing repositories; SKILL.md parsed per the specification at sync.
+- Versioned entries: repo entries may list refs (tags, releases, branches, commits); each ref yields its own catalog entries, with the version shown in the UI.
+- Custom metadata (trust tier, provider, category, labels) assigned in the source file; per-skill overrides; include/exclude filtering.
+- Catalog UI: gallery, detail with rendered SKILL.md, filters, install instructions; a read-only admin settings page (source status, preview, manual sync).
+- `marketplace.json` endpoint, with optional URL rewriting for deployments fronting repos with an internal git mirror.
+
+### Non-Goals
+
+- Skill delivery into agent pods - consumes this API; needs no plugin changes.
+- Mirroring / air-gapped distribution - deployment packaging; reading a mirror instead of GitHub is a config change.
+- Writable source management (API or UI) - sources are managed by editing the mounted files; configuration access is the trust boundary.
+- Security scanning of skill content - deferred.
+- Skill authoring/editing - read-only, one-way, source-authoritative.
+- Usage analytics - deferred.
+- Cross-plugin unified search - Hub-wide concern.
+
+## Proposal
+
+### 1. New `skill` plugin
+
+A standard Hub catalog plugin, following the existing plugin architecture.
+
+### 2. Skill sources
+
+Registered like any other catalog source, as `type: git`; the source's configured file lists git repositories and their catalog metadata:
+
+```yaml
+source: Community Skills
+trustTier: communityContributed
+repositories:
+  - url: https://github.com/example/skills.git
+    refs: [main, v1.0]            # optional; tags/releases/branches/commits -
+                                  #   each ref yields its own catalog entries.
+                                  #   Also: scanPaths, authSecretName,
+                                  #   canonicalUrl (when url is a mirror)
+    provider: Example Org
+    category: DevOps
+    labels: [community]
+    includedSkills: ["*"]
+    excludedSkills: ["*-draft"]
+    skillOverrides: [{name: deploy, category: SRE}]
+```
+
+At sync, the plugin reads each listed repository at each listed ref directly (a temporary shallow clone used only for parsing, then discarded), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref, with the resolved commit SHA recorded. Removed skills, refs, repos, or sources are cleaned up.
+
+### 3. Custom metadata
+
+Trust tier, provider, category, and labels come from the source file and are applied to its skills at sync - never read from repo content. `trustTier` is simply a label - one of `platformProvided`, `partnerVerified`, `organizationApproved`, `communityContributed` (downstream products may map display names) - shown as a badge and filterable, with no ordering or special semantics. Sources are only manageable by editing the mounted files.
+
+### 4. Skill identity
+
+Permanent identity is `(repository, path)` - the upstream repo URL plus the skill's directory - with `version` distinguishing entries. The index is an ephemeral cache; internal IDs are not durable. This keeps external references stable across rebuilds and across deployments reading the same skill through different URLs.
+
+### 5. API surface
+
+```
+GET  /skills                    # name, q, source, sourceLabel, filterQuery, paging
+GET  /skills/{id}
+GET  /skills/filter_options
+GET  /marketplace.json
+POST .../sources/preview        # existing endpoint, assetType: skills
+```
+
+The `Skill` resource carries the SKILL.md fields (including the body as `readme`), the identity (`repository`, `path`, `version`, `resolvedCommit`), and the catalog metadata (tier, provider, category, labels, supporting-file paths). Supporting-file contents are not stored - they are linked to the repo.
+
+### 6. Marketplace endpoint
+
+`GET .../marketplace.json` conforms to the [Claude Code plugin marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces):
+
+```
+/plugin marketplace add https://hub.example.com/api/skill_catalog/v1alpha1
+/plugin install deploy@example-skill-catalog
+```
+
+Source URLs default to the repos' own URLs; optional `skill_content_mirror: {internalBaseUrl, externalBaseUrl}` rewrites them for deployments fronting repos with an internal mirror (external base by default, internal for `?audience=cluster`). When a skill has entries at multiple refs, the repo's first-listed ref is exposed. User-docs note: `npx skills add` consumes git repos directly, never this endpoint.
+
+### 7. UI
+
+Follows the MCP catalog UI on the shared catalog components, with a BFF proxy handler. Gallery cards (name, provider, tier badge, version label, description, category/license chips, labels); detail page (rendered readme, metadata sidebar, supporting files linked to the repo, install instructions with copy-paste marketplace/npx/manual commands); filters from `filter_options`; read-only admin settings page (source status, include/exclude preview, manual sync).
+
+## Risks and Mitigations
+
+- **Hub fetches remote content at sync** → temporary shallow clones only (isolated, cleaned up), timeouts and size limits, parse-only (repo content is never executed), Secret-based auth for private repos.
+- **Malicious or oversized configured repos** → source management requires configuration access, limits, degraded-source status surfacing, future scan hook.
+
+## Alternatives
+
+- **Pre-parse skill metadata into the source file.** Rejected: it duplicates the parser outside Hub and fixes metadata at file-generation time; with repo locations in the file, one parser refreshes from the repos at every sync.
+- **Store supporting-file contents in the DB.** Rejected: content is always reachable in the source repo.
+- **Semantic versioning.** Rejected: not in the SKILL.md spec; refs (tags/releases/commits) chosen in the source file are explicit and honest.

--- a/proposals/KEP-0005-skills-catalog/README.md
+++ b/proposals/KEP-0005-skills-catalog/README.md
@@ -8,7 +8,7 @@ Skill sources are git repositories, listed in a YAML source file (ConfigMap-moun
 
 ## Motivation
 
-Agent skills have an open specification, growing public repositories, and installation tooling (`npx skills add`, Claude Code marketplaces). Organizations need what Hub already provides for models, MCP servers, and agents: a curated, filterable catalog with provenance and a governed acquisition path. Skills complete the catalog family.
+Agent skills have an open specification, growing public repositories, and installation tooling (`npx skills add`, Claude Code marketplaces). Organizations need what Hub already provides for models, MCP servers, and agents: a curated, filterable catalog with provenance and a governed acquisition path. Skills extend the catalog family.
 
 ### Goals
 
@@ -56,7 +56,7 @@ repositories:
     skillOverrides: [{name: deploy, category: SRE}]
 ```
 
-At sync, the plugin reads each listed repository at each listed ref directly (a temporary shallow clone used only for parsing, then discarded), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref, with the resolved commit SHA recorded. Removed skills, refs, repos, or sources are cleaned up.
+At sync, the plugin reads each listed repository at each listed ref directly (a temporary shallow clone used only for parsing, then discarded), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref, with the resolved commit SHA recorded. Removed skills, refs, repos, or sources are cleaned up. Capability to pull from private git repositories with safe credential configuration will be supported.
 
 ### 3. Custom metadata
 
@@ -69,11 +69,11 @@ Permanent identity is `(repository, path)` - the upstream repo URL plus the skil
 ### 5. API surface
 
 ```
-GET  /skills                    # name, q, source, sourceLabel, filterQuery, paging
+GET  /skills    # name, q, source, sourceLabel, filterQuery, paging
 GET  /skills/{id}
 GET  /skills/filter_options
-GET  /marketplace.json
-POST .../sources/preview        # existing endpoint, assetType: skills
+GET  /claude/marketplace.json
+POST .../sources/preview  # existing endpoint, assetType: skills
 ```
 
 The `Skill` resource carries the SKILL.md fields (including the body as `readme`), the identity (`repository`, `path`, `version`, `resolvedCommit`), and the catalog metadata (tier, provider, category, labels, supporting-file paths). Supporting-file contents are not stored - they are linked to the repo.

--- a/proposals/KEP-0005-skills-catalog/README.md
+++ b/proposals/KEP-0005-skills-catalog/README.md
@@ -4,7 +4,7 @@
 
 Add a `skill` catalog plugin that indexes AI agent skills - directories containing a `SKILL.md` per the [Agent Skills specification](https://agentskills.io/specification) - serving them through the standard catalog API, a catalog UI alongside the model/MCP/agent catalogs, and a plugin-marketplace endpoint so compatible agents install skills with one `marketplace add`.
 
-Skill sources are git repositories, listed in a YAML source file (ConfigMap-mountable) together with their catalog metadata. At sync, the plugin reads the repos directly and rebuilds the ephemeral database index; repos are never stored.
+Skill sources are git repositories, listed in a YAML source file (which can be mounted from a ConfigMap) along with their catalog metadata. Each time the catalog syncs, the plugin reads the repositories directly and rebuilds its index from scratch. The repositories themselves are never stored.
 
 ## Motivation
 
@@ -13,20 +13,20 @@ Agent skills have an open specification, growing public repositories, and instal
 ### Goals
 
 - `skill` plugin; API base `/api/skill_catalog/v1alpha1`.
-- A `git-skills-plugin` source type - named per the existing convention of naming source types for what they read (`yaml`, `hf`) - configured via a YAML file listing repositories; SKILL.md parsed per the specification at sync.
-- Versioned entries: repo entries may list refs (tags, releases, branches, commits); each ref yields its own catalog entries, with the version shown in the UI.
+- A `git-skills-plugin` source type - named after what it reads, following the existing convention (`yaml`, `hf`) - configured through a YAML file that lists repositories; SKILL.md files are parsed per the specification at sync time.
+- Versioned entries: a repository can list multiple refs (tags, releases, branches, or commits). Each ref becomes its own set of catalog entries, with the version shown in the UI.
 - Custom metadata (trust tier, provider, category, labels) assigned in the source file; per-skill overrides; include/exclude filtering.
 - Catalog UI: gallery, detail with rendered SKILL.md, filters, install instructions; an admin settings page that manages sources (add/modify/delete source files and repo entries, with include/exclude preview before save) alongside sync status and manual sync.
 - `marketplace.json` endpoint, with optional URL rewriting for deployments fronting repos with an internal git mirror.
 
 ### Non-Goals
 
-- Skill delivery into agent pods - consumes this API; needs no plugin changes.
-- Mirroring / air-gapped distribution - deployment packaging; reading a mirror instead of GitHub is a config change.
-- Security scanning of skill content - deferred.
-- Skill authoring/editing - read-only, one-way, source-authoritative.
-- Usage analytics - deferred.
-- Cross-plugin unified search - Hub-wide concern.
+- Delivering skills into agent pods. That consumes this API and needs no changes to the plugin.
+- Mirroring or air-gapped distribution. That is a deployment-packaging concern; reading from a mirror instead of GitHub is just a config change.
+- Security scanning of skill content. Deferred.
+- Authoring or editing skills. The catalog is read-only and one-way; the source repositories are authoritative.
+- Usage analytics. Deferred.
+- Unified search across plugins. That is a Hub-wide concern.
 
 ## Proposal
 
@@ -55,17 +55,17 @@ repositories:
     skillOverrides: [{name: deploy, category: SRE}]
 ```
 
-At sync, the plugin reads each listed repository at each listed ref directly (a temporary shallow clone used only for parsing, then discarded), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref, with the resolved commit SHA recorded. Removed skills, refs, repos, or sources are cleaned up. Capability to pull from private git repositories with safe credential configuration will be supported.
+Each time the catalog syncs, the plugin reads each listed repository at each listed ref (making a temporary, lightweight copy used only for parsing, then throwing it away), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref, and the exact commit it resolved to is recorded. Skills, refs, repositories, or sources that have been removed are cleaned up. Pulling from private git repositories with securely configured credentials will be supported.
 
-ConfigMap-backed source file picked up by hot-reload; immutably mounted files render read-only in the UI.
+Source files stored in a ConfigMap are picked up automatically whenever they change. Files that are mounted read-only appear as read-only in the UI.
 
 ### 3. Custom metadata
 
-Trust tier, provider, category, and labels come from the source file and are applied to its skills at sync - never read from repo content. `trustTier` is simply a label - one of `platformProvided`, `partnerVerified`, `organizationApproved`, `communityContributed` (downstream products may map display names) - shown as a badge and filterable, with no ordering or special semantics.
+Trust tier, provider, category, and labels come from the source file and are applied to its skills at sync time - they are never read from the repository's content. `trustTier` is simply a label - one of `platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed` (downstream products may show their own display names). It appears as a badge and can be filtered on, but carries no ordering or special meaning.
 
 ### 4. Skill identity
 
-Permanent identity is `(repository, path)` - the upstream repo URL plus the skill's directory - with `version` distinguishing entries. The index is an ephemeral cache; internal IDs are not durable. This keeps external references stable across rebuilds and across deployments reading the same skill through different URLs.
+A skill's permanent identity is `(repository, path)` - the upstream repository URL plus the skill's directory - with `version` telling entries apart. The index is a temporary cache, so its internal IDs are not stable. Using the repository and path as the identity keeps external references stable across index rebuilds, and even across deployments that read the same skill through different URLs.
 
 ### 5. API surface
 
@@ -77,7 +77,7 @@ GET  /claude/marketplace.json
 POST .../sources/preview  # existing endpoint, assetType: skills
 ```
 
-The `Skill` resource carries the SKILL.md fields (including the body as `readme`), the identity (`repository`, `path`, `version`, `resolvedCommit`), and the catalog metadata (tier, provider, category, labels, supporting-file paths). Supporting-file contents are not stored - they are linked to the repo.
+The `Skill` resource carries the SKILL.md fields (including the body as `readme`), the identity (`repository`, `path`, `version`, `resolvedCommit`), and the catalog metadata (tier, provider, category, labels, and the paths of supporting files). The contents of supporting files are not stored - the catalog links to them in the repository instead.
 
 ### 6. Marketplace endpoint
 
@@ -88,19 +88,19 @@ The `Skill` resource carries the SKILL.md fields (including the body as `readme`
 /plugin install deploy@example-skill-catalog
 ```
 
-Source URLs default to the repos' own URLs; optional `skill_content_mirror: {internalBaseUrl, externalBaseUrl}` rewrites them for deployments fronting repos with an internal mirror (external base by default, internal for `?audience=cluster`). When a skill has entries at multiple refs, the repo's first-listed ref is exposed. User-docs note: `npx skills add` consumes git repos directly, never this endpoint.
+Source URLs default to the repositories' own URLs. An optional `skill_content_mirror: {internalBaseUrl, externalBaseUrl}` setting rewrites them for deployments that put an internal mirror in front of the repositories (using the external base by default, and the internal base for `?audience=cluster`). When a skill has entries at multiple refs, the repository's first-listed ref is the one exposed. A note for user docs: `npx skills add` reads git repositories directly, never this endpoint.
 
 ### 7. UI
 
-Follows the MCP catalog UI on the shared catalog components, with a BFF proxy handler. Gallery cards (name, provider, tier badge, version label, description, category/license chips, labels); detail page (rendered readme, metadata sidebar, supporting files linked to the repo, install instructions with copy-paste marketplace/npx/manual commands); filters from `filter_options`; read-only admin settings page (source status, include/exclude preview, manual sync).
+Follows the MCP catalog UI, built on the shared catalog components, with a BFF (backend-for-frontend) proxy handler. It includes gallery cards (name, provider, tier badge, version label, description, category/license chips, labels); a detail page (rendered readme, metadata sidebar, supporting files linked to the repository, and install instructions with copy-paste marketplace/npx/manual commands); filters driven by `filter_options`; and an admin settings page (add, edit, or delete source files and repository entries with a preview before saving, plus sync status and manual sync).
 
 ## Risks and Mitigations
 
-- **Hub fetches remote content at sync** → temporary shallow clones only (isolated, cleaned up), timeouts and size limits, parse-only (repo content is never executed), Secret-based auth for private repos.
-- **Malicious or oversized configured repos** → source management requires configuration access, limits, degraded-source status surfacing, future scan hook.
+- **Hub fetches remote content at sync** → only temporary, lightweight copies are made (kept isolated and cleaned up afterward), with timeouts and size limits; content is only parsed, never executed; and private repositories authenticate through Kubernetes Secrets.
+- **Malicious or oversized configured repos** → changing sources requires configuration access; limits are enforced; a source in trouble shows a degraded status; and a scanning hook is planned for the future.
 
 ## Alternatives
 
-- **Pre-parse skill metadata into the source file.** Rejected: it duplicates the parser outside Hub and fixes metadata at file-generation time; with repo locations in the file, one parser refreshes from the repos at every sync.
-- **Store supporting-file contents in the DB.** Rejected: content is always reachable in the source repo.
-- **Semantic versioning.** Rejected: not in the SKILL.md spec; refs (tags/releases/commits) chosen in the source file are explicit and honest.
+- **Pre-parse skill metadata into the source file.** Rejected: it would duplicate the parser outside Hub and freeze the metadata at the moment the file is generated. By listing repository locations in the file instead, a single parser refreshes the metadata from the repositories on every sync.
+- **Store supporting-file contents in the database.** Rejected: the content is always available in the source repository.
+- **Semantic versioning.** Rejected: it isn't part of the SKILL.md spec. The refs (tags, releases, commits) chosen in the source file are explicit and honest.

--- a/proposals/KEP-0005-skills-catalog/README.md
+++ b/proposals/KEP-0005-skills-catalog/README.md
@@ -13,17 +13,16 @@ Agent skills have an open specification, growing public repositories, and instal
 ### Goals
 
 - `skill` plugin; API base `/api/skill_catalog/v1alpha1`.
-- A `git` source type - named per the existing convention of naming source types for what they read (`yaml`, `hf`) - configured via a YAML file listing repositories; SKILL.md parsed per the specification at sync.
+- A `git-skills-plugin` source type - named per the existing convention of naming source types for what they read (`yaml`, `hf`) - configured via a YAML file listing repositories; SKILL.md parsed per the specification at sync.
 - Versioned entries: repo entries may list refs (tags, releases, branches, commits); each ref yields its own catalog entries, with the version shown in the UI.
 - Custom metadata (trust tier, provider, category, labels) assigned in the source file; per-skill overrides; include/exclude filtering.
-- Catalog UI: gallery, detail with rendered SKILL.md, filters, install instructions; a read-only admin settings page (source status, preview, manual sync).
+- Catalog UI: gallery, detail with rendered SKILL.md, filters, install instructions; an admin settings page that manages sources (add/modify/delete source files and repo entries, with include/exclude preview before save) alongside sync status and manual sync.
 - `marketplace.json` endpoint, with optional URL rewriting for deployments fronting repos with an internal git mirror.
 
 ### Non-Goals
 
 - Skill delivery into agent pods - consumes this API; needs no plugin changes.
 - Mirroring / air-gapped distribution - deployment packaging; reading a mirror instead of GitHub is a config change.
-- Writable source management (API or UI) - sources are managed by editing the mounted files; configuration access is the trust boundary.
 - Security scanning of skill content - deferred.
 - Skill authoring/editing - read-only, one-way, source-authoritative.
 - Usage analytics - deferred.
@@ -37,7 +36,7 @@ A standard Hub catalog plugin, following the existing plugin architecture.
 
 ### 2. Skill sources
 
-Registered like any other catalog source, as `type: git`; the source's configured file lists git repositories and their catalog metadata:
+Registered like any other catalog source, as `type: git-skills-plugin`; the source's configured file lists git repositories and their catalog metadata:
 
 ```yaml
 source: Community Skills
@@ -58,9 +57,11 @@ repositories:
 
 At sync, the plugin reads each listed repository at each listed ref directly (a temporary shallow clone used only for parsing, then discarded), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref, with the resolved commit SHA recorded. Removed skills, refs, repos, or sources are cleaned up. Capability to pull from private git repositories with safe credential configuration will be supported.
 
+ConfigMap-backed source file picked up by hot-reload; immutably mounted files render read-only in the UI.
+
 ### 3. Custom metadata
 
-Trust tier, provider, category, and labels come from the source file and are applied to its skills at sync - never read from repo content. `trustTier` is simply a label - one of `platformProvided`, `partnerVerified`, `organizationApproved`, `communityContributed` (downstream products may map display names) - shown as a badge and filterable, with no ordering or special semantics. Sources are only manageable by editing the mounted files.
+Trust tier, provider, category, and labels come from the source file and are applied to its skills at sync - never read from repo content. `trustTier` is simply a label - one of `platformProvided`, `partnerVerified`, `organizationApproved`, `communityContributed` (downstream products may map display names) - shown as a badge and filterable, with no ordering or special semantics.
 
 ### 4. Skill identity
 

--- a/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
+++ b/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
@@ -1,9 +1,9 @@
 # Skill Catalog - High-Level Architecture
 
-- **Part I - Core (upstream Kubeflow Hub, connected model).** Everything in the Hub KEP; self-sufficient wherever git sources are reachable.
-- **Part II - Optional disconnected support.** Default source files + a self-serving skills-content image (built-in smart-HTTP git server), deployed only when the cluster cannot reach the source repos. Adds **zero code** to the Hub plugin: disconnected support is configuration plus one optional Deployment.
+- **Part I - Core (upstream Kubeflow Hub, connected setup).** Everything in the Hub KEP. It works on its own anywhere the git sources can be reached.
+- **Part II - Optional disconnected support.** A set of default source files plus a self-serving skills-content image (a container with a built-in git server). This is deployed only when the cluster cannot reach the source repositories. It adds **no code** to the Hub plugin: disconnected support is just configuration plus one optional Deployment.
 
-**Governing principle:** git repos are the only place skills live; everything else is a view. Postgres is an ephemeral cache rebuilt by reading git (temporary shallow clones for parsing only; repos are never stored); the agent assembler checks skills out of the same repos the catalog reads. One SKILL.md parser exists (in Hub): Hub is the only component needing skill *metadata*; every other consumer takes *content* directly from git.
+**Governing principle:** git repositories are the only place skills actually live; everything else is a view onto them. Postgres is a temporary cache, rebuilt by reading git (temporary lightweight copies for parsing only; the repositories are never stored). The agent assembler checks skills out of the same repositories the catalog reads. There is exactly one SKILL.md parser, and it lives in Hub: Hub is the only component that needs skill *metadata*, while every other consumer takes skill *content* directly from git.
 
 ---
 
@@ -15,7 +15,7 @@
 flowchart TB
     AUTHOR["Skill authors<br/>SKILL.md in git repos"] --> GIT[("Git repos<br/>GitHub / GitLab / any smart-HTTP server")]
     ADMIN["Admins<br/>manage source files (repo lists, refs,<br/>tier/provider/category) via Admin UI / GitOps"] --> HUB["Kubeflow Hub skill plugin<br/>resolve, parse, index, serve"]
-    GIT -->|"read at sync per ref<br/>temp shallow clone, parse-only"| HUB
+    GIT -->|"read at sync per ref<br/>temporary copy, parse-only"| HUB
     DEV["Agent developer"] -->|"browse / select"| HUB
     HUB -->|"API: skill selection"| AGENT["Agent pods<br/>skill-assembler init container"]
     GIT -->|"sparse checkout"| AGENT
@@ -25,13 +25,13 @@ flowchart TB
 
 ## 2. Two Planes, One Meeting Point
 
-Metadata (browse/choose) and content (obtain/run) travel separately and meet only at the canonical identity `(repository, path)`. Both planes read the same repos, so they can never drift.
+Metadata (for browsing and choosing) and content (for obtaining and running) travel separately, and meet only at the canonical identity `(repository, path)`. Both planes read the same repositories, so they can never drift apart.
 
 ```mermaid
 flowchart LR
     REPOS[("Git repos<br/>single source of truth")]
     subgraph meta["Metadata plane"]
-        SCAN["resolve, scan, parse<br/>temp clone, discarded"] --> PG[("Postgres<br/>ephemeral, rebuilt each sync")] --> API["REST API, UI, marketplace.json"]
+        SCAN["resolve, scan, parse<br/>temporary copy, discarded"] --> PG[("Postgres<br/>temporary, rebuilt each sync")] --> API["REST API, UI, marketplace.json"]
     end
     subgraph content["Content plane"]
         SPARSE["git sparse checkout / clone"] --> CONS["assembler, npx, manual copy"]
@@ -43,25 +43,25 @@ flowchart LR
 
 ## 3. Hub Skill Plugin - Components
 
-A new source type `git`, named per Hub's convention of naming source types for what they read (`yaml`, `hf`). Its configured file lists git repositories, refs, and custom metadata, not pre-parsed skill data.
+A new source type `git`, named after what it reads, following Hub's convention (`yaml`, `hf`). Its configured file lists git repositories, refs, and custom metadata - not pre-parsed skill data.
 
 ```mermaid
 flowchart TB
     CFG[/"catalog-sources.yaml, skill_catalogs section<br/>type git, yamlCatalogPath, hot-reloaded"/] --> LOADER
     SF[/"source files (data image or ConfigMap)<br/>repos + refs + tier, provider, category, labels"/] --> LOADER
     subgraph plugin["skill plugin"]
-        LOADER["loader<br/>leader-elected sync, orphans, source status"]
-        RES["repo resolver<br/>temp shallow clone per repo and ref<br/>parse-only, discarded after indexing"]
+        LOADER["loader<br/>sync (single leader), stale-entry cleanup, source status"]
+        RES["repo resolver<br/>temporary copy per repo and ref<br/>parse-only, deleted after indexing"]
         PARSER["SKILL.md parser<br/>THE one parser"]
         SVC["service<br/>list, get, filterQuery"]
         MKT["marketplace.json renderer<br/>optional mirror URL rewrite"]
     end
     LOADER --> RES --> PARSER --> DB[("shared GORM DB<br/>skill index")]
     SVC --> DB
-    UI["Catalog UI<br/>gallery, detail, settings (source management)", and add the write edge"] --> BFF["BFF"] --> SVC & MKT
+    UI["Catalog UI<br/>gallery, detail, settings (source management)"] -->|"read + write"| BFF["BFF"] --> SVC & MKT
 ```
 
-## 4. Sync Flow - Rebuilding the Ephemeral Index
+## 4. Sync Flow - Rebuilding the Temporary Index
 
 ```mermaid
 sequenceDiagram
@@ -70,15 +70,15 @@ sequenceDiagram
     participant R as resolver + parser
     participant DB as Postgres
     C->>L: sync
-    L->>L: remove skills of deleted sources
+    L->>L: remove skills from deleted sources
     loop each source file, each repo and ref
         L->>R: resolve(repo, ref)
-        R->>R: temp shallow clone at ref (Secret auth, limits)
-        R->>R: scan for SKILL.md, parse + validate (lenient)
+        R->>R: make a temporary copy at ref (Secret auth, limits)
+        R->>R: find SKILL.md, parse + validate (lenient)
         R->>R: version = ref, resolvedCommit = SHA
-        R->>R: stamp custom metadata (tier, provider, category, labels, overrides)
-        R->>DB: upsert by (repository, path, version), delete orphans
-        R->>R: discard temp clone
+        R->>R: apply custom metadata (tier, provider, category, labels, overrides)
+        R->>DB: insert or update by (repository, path, version), remove stale entries
+        R->>R: delete the temporary copy
         L->>DB: status available / partially-available / error
     end
     L->>DB: refresh filter options
@@ -86,7 +86,7 @@ sequenceDiagram
 
 ## 5. Identity - Canonical vs Fetch URL
 
-Internal IDs are not durable (the index is a cache); the canonical identity is the only permanent reference, unchanged even when a deployment reads through a different URL. `version` (the ref) distinguishes entries.
+Internal IDs are not stable, since the index is just a cache. The canonical identity is the only permanent reference, and it stays the same even when a deployment reads through a different URL. `version` (the ref) tells entries apart.
 
 ```mermaid
 flowchart TB
@@ -98,12 +98,12 @@ flowchart TB
 
 ## 6. Custom Metadata - Who Sets Tier / Provider / Category
 
-Custom metadata lives in the source files and is stamped at sync; it is never stored in the wipeable index and never read from repo content. Sources change by editing the mounted files directly (kubectl / GitOps) or through the admin settings page, whose edits persist to a ConfigMap-backed source file (hot-reloaded); immutably mounted files render read-only in the UI. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`) shown as a badge and filterable, with no ordering or special semantics.
+Custom metadata lives in the source files and is applied at sync time. It is never kept in the rebuildable index and never read from repository content. Sources are changed either by editing the mounted files directly (kubectl / GitOps) or through the admin settings page, whose edits are saved to a ConfigMap-backed source file (and picked up automatically). Files mounted as read-only appear read-only in the UI. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`), shown as a badge and available as a filter, with no ordering or special meaning.
 
 | Entry path | Who | Sets |
 |---|---|---|
 | Platform-shipped source files (PR-reviewed; Part II) | Platform team | All fields |
-| Deployment-managed source files (admin settings UI or kubectl / GitOps) | Catalog admins | All fields; UI edits persist to a ConfigMap-backed file" |
+| Deployment-managed source files (admin settings UI or kubectl / GitOps) | Catalog admins | All fields; UI edits are saved to a ConfigMap-backed file |
 | `skillOverrides` on a repo entry | Either | Per-skill category/labels |
 | SKILL.md `metadata` frontmatter | Skill authors | `customProperties` only, never tier/provider |
 
@@ -121,16 +121,16 @@ The skill detail page renders all three with environment-correct, copy-paste-rea
 
 # Part II - Optional Disconnected Support (Self-Serving Skills-Content Image)
 
-> Optional: deploy only when the cluster cannot reach the source repos (air-gapped/disconnected); The air gap changes one thing: both planes need an in-cluster git server. The **skills-content image serves itself**: it carries the bare repo clones and a built-in smart-HTTP git server entrypoint, so one Deployment covers both planes (Hub resolves repos on it, the assembler checks out of it), preserving the no-drift invariant. Hub's only delta is configuration (the disconnected source-file variant + `skill_content_mirror`).
+> Optional: deploy this only when the cluster cannot reach the source repositories (an air-gapped or disconnected setup). The air gap changes just one thing: both planes now need a git server running inside the cluster. The **skills-content image serves itself**: it carries copies of the repositories together with a built-in git server, so a single Deployment covers both planes (Hub resolves repositories from it, and the assembler checks skills out of it), keeping the no-drift guarantee intact. Hub's only change is configuration (the disconnected variant of the source files, plus `skill_content_mirror`).
 
 ## 9. Content Pipeline
 
-A separate pipeline owns the **default source files from git repos** and builds a **skills-content image** that contains all the different skills repos.
+A separate pipeline owns the **default source files from git repositories** and builds a **skills-content image** that contains copies of all the skills repositories.
 
-- **Source files** these are same YAML configuration files from Phase I the define metadata and git repo locations about the skills.
-- **Bare repo clones + the git server** go in a separate immutable `skills-content` image, pulled only in disconnected deployments. Its entrypoint is `skills-git-server`, a small stdlib-only Go binary that serves `/content/repos` over git's smart HTTP protocol via `git http-backend`. Run it and it is the git server; mount/copy it and it is data.
+- **Source files** are the same YAML configuration files from Part I - the ones that define each skill's metadata and git repository location.
+- **The repository copies plus the git server** go into a separate, immutable `skills-content` image, pulled only in disconnected deployments. Its entrypoint is `skills-git-server`, a small Go binary (standard library only) that serves `/content/repos` over git's HTTP protocol via `git http-backend`. Run the image and it is a git server; mount or copy from it and it is just data.
 
-Clones keep their upstream {org}/{repo} names, so everything lines up by construction: the mirror URL is just the canonical URL with its host swapped (github.com/acme/skills.git → {mirrorBase}/acme/skills.git), and the server serves each repo at that same path (/acme/skills.git → /content/repos/acme/skills.git). No lookup tables anywhere, and the org prefix keeps two repos with the same name from colliding.
+The copies keep their upstream `{org}/{repo}` names, so everything lines up automatically: the mirror URL is just the canonical URL with its host swapped (github.com/acme/skills.git → {mirrorBase}/acme/skills.git), and the server serves each repository at that same path (/acme/skills.git → /content/repos/acme/skills.git). There are no lookup tables anywhere, and the org prefix keeps two repositories with the same name from colliding.
 
 ```mermaid
 flowchart LR
@@ -147,7 +147,7 @@ flowchart LR
 
 ## 10. Serving the Mirror - Stateless by Construction
 
-No PVC, no database, no loader Job, no admin credentials: the running image **is** the served content. Content update = roll the Deployment to the new image tag. The server is read-only by construction: anonymous push is disabled in `git http-backend` by default, and the container filesystem is an immutable image layer. CVE surface is UBI-minimal + `git-core` + a stdlib-only Go wrapper; there is no web UI, auth system, or persistent state to attack.
+No persistent volume, no database, no loader Job, no admin credentials: the running image **is** the content it serves. To update the content, you roll the Deployment to a new image tag. The server is read-only by design: anonymous push is disabled in `git http-backend` by default, and the container filesystem is an immutable image layer. The attack surface is small - a minimal UBI base plus `git-core` plus a standard-library-only Go wrapper - with no web UI, auth system, or persistent state to attack.
 
 ```mermaid
 flowchart TB
@@ -165,9 +165,9 @@ flowchart TB
     SRV -->|"npx / git clone via Route"| LAPTOP
 ```
 
-One canonical identity, three URLs by audience: in-cluster consumers use the Service URL, laptops the Route URL, and all records (assembly manifest, audit) keep the canonical upstream URL, comparable with connected deployments. Smart HTTP fully supports the operations the system needs: shallow clones, blobless/partial clones, sparse checkout, npx.
+One canonical identity, three URLs depending on the audience: in-cluster consumers use the Service URL, laptops use the Route URL, and all records (the assembly manifest and audit logs) keep the canonical upstream URL, so they stay comparable with connected deployments. Git's HTTP protocol fully supports the operations the system needs: shallow clones, partial clones, sparse checkout, and npx.
 
-*Note:* because the Hub plugin only sees URLs, any git hosting reachable from the cluster (an internal GitLab, Gitea, etc.) can serve as the mirror instead; the self-serving image is simply the zero-state default. Trade-off accepted: no repo-browsing web UI (the catalog UI covers skill browsing) and no push path (the mirror is read-only by design).
+*Note:* because the Hub plugin only ever sees URLs, any git host the cluster can reach (an internal GitLab, Gitea, and so on) can serve as the mirror instead. The self-serving image is simply the default when nothing else is available. Trade-offs accepted: no web UI for browsing repositories (the catalog UI handles skill browsing) and no way to push (the mirror is read-only by design).
 
 ---
 
@@ -175,10 +175,10 @@ One canonical identity, three URLs by audience: in-cluster consumers use the Ser
 
 | Invariant | Part | Consequence |
 |---|---|---|
-| Git is the only durable store of content and source of metadata | I | Postgres droppable/rebuildable anytime; repos never stored in Hub |
-| One parser (Hub), fed by source files | I | Spec changes implemented once; metadata refreshes from repos at every sync |
-| Canonical identity `(repository, path)` + ref-based versions | I | Audit/pinning comparable across rebuilds, deployments, environments |
-| "Custom metadata = source files; UI edits persist to the same files | One durable format regardless of entry path; labels as trustworthy as admin/ConfigMap access |
-| Catalog never writes to sources | I | One-way, source-authoritative |
-| Assembler is harness-agnostic (layout config) | I | New harnesses need a layout entry, not a delivery system |
-| Disconnected support = the self-serving content image + configuration, zero plugin code | II | Upstream carries no deployment concerns; the gap is crossed by an immutable image that is also the server |
+| Git is the only lasting store of content and source of metadata | I | Postgres can be dropped and rebuilt anytime; repositories are never stored in Hub |
+| One parser (in Hub), fed by source files | I | Spec changes are implemented once; metadata refreshes from the repositories on every sync |
+| Canonical identity `(repository, path)` plus ref-based versions | I | Audit and pinning stay comparable across rebuilds, deployments, and environments |
+| Custom metadata comes from source files; UI edits are saved back to those same files | I | One durable format no matter how it was entered; labels are as trustworthy as admin/ConfigMap access |
+| The catalog never writes to sources | I | One-way; the source repositories are authoritative |
+| The assembler is harness-agnostic (driven by layout config) | I | New harnesses need only a layout entry, not a whole delivery system |
+| Disconnected support = the self-serving content image plus configuration, with no plugin code | II | Upstream carries no deployment concerns; the gap is crossed by an immutable image that is also the server |

--- a/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
+++ b/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
@@ -117,44 +117,20 @@ Custom metadata lives in the source files and is stamped at sync; it is never st
 
 The skill detail page renders all three with environment-correct, copy-paste-ready URLs.
 
-## 8. Agent Delivery - Sparse Checkout Assembly
-
-10 skills out of a 2000-skill catalog transfer ~0.5% of the data: one init container, one shared volume, seconds at pod start. Identical in Part II; only fetch URLs differ.
-
-```mermaid
-sequenceDiagram
-    participant UI as Agent-creation UI / operator
-    participant CAT as Catalog API
-    participant ASM as skill-assembler (init container)
-    participant GIT as Git source
-    participant POD as Agent container
-    UI->>CAT: browse / select skills
-    CAT-->>UI: identities (repository, path, ref) + fetchUrl
-    UI->>ASM: config (repository, path, ref, fetchUrl, output layout)
-    loop each unique repo
-        ASM->>GIT: shallow blobless sparse clone, sparse-checkout set paths, pinned ref
-        ASM->>ASM: copy into layout (flat / .agents/skills / .claude/skills / custom)
-    end
-    ASM->>ASM: write /output/.skill-manifest.yaml (repository, path, name, resolvedRef)
-    ASM-->>POD: shared emptyDir ready, harness loads skills
-```
-
-Any requested skill missing means the init container fails loudly (never half-assembled). The manifest answers "which skill versions is this agent running" from the pod alone, in canonical terms.
-
 ---
 
 # Part II - Optional Disconnected Support (Self-Serving Skills-Content Image)
 
-> Optional: deploy only when the cluster cannot reach the source repos (air-gapped/disconnected); not part of the upstream Hub proposal. The air gap changes one thing: both planes need an in-cluster git server. The **skills-content image serves itself**: it carries the bare repo clones and a built-in smart-HTTP git server entrypoint, so one Deployment covers both planes (Hub resolves repos on it, the assembler checks out of it), preserving the no-drift invariant. Hub's only delta is configuration (the disconnected source-file variant + `skill_content_mirror`).
+> Optional: deploy only when the cluster cannot reach the source repos (air-gapped/disconnected); The air gap changes one thing: both planes need an in-cluster git server. The **skills-content image serves itself**: it carries the bare repo clones and a built-in smart-HTTP git server entrypoint, so one Deployment covers both planes (Hub resolves repos on it, the assembler checks out of it), preserving the no-drift invariant. Hub's only delta is configuration (the disconnected source-file variant + `skill_content_mirror`).
 
-## 9. Content Pipeline (model-metadata-collection)
+## 9. Content Pipeline
 
-m-m-c owns the **default source files** (the same role it plays for models/MCP/agents) and builds the **skills-content image**. No SKILL.md parsing here. Two artifacts, deliberately separate:
+A separate pipeline owns the **default source files from git repos** and builds a **skills-content image** that contains all the different skills repos.
 
-- **Source files** (small) ride in the existing shared data image, pulled by every deployment.
-- **Bare repo clones + the git server** go in a separate immutable `skills-content` image, pulled only in disconnected deployments. Its entrypoint is `skills-git-server`, a small stdlib-only Go binary (in m-m-c) that serves `/content/repos` over git's smart HTTP protocol via `git http-backend`. Run it and it is the git server; mount/copy it and it is data.
+- **Source files** these are same YAML configuration files from Phase I the define metadata and git repo locations about the skills.
+- **Bare repo clones + the git server** go in a separate immutable `skills-content` image, pulled only in disconnected deployments. Its entrypoint is `skills-git-server`, a small stdlib-only Go binary that serves `/content/repos` over git's smart HTTP protocol via `git http-backend`. Run it and it is the git server; mount/copy it and it is data.
 
-The `{org}/{repo}` clone layout is load-bearing: it makes the canonical-to-mirror rewrite (diagram 5) deterministic, and it maps one-to-one to the served URLs (`/{org}/{repo}.git`).
+Clones keep their upstream {org}/{repo} names, so everything lines up by construction: the mirror URL is just the canonical URL with its host swapped (github.com/acme/skills.git → {mirrorBase}/acme/skills.git), and the server serves each repo at that same path (/acme/skills.git → /content/repos/acme/skills.git). No lookup tables anywhere, and the org prefix keeps two repos with the same name from colliding.
 
 ```mermaid
 flowchart LR

--- a/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
+++ b/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
@@ -14,7 +14,7 @@
 ```mermaid
 flowchart TB
     AUTHOR["Skill authors<br/>SKILL.md in git repos"] --> GIT[("Git repos<br/>GitHub / GitLab / any smart-HTTP server")]
-    ADMIN["Admins<br/>edit source files (repo lists, refs,<br/>tier/provider/category) via kubectl / GitOps"] --> HUB["Kubeflow Hub skill plugin<br/>resolve, parse, index, serve"]
+    ADMIN["Admins<br/>manage source files (repo lists, refs,<br/>tier/provider/category) via Admin UI / GitOps"] --> HUB["Kubeflow Hub skill plugin<br/>resolve, parse, index, serve"]
     GIT -->|"read at sync per ref<br/>temp shallow clone, parse-only"| HUB
     DEV["Agent developer"] -->|"browse / select"| HUB
     HUB -->|"API: skill selection"| AGENT["Agent pods<br/>skill-assembler init container"]
@@ -58,7 +58,7 @@ flowchart TB
     end
     LOADER --> RES --> PARSER --> DB[("shared GORM DB<br/>skill index")]
     SVC --> DB
-    UI["Catalog UI<br/>gallery, detail, read-only settings"] --> BFF["BFF"] --> SVC & MKT
+    UI["Catalog UI<br/>gallery, detail, settings (source management)", and add the write edge"] --> BFF["BFF"] --> SVC & MKT
 ```
 
 ## 4. Sync Flow - Rebuilding the Ephemeral Index
@@ -98,12 +98,12 @@ flowchart TB
 
 ## 6. Custom Metadata - Who Sets Tier / Provider / Category
 
-Custom metadata lives in the source files and is stamped at sync; it is never stored in the wipeable index and never read from repo content. There is no API write path: sources change by editing the mounted files. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`) shown as a badge and filterable, with no ordering or special semantics.
+Custom metadata lives in the source files and is stamped at sync; it is never stored in the wipeable index and never read from repo content. Sources change by editing the mounted files directly (kubectl / GitOps) or through the admin settings page, whose edits persist to a ConfigMap-backed source file (hot-reloaded); immutably mounted files render read-only in the UI. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`) shown as a badge and filterable, with no ordering or special semantics.
 
 | Entry path | Who | Sets |
 |---|---|---|
-| Platform-shipped source files (PR-reviewed; Part II: authored in m-m-c) | Platform team | All fields |
-| Deployment-edited source files (kubectl / GitOps) | Cluster admins | All fields; admin = whoever holds ConfigMap access |
+| Platform-shipped source files (PR-reviewed; Part II) | Platform team | All fields |
+| Deployment-managed source files (admin settings UI or kubectl / GitOps) | Catalog admins | All fields; UI edits persist to a ConfigMap-backed file" |
 | `skillOverrides` on a repo entry | Either | Per-skill category/labels |
 | SKILL.md `metadata` frontmatter | Skill authors | `customProperties` only, never tier/provider |
 
@@ -178,7 +178,7 @@ One canonical identity, three URLs by audience: in-cluster consumers use the Ser
 | Git is the only durable store of content and source of metadata | I | Postgres droppable/rebuildable anytime; repos never stored in Hub |
 | One parser (Hub), fed by source files | I | Spec changes implemented once; metadata refreshes from repos at every sync |
 | Canonical identity `(repository, path)` + ref-based versions | I | Audit/pinning comparable across rebuilds, deployments, environments |
-| Custom metadata = source files; no API write path | I | Labels are exactly as trustworthy as ConfigMap RBAC |
+| "Custom metadata = source files; UI edits persist to the same files | One durable format regardless of entry path; labels as trustworthy as admin/ConfigMap access |
 | Catalog never writes to sources | I | One-way, source-authoritative |
 | Assembler is harness-agnostic (layout config) | I | New harnesses need a layout entry, not a delivery system |
 | Disconnected support = the self-serving content image + configuration, zero plugin code | II | Upstream carries no deployment concerns; the gap is crossed by an immutable image that is also the server |

--- a/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
+++ b/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
@@ -130,7 +130,7 @@ A separate pipeline owns the **default source files from git repositories** and 
 - **Source files** are the same YAML configuration files from Part I - the ones that define each skill's metadata and git repository location.
 - **The repository copies plus the git server** go into a separate, immutable `skills-content` image, pulled only in disconnected deployments. Its entrypoint is `skills-git-server`, a small Go binary (standard library only) that serves `/content/repos` over git's HTTP protocol via `git http-backend`. Run the image and it is a git server; mount or copy from it and it is just data.
 
-The copies keep their upstream `{org}/{repo}` names, so everything lines up automatically: the mirror URL is just the canonical URL with its host swapped (github.com/acme/skills.git → {mirrorBase}/acme/skills.git), and the server serves each repository at that same path (/acme/skills.git → /content/repos/acme/skills.git). There are no lookup tables anywhere, and the org prefix keeps two repositories with the same name from colliding.
+The clones keep their upstream `{org}/{repo}` names, so everything lines up automatically: the mirror URL is just the canonical URL with its host swapped (github.com/acme/skills.git → {mirrorBase}/acme/skills.git), and the server serves each repository at that same path (/acme/skills.git → /content/repos/acme/skills.git). There are no lookup tables anywhere, and the org prefix keeps two repositories with the same name from colliding.
 
 ```mermaid
 flowchart LR
@@ -147,7 +147,7 @@ flowchart LR
 
 ## 10. Serving the Mirror - Stateless by Construction
 
-No persistent volume, no database, no loader Job, no admin credentials: the running image **is** the content it serves. To update the content, you roll the Deployment to a new image tag. The server is read-only by design: anonymous push is disabled in `git http-backend` by default, and the container filesystem is an immutable image layer. The attack surface is small - a minimal UBI base plus `git-core` plus a standard-library-only Go wrapper - with no web UI, auth system, or persistent state to attack.
+No PVC, no database, no loader Job, no admin credentials: the running image **is** the content it serves. To update the content, you roll the Deployment to a new image tag. The server is read-only by design: anonymous push is disabled in `git http-backend` by default, and the container filesystem is an immutable image layer. The attack surface is small - a minimal UBI base plus `git-core` plus a standard-library-only Go wrapper - with no web UI, auth system, or persistent state to attack.
 
 ```mermaid
 flowchart TB
@@ -165,7 +165,7 @@ flowchart TB
     SRV -->|"npx / git clone via Route"| LAPTOP
 ```
 
-One canonical identity, three URLs depending on the audience: in-cluster consumers use the Service URL, laptops use the Route URL, and all records (the assembly manifest and audit logs) keep the canonical upstream URL, so they stay comparable with connected deployments. Git's HTTP protocol fully supports the operations the system needs: shallow clones, partial clones, sparse checkout, and npx.
+One canonical identity, three URLs depending on the audience: in-cluster consumers use the Service URL, laptops use the Route URL, and all records (the assembly manifest and audit logs) keep the canonical upstream URL, so they stay comparable with connected deployments. Smart HTTP fully supports the operations the system needs: shallow clones, partial clones, sparse checkout, and npx.
 
 *Note:* because the Hub plugin only ever sees URLs, any git host the cluster can reach (an internal GitLab, Gitea, and so on) can serve as the mirror instead. The self-serving image is simply the default when nothing else is available. Trade-offs accepted: no web UI for browsing repositories (the catalog UI handles skill browsing) and no way to push (the mirror is read-only by design).
 

--- a/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
+++ b/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
@@ -1,0 +1,208 @@
+# Skill Catalog - High-Level Architecture
+
+- **Part I - Core (upstream Kubeflow Hub, connected model).** Everything in the Hub KEP; self-sufficient wherever git sources are reachable.
+- **Part II - Optional disconnected support.** Default source files + a self-serving skills-content image (built-in smart-HTTP git server), deployed only when the cluster cannot reach the source repos. Adds **zero code** to the Hub plugin: disconnected support is configuration plus one optional Deployment.
+
+**Governing principle:** git repos are the only place skills live; everything else is a view. Postgres is an ephemeral cache rebuilt by reading git (temporary shallow clones for parsing only; repos are never stored); the agent assembler checks skills out of the same repos the catalog reads. One SKILL.md parser exists (in Hub): Hub is the only component needing skill *metadata*; every other consumer takes *content* directly from git.
+
+---
+
+# Part I - Core Architecture 
+
+## 1. System Context
+
+```mermaid
+flowchart TB
+    AUTHOR["Skill authors<br/>SKILL.md in git repos"] --> GIT[("Git repos<br/>GitHub / GitLab / any smart-HTTP server")]
+    ADMIN["Admins<br/>edit source files (repo lists, refs,<br/>tier/provider/category) via kubectl / GitOps"] --> HUB["Kubeflow Hub skill plugin<br/>resolve, parse, index, serve"]
+    GIT -->|"read at sync per ref<br/>temp shallow clone, parse-only"| HUB
+    DEV["Agent developer"] -->|"browse / select"| HUB
+    HUB -->|"API: skill selection"| AGENT["Agent pods<br/>skill-assembler init container"]
+    GIT -->|"sparse checkout"| AGENT
+    HUB -->|"marketplace.json"| LAPTOP["Laptops<br/>Claude Code, npx, git"]
+    GIT -->|"npx skills add / git clone"| LAPTOP
+```
+
+## 2. Two Planes, One Meeting Point
+
+Metadata (browse/choose) and content (obtain/run) travel separately and meet only at the canonical identity `(repository, path)`. Both planes read the same repos, so they can never drift.
+
+```mermaid
+flowchart LR
+    REPOS[("Git repos<br/>single source of truth")]
+    subgraph meta["Metadata plane"]
+        SCAN["resolve, scan, parse<br/>temp clone, discarded"] --> PG[("Postgres<br/>ephemeral, rebuilt each sync")] --> API["REST API, UI, marketplace.json"]
+    end
+    subgraph content["Content plane"]
+        SPARSE["git sparse checkout / clone"] --> CONS["assembler, npx, manual copy"]
+    end
+    REPOS --> SCAN
+    REPOS --> SPARSE
+    API -.->|"selection: repository + path + ref"| SPARSE
+```
+
+## 3. Hub Skill Plugin - Components
+
+A new source type `git`, named per Hub's convention of naming source types for what they read (`yaml`, `hf`). Its configured file lists git repositories, refs, and custom metadata, not pre-parsed skill data.
+
+```mermaid
+flowchart TB
+    CFG[/"catalog-sources.yaml, skill_catalogs section<br/>type git, yamlCatalogPath, hot-reloaded"/] --> LOADER
+    SF[/"source files (data image or ConfigMap)<br/>repos + refs + tier, provider, category, labels"/] --> LOADER
+    subgraph plugin["skill plugin"]
+        LOADER["loader<br/>leader-elected sync, orphans, source status"]
+        RES["repo resolver<br/>temp shallow clone per repo and ref<br/>parse-only, discarded after indexing"]
+        PARSER["SKILL.md parser<br/>THE one parser"]
+        SVC["service<br/>list, get, filterQuery"]
+        MKT["marketplace.json renderer<br/>optional mirror URL rewrite"]
+    end
+    LOADER --> RES --> PARSER --> DB[("shared GORM DB<br/>skill index")]
+    SVC --> DB
+    UI["Catalog UI<br/>gallery, detail, read-only settings"] --> BFF["BFF"] --> SVC & MKT
+```
+
+## 4. Sync Flow - Rebuilding the Ephemeral Index
+
+```mermaid
+sequenceDiagram
+    participant C as trigger (hot-reload / interval / manual)
+    participant L as Loader (leader)
+    participant R as resolver + parser
+    participant DB as Postgres
+    C->>L: sync
+    L->>L: remove skills of deleted sources
+    loop each source file, each repo and ref
+        L->>R: resolve(repo, ref)
+        R->>R: temp shallow clone at ref (Secret auth, limits)
+        R->>R: scan for SKILL.md, parse + validate (lenient)
+        R->>R: version = ref, resolvedCommit = SHA
+        R->>R: stamp custom metadata (tier, provider, category, labels, overrides)
+        R->>DB: upsert by (repository, path, version), delete orphans
+        R->>R: discard temp clone
+        L->>DB: status available / partially-available / error
+    end
+    L->>DB: refresh filter options
+```
+
+## 5. Identity - Canonical vs Fetch URL
+
+Internal IDs are not durable (the index is a cache); the canonical identity is the only permanent reference, unchanged even when a deployment reads through a different URL. `version` (the ref) distinguishes entries.
+
+```mermaid
+flowchart TB
+    ID["Canonical (permanent)<br/>repository = github.com/acme/skills.git<br/>path = skills/deploy"]
+    ID --> F1["Default<br/>fetch = canonical"]
+    ID --> F2["Mirror deployment<br/>fetch = mirrorBase/acme/skills.git<br/>canonicalUrl preserved in the source file"]
+    ID -.- N["Rewrite is deterministic (mirrors preserve org/repo layout).<br/>Audit, dedup, pinning always use canonical.<br/>marketplace.json picks the fetch URL by audience."]
+```
+
+## 6. Custom Metadata - Who Sets Tier / Provider / Category
+
+Custom metadata lives in the source files and is stamped at sync; it is never stored in the wipeable index and never read from repo content. There is no API write path: sources change by editing the mounted files. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`) shown as a badge and filterable, with no ordering or special semantics.
+
+| Entry path | Who | Sets |
+|---|---|---|
+| Platform-shipped source files (PR-reviewed; Part II: authored in m-m-c) | Platform team | All fields |
+| Deployment-edited source files (kubectl / GitOps) | Cluster admins | All fields; admin = whoever holds ConfigMap access |
+| `skillOverrides` on a repo entry | Either | Per-skill category/labels |
+| SKILL.md `metadata` frontmatter | Skill authors | `customProperties` only, never tier/provider |
+
+## 7. Consumers - Three Install Protocols
+
+| Protocol | Input | Notes |
+|---|---|---|
+| `/plugin marketplace add <catalog-url>` | The catalog's `marketplace.json` | Claude Code + compatible agents; one add = whole curated catalog. Key feature |
+| `npx skills add <repo-url>` | A **git repo** URL, never the catalog URL | Upstream repos, or the mirror Route (Part II) |
+| Manual | `git clone` + copy | Into the agent's skills dir (`~/.claude/skills/`, `~/.agents/skills/`, ...) |
+
+The skill detail page renders all three with environment-correct, copy-paste-ready URLs.
+
+## 8. Agent Delivery - Sparse Checkout Assembly
+
+10 skills out of a 2000-skill catalog transfer ~0.5% of the data: one init container, one shared volume, seconds at pod start. Identical in Part II; only fetch URLs differ.
+
+```mermaid
+sequenceDiagram
+    participant UI as Agent-creation UI / operator
+    participant CAT as Catalog API
+    participant ASM as skill-assembler (init container)
+    participant GIT as Git source
+    participant POD as Agent container
+    UI->>CAT: browse / select skills
+    CAT-->>UI: identities (repository, path, ref) + fetchUrl
+    UI->>ASM: config (repository, path, ref, fetchUrl, output layout)
+    loop each unique repo
+        ASM->>GIT: shallow blobless sparse clone, sparse-checkout set paths, pinned ref
+        ASM->>ASM: copy into layout (flat / .agents/skills / .claude/skills / custom)
+    end
+    ASM->>ASM: write /output/.skill-manifest.yaml (repository, path, name, resolvedRef)
+    ASM-->>POD: shared emptyDir ready, harness loads skills
+```
+
+Any requested skill missing means the init container fails loudly (never half-assembled). The manifest answers "which skill versions is this agent running" from the pod alone, in canonical terms.
+
+---
+
+# Part II - Optional Disconnected Support (Self-Serving Skills-Content Image)
+
+> Optional: deploy only when the cluster cannot reach the source repos (air-gapped/disconnected); not part of the upstream Hub proposal. The air gap changes one thing: both planes need an in-cluster git server. The **skills-content image serves itself**: it carries the bare repo clones and a built-in smart-HTTP git server entrypoint, so one Deployment covers both planes (Hub resolves repos on it, the assembler checks out of it), preserving the no-drift invariant. Hub's only delta is configuration (the disconnected source-file variant + `skill_content_mirror`).
+
+## 9. Content Pipeline (model-metadata-collection)
+
+m-m-c owns the **default source files** (the same role it plays for models/MCP/agents) and builds the **skills-content image**. No SKILL.md parsing here. Two artifacts, deliberately separate:
+
+- **Source files** (small) ride in the existing shared data image, pulled by every deployment.
+- **Bare repo clones + the git server** go in a separate immutable `skills-content` image, pulled only in disconnected deployments. Its entrypoint is `skills-git-server`, a small stdlib-only Go binary (in m-m-c) that serves `/content/repos` over git's smart HTTP protocol via `git http-backend`. Run it and it is the git server; mount/copy it and it is data.
+
+The `{org}/{repo}` clone layout is load-bearing: it makes the canonical-to-mirror rewrite (diagram 5) deterministic, and it maps one-to-one to the served URLs (`/{org}/{repo}.git`).
+
+```mermaid
+flowchart LR
+    SCHED["scheduled rebuild<br/>nightly/weekly"] --> SRC
+    subgraph mmc["model-metadata-collection CI"]
+        SRC["source files per tier<br/>PR-reviewed, repos + refs + custom metadata<br/>connected + disconnected variants"]
+        SRC --> DATA["shared data image<br/>/app/data (source files)"]
+        SRC --> CLONE["git clone --bare each repo"]
+        CLONE --> IMG["skills-content image, immutable, versioned<br/>/content/repos/org/repo.git + manifest.yaml<br/>entrypoint skills-git-server (smart HTTP)"]
+    end
+    DATA ==> REG[("disconnected registry")]
+    IMG ==>|"oc mirror / media across the gap"| REG
+```
+
+## 10. Serving the Mirror - Stateless by Construction
+
+No PVC, no database, no loader Job, no admin credentials: the running image **is** the served content. Content update = roll the Deployment to the new image tag. The server is read-only by construction: anonymous push is disabled in `git http-backend` by default, and the container filesystem is an immutable image layer. CVE surface is UBI-minimal + `git-core` + a stdlib-only Go wrapper; there is no web UI, auth system, or persistent state to attack.
+
+```mermaid
+flowchart TB
+    subgraph os["Disconnected OpenShift cluster"]
+        REG[("registry<br/>skills-content image")]
+        SRV["skills-git-server Deployment<br/>runs the skills-content image<br/>Service skills-git.hub.svc port 8080, external Route"]
+        HUB["Hub skill plugin<br/>overlay with disconnected source files<br/>(mirror urls + canonicalUrl), skill_content_mirror"]
+        AGENT["Agent pods / assembler"]
+        REG -->|"image pull"| SRV
+        SRV -->|"resolve at sync, internal URL"| HUB
+        SRV -->|"sparse checkout, internal URL"| AGENT
+        HUB -->|"API"| AGENT
+    end
+    HUB -->|"marketplace.json with external Route URLs"| LAPTOP["Laptops on internal network"]
+    SRV -->|"npx / git clone via Route"| LAPTOP
+```
+
+One canonical identity, three URLs by audience: in-cluster consumers use the Service URL, laptops the Route URL, and all records (assembly manifest, audit) keep the canonical upstream URL, comparable with connected deployments. Smart HTTP fully supports the operations the system needs: shallow clones, blobless/partial clones, sparse checkout, npx.
+
+*Note:* because the Hub plugin only sees URLs, any git hosting reachable from the cluster (an internal GitLab, Gitea, etc.) can serve as the mirror instead; the self-serving image is simply the zero-state default. Trade-off accepted: no repo-browsing web UI (the catalog UI covers skill browsing) and no push path (the mirror is read-only by design).
+
+---
+
+## Design Invariants
+
+| Invariant | Part | Consequence |
+|---|---|---|
+| Git is the only durable store of content and source of metadata | I | Postgres droppable/rebuildable anytime; repos never stored in Hub |
+| One parser (Hub), fed by source files | I | Spec changes implemented once; metadata refreshes from repos at every sync |
+| Canonical identity `(repository, path)` + ref-based versions | I | Audit/pinning comparable across rebuilds, deployments, environments |
+| Custom metadata = source files; no API write path | I | Labels are exactly as trustworthy as ConfigMap RBAC |
+| Catalog never writes to sources | I | One-way, source-authoritative |
+| Assembler is harness-agnostic (layout config) | I | New harnesses need a layout entry, not a delivery system |
+| Disconnected support = the self-serving content image + configuration, zero plugin code | II | Upstream carries no deployment concerns; the gap is crossed by an immutable image that is also the server |

--- a/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
+++ b/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
@@ -47,18 +47,20 @@ A new source type `git`, named after what it reads, following Hub's convention (
 
 ```mermaid
 flowchart TB
-    CFG[/"catalog-sources.yaml, skill_catalogs section<br/>type git, yamlCatalogPath, hot-reloaded"/] --> LOADER
-    SF[/"source files (data image or ConfigMap)<br/>repos + refs + tier, provider, category, labels"/] --> LOADER
+    CFG[/"catalog-sources.yaml, skill_catalogs section<br/>type git-skills-plugin, hot-reloaded"/] --> LOADER
+    DEF[/"default sources (read-only ConfigMap)<br/>repos via file (yamlCatalogPath) or inline"/] --> LOADER
+    USER[/"user-managed sources (ConfigMap)<br/>UI-written, repos inline, merged over defaults"/] --> LOADER
     subgraph plugin["skill plugin"]
-        LOADER["loader<br/>sync (single leader), stale-entry cleanup, source status"]
-        RES["repo resolver<br/>temporary copy per repo and ref<br/>parse-only, deleted after indexing"]
+        LOADER["loader<br/>sync (single leader), stale-entry cleanup, source status<br/>debounced triggers, in-flight-clone cap"]
+        RES["repo resolver<br/>temporary copy per repo and ref<br/>parse-only, deleted; timeout/size/max-refs"]
         PARSER["SKILL.md parser<br/>THE one parser"]
         SVC["service<br/>list, get, filterQuery"]
-        MKT["marketplace.json renderer<br/>optional mirror URL rewrite"]
+        MKT["marketplace.json renderer<br/>all refs, pinned to resolvedCommit"]
     end
     LOADER --> RES --> PARSER --> DB[("shared GORM DB<br/>skill index")]
     SVC --> DB
-    UI["Catalog UI<br/>gallery, detail, settings (source management)"] -->|"read + write"| BFF["BFF"] --> SVC & MKT
+    UI["Catalog UI<br/>gallery, detail, settings (source management)"] --> BFF["BFF"] --> SVC & MKT
+    BFF -->|"add/edit/delete via existing catalog-settings pattern"| USER
 ```
 
 ## 4. Sync Flow - Rebuilding the Temporary Index
@@ -86,7 +88,7 @@ sequenceDiagram
 
 ## 5. Identity - Canonical vs Fetch URL
 
-Internal IDs are not stable, since the index is just a cache. The canonical identity is the only permanent reference, and it stays the same even when a deployment reads through a different URL. `version` (the ref) tells entries apart.
+Internal IDs are not stable, since the index is just a cache. The canonical identity is the only permanent reference, and it stays the same even when a deployment reads through a different URL. `version` (the ref) tells entries apart - a branch surfaces as `latest`, and every entry records the commit it resolved to (`resolvedCommit`), which the marketplace pins to so installs are reproducible even for `latest`.
 
 ```mermaid
 flowchart TB
@@ -98,12 +100,12 @@ flowchart TB
 
 ## 6. Custom Metadata - Who Sets Tier / Provider / Category
 
-Custom metadata lives in the source files and is applied at sync time. It is never kept in the rebuildable index and never read from repository content. Sources are changed either by editing the mounted files directly (kubectl / GitOps) or through the admin settings page, whose edits are saved to a ConfigMap-backed source file (and picked up automatically). Files mounted as read-only appear read-only in the UI. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`), shown as a badge and available as a filter, with no ordering or special meaning.
+Custom metadata lives in the source files and is applied at sync time. It is never kept in the rebuildable index and never read from repository content. Source management reuses the existing model/MCP catalog-settings mechanism: read-only default sources merged with a user-managed ConfigMap that the settings UI writes via the BFF (auth as Secrets). Adding a skills git source through the UI works like adding a HuggingFace source for models; editing the ConfigMap directly (kubectl / GitOps) works too. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`), shown as a badge and available as a filter, with no ordering or special meaning.
 
 | Entry path | Who | Sets |
 |---|---|---|
-| Platform-shipped source files (PR-reviewed; Part II) | Platform team | All fields |
-| Deployment-managed source files (admin settings UI or kubectl / GitOps) | Catalog admins | All fields; UI edits are saved to a ConfigMap-backed file |
+| Default sources (read-only; Part II) | Platform team | All fields; read-only in the UI |
+| User-managed sources (admin settings UI or kubectl / GitOps) | Catalog admins | All fields; UI writes the user-managed ConfigMap |
 | `skillOverrides` on a repo entry | Either | Per-skill category/labels |
 | SKILL.md `metadata` frontmatter | Skill authors | `customProperties` only, never tier/provider |
 


### PR DESCRIPTION
This is proposal for adding Skills catalog along with Model/MCP/Agent catalogs

## Description

Add a `skill` catalog plugin that indexes AI agent skills - directories containing a `SKILL.md` per the [Agent Skills specification](https://agentskills.io/specification)


