### PR TITLE
fix(catalog): watch YAML data files for live reload in MCP and agent catalogs

### DIFF
--- a/catalog/internal/catalog/agentcatalog/loader.go
+++ b/catalog/internal/catalog/agentcatalog/loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sync"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/golang/glog"
@@ -61,39 +62,33 @@ func (l *AgentLoader) PerformLeaderOperations(ctx context.Context, allKnownSourc
 
 	ctx, cancel := context.WithCancel(ctx)
 	l.setCloser(cancel)
+	// Drain in-flight writes from the previous invocation before running cleanup,
+	// so a concurrent write from an old goroutine cannot re-insert data that
+	// cleanup is about to remove.
+	l.state.WaitForInflightWrites(30 * time.Second)
 
 	if err := l.removeAgentsFromMissingSources(allKnownSourceIDs); err != nil {
 		glog.Errorf("error removing agents from missing sources: %v", err)
 	}
 
 	allSources := l.Sources.AllSources()
-
 	for id, source := range allSources {
 		if !source.IsEnabled() {
 			basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, id, basecatalog.SourceStatusDisabled, "")
 			continue
 		}
-
 		if source.Type != "yaml" {
 			glog.Warningf("unknown %s provider type: %s", "agent", source.Type)
 			basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, id, basecatalog.SourceStatusError, "unknown provider type: "+source.Type)
 			continue
 		}
-
-		if err := l.loadFromYAML(ctx, id, source); err != nil {
-			glog.Errorf("error loading %s from source %s: %v", "agent", id, err)
-			basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, id, basecatalog.SourceStatusError, err.Error())
-			continue
-		}
-
-		basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, id, basecatalog.SourceStatusAvailable, "")
+		sourceID := id
+		src := source
+		l.state.TrackWrite() // released after the initial load completes
+		go l.watchAndLoadFromYAML(ctx, sourceID, src)
 	}
 
-	if err := l.services.PropertyOptionsRepository.Refresh(models.ContextPropertyOptionType); err != nil {
-		glog.Errorf("error refreshing property options after agent load: %v", err)
-	}
-
-	glog.Infof("%s loader leader operations complete", "agent")
+	glog.Infof("%s loader leader operations launched", "agent")
 	return nil
 }
 
@@ -163,6 +158,61 @@ func (l *AgentLoader) loadFromYAML(ctx context.Context, sourceID string, source 
 	}
 
 	return nil
+}
+
+// watchAndLoadFromYAML performs the initial load from a YAML source, then watches
+// the data file for changes and reloads on each change until ctx is cancelled.
+// The caller must have called l.state.TrackWrite() before launching this as a goroutine;
+// this function calls l.state.WriteComplete() once the initial load is done.
+func (l *AgentLoader) watchAndLoadFromYAML(ctx context.Context, sourceID string, source basecatalog.PluginSource) {
+	releaseInitialLoad := sync.OnceFunc(l.state.WriteComplete)
+	defer releaseInitialLoad() // safety net: ensures TrackWrite is released even on panic
+
+	// Set up the watcher before the initial load so that changes arriving
+	// during or just after the read are not missed.
+	yamlPath, err := resolveYAMLPath(source)
+	if err != nil {
+		glog.Errorf("unable to resolve YAML path for agent source %s: %v", sourceID, err)
+		return
+	}
+
+	ch, watchErr := basecatalog.GetMonitor().Path(ctx, yamlPath)
+	if watchErr != nil {
+		glog.Errorf("unable to watch agent catalog file %s: %v", yamlPath, watchErr)
+	}
+
+	doLoad := func() {
+		if err := l.loadFromYAML(ctx, sourceID, source); err != nil {
+			glog.Errorf("error loading agent from source %s: %v", sourceID, err)
+			basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusError, err.Error())
+			return
+		}
+		basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusAvailable, "")
+		if err := l.services.PropertyOptionsRepository.Refresh(models.ContextPropertyOptionType); err != nil {
+			glog.Errorf("error refreshing property options after agent load: %v", err)
+		}
+	}
+
+	doLoad()
+	releaseInitialLoad() // release the TrackWrite slot after the initial load
+
+	if ch == nil {
+		// Watcher setup failed; no live updates possible.
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+			glog.Infof("Reloading agent catalog from %s (file changed)", yamlPath)
+			doLoad()
+		}
+	}
 }
 
 func (l *AgentLoader) ReloadParsing() error {

--- a/catalog/internal/catalog/agentcatalog/loader_test.go
+++ b/catalog/internal/catalog/agentcatalog/loader_test.go
@@ -40,7 +40,7 @@ func setupAgentLoaderTest(t *testing.T) (*gorm.DB, Services, func()) {
 	return sharedDB, services, cleanup
 }
 
-func runAgentLeaderOperations(t *testing.T, baseLoader *basecatalog.BaseLoader, loader *AgentLoader) {
+func runAgentLeaderOperations(ctx context.Context, t *testing.T, baseLoader *basecatalog.BaseLoader, loader *AgentLoader) {
 	t.Helper()
 
 	require.NoError(t, loader.ParseAllConfigs())
@@ -49,7 +49,7 @@ func runAgentLeaderOperations(t *testing.T, baseLoader *basecatalog.BaseLoader, 
 
 	leaderDone := make(chan error, 1)
 	go func() {
-		leaderDone <- loader.PerformLeaderOperations(context.Background(), mapset.NewSet[string]())
+		leaderDone <- loader.PerformLeaderOperations(ctx, mapset.NewSet[string]())
 	}()
 
 	select {
@@ -108,7 +108,7 @@ func TestAgentLoaderTemplateSaveFlow_InitialLoad(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewAgentLoader(services, baseLoader)
-	runAgentLeaderOperations(t, baseLoader, loader)
+	runAgentLeaderOperations(t.Context(), t, baseLoader, loader)
 
 	agent, err := services.AgentRepository.GetByName("test_agent_catalog:test-agent")
 	require.NoError(t, err)
@@ -150,11 +150,17 @@ func TestAgentLoaderTemplateSaveFlow_ReloadReplacesTemplates(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewAgentLoader(services, baseLoader)
-	runAgentLeaderOperations(t, baseLoader, loader)
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	defer cancel1()
+	runAgentLeaderOperations(ctx1, t, baseLoader, loader)
 
 	agentBefore, err := services.AgentRepository.GetByName("test_agent_catalog:test-agent")
 	require.NoError(t, err)
 	agentIDBefore := *agentBefore.GetID()
+
+	// Cancel loader1's watcher goroutines before modifying the file to avoid
+	// concurrent writes from the old loader during the reload.
+	cancel1()
 
 	// Reload with a completely different template set for the same agent.
 	require.NoError(t, os.WriteFile(agentsFile, []byte(`agents:
@@ -167,7 +173,7 @@ func TestAgentLoaderTemplateSaveFlow_ReloadReplacesTemplates(t *testing.T) {
 
 	baseLoader2 := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader2 := NewAgentLoader(services, baseLoader2)
-	runAgentLeaderOperations(t, baseLoader2, loader2)
+	runAgentLeaderOperations(t.Context(), t, baseLoader2, loader2)
 
 	agentAfter, err := services.AgentRepository.GetByName("test_agent_catalog:test-agent")
 	require.NoError(t, err)
@@ -181,6 +187,81 @@ func TestAgentLoaderTemplateSaveFlow_ReloadReplacesTemplates(t *testing.T) {
 	assert.Equal(t, "test_agent_catalog:test-agent:template-c.yaml", *attrs.Name)
 	require.NotNil(t, attrs.Content)
 	assert.Equal(t, "content-c", *attrs.Content)
+}
+
+// TestAgentLoaderFileWatchReload verifies that modifying a YAML data file while
+// the loader is running triggers a live reload: the new agent appears in the DB
+// and the stale agent from the previous load is removed by orphan cleanup.
+func TestAgentLoaderFileWatchReload(t *testing.T) {
+	_, services, cleanup := setupAgentLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+
+	agentsFile := filepath.Join(tmpDir, "agents.yaml")
+	require.NoError(t, os.WriteFile(agentsFile, []byte(`agents:
+  - name: "watch-agent-old"
+    description: "Initial agent"
+`), 0644))
+
+	sourcesFile := filepath.Join(tmpDir, "sources.yaml")
+	require.NoError(t, os.WriteFile(sourcesFile, []byte(`agent_catalogs:
+  - name: "File Watch Agent Catalog"
+    id: file_watch_agent_catalog
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: `+agentsFile+`
+`), 0644))
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewAgentLoader(services, baseLoader)
+
+	// Keep ctx alive so the file-watch goroutines continue running during the test.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runAgentLeaderOperations(ctx, t, baseLoader, loader)
+
+	// Verify initial state: the original agent is in the DB.
+	agent, err := services.AgentRepository.GetByName("file_watch_agent_catalog:watch-agent-old")
+	require.NoError(t, err)
+	require.NotNil(t, agent.GetID())
+
+	// Update the YAML file with a different agent name — the file-watch path
+	// should trigger a live reload that adds the new agent and (via orphan cleanup
+	// in removeOrphanedAgentsFromSource) removes the old one.
+	require.NoError(t, os.WriteFile(agentsFile, []byte(`agents:
+  - name: "watch-agent-new"
+    description: "Updated agent"
+`), 0644))
+
+	// Wait for the file-watcher to detect the change and commit the reload to DB.
+	// The monitor pauses 1 second after an fsnotify event before dispatching, so
+	// we allow a generous timeout.
+	assert.Eventually(t, func() bool {
+		a, err := services.AgentRepository.GetByName("file_watch_agent_catalog:watch-agent-new")
+		return err == nil && a != nil
+	}, 15*time.Second, 100*time.Millisecond, "file-watch reload should add the new agent to the catalog")
+
+	// removeOrphanedAgentsFromSource runs after the sentinel — which arrives after
+	// the new agent is already committed, so poll until cleanup finishes.
+	assert.Eventually(t, func() bool {
+		result, err := services.AgentRepository.List(&models.AgentListOptions{
+			SourceIDs: &[]string{"file_watch_agent_catalog"},
+		})
+		if err != nil {
+			return false
+		}
+		for _, a := range result.Items {
+			if attrs := a.GetAttributes(); attrs != nil && attrs.Name != nil {
+				if *attrs.Name == "file_watch_agent_catalog:watch-agent-old" {
+					return false
+				}
+			}
+		}
+		return true
+	}, 15*time.Second, 100*time.Millisecond, "orphaned agent from previous load should be removed")
 }
 
 // TestAgentLoaderTemplateSaveFlow_ReloadWithNoTemplatesRemovesAll verifies
@@ -201,7 +282,9 @@ func TestAgentLoaderTemplateSaveFlow_ReloadWithNoTemplatesRemovesAll(t *testing.
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewAgentLoader(services, baseLoader)
-	runAgentLeaderOperations(t, baseLoader, loader)
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	defer cancel1()
+	runAgentLeaderOperations(ctx1, t, baseLoader, loader)
 
 	agent, err := services.AgentRepository.GetByName("test_agent_catalog:test-agent")
 	require.NoError(t, err)
@@ -209,6 +292,10 @@ func TestAgentLoaderTemplateSaveFlow_ReloadWithNoTemplatesRemovesAll(t *testing.
 
 	templatesBefore := listTemplatesForParent(t, services, agentID)
 	require.Len(t, templatesBefore, 1)
+
+	// Cancel loader1's watcher goroutines before modifying the file to avoid
+	// concurrent writes from the old loader during the reload.
+	cancel1()
 
 	// Reload the same agent with its templates list removed entirely.
 	require.NoError(t, os.WriteFile(agentsFile, []byte(`agents:
@@ -218,7 +305,7 @@ func TestAgentLoaderTemplateSaveFlow_ReloadWithNoTemplatesRemovesAll(t *testing.
 
 	baseLoader2 := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader2 := NewAgentLoader(services, baseLoader2)
-	runAgentLeaderOperations(t, baseLoader2, loader2)
+	runAgentLeaderOperations(t.Context(), t, baseLoader2, loader2)
 
 	templatesAfter := listTemplatesForParent(t, services, agentID)
 	assert.Empty(t, templatesAfter, "stale template artifacts must be cleared when the reloaded agent declares no templates")

--- a/catalog/internal/catalog/agentcatalog/yaml_provider.go
+++ b/catalog/internal/catalog/agentcatalog/yaml_provider.go
@@ -30,21 +30,21 @@ type yamlAgentTemplate struct {
 }
 
 type yamlAgent struct {
-	Name             string                              `yaml:"name" json:"name"`
-	ExternalID       *string                             `yaml:"externalId,omitempty" json:"externalId,omitempty"`
-	DisplayName      *string                             `yaml:"displayName,omitempty" json:"displayName,omitempty"`
-	Description      *string                             `yaml:"description,omitempty" json:"description,omitempty"`
-	Readme           *string                             `yaml:"readme,omitempty" json:"readme,omitempty"`
-	Framework        *string                             `yaml:"framework,omitempty" json:"framework,omitempty"`
-	Labels           []string                            `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Logo             *string                             `yaml:"logo,omitempty" json:"logo,omitempty"`
-	RepositoryUrl    *string                             `yaml:"repositoryUrl,omitempty" json:"repositoryUrl,omitempty"`
-	Env              []yamlAgentEnvVar                   `yaml:"env,omitempty" json:"env,omitempty"`
-	Artifacts        []yamlAgentArtifact                 `yaml:"artifacts,omitempty" json:"artifacts,omitempty"`
-	Templates        []yamlAgentTemplate                 `yaml:"templates,omitempty" json:"templates,omitempty"`
-	CustomProperties *map[string]openapi.MetadataValue   `yaml:"customProperties,omitempty" json:"customProperties,omitempty"`
-	CreateTimeSinceEpoch     *string                     `yaml:"createTimeSinceEpoch,omitempty" json:"createTimeSinceEpoch,omitempty"`
-	LastUpdateTimeSinceEpoch *string                     `yaml:"lastUpdateTimeSinceEpoch,omitempty" json:"lastUpdateTimeSinceEpoch,omitempty"`
+	Name                     string                            `yaml:"name" json:"name"`
+	ExternalID               *string                           `yaml:"externalId,omitempty" json:"externalId,omitempty"`
+	DisplayName              *string                           `yaml:"displayName,omitempty" json:"displayName,omitempty"`
+	Description              *string                           `yaml:"description,omitempty" json:"description,omitempty"`
+	Readme                   *string                           `yaml:"readme,omitempty" json:"readme,omitempty"`
+	Framework                *string                           `yaml:"framework,omitempty" json:"framework,omitempty"`
+	Labels                   []string                          `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Logo                     *string                           `yaml:"logo,omitempty" json:"logo,omitempty"`
+	RepositoryUrl            *string                           `yaml:"repositoryUrl,omitempty" json:"repositoryUrl,omitempty"`
+	Env                      []yamlAgentEnvVar                 `yaml:"env,omitempty" json:"env,omitempty"`
+	Artifacts                []yamlAgentArtifact               `yaml:"artifacts,omitempty" json:"artifacts,omitempty"`
+	Templates                []yamlAgentTemplate               `yaml:"templates,omitempty" json:"templates,omitempty"`
+	CustomProperties         *map[string]openapi.MetadataValue `yaml:"customProperties,omitempty" json:"customProperties,omitempty"`
+	CreateTimeSinceEpoch     *string                           `yaml:"createTimeSinceEpoch,omitempty" json:"createTimeSinceEpoch,omitempty"`
+	LastUpdateTimeSinceEpoch *string                           `yaml:"lastUpdateTimeSinceEpoch,omitempty" json:"lastUpdateTimeSinceEpoch,omitempty"`
 }
 
 type yamlAgentCatalog struct {
@@ -169,7 +169,7 @@ func yamlTemplateToEntity(tmpl yamlAgentTemplate, agentName string, sourceID str
 	attrs := &models.AgentTemplateArtifactAttributes{
 		Name:         &qualifiedName,
 		Content:      &tmpl.Content,
-		ArtifactType: strPtr(models.AgentTemplateArtifactType),
+		ArtifactType: new(models.AgentTemplateArtifactType),
 	}
 
 	entity := &models.AgentTemplateArtifactImpl{
@@ -183,8 +183,6 @@ func yamlTemplateToEntity(tmpl yamlAgentTemplate, agentName string, sourceID str
 
 	return entity
 }
-
-func strPtr(s string) *string { return &s }
 
 func resolveYAMLPath(source basecatalog.PluginSource) (string, error) {
 	yamlPath, ok := source.Properties["yamlCatalogPath"].(string)

--- a/catalog/internal/catalog/basecatalog/loader_base.go
+++ b/catalog/internal/catalog/basecatalog/loader_base.go
@@ -17,6 +17,7 @@ type LoaderState interface {
 	ShouldWriteDatabase() bool
 	TrackWrite()
 	WriteComplete()
+	WaitForInflightWrites(timeout time.Duration)
 	SetCloser(closer func())
 	Paths() []string
 }

--- a/catalog/internal/catalog/mcpcatalog/loader.go
+++ b/catalog/internal/catalog/mcpcatalog/loader.go
@@ -285,11 +285,16 @@ func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, cancel context
 		if ctx.Err() != nil {
 			return
 		}
-		ml.state.TrackWrite()
-		err := ml.removeOrphanedServersFromSource(sourceID, validServerNames)
-		ml.state.WriteComplete()
-		if err != nil {
-			glog.Warningf("Failed to remove orphaned servers from source %s: %v", sourceID, err)
+		// Skip orphan cleanup on complete failure to preserve stale-but-functional
+		// data until the error is fixed.
+		completeFailure := validServerNames.Cardinality() == 0 && len(failedServers) > 0
+		if !completeFailure {
+			ml.state.TrackWrite()
+			err := ml.removeOrphanedServersFromSource(sourceID, validServerNames)
+			ml.state.WriteComplete()
+			if err != nil {
+				glog.Warningf("Failed to remove orphaned servers from source %s: %v", sourceID, err)
+			}
 		}
 		if len(failedServers) > 0 {
 			if successCount > 0 {

--- a/catalog/internal/catalog/mcpcatalog/loader.go
+++ b/catalog/internal/catalog/mcpcatalog/loader.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sync"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/golang/glog"
@@ -24,14 +25,6 @@ type MCPPartiallyAvailableError struct {
 func (e *MCPPartiallyAvailableError) Error() string {
 	return fmt.Sprintf("Failed to load some MCP servers: %v", e.FailedServers)
 }
-
-func (e *MCPPartiallyAvailableError) Is(target error) bool {
-	_, ok := target.(*MCPPartiallyAvailableError)
-	return ok
-}
-
-// ErrMCPPartiallyAvailable is used with errors.Is() to check for this error type.
-var ErrMCPPartiallyAvailable error = &MCPPartiallyAvailableError{}
 
 // MCPLoaderEventHandler is called after an MCP server is successfully loaded
 type MCPLoaderEventHandler func(ctx context.Context, record MCPServerProviderRecord) error
@@ -105,22 +98,24 @@ func (ml *MCPLoader) ParseAllConfigs() error {
 // allKnownSourceIDs is the union of model and MCP source IDs, used to prevent
 // cross-contamination when cleaning up shared CatalogSource records.
 // This is called by the unified loader when becoming leader.
+// It returns immediately after launching background goroutines; those goroutines
+// continue watching for file changes until ctx is cancelled.
 func (ml *MCPLoader) PerformLeaderOperations(ctx context.Context, allKnownSourceIDs mapset.Set[string]) error {
 	glog.Info("MCP loader performing leader operations")
 
 	ctx, cancel := context.WithCancel(ctx)
 	ml.setCloser(cancel)
+	// Drain in-flight writes from the previous invocation before running cleanup,
+	// so a concurrent write from an old goroutine cannot re-insert data that
+	// cleanup is about to remove.
+	ml.state.WaitForInflightWrites(30 * time.Second)
 
 	// Get all sources from the collection
 	allSources := ml.Sources.AllSources()
 
-	// Load servers from all sources
-	err := ml.loadAllServers(ctx, allSources, allKnownSourceIDs)
-	if err != nil {
-		return fmt.Errorf("failed to load MCP servers: %w", err)
-	}
+	ml.loadAllServers(ctx, allSources, allKnownSourceIDs)
 
-	glog.Info("MCP loader leader operations complete")
+	glog.Info("MCP loader leader operations launched")
 	return nil
 }
 
@@ -184,11 +179,20 @@ func (ml *MCPLoader) updateSources(path string, config *basecatalog.SourceConfig
 	return ml.Sources.Merge(path, sources)
 }
 
-// loadAllServers loads MCP servers from all configured sources
-func (ml *MCPLoader) loadAllServers(ctx context.Context, sources map[string]basecatalog.MCPSource, allKnownSourceIDs mapset.Set[string]) error {
-	// Track enabled and all source IDs separately for cleanup logic.
+// loadAllServers loads MCP servers from all configured sources.
+// It returns immediately after launching per-source goroutines. Each goroutine
+// continues watching for file changes until ctx is cancelled.
+func (ml *MCPLoader) loadAllServers(ctx context.Context, sources map[string]basecatalog.MCPSource, allKnownSourceIDs mapset.Set[string]) {
+	// First pass: classify sources and handle disabled/unknown types synchronously.
 	enabledSourceIDs := mapset.NewSet[string]()
 	allSourceIDs := mapset.NewSet[string]()
+
+	type providerEntry struct {
+		source   basecatalog.MCPSource
+		provider MCPProvider
+		filter   *ServerFilter
+	}
+	var toLoad []providerEntry
 
 	for _, source := range sources {
 		allSourceIDs.Add(source.ID)
@@ -199,9 +203,6 @@ func (ml *MCPLoader) loadAllServers(ctx context.Context, sources map[string]base
 			continue
 		}
 
-		glog.Infof("Loading MCP servers from source: %s (id: %s)", source.Name, source.ID)
-
-		// Get the provider function for this source type
 		providerFunc, ok := GetMCPProvider(source.Type)
 		if !ok {
 			glog.Warningf("Unknown MCP provider type: %s (source: %s)", source.Type, source.Name)
@@ -209,7 +210,6 @@ func (ml *MCPLoader) loadAllServers(ctx context.Context, sources map[string]base
 			continue
 		}
 
-		// Create the provider
 		provider, err := providerFunc(source)
 		if err != nil {
 			glog.Errorf("Error creating MCP provider for source %s: %v", source.Name, err)
@@ -217,7 +217,6 @@ func (ml *MCPLoader) loadAllServers(ctx context.Context, sources map[string]base
 			continue
 		}
 
-		// Build server name filter from source include/exclude config
 		filter, err := NewServerFilterFromSource(&source)
 		if err != nil {
 			glog.Errorf("Error building server filter for source %s: %v", source.Name, err)
@@ -225,67 +224,110 @@ func (ml *MCPLoader) loadAllServers(ctx context.Context, sources map[string]base
 			continue
 		}
 
-		// Load servers from this provider
-		err = ml.loadServersFromProvider(ctx, source.ID, provider, filter)
-		if err != nil {
-			if errors.Is(err, ErrMCPPartiallyAvailable) {
-				glog.Warningf("Partial error loading servers from source %s: %v", source.Name, err)
-				if ctx.Err() == nil {
-					basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, source.ID, basecatalog.SourceStatusPartiallyAvailable, err.Error())
-				}
-				// Still count as active for cleanup purposes (some servers are loaded)
-				enabledSourceIDs.Add(source.ID)
-			} else {
-				glog.Errorf("Error loading servers from source %s: %v", source.Name, err)
-				basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, source.ID, basecatalog.SourceStatusError, err.Error())
-			}
-			continue
-		}
-
+		// Mark as enabled before launching goroutines, so removeServersFromMissingSources
+		// does not bulk-delete this source's data before the goroutine has a chance to
+		// load it. If all servers fail, finalizeBatch calls removeOrphanedServersFromSource
+		// which cleans up individual stale entries.
 		enabledSourceIDs.Add(source.ID)
-
-		// Mark source as available if context is still valid
-		if ctx.Err() == nil {
-			basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, source.ID, basecatalog.SourceStatusAvailable, "")
-		}
+		toLoad = append(toLoad, providerEntry{source, provider, filter})
 	}
 
-	// Clean up servers from sources that are no longer configured or enabled
-	err := ml.removeServersFromMissingSources(enabledSourceIDs, allSourceIDs, allKnownSourceIDs)
-	if err != nil {
-		return fmt.Errorf("failed to remove servers from missing sources: %w", err)
+	// Clean up servers from sources that are no longer configured or enabled.
+	if err := ml.removeServersFromMissingSources(enabledSourceIDs, allSourceIDs, allKnownSourceIDs); err != nil {
+		glog.Errorf("failed to remove servers from missing sources: %v", err)
 	}
 
-	return nil
+	// Launch a goroutine per source. Each goroutine gets its own child context so
+	// it can cancel the provider (closing the channel) instead of draining it.
+	// TrackWrite is called before launching so that WaitForInflightWrites cannot
+	// return before the goroutine's initial batch is done.
+	for _, entry := range toLoad {
+		source := entry.source
+		provider := entry.provider
+		filter := entry.filter
+		sourceCtx, sourceCancel := context.WithCancel(ctx)
+		ml.state.TrackWrite()
+		glog.Infof("Loading MCP servers from source: %s (id: %s)", source.Name, source.ID)
+		go ml.loadServersFromProvider(sourceCtx, sourceCancel, source.ID, provider, filter)
+	}
 }
 
-// loadServersFromProvider loads all servers from a single provider.
-// Returns MCPPartiallyAvailableError if some servers loaded successfully but others failed.
-// Returns a regular error if all servers failed to load.
-func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, sourceID string, provider MCPProvider, filter *ServerFilter) error {
+// loadServersFromProvider consumes records from provider until the channel closes
+// or ctx is cancelled. A zero-value record (sentinel) marks the end of a batch:
+// orphan cleanup and source status are updated at that point, and batch state
+// resets for the next batch. This allows the provider to be long-lived and
+// re-emit records when the underlying file changes.
+//
+// The caller must have called ml.state.TrackWrite() before launching this as a
+// goroutine. This function calls ml.state.WriteComplete() exactly once, when the
+// initial batch is done, so that WaitForInflightWrites can unblock tests that
+// call it after PerformLeaderOperations returns.
+//
+// cancel is the CancelFunc for ctx. Calling it stops the provider goroutine
+// (which selects on ctx.Done()) and causes the provider channel to close,
+// allowing this function to return without draining the channel.
+func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, cancel context.CancelFunc, sourceID string, provider MCPProvider, filter *ServerFilter) {
+	defer cancel() // ensure the provider goroutine exits when this function returns
+
 	recordChan := provider.Servers(ctx)
 
 	validServerNames := mapset.NewSet[string]()
 	var failedServers []string
 	successCount := 0
 
+	// releaseInitialBatch is called exactly once to release the TrackWrite slot
+	// reserved by the caller. It fires on the first sentinel or channel-close,
+	// signalling that the initial batch of writes is complete.
+	releaseInitialBatch := sync.OnceFunc(ml.state.WriteComplete)
+	defer releaseInitialBatch() // ensure TrackWrite is released even on panic or unexpected return
+
+	finalizeBatch := func() {
+		if ctx.Err() != nil {
+			return
+		}
+		ml.state.TrackWrite()
+		err := ml.removeOrphanedServersFromSource(sourceID, validServerNames)
+		ml.state.WriteComplete()
+		if err != nil {
+			glog.Warningf("Failed to remove orphaned servers from source %s: %v", sourceID, err)
+		}
+		if len(failedServers) > 0 {
+			if successCount > 0 {
+				basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusPartiallyAvailable,
+					(&MCPPartiallyAvailableError{FailedServers: failedServers}).Error())
+			} else {
+				basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusError,
+					fmt.Sprintf("all MCP servers failed to load from source %s (failed: %v)", sourceID, failedServers))
+			}
+		} else {
+			basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusAvailable, "")
+		}
+	}
+
 	for record := range recordChan {
-		// Check context cancellation before processing each record
 		if ctx.Err() != nil {
 			glog.Info("Context cancelled, stopping MCP server processing")
-			//nolint:revive
-			for range recordChan {
-			}
-			return ctx.Err()
+			releaseInitialBatch()
+			return
 		}
 
-		// Check if we're still the leader before each write
 		if !ml.state.ShouldWriteDatabase() {
 			glog.Info("No longer leader, stopping MCP server processing")
-			//nolint:revive
-			for range recordChan {
-			}
-			return nil
+			releaseInitialBatch()
+			// cancel() via defer will close ctx, which causes the provider to exit
+			// and close the channel — no need to drain here.
+			return
+		}
+
+		// Sentinel: end of a batch. Finalize, reset state, and continue watching.
+		if record.Server == nil && record.Error == nil {
+			glog.Infof("%s: loaded %d MCP servers", sourceID, successCount)
+			finalizeBatch()
+			releaseInitialBatch() // signal that the initial batch of writes is done
+			validServerNames = mapset.NewSet[string]()
+			failedServers = nil
+			successCount = 0
+			continue
 		}
 
 		if record.Error != nil {
@@ -294,20 +336,13 @@ func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, sourceID strin
 			continue
 		}
 
-		if record.Server == nil {
-			continue
-		}
-
-		// Set the source_id property
 		ml.setServerSourceID(record.Server, sourceID)
 
-		// Track valid server names for cleanup
 		serverName := ""
 		if record.Server.GetAttributes() != nil && record.Server.GetAttributes().Name != nil {
 			serverName = *record.Server.GetAttributes().Name
 		}
 
-		// Apply include/exclude filter
 		if !filter.Allows(serverName) {
 			if serverName == "" {
 				glog.Warningf("MCP server with no name was dropped by includedServers/excludedServers filter; check includedServers/excludedServers configuration")
@@ -321,8 +356,7 @@ func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, sourceID strin
 			validServerNames.Add(serverName)
 		}
 
-		// Save server to database
-		if err := ml.updateDatabase(ctx, record); err != nil {
+		if err := ml.updateDatabase(record); err != nil {
 			glog.Errorf("Error saving MCP server: %v", err)
 			if serverName != "" {
 				failedServers = append(failedServers, serverName)
@@ -334,7 +368,6 @@ func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, sourceID strin
 
 		successCount++
 
-		// Call event handlers
 		for _, handler := range ml.handlers {
 			if err := handler(ctx, record); err != nil {
 				glog.Warningf("Event handler error: %v", err)
@@ -342,22 +375,12 @@ func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, sourceID strin
 		}
 	}
 
-	// Only clean up orphans if context is still valid
-	if ctx.Err() == nil {
-		if err := ml.removeOrphanedServersFromSource(sourceID, validServerNames); err != nil {
-			glog.Warningf("Failed to remove orphaned servers from source %s: %v", sourceID, err)
-		}
+	// Channel closed without a sentinel (one-shot provider or context cancelled).
+	// Finalize the current batch if any records were processed.
+	if successCount > 0 || len(failedServers) > 0 {
+		finalizeBatch()
 	}
-
-	// Report partial or full failure
-	if len(failedServers) > 0 {
-		if successCount > 0 {
-			return &MCPPartiallyAvailableError{FailedServers: failedServers}
-		}
-		return fmt.Errorf("all MCP servers failed to load from source %s (failed: %v)", sourceID, failedServers)
-	}
-
-	return nil
+	releaseInitialBatch()
 }
 
 // setServerSourceID sets the source_id property on an MCP server
@@ -386,7 +409,7 @@ func (ml *MCPLoader) setServerSourceID(server *models.MCPServerImpl, sourceID st
 }
 
 // updateDatabase saves an MCP server and its tools to the database
-func (ml *MCPLoader) updateDatabase(ctx context.Context, record MCPServerProviderRecord) error {
+func (ml *MCPLoader) updateDatabase(record MCPServerProviderRecord) error {
 	ml.state.TrackWrite()
 	defer ml.state.WriteComplete()
 

--- a/catalog/internal/catalog/mcpcatalog/loader_test.go
+++ b/catalog/internal/catalog/mcpcatalog/loader_test.go
@@ -73,7 +73,7 @@ func TestMCPLoaderBasicLoad(t *testing.T) {
 	// Create and start the loader
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Parse configs
 	err = loader.ParseAllConfigs()
@@ -181,7 +181,7 @@ func TestMCPLoaderToolAccessTypeAndParameters(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = loader.ParseAllConfigs()
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestMCPLoaderDisabledSource(t *testing.T) {
 	// Create and start the loader
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Parse configs
 	err = loader.ParseAllConfigs()
@@ -357,7 +357,7 @@ func TestMCPLoaderEventHandlers(t *testing.T) {
 		return nil
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Parse configs
 	err = loader.ParseAllConfigs()
@@ -423,7 +423,7 @@ func TestMCPLoaderRemoveOrphans(t *testing.T) {
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Parse configs
 	err = loader.ParseAllConfigs()
@@ -533,7 +533,7 @@ func TestMCPLoaderRespectsContextCancellation(t *testing.T) {
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	// Track how many servers were processed via event handler
 	serverCount := 0
@@ -600,7 +600,7 @@ func TestMCPLoaderSavesSourceStatus(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = loader.ParseAllConfigs()
 	require.NoError(t, err)
@@ -665,7 +665,7 @@ func TestMCPLoaderSavesDisabledSourceStatus(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = loader.ParseAllConfigs()
 	require.NoError(t, err)
@@ -723,7 +723,7 @@ func TestMCPLoaderSavesErrorSourceStatus(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = loader.ParseAllConfigs()
 	require.NoError(t, err)
@@ -905,7 +905,7 @@ func TestMCPLoaderExcludedServersNotSaved(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = loader.ParseAllConfigs()
 	require.NoError(t, err)
@@ -966,7 +966,7 @@ func TestMCPLoaderIncludedServersOnly(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = loader.ParseAllConfigs()
 	require.NoError(t, err)
@@ -1025,7 +1025,7 @@ func TestMCPLoaderNoFilterAllowsAll(t *testing.T) {
 
 	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
 	loader := NewMCPLoaderWithState(services, baseLoader)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = loader.ParseAllConfigs()
 	require.NoError(t, err)
@@ -1078,4 +1078,98 @@ func TestMCPLoaderInvalidServerFilterRejected(t *testing.T) {
 	err = loader.ParseAllConfigs()
 	require.Error(t, err, "empty includedServers pattern should be rejected at config load time")
 	assert.Contains(t, err.Error(), "includedServers")
+}
+
+func runMCPLeaderOperations(ctx context.Context, t *testing.T, baseLoader *basecatalog.BaseLoader, loader *MCPLoader) {
+	t.Helper()
+	require.NoError(t, loader.ParseAllConfigs())
+	baseLoader.SetLeader(true)
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- loader.PerformLeaderOperations(ctx, mapset.NewSet[string]())
+	}()
+	select {
+	case err := <-leaderDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for leader operations")
+	}
+	baseLoader.WaitForInflightWrites(5 * time.Second)
+}
+
+// TestMCPLoaderFileWatchReload verifies that modifying a YAML data file while the
+// loader is running triggers a live reload: the new server appears in the DB
+// and the stale server from the previous load is removed by orphan cleanup.
+func TestMCPLoaderFileWatchReload(t *testing.T) {
+	_, services, cleanup := setupMCPLoaderTest(t)
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+
+	serversFile := filepath.Join(tmpDir, "servers.yaml")
+	require.NoError(t, os.WriteFile(serversFile, []byte(`mcp_servers:
+  - name: "watch-server-old"
+    version: "1.0.0"
+    description: "Initial server"
+`), 0644))
+
+	sourcesFile := filepath.Join(tmpDir, "sources.yaml")
+	require.NoError(t, os.WriteFile(sourcesFile, []byte(`mcp_catalogs:
+  - name: "File Watch MCP Catalog"
+    id: file_watch_mcp_catalog
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: `+serversFile+`
+`), 0644))
+
+	baseLoader := basecatalog.NewBaseLoader([]string{sourcesFile})
+	loader := NewMCPLoaderWithState(services, baseLoader)
+
+	// Keep ctx alive so the file-watch goroutines continue running during the test.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runMCPLeaderOperations(ctx, t, baseLoader, loader)
+
+	// Verify initial state: the original server is in the DB.
+	server, err := services.MCPServerRepository.GetByNameAndVersion("watch-server-old", "1.0.0")
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	// Update the YAML file with a different server name — the file-watch path
+	// should trigger a live reload that adds the new server and (via orphan cleanup
+	// in finalizeBatch) removes the old one.
+	require.NoError(t, os.WriteFile(serversFile, []byte(`mcp_servers:
+  - name: "watch-server-new"
+    version: "2.0.0"
+    description: "Updated server"
+`), 0644))
+
+	// Wait for the file-watcher to detect the change and commit the reload to DB.
+	// The monitor pauses 1 second after an fsnotify event before dispatching, so
+	// we allow a generous timeout.
+	assert.Eventually(t, func() bool {
+		s, err := services.MCPServerRepository.GetByNameAndVersion("watch-server-new", "2.0.0")
+		return err == nil && s != nil
+	}, 15*time.Second, 100*time.Millisecond, "file-watch reload should add the new MCP server to the catalog")
+
+	// finalizeBatch runs orphan cleanup after the sentinel — which arrives after
+	// the new server is already committed, so poll until cleanup finishes.
+	assert.Eventually(t, func() bool {
+		result, err := services.MCPServerRepository.List(mcpmodels.MCPServerListOptions{
+			SourceIDs: &[]string{"file_watch_mcp_catalog"},
+		})
+		if err != nil || result == nil {
+			return false
+		}
+		for _, s := range result.Items {
+			if attrs := s.GetAttributes(); attrs != nil && attrs.Name != nil {
+				if *attrs.Name == "watch-server-old" {
+					return false
+				}
+			}
+		}
+		return true
+	}, 15*time.Second, 100*time.Millisecond, "orphaned server from previous load should be removed")
 }

--- a/catalog/internal/catalog/mcpcatalog/providers.go
+++ b/catalog/internal/catalog/mcpcatalog/providers.go
@@ -221,14 +221,14 @@ func (yp *yamlMCPProvider) Servers(ctx context.Context) <-chan MCPServerProvider
 		// Set up watchers before the initial emit so that changes arriving
 		// during or just after the read are not missed.
 		merged := make(chan struct{}, 1)
-		watchFailed := false
+		watchCount := 0
 		for _, path := range yp.paths {
 			ch, err := basecatalog.GetMonitor().Path(ctx, path)
 			if err != nil {
 				glog.Errorf("unable to watch MCP catalog file %s: %v", path, err)
-				watchFailed = true
-				break
+				continue
 			}
+			watchCount++
 			go func(c <-chan struct{}) {
 				for {
 					select {
@@ -265,8 +265,8 @@ func (yp *yamlMCPProvider) Servers(ctx context.Context) <-chan MCPServerProvider
 			return
 		}
 
-		if watchFailed {
-			// Watcher setup failed; no live updates possible.
+		if watchCount == 0 {
+			// All watcher setups failed; no live updates possible.
 			return
 		}
 

--- a/catalog/internal/catalog/mcpcatalog/providers.go
+++ b/catalog/internal/catalog/mcpcatalog/providers.go
@@ -207,19 +207,81 @@ func NewYamlMCPProvider(source basecatalog.MCPSource) (MCPProvider, error) {
 	}, nil
 }
 
-// Servers implements MCPProvider
+// Servers implements MCPProvider. It emits all servers from the configured
+// paths, then sends a sentinel (zero-value MCPServerProviderRecord) to signal
+// that the initial batch is complete. It then watches each path for changes
+// and re-emits on every file change, followed by another sentinel.
+// The channel is closed when ctx is cancelled.
 func (yp *yamlMCPProvider) Servers(ctx context.Context) <-chan MCPServerProviderRecord {
 	recordChan := make(chan MCPServerProviderRecord)
 
 	go func() {
 		defer close(recordChan)
 
+		// Emit the initial batch.
 		for _, path := range yp.paths {
 			select {
 			case <-ctx.Done():
 				return
 			default:
 				yp.emit(ctx, path, recordChan)
+			}
+		}
+
+		// Signal that the initial batch is done.
+		select {
+		case recordChan <- MCPServerProviderRecord{}:
+		case <-ctx.Done():
+			return
+		}
+
+		// Watch each path for changes and re-emit on any file change.
+		// If monitoring setup fails, log and return — the initial load succeeded.
+		merged := make(chan struct{}, 1)
+		for _, path := range yp.paths {
+			ch, err := basecatalog.GetMonitor().Path(ctx, path)
+			if err != nil {
+				glog.Errorf("unable to watch MCP catalog file %s: %v", path, err)
+				return
+			}
+			go func(c <-chan struct{}) {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case _, ok := <-c:
+						if !ok {
+							return
+						}
+						// Non-blocking send: one pending notification is enough.
+						select {
+						case merged <- struct{}{}:
+						default:
+						}
+					}
+				}
+			}(ch)
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-merged:
+				glog.Infof("Reloading MCP catalog (file changed)")
+				for _, path := range yp.paths {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						yp.emit(ctx, path, recordChan)
+					}
+				}
+				select {
+				case recordChan <- MCPServerProviderRecord{}:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}()
@@ -247,17 +309,19 @@ func (yp *yamlMCPProvider) emit(ctx context.Context, path string, recordChan cha
 	catalog, err := yp.read(path)
 	if err != nil {
 		glog.Errorf("Error reading MCP catalog from %s: %v", path, err)
-		recordChan <- MCPServerProviderRecord{Error: err}
+		select {
+		case recordChan <- MCPServerProviderRecord{Error: err}:
+		case <-ctx.Done():
+		}
 		return
 	}
 
 	for _, yamlServer := range catalog.MCPServers {
+		record := yamlServer.ToMCPServerProviderRecord()
 		select {
+		case recordChan <- record:
 		case <-ctx.Done():
 			return
-		default:
-			record := yamlServer.ToMCPServerProviderRecord()
-			recordChan <- record
 		}
 	}
 }

--- a/catalog/internal/catalog/mcpcatalog/providers.go
+++ b/catalog/internal/catalog/mcpcatalog/providers.go
@@ -218,31 +218,16 @@ func (yp *yamlMCPProvider) Servers(ctx context.Context) <-chan MCPServerProvider
 	go func() {
 		defer close(recordChan)
 
-		// Emit the initial batch.
-		for _, path := range yp.paths {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				yp.emit(ctx, path, recordChan)
-			}
-		}
-
-		// Signal that the initial batch is done.
-		select {
-		case recordChan <- MCPServerProviderRecord{}:
-		case <-ctx.Done():
-			return
-		}
-
-		// Watch each path for changes and re-emit on any file change.
-		// If monitoring setup fails, log and return — the initial load succeeded.
+		// Set up watchers before the initial emit so that changes arriving
+		// during or just after the read are not missed.
 		merged := make(chan struct{}, 1)
+		watchFailed := false
 		for _, path := range yp.paths {
 			ch, err := basecatalog.GetMonitor().Path(ctx, path)
 			if err != nil {
 				glog.Errorf("unable to watch MCP catalog file %s: %v", path, err)
-				return
+				watchFailed = true
+				break
 			}
 			go func(c <-chan struct{}) {
 				for {
@@ -261,6 +246,28 @@ func (yp *yamlMCPProvider) Servers(ctx context.Context) <-chan MCPServerProvider
 					}
 				}
 			}(ch)
+		}
+
+		// Emit the initial batch.
+		for _, path := range yp.paths {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				yp.emit(ctx, path, recordChan)
+			}
+		}
+
+		// Signal that the initial batch is done.
+		select {
+		case recordChan <- MCPServerProviderRecord{}:
+		case <-ctx.Done():
+			return
+		}
+
+		if watchFailed {
+			// Watcher setup failed; no live updates possible.
+			return
 		}
 
 		for {

--- a/catalog/internal/catalog/mcpcatalog/providers_test.go
+++ b/catalog/internal/catalog/mcpcatalog/providers_test.go
@@ -103,7 +103,7 @@ func TestYamlMCPProviderEmitWithDisplayNameKey(t *testing.T) {
 	provider, err := NewYamlMCPProvider(source)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	recordChan := provider.Servers(ctx)
 
 	record, ok := <-recordChan
@@ -216,13 +216,16 @@ func TestYamlMCPProviderEmit(t *testing.T) {
 	provider, err := NewYamlMCPProvider(source)
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	recordChan := provider.Servers(ctx)
+	recordChan := provider.Servers(t.Context())
 
 	servers := make([]string, 0)
 	for record := range recordChan {
+		// Sentinel marks end of the initial batch; stop reading.
+		if record.Server == nil && record.Error == nil {
+			break
+		}
 		assert.Nil(t, record.Error)
-		assert.NotNil(t, record.Server)
+		require.NotNil(t, record.Server)
 		attrs := record.Server.GetAttributes()
 		require.NotNil(t, attrs)
 		servers = append(servers, *attrs.Name)
@@ -258,7 +261,7 @@ func TestYamlMCPProviderEmitWithCancellation(t *testing.T) {
 	provider, err := NewYamlMCPProvider(source)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	recordChan := provider.Servers(ctx)
 
@@ -312,12 +315,13 @@ func TestYamlMCPProviderInvalidFile(t *testing.T) {
 	provider, err := NewYamlMCPProvider(source)
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	recordChan := provider.Servers(ctx)
-
 	// Should emit exactly one error record so the caller can mark the source as errored.
 	var records []MCPServerProviderRecord
-	for record := range recordChan {
+	for record := range provider.Servers(t.Context()) {
+		// Skip sentinels (end-of-batch markers).
+		if record.Server == nil && record.Error == nil {
+			continue
+		}
 		records = append(records, record)
 	}
 	require.Len(t, records, 1, "expected one error record for unreadable file")
@@ -976,11 +980,12 @@ func TestYamlMCPProviderEmitWithRuntimeMetadata(t *testing.T) {
 	provider, err := NewYamlMCPProvider(source)
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	recordChan := provider.Servers(ctx)
-
 	var record MCPServerProviderRecord
-	for r := range recordChan {
+	for r := range provider.Servers(t.Context()) {
+		// Sentinel marks end of batch; stop and use last real record.
+		if r.Server == nil && r.Error == nil {
+			break
+		}
 		record = r
 	}
 

--- a/catalog/internal/catalog/modelcatalog/loader.go
+++ b/catalog/internal/catalog/modelcatalog/loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sync"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/golang/glog"
@@ -78,6 +79,20 @@ type ModelLoader struct {
 	services      Services
 	handlers      []LoaderEventHandler
 	loadedSources map[string]bool // tracks which source IDs have been loaded
+
+	closerMu sync.Mutex
+	closer   func()
+}
+
+// setCloser stores a cancel function that aborts the current leader operations.
+// If a previous cancel function exists it is called first, preempting the old run.
+func (l *ModelLoader) setCloser(closer func()) {
+	l.closerMu.Lock()
+	defer l.closerMu.Unlock()
+	if l.closer != nil {
+		l.closer()
+	}
+	l.closer = closer
 }
 
 // UpdateServices replaces the loader's repository references after a database
@@ -136,6 +151,12 @@ func (l *ModelLoader) ParseAllConfigs() error {
 // cross-contamination when cleaning up shared CatalogSource records.
 // This is called by the unified loader when becoming leader.
 func (l *ModelLoader) PerformLeaderOperations(ctx context.Context, allKnownSourceIDs mapset.Set[string]) error {
+	ctx, cancel := context.WithCancel(ctx)
+	l.setCloser(cancel)
+	// Drain in-flight writes from the previous invocation before running cleanup,
+	// so a concurrent write from an old goroutine cannot re-insert data that
+	// cleanup is about to remove.
+	l.state.WaitForInflightWrites(30 * time.Second)
 	return l.performLeaderWrites(ctx, allKnownSourceIDs)
 }
 
@@ -260,9 +281,6 @@ func (l *ModelLoader) updateLabels(path string, config *basecatalog.SourceConfig
 }
 
 func (l *ModelLoader) updateDatabase(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	l.state.SetCloser(cancel)
-
 	records := l.readProviderRecords(ctx)
 
 	go func() {

--- a/catalog/internal/catalog/modelcatalog/loader.go
+++ b/catalog/internal/catalog/modelcatalog/loader.go
@@ -413,14 +413,17 @@ func (l *ModelLoader) readProviderRecords(ctx context.Context) <-chan ModelProvi
 
 			modelNames := []string{}
 			failedModels := []string{}
-			statusSaved := false
 
 			for r := range records {
-				// Per-model validation errors (Error set, no Model). The Hugging Face
-				// provider also sends a nil-Model completion record with
+				// Per-model validation errors or source read errors (Error set, no Model).
+				// The Hugging Face provider also sends a nil-Model completion record with
 				// ErrPartiallyAvailable; that is handled below as batch completion, not here.
 				if r.Error != nil && r.Model == nil && !errors.Is(r.Error, ErrPartiallyAvailable) {
-					glog.Errorf("%s: model validation error: %v", sourceID, r.Error)
+					if _, ok := errors.AsType[*SourceReadError](r.Error); ok {
+						glog.Errorf("%s: source read error: %v", sourceID, r.Error)
+					} else {
+						glog.Errorf("%s: model validation error: %v", sourceID, r.Error)
+					}
 					failedModels = append(failedModels, r.Error.Error())
 					continue
 				}
@@ -433,13 +436,19 @@ func (l *ModelLoader) readProviderRecords(ctx context.Context) <-chan ModelProvi
 					modelNameSet := mapset.NewSet(modelNames...)
 					modelNames = modelNames[:0]
 
-					go func() {
+					// Skip orphan cleanup on complete failure to preserve stale-but-functional
+					// data until the error is fixed. An empty catalog (no models, no errors)
+					// is a valid state and still runs cleanup.
+					completeFailure := modelNameSet.Cardinality() == 0 && len(failedModels) > 0
+					if !completeFailure {
+						l.state.TrackWrite()
 						count, err := l.removeOrphanedModelsFromSource(sourceID, modelNameSet)
+						l.state.WriteComplete()
 						if err != nil {
 							glog.Errorf("error removing orphaned models: %v", err)
 						}
 						glog.Infof("%s: cleaned up %d models", sourceID, count)
-					}()
+					}
 
 					// Only save status if context is still valid (no reload in progress)
 					if ctx.Err() == nil {
@@ -470,8 +479,11 @@ func (l *ModelLoader) readProviderRecords(ctx context.Context) <-chan ModelProvi
 						} else {
 							basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusAvailable, "")
 						}
-						statusSaved = true
 					}
+
+					// Reset batch state for the next reload cycle.
+					failedModels = failedModels[:0]
+
 					continue
 				}
 
@@ -486,9 +498,9 @@ func (l *ModelLoader) readProviderRecords(ctx context.Context) <-chan ModelProvi
 				ch <- r
 			}
 
-			// If the channel closed without a nil Model marker and status wasn't already saved,
-			// save available status if context is still valid and we processed some models
-			if !statusSaved && ctx.Err() == nil && len(modelNames) > 0 {
+			// If the channel closed without a nil Model marker (one-shot provider),
+			// save available status if context is still valid and we processed some models.
+			if ctx.Err() == nil && len(modelNames) > 0 {
 				basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusAvailable, "")
 			}
 		}(ctx, source.Id)

--- a/catalog/internal/catalog/modelcatalog/loader_test.go
+++ b/catalog/internal/catalog/modelcatalog/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/models"
 	sharedmodels "github.com/kubeflow/hub/catalog/internal/db/models"
 	apimodels "github.com/kubeflow/hub/catalog/pkg/openapi"
+	mrmodels "github.com/kubeflow/hub/internal/platform/db/entity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -556,4 +558,303 @@ func TestSourceStatusPartialVsFull(t *testing.T) {
 			assert.Contains(t, st.Error, tt.wantErrContain)
 		})
 	}
+}
+
+// TestSourceStatusOnReloadError verifies that when the provider emits only an
+// error record + sentinel (as yamlModelProvider now does on read failure), the
+// source status is set to "error" rather than staying "available".
+func TestSourceStatusOnReloadError(t *testing.T) {
+	const sourceID = "reload-error-source"
+
+	providerName := "reload-error-provider"
+	require.NoError(t, RegisterModelProvider(providerName, func(ctx context.Context, source *basecatalog.ModelSource, reldir string) (<-chan ModelProviderRecord, error) {
+		ch := make(chan ModelProviderRecord, 2)
+		go func() {
+			defer close(ch)
+			ch <- ModelProviderRecord{Error: fmt.Errorf("YAML parse error: unexpected token")}
+			ch <- ModelProviderRecord{} // sentinel
+		}()
+		return ch, nil
+	}))
+
+	mockSourceRepo := &MockCatalogSourceRepository{}
+	services := Services{
+		CatalogModelRepository:           &MockCatalogModelRepository{},
+		CatalogArtifactRepository:        &MockCatalogArtifactRepository{},
+		CatalogModelArtifactRepository:   &MockCatalogModelArtifactRepository{},
+		CatalogMetricsArtifactRepository: &MockCatalogMetricsArtifactRepository{},
+		CatalogSourceRepository:          mockSourceRepo,
+		PropertyOptionsRepository:        &MockPropertyOptionsRepository{},
+	}
+
+	baseLoader := basecatalog.NewBaseLoader([]string{})
+	baseLoader.SetLeader(true)
+	loader := NewModelLoader(services, baseLoader)
+
+	cfg := &basecatalog.SourceConfig{
+		ModelCatalogs: []basecatalog.ModelSource{
+			{
+				CatalogSource: apimodels.CatalogSource{
+					Id:      sourceID,
+					Name:    "Test",
+					Enabled: new(true),
+				},
+				Type: providerName,
+			},
+		},
+	}
+	require.NoError(t, loader.updateSources("test-path", cfg))
+
+	ctx := context.Background()
+	require.NoError(t, loader.PerformLeaderOperations(ctx, mapset.NewSet(sourceID)))
+
+	var st sharedmodels.SourceStatus
+	assert.Eventually(t, func() bool {
+		statuses, err := mockSourceRepo.GetAllStatuses()
+		if err != nil {
+			return false
+		}
+		var ok bool
+		st, ok = statuses[sourceID]
+		return ok && st.Status != ""
+	}, 3*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, basecatalog.SourceStatusError, st.Status, "expected error status when all models fail to load")
+}
+
+// TestSourceStatusRecoveryAfterError verifies that when a provider first emits
+// an error batch and then a successful batch (simulating a file fix), the source
+// status transitions from "error" to "available".
+func TestSourceStatusRecoveryAfterError(t *testing.T) {
+	const sourceID = "recovery-source"
+
+	// Use a channel to control what the provider emits. First batch is an error,
+	// second batch is a successful model.
+	sendBatch := make(chan bool, 2)
+	sendBatch <- false // first batch: error
+	sendBatch <- true  // second batch: success
+
+	providerName := "recovery-provider-" + sourceID
+	require.NoError(t, RegisterModelProvider(providerName, func(ctx context.Context, source *basecatalog.ModelSource, reldir string) (<-chan ModelProviderRecord, error) {
+		ch := make(chan ModelProviderRecord, 4)
+		go func() {
+			defer close(ch)
+			for success := range sendBatch {
+				if !success {
+					ch <- ModelProviderRecord{Error: fmt.Errorf("YAML parse error")}
+					ch <- ModelProviderRecord{} // sentinel
+				} else {
+					name := "ok-model"
+					ch <- ModelProviderRecord{
+						Model: &models.CatalogModelImpl{
+							Attributes: &models.CatalogModelAttributes{Name: &name},
+						},
+					}
+					ch <- ModelProviderRecord{} // sentinel
+					return
+				}
+			}
+		}()
+		return ch, nil
+	}))
+
+	mockSourceRepo := &MockCatalogSourceRepository{}
+	services := Services{
+		CatalogModelRepository:           &MockCatalogModelRepository{},
+		CatalogArtifactRepository:        &MockCatalogArtifactRepository{},
+		CatalogModelArtifactRepository:   &MockCatalogModelArtifactRepository{},
+		CatalogMetricsArtifactRepository: &MockCatalogMetricsArtifactRepository{},
+		CatalogSourceRepository:          mockSourceRepo,
+		PropertyOptionsRepository:        &MockPropertyOptionsRepository{},
+	}
+
+	baseLoader := basecatalog.NewBaseLoader([]string{})
+	baseLoader.SetLeader(true)
+	loader := NewModelLoader(services, baseLoader)
+
+	cfg := &basecatalog.SourceConfig{
+		ModelCatalogs: []basecatalog.ModelSource{
+			{
+				CatalogSource: apimodels.CatalogSource{
+					Id:      sourceID,
+					Name:    "Test",
+					Enabled: new(true),
+				},
+				Type: providerName,
+			},
+		},
+	}
+	require.NoError(t, loader.updateSources("test-path", cfg))
+
+	ctx := context.Background()
+	require.NoError(t, loader.PerformLeaderOperations(ctx, mapset.NewSet(sourceID)))
+
+	// Eventually the source should recover to "available".
+	var st sharedmodels.SourceStatus
+	assert.Eventually(t, func() bool {
+		statuses, err := mockSourceRepo.GetAllStatuses()
+		if err != nil {
+			return false
+		}
+		var ok bool
+		st, ok = statuses[sourceID]
+		return ok && st.Status == basecatalog.SourceStatusAvailable
+	}, 3*time.Second, 10*time.Millisecond, "expected status to recover to available")
+
+	assert.Equal(t, basecatalog.SourceStatusAvailable, st.Status)
+}
+
+// TestFailedModelsResetBetweenBatches verifies that a validation error in one
+// batch does not pollute the status calculation in subsequent batches.
+func TestFailedModelsResetBetweenBatches(t *testing.T) {
+	const sourceID = "batch-reset-source"
+
+	providerName := "batch-reset-provider"
+	require.NoError(t, RegisterModelProvider(providerName, func(ctx context.Context, source *basecatalog.ModelSource, reldir string) (<-chan ModelProviderRecord, error) {
+		ch := make(chan ModelProviderRecord, 8)
+		go func() {
+			defer close(ch)
+			// Batch 1: one validation error + one good model + sentinel → partially-available
+			ch <- ModelProviderRecord{Error: fmt.Errorf("model %q artifact 0: URI invalid", "bad-model")}
+			goodName := "good-model"
+			ch <- ModelProviderRecord{
+				Model: &models.CatalogModelImpl{
+					Attributes: &models.CatalogModelAttributes{Name: &goodName},
+				},
+			}
+			ch <- ModelProviderRecord{} // sentinel
+
+			// Batch 2: only good model + sentinel → should be available (not partially-available)
+			good2 := "good-model-2"
+			ch <- ModelProviderRecord{
+				Model: &models.CatalogModelImpl{
+					Attributes: &models.CatalogModelAttributes{Name: &good2},
+				},
+			}
+			ch <- ModelProviderRecord{} // sentinel
+		}()
+		return ch, nil
+	}))
+
+	mockSourceRepo := &MockCatalogSourceRepository{}
+	services := Services{
+		CatalogModelRepository:           &MockCatalogModelRepository{},
+		CatalogArtifactRepository:        &MockCatalogArtifactRepository{},
+		CatalogModelArtifactRepository:   &MockCatalogModelArtifactRepository{},
+		CatalogMetricsArtifactRepository: &MockCatalogMetricsArtifactRepository{},
+		CatalogSourceRepository:          mockSourceRepo,
+		PropertyOptionsRepository:        &MockPropertyOptionsRepository{},
+	}
+
+	baseLoader := basecatalog.NewBaseLoader([]string{})
+	baseLoader.SetLeader(true)
+	loader := NewModelLoader(services, baseLoader)
+
+	cfg := &basecatalog.SourceConfig{
+		ModelCatalogs: []basecatalog.ModelSource{
+			{
+				CatalogSource: apimodels.CatalogSource{
+					Id:      sourceID,
+					Name:    "Test",
+					Enabled: new(true),
+				},
+				Type: providerName,
+			},
+		},
+	}
+	require.NoError(t, loader.updateSources("test-path", cfg))
+
+	ctx := context.Background()
+	require.NoError(t, loader.PerformLeaderOperations(ctx, mapset.NewSet(sourceID)))
+
+	// The final status should be "available" (batch 2 was clean), not
+	// "partially-available" (which would mean failedModels leaked from batch 1).
+	var st sharedmodels.SourceStatus
+	assert.Eventually(t, func() bool {
+		statuses, err := mockSourceRepo.GetAllStatuses()
+		if err != nil {
+			return false
+		}
+		var ok bool
+		st, ok = statuses[sourceID]
+		// Wait until we've seen at least two status saves (partially-available then available)
+		return ok && st.Status == basecatalog.SourceStatusAvailable
+	}, 3*time.Second, 10*time.Millisecond, "expected final status to be available, not partially-available from previous batch")
+
+	assert.Equal(t, basecatalog.SourceStatusAvailable, st.Status)
+}
+
+// TestOrphanCleanupSkippedOnCompleteFailure verifies that existing models are
+// preserved in the database when a reload fails completely. The List method is
+// used by removeOrphanedModelsFromSource; we verify it is NOT called.
+func TestOrphanCleanupSkippedOnCompleteFailure(t *testing.T) {
+	const sourceID = "orphan-skip-source"
+
+	providerName := "orphan-skip-provider"
+	require.NoError(t, RegisterModelProvider(providerName, func(ctx context.Context, source *basecatalog.ModelSource, reldir string) (<-chan ModelProviderRecord, error) {
+		ch := make(chan ModelProviderRecord, 2)
+		go func() {
+			defer close(ch)
+			ch <- ModelProviderRecord{Error: fmt.Errorf("read error")}
+			ch <- ModelProviderRecord{} // sentinel: total failure
+		}()
+		return ch, nil
+	}))
+
+	trackingRepo := &MockCatalogModelRepositoryWithListTracking{
+		MockCatalogModelRepository: MockCatalogModelRepository{},
+	}
+	services := Services{
+		CatalogModelRepository:           trackingRepo,
+		CatalogArtifactRepository:        &MockCatalogArtifactRepository{},
+		CatalogModelArtifactRepository:   &MockCatalogModelArtifactRepository{},
+		CatalogMetricsArtifactRepository: &MockCatalogMetricsArtifactRepository{},
+		CatalogSourceRepository:          &MockCatalogSourceRepository{},
+		PropertyOptionsRepository:        &MockPropertyOptionsRepository{},
+	}
+
+	baseLoader := basecatalog.NewBaseLoader([]string{})
+	baseLoader.SetLeader(true)
+	loader := NewModelLoader(services, baseLoader)
+
+	cfg := &basecatalog.SourceConfig{
+		ModelCatalogs: []basecatalog.ModelSource{
+			{
+				CatalogSource: apimodels.CatalogSource{
+					Id:      sourceID,
+					Name:    "Test",
+					Enabled: new(true),
+				},
+				Type: providerName,
+			},
+		},
+	}
+	require.NoError(t, loader.updateSources("test-path", cfg))
+
+	ctx := context.Background()
+	require.NoError(t, loader.PerformLeaderOperations(ctx, mapset.NewSet(sourceID)))
+
+	assert.Never(t, func() bool {
+		return trackingRepo.ListCalled()
+	}, 500*time.Millisecond, 10*time.Millisecond, "orphan cleanup (List) should not be called when all models fail to load")
+}
+
+// MockCatalogModelRepositoryWithListTracking tracks whether List was called.
+type MockCatalogModelRepositoryWithListTracking struct {
+	MockCatalogModelRepository
+	mu         sync.Mutex
+	listCalled bool
+}
+
+func (m *MockCatalogModelRepositoryWithListTracking) List(opts models.CatalogModelListOptions) (*mrmodels.ListWrapper[models.CatalogModel], error) {
+	m.mu.Lock()
+	m.listCalled = true
+	m.mu.Unlock()
+	return m.MockCatalogModelRepository.List(opts)
+}
+
+func (m *MockCatalogModelRepositoryWithListTracking) ListCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.listCalled
 }

--- a/catalog/internal/catalog/modelcatalog/yaml_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog.go
@@ -326,31 +326,41 @@ type yamlCatalog struct {
 	Models []yamlModel `yaml:"models"`
 }
 
+// SourceReadError wraps a file-level read or parse failure so the consumer can
+// distinguish it from per-model validation errors.
+type SourceReadError struct {
+	err error
+}
+
+func (e *SourceReadError) Error() string { return e.err.Error() }
+func (e *SourceReadError) Unwrap() error { return e.err }
+
 type yamlModelProvider struct {
 	path   string
 	filter *ModelFilter
 }
 
 func (p *yamlModelProvider) Models(ctx context.Context) (<-chan ModelProviderRecord, error) {
-	// read the catalog and report errors
-	catalog, err := p.read()
-	if err != nil {
-		return nil, err
-	}
-
 	ch := make(chan ModelProviderRecord)
 	go func() {
 		defer close(ch)
 
-		// Send the initial list right away.
-		p.emit(ctx, catalog, ch)
+		// Set up the watcher before the initial read so that changes arriving
+		// during or just after the read are not missed.
+		changes, watchErr := basecatalog.GetMonitor().Path(ctx, p.path)
+		if watchErr != nil {
+			glog.Errorf("unable to watch YAML catalog file: %v", watchErr)
+		}
 
-		// Watch for changes
-		changes, err := basecatalog.GetMonitor().Path(ctx, p.path)
+		catalog, err := p.read()
 		if err != nil {
-			// Not fatal, we still have the inital load, but there
-			// won't be any updates.
-			glog.Errorf("unable to watch YAML catalog file: %v", err)
+			p.emitError(ctx, err, ch)
+		} else {
+			p.emit(ctx, catalog, ch)
+		}
+
+		if changes == nil {
+			// Watcher setup failed; no live updates possible.
 			return
 		}
 
@@ -358,21 +368,39 @@ func (p *yamlModelProvider) Models(ctx context.Context) (<-chan ModelProviderRec
 			select {
 			case <-ctx.Done():
 				return
-			case <-changes:
+			case _, ok := <-changes:
+				if !ok {
+					return
+				}
 				glog.Infof("Reloading YAML catalog %s", p.path)
-
 				catalog, err = p.read()
 				if err != nil {
 					glog.Errorf("unable to load YAML catalog: %v", err)
+					p.emitError(ctx, err, ch)
 					continue
 				}
-
 				p.emit(ctx, catalog, ch)
 			}
 		}
 	}()
 
 	return ch, nil
+}
+
+// emitError wraps readErr as a SourceReadError and sends it followed by a
+// sentinel so the consumer can update the source status to "error" while
+// keeping the channel alive for future reload attempts.
+func (p *yamlModelProvider) emitError(ctx context.Context, readErr error, out chan<- ModelProviderRecord) {
+	done := ctx.Done()
+	select {
+	case out <- ModelProviderRecord{Error: &SourceReadError{err: readErr}}:
+	case <-done:
+		return
+	}
+	select {
+	case out <- ModelProviderRecord{}:
+	case <-done:
+	}
 }
 
 func (p *yamlModelProvider) read() (*yamlCatalog, error) {

--- a/catalog/internal/catalog/modelcatalog/yaml_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/yaml_catalog_test.go
@@ -1062,3 +1062,147 @@ func modelNameFromRecord(t *testing.T, record ModelProviderRecord) string {
 	require.NotNil(t, attrs.Name)
 	return *attrs.Name
 }
+
+// TestModels_InitialReadFailure verifies that when the YAML file is initially
+// invalid, Models() still returns a channel (no error), and the channel emits
+// an error record followed by a sentinel.
+func TestModels_InitialReadFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("!!invalid: yaml: :::"), 0600))
+
+	p := &yamlModelProvider{path: path, filter: &ModelFilter{}}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ch, err := p.Models(ctx)
+	require.NoError(t, err, "Models() should not return an error for a bad data file")
+	require.NotNil(t, ch)
+
+	// First record: error record (Model nil, Error non-nil)
+	r1 := <-ch
+	assert.Nil(t, r1.Model)
+	assert.Error(t, r1.Error)
+
+	// Second record: sentinel (both nil)
+	r2 := <-ch
+	assert.Nil(t, r2.Model)
+	assert.Nil(t, r2.Error)
+}
+
+// TestModels_RecoveryAfterInitialFailure verifies that when the initial YAML
+// file is invalid but then fixed, the file watcher detects the fix and emits
+// valid model records.
+//
+// The watcher is set up BEFORE the initial read, so by the time the test reads
+// the error+sentinel and writes the fixed file, the watcher is guaranteed to
+// already be watching.
+func TestModels_RecoveryAfterInitialFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("!!invalid yaml"), 0600))
+
+	p := &yamlModelProvider{path: path, filter: &ModelFilter{}}
+	// Use t.Context() so the context stays alive for the full test lifetime.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, err := p.Models(ctx)
+	require.NoError(t, err)
+
+	// Drain the initial error + sentinel. Because Models() sets up the watcher
+	// before the initial read, by the time we finish reading these two records
+	// the watcher is already registered and watching the file.
+	r1 := <-ch
+	assert.Nil(t, r1.Model)
+	assert.Error(t, r1.Error)
+	r2 := <-ch
+	assert.Nil(t, r2.Model)
+
+	// Fix the file. The watcher is already running at this point.
+	validYAML := `source: test
+models:
+  - name: recovered-model
+    artifacts:
+      - uri: "https://example.com/model.bin"
+`
+	require.NoError(t, os.WriteFile(path, []byte(validYAML), 0600))
+
+	// Wait for the watcher to fire and emit the recovered model. The monitor
+	// pauses 1 second after an fsnotify event before dispatching, so we allow
+	// a generous timeout.
+	var gotModel bool
+	assert.Eventually(t, func() bool {
+		select {
+		case r, ok := <-ch:
+			if !ok {
+				return false
+			}
+			if r.Model != nil {
+				gotModel = true
+				return true
+			}
+		default:
+		}
+		return false
+	}, 15*time.Second, 100*time.Millisecond, "file-watch reload should emit a valid model after the file is fixed")
+	assert.True(t, gotModel)
+}
+
+// TestModels_ReloadErrorEmitsSentinel verifies that when a valid YAML file is
+// replaced with an invalid one, the reload emits an error record + sentinel
+// instead of silently continuing, so the consumer can update the source status.
+//
+// The watcher is set up BEFORE the initial read, so the file write happens
+// after the watcher is already watching — no race.
+func TestModels_ReloadErrorEmitsSentinel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.yaml")
+
+	validYAML := `source: test
+models:
+  - name: my-model
+    artifacts:
+      - uri: "https://example.com/model.bin"
+`
+	require.NoError(t, os.WriteFile(path, []byte(validYAML), 0600))
+
+	p := &yamlModelProvider{path: path, filter: &ModelFilter{}}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, err := p.Models(ctx)
+	require.NoError(t, err)
+
+	// Drain the initial successful batch (model + sentinel). Because Models()
+	// sets up the watcher before the initial read, the watcher is already
+	// running once we finish reading these records.
+	for {
+		r := <-ch
+		if r.Model == nil {
+			break
+		}
+	}
+
+	// Overwrite with invalid YAML. The watcher is already watching.
+	require.NoError(t, os.WriteFile(path, []byte("!!!not: valid: yaml"), 0600))
+
+	// Wait for the reload to emit an error record. The monitor pauses 1 second
+	// after an fsnotify event before dispatching, so we allow a generous timeout.
+	var gotErr bool
+	assert.Eventually(t, func() bool {
+		select {
+		case r, ok := <-ch:
+			if !ok {
+				return false
+			}
+			if r.Model == nil && r.Error != nil {
+				gotErr = true
+				return true
+			}
+		default:
+		}
+		return false
+	}, 15*time.Second, 100*time.Millisecond, "file-watch reload should emit an error record after invalid YAML is written")
+	assert.True(t, gotErr)
+}

--- a/catalog/internal/plugin/base.go
+++ b/catalog/internal/plugin/base.go
@@ -97,6 +97,9 @@ func (pb *PluginBase) watchFile(ctx context.Context, path string) {
 				pb.healthy.Store(false)
 				glog.Errorf("unable to perform %s leader writes on reload: %v", pb.cfg.Name, err)
 			} else {
+				// Wait for the initial load batch to finish before marking healthy,
+				// so API clients don't see stale data after a config reload.
+				pb.cfg.State.WaitForInflightWrites(30 * time.Second)
 				pb.healthy.Store(true)
 			}
 		}
@@ -120,6 +123,9 @@ func (pb *PluginBase) OnBecomeLeader(ctx context.Context) error {
 		pb.cfg.State.SetLeader(false)
 		return fmt.Errorf("%s leader operations: %w", pb.cfg.Name, err)
 	}
+	// Wait for the initial load batch to finish before calling OnLeaderReady and
+	// marking healthy, so the plugin is fully populated when readiness probes fire.
+	pb.cfg.State.WaitForInflightWrites(30 * time.Second)
 
 	if pb.cfg.OnLeaderReady != nil {
 		if err := pb.cfg.OnLeaderReady(ctx); err != nil {


### PR DESCRIPTION
## Description

Previously, only sources.yaml was watched for file changes. YAML data files referenced via yamlCatalogPath required a pod restart or a sources.yaml touch to pick up edits.

MCP catalog: make yamlMCPProvider.Servers() long-lived. After emitting the initial batch it sends a zero-value sentinel record, registers a file watcher on each data file via basecatalog.GetMonitor().Path(), and re-emits + re-sends the sentinel on every detected change. The loader's PerformLeaderOperations now returns immediately after launching per-source goroutines; loadServersFromProvider uses sync.OnceFunc to release the pre-registered TrackWrite slot on the first sentinel so that WaitForInflightWrites unblocks correctly. Subsequent batches (file reloads) perform orphan cleanup and status updates the same way as the initial batch.

Agent catalog: add watchAndLoadFromYAML that performs the initial load, releases its TrackWrite slot, then loops on GetMonitor().Path() events to reload on change. PerformLeaderOperations is restructured to launch goroutines and return immediately, matching the MCP and model loader patterns.

Tests updated to use t.Context() so background goroutines are cancelled when each test ends, and to break on sentinel records rather than waiting for channel close.

## How Has This Been Tested?
Verified locally on a dev cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
