### PR TITLE
fix(docs): update the release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 This document describes the Release process followed by this Kubeflow Hub component project, enacted by its Maintainers.
 
-# Principles
+## Principles
 
 The Kubeflow Hub follows the [Github Release Workflow](https://github.com/kubeflow/hub/releases), and performs periodic releases in accordance with the Kubeflow Platform WG recommendations.
 
@@ -22,7 +22,7 @@ The Release of the Kubeflow Hub provides:
 - a collection of Kubernetes Manifests, which get synchronized to the `kubeflow/manifests` repository
 - an update to the Kubeflow website
 
-# Instructions
+## Instructions
 
 These instructions can be followed by the Maintainers with write access on the repository.
 
@@ -34,8 +34,6 @@ origin	git@github.com:<your username>/hub.git (push)
 upstream	git@github.com:kubeflow/hub.git (fetch)
 upstream	git@github.com:kubeflow/hub.git (push)
 ```
-
-and for the rest of this instructions, the `<your username>` will be referred as `mr_maintainer`.
 
 Prerequisites:
 - on main branch, the version indicated by the [pyproject.toml](https://github.com/kubeflow/hub/blob/d2312907025adbe83d3faafbecf1474824d055ed/clients/python/pyproject.toml#L3) and [metadadata](https://github.com/kubeflow/hub/blob/d2312907025adbe83d3faafbecf1474824d055ed/clients/python/src/model_registry/__init__.py#L3) of the Model Registry Python client is current (that is, is already valorized to the _target_ release number).
@@ -50,25 +48,22 @@ Example for `0.2.10` release:
 
 ```sh
 VVERSION=v0.2.10
-TDATE=$(date "+%Y%m%d")
 ```
 
-> [!NOTE]
-> We no longer explicits the `-alpha` suffix (see [here](https://github.com/kubeflow/hub/issues/435#issuecomment-2384745910)).
-
-- create the release branch upstream
+## Prepare the release branch
 
 ```
-git checkout -b release/$VVERSION
+git switch main
+git switch -c release/$VVERSION
 git push upstream release/$VVERSION
 ```
 
-this creates the release branch upstream.
+This creates the release branch upstream.
 
 Create a PR to update what's needed on the release branch, i.e. to update the manifest images.
 
 ```
-git checkout -b mr_maintainer-$TDATE-upstreamSync
+git switch -c $VVERSION-manifests
 pushd manifests/kustomize/base && kustomize edit set image ghcr.io/kubeflow/hub/server=ghcr.io/kubeflow/hub/server:$VVERSION && popd
 pushd manifests/kustomize/options/csi && kustomize edit set image ghcr.io/kubeflow/hub/storage-initializer=ghcr.io/kubeflow/hub/storage-initializer:$VVERSION && popd
 pushd manifests/kustomize/options/ui/base && kustomize edit set image model-registry-ui=ghcr.io/kubeflow/hub/ui:$VVERSION && popd
@@ -76,78 +71,106 @@ pushd manifests/kustomize/options/catalog/base && kustomize edit set image ghcr.
 VERSION=$(echo $VVERSION | cut -b 2-)
 sed -i "s/^\(version = \"\)[^\"]*\"/\1$VERSION\"/" clients/python/pyproject.toml
 sed -i "s/^\(__version__ = \"\)[^\"]*\"/\1$VERSION\"/" clients/python/src/model_registry/__init__.py
-git add .
-git commit -s
-
-# suggested commit msg: "chore: align manifest for 0.2.10"
-
-# using `git push origin`
-# will give back convenient command on the screen for copy/paste:
-# eg: git push --set-upstream origin mr_maintainer-20241108-upstreamSync
-git push --set-upstream origin mr_maintainer-$TDATE-upstreamSync
+git commit -asm "chore: update manifests for release $VVERSION"
 ```
 
-**Note:** On mac, replace the `sed -i` in the above command with `sed -i ''`.
+**Note:** On mac, replace `sed -i` with `sed -i ''`.
 
-- create PR ⚠️ targeting the _release branch_ ⚠️ specifically (title ~like: `chore: align manifest for 0.2.10`)
-- merge the PR (you can manually add the approved, lgtm labels)
+Look at the changes in the last commit (`git show`) and verify that they are correct.
 
-- optional. if you create the tag from local git (see point below); await GHA complete that push Container images to docker.io or any other KF registry: https://github.com/kubeflow/hub/actions
-- create [the Release from GitHub](https://github.com/kubeflow/hub/releases/new), ⚠️ select the _release branch_ ⚠️ , input the _new tag_<br/>(in this example the tag is created from GitHub; alternatively, you could just do the tag manually by checking out the release branch locally--remember to pull!!--and issuing the tag from local machine).
-- encouraging to use the "alpha" version policy of KF in the beginning of the release markdown (see previous releases).
+Create a PR targeting the release branch. If the GitHub CLI is configured: `gh pr create --base release/$VVERSION` Otherwise push the branch and create the PR in the usual way.
 
-It is helpful to prefix this in the release notes:
+Wait for the build to pass, then merge the PR (you can manually add the approved, lgtm labels).
+
+**IMPORTANT:** After the merge, update your local branch:
+
+```
+git switch release/$VVERSION
+git pull
+```
+
+## Create the release
+
+Create [the Release from GitHub](https://github.com/kubeflow/hub/releases/new):
+- **Tag:** _Create new tag_, then enter the new version (with the `v`: `v0.3.14`)
+- **Target:** ⚠️ select the _release branch_ ⚠️
+- **Release title:** enter the version number (again, with the `v`)
+- **Release notes:** select the previous release, then "Generate Release Notes" (don't trust *Auto*!)
+
+Paste the following at the beginning of the release notes:
 
 ```md
 > **Alpha**
 > This Kubeflow component has alpha status with limited support. See the [Kubeflow versioning policies](https://www.kubeflow.org/docs/started/support/#application-status). The Kubeflow team is interested in your [feedback](https://github.com/kubeflow/hub/issues/new/choose) about the usability of the feature.
 ```
 
-- release the MR Python client
+Push **Save Draft** (releases are immutable, we're not ready to publish yet).
+
+## Tag the release
+
+Create the tag from the release branch:
 
 ```
-git checkout release/$VVERSION
+git switch release/$VVERSION
+git pull
+git tag $VVERSION -m $VVERSION
+git push origin $VVERSION
+```
+
+Watch the build progress from Git Hub: _https://github.com/kubeflow/hub/tree/vX.Y.Z_ (`xdg-open https://github.com/kubeflow/hub/tree/$VVERSION`).
+
+The GHA will attach SBOM artifacts to the draft release.
+
+**Wait for the build to finish before continuing.**
+
+## Publish the release
+
+Return to the draft release from the [releases](https://github.com/kubeflow/hub/releases) page, and publish the release.
+
+## Create the other tags
+
+Create tags for the Python client, `pkg/openapi` and the Inference Controller:
+
+```
+git switch release/$VVERSION
 git pull upstream release/$VVERSION
-git tag py-$VVERSION
-git push upstream py-$VVERSION
-```
-
-- add a Tag for the pkg/openapi
-
-```
-git checkout release/$VVERSION
-git pull upstream release/$VVERSION
-git tag pkg/openapi/$VVERSION
-git push upstream pkg/openapi/$VVERSION
-```
-
-- add a Tag for the pkg/inferenceservice-controller
-
-```
-git checkout release/$VVERSION
-git pull upstream release/$VVERSION
-git tag pkg/inferenceservice-controller/$VVERSION
-git push upstream pkg/inferenceservice-controller/$VVERSION
+git tag py-$VVERSION -m py-$VVERSION
+git tag pkg/openapi/$VVERSION -m pkg/openapi/$VVERSION
+git tag pkg/inferenceservice-controller/$VVERSION -m pkg/inferenceservice-controller/$VVERSION
+git push upstream py-$VVERSION pkg/openapi/$VVERSION pkg/inferenceservice-controller/$VVERSION
 ```
 
 At this point, a release as been created, both the container images and the Python client on pypi.
 
-## KF/manifests
+## `kubeflow/community-distribution`
 
-The KF/hub manifests need to be sync'd to KF/manifests repository using the Manifest/Platform WG provided script (in the KF/manifests repo).
+The `kubeflow/hub` manifests need to be sync'd to `kubeflow/community-distribution` repository.
 
-Example PR:
-- https://github.com/kubeflow/manifests/pull/3053
+From a local clone of `community-distribution`:
 
-It is supposed to work by leveraging sync script in KF/manifests repo:
-- https://github.com/pboyd/kubeflow-manifests/blob/163b45fcb55bdcbafa33a843a856a6bd96c5cecd/scripts/synchronize-hub-manifests.sh
+```
+git switch master
+git pull
+sed -i "s/^\(COMMIT=\"\)[^\"]*\"/\1$VVERSION\"/" scripts/synchronize-hub-manifests.sh
+./scripts/synchronize-hub-manifests.sh
+```
 
-## KF/website
+**Note:** As above, on Mac, use `sed -i ''`
 
-Update latest MR release version number in the KF/website repo.
+This will create a new branch and make a commit with the updated manifests. Verify the changes with `git show`, then create the PR: `gh pr create` (or push the branch and make a PR using your usual method).
 
-Example PR:
-- https://github.com/kubeflow/website/pull/4046
+## `kubeflow/website`
+
+From a local close of `kubeflow/website`:
+
+```
+git switch master
+git pull
+echo $VVERSION >layouts/shortcodes/hub/latest-version.html
+git commit -asm "hub: bump hub version to $VVERSION"
+```
+
+Then create a PR: `gh pr create` (or however you normally make a PR).
 
 Please notice the OpenAPI spec in the Reference section is automatically updated, since it is sourced from the repo: https://github.com/kubeflow/website/blob/b97081e8e19a06430268e1fa9a38808f2a04cf69/content/en/docs/components/hub/reference/rest-api.md?plain=1#L44-L46
 


### PR DESCRIPTION
## Description

Fixing a few things in `RELEASE.md`:

* Releases are immutable now, which prevents the SBOM attestation jobs in GHA from attaching artifacts after the release has been published. We can work-around it by creating a draft release then making the tag manually, and waiting for the jobs.
* Simplify the commands to create the other tags. Add more details about updating `kubeflow/manifests` and `kubeflow/website`.

## How Has This Been Tested?
Docs only. We can try it with the next release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
