### PR TITLE
fix(ui): open agents catalog details via /overview route

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts
@@ -217,7 +217,8 @@ describe('Agents Catalog Gallery', () => {
     initAgentsCatalogIntercepts({ agentsPerCategory: 1 });
     agentsCatalog.visit();
     agentsCatalog.findCardDetailLink('agent_templates-agent-1').click();
-    cy.url().should('include', '/agents-catalog/');
+    cy.url().should('include', '/agents-catalog/agent_templates-agent-1/overview');
+    cy.findByTestId('app-page-title').should('exist');
   });
 
   it('should display labels on agent cards with mapped display names', () => {

--- a/clients/ui/frontend/src/app/pages/agentsCatalog/AgentsCatalogRoutes.tsx
+++ b/clients/ui/frontend/src/app/pages/agentsCatalog/AgentsCatalogRoutes.tsx
@@ -10,8 +10,11 @@ const AgentsCatalogRoutes: React.FC = () => (
     <Routes>
       <Route path="/*" element={<AgentsCatalogCoreLoader />}>
         <Route index element={<AgentsCatalog />} />
-        <Route path=":agentId" element={<Navigate to="overview" replace />} />
-        <Route path=":agentId/overview" element={<AgentDetailsPage />} />
+        <Route path=":agentId">
+          <Route index element={<Navigate to="overview" replace />} />
+          <Route path="overview" element={<AgentDetailsPage />} />
+          <Route path="*" element={<Navigate to="." />} />
+        </Route>
         <Route path="*" element={<Navigate to="." />} />
       </Route>
     </Routes>

--- a/clients/ui/frontend/src/app/routes/agentsCatalog/__tests__/agentsCatalog.spec.ts
+++ b/clients/ui/frontend/src/app/routes/agentsCatalog/__tests__/agentsCatalog.spec.ts
@@ -9,9 +9,9 @@ describe('agentsCatalog routes', () => {
   });
 
   it('should build encoded agent details path', () => {
-    expect(getAgentsCatalogDetailsRoute('my-agent')).toBe('/agents-catalog/my-agent');
+    expect(getAgentsCatalogDetailsRoute('my-agent')).toBe('/agents-catalog/my-agent/overview');
     expect(getAgentsCatalogDetailsRoute('agent/with/slashes')).toBe(
-      '/agents-catalog/agent%2Fwith%2Fslashes',
+      '/agents-catalog/agent%2Fwith%2Fslashes/overview',
     );
   });
 });

--- a/clients/ui/frontend/src/app/routes/agentsCatalog/agentsCatalog.ts
+++ b/clients/ui/frontend/src/app/routes/agentsCatalog/agentsCatalog.ts
@@ -1,4 +1,4 @@
 export const agentsCatalogUrl = (): string => '/agents-catalog';
 
 export const getAgentsCatalogDetailsRoute = (agentId: string): string =>
-  `${agentsCatalogUrl()}/${encodeURIComponent(agentId)}`;
+  `${agentsCatalogUrl()}/${encodeURIComponent(agentId)}/overview`;


### PR DESCRIPTION
## Description

Agents catalog card links navigated to `/agents-catalog/:agentId` and relied on a sibling `<Navigate to="overview" />` redirect. That redirect renders `null` into the catalog outlet, and under nested host tab/splat routing (e.g. ODH dashboard Module Federation) the rematch to `:agentId/overview` can fail — leaving a blank details page until a full refresh of `/overview`.

### Changes
- Point `getAgentsCatalogDetailsRoute` at `/:agentId/overview` so card clicks skip the broken intermediate hop
- Nest the overview route under `:agentId` (same pattern as model catalog)
- Strengthen the Cypress card navigation assertion to require the overview URL and details title

## How Has This Been Tested?

- `npm run test:unit -- --testPathPattern='agentsCatalog/__tests__/agentsCatalog.spec'` in `clients/ui/frontend`

## Test Impact

Updated unit expectations for the details route helper and the Cypress gallery navigation test.


Made with [Cursor](https://cursor.com)