### PR TITLE
(fix):the agents catalog label texts

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/agentsCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/agentsCatalog.ts
@@ -106,8 +106,8 @@ class AgentDetailsPage {
     return cy.findByTestId('agent-framework');
   }
 
-  findGitHubButton() {
-    return cy.findByTestId('agent-github-button');
+  findRepositoryButton() {
+    return cy.findByTestId('agent-repository-button');
   }
 
   findAgentNotFound() {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts
@@ -115,15 +115,15 @@ describe('Agent Details Page', () => {
   });
 
   describe('Action buttons', () => {
-    it('should show Open GitHub button when repositoryUrl is present', () => {
+    it('should show Open repository button when repositoryUrl is present', () => {
       initAgentsCatalogIntercepts();
       const agent = mockAgent({ name: 'gh-agent', repositoryUrl: 'https://github.com/test' });
       interceptSingleAgent(agent);
 
       agentDetailsPage.visit('gh-agent');
-      agentDetailsPage.findGitHubButton().should('be.visible');
+      agentDetailsPage.findRepositoryButton().should('be.visible');
       agentDetailsPage
-        .findGitHubButton()
+        .findRepositoryButton()
         .should('have.attr', 'href', 'https://github.com/test')
         .and('have.attr', 'target', '_blank');
     });
@@ -134,7 +134,7 @@ describe('Agent Details Page', () => {
       interceptSingleAgent(agent);
 
       agentDetailsPage.visit('no-gh');
-      agentDetailsPage.findGitHubButton().should('not.exist');
+      agentDetailsPage.findRepositoryButton().should('not.exist');
     });
   });
 

--- a/clients/ui/frontend/src/app/pages/agentsCatalog/AgentsCatalogCoreLoader.tsx
+++ b/clients/ui/frontend/src/app/pages/agentsCatalog/AgentsCatalogCoreLoader.tsx
@@ -11,7 +11,7 @@ import {
 import { useThemeContext } from 'mod-arch-kubeflow';
 import { Outlet } from 'react-router-dom';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
-import { EmptyCatalogState } from '~/app/shared/components/catalog';
+import { EmptyCatalogState, hasSourcesWithModels } from '~/app/shared/components/catalog';
 import { AGENTS_CATALOG_TITLE, AGENTS_CATALOG_DESCRIPTION } from '~/app/pages/agentsCatalog/const';
 
 const AgentsCatalogCoreLoader: React.FC = () => {
@@ -61,7 +61,7 @@ const AgentsCatalogCoreLoader: React.FC = () => {
     );
   }
 
-  if (catalogSources?.items?.length === 0) {
+  if (catalogSources?.items?.length === 0 || !hasSourcesWithModels(catalogSources)) {
     return (
       <ApplicationsPage
         title={

--- a/clients/ui/frontend/src/app/pages/agentsCatalog/AgentsCatalogCoreLoader.tsx
+++ b/clients/ui/frontend/src/app/pages/agentsCatalog/AgentsCatalogCoreLoader.tsx
@@ -11,7 +11,7 @@ import {
 import { useThemeContext } from 'mod-arch-kubeflow';
 import { Outlet } from 'react-router-dom';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
-import { EmptyCatalogState, hasSourcesWithModels } from '~/app/shared/components/catalog';
+import { EmptyCatalogState } from '~/app/shared/components/catalog';
 import { AGENTS_CATALOG_TITLE, AGENTS_CATALOG_DESCRIPTION } from '~/app/pages/agentsCatalog/const';
 
 const AgentsCatalogCoreLoader: React.FC = () => {
@@ -33,7 +33,7 @@ const AgentsCatalogCoreLoader: React.FC = () => {
         empty
         emptyStatePage={
           <Bullseye>
-            <Alert title="Agents catalog source load error" variant="danger" isInline>
+            <Alert title="Unable to load agent catalog" variant="danger" isInline>
               {catalogSourcesLoadError.message}
             </Alert>
           </Bullseye>
@@ -61,7 +61,7 @@ const AgentsCatalogCoreLoader: React.FC = () => {
     );
   }
 
-  if (catalogSources?.items?.length === 0 || !hasSourcesWithModels(catalogSources)) {
+  if (catalogSources?.items?.length === 0) {
     return (
       <ApplicationsPage
         title={
@@ -79,7 +79,7 @@ const AgentsCatalogCoreLoader: React.FC = () => {
             description={
               isMUITheme
                 ? 'To discover agents, follow the instructions in the docs below.'
-                : 'There are no agent sources to display. Request that your administrator configure agent sources for the catalog.'
+                : 'Request that your administrator configure agent template sources for this catalog.'
             }
             headerIcon={() => (
               <img src={typedEmptyImage(ProjectObjectType.modelRegistrySettings)} alt="" />

--- a/clients/ui/frontend/src/app/pages/agentsCatalog/const.ts
+++ b/clients/ui/frontend/src/app/pages/agentsCatalog/const.ts
@@ -2,7 +2,7 @@ import type { AgentFilterCategoryKey } from '~/app/pages/agentsCatalog/types/age
 
 export const AGENTS_CATALOG_TITLE = 'Agents Catalog';
 export const AGENTS_CATALOG_DESCRIPTION =
-  'Discover agents that are available for your organization.';
+  'Discover agent templates that are available for your organization.';
 
 export const AGENT_FILTER_KEYS: AgentFilterCategoryKey[] = ['framework'];
 

--- a/clients/ui/frontend/src/app/pages/agentsCatalog/screens/AgentDetailsPage.tsx
+++ b/clients/ui/frontend/src/app/pages/agentsCatalog/screens/AgentDetailsPage.tsx
@@ -81,9 +81,9 @@ const AgentDetailsPage: React.FC = () => {
                         href={agent.repositoryUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        data-testid="agent-github-button"
+                        data-testid="agent-repository-button"
                       >
-                        Open GitHub
+                        Open repository
                       </Button>
                     </ActionListItem>
                   )}

--- a/clients/ui/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-shared';
-import { SearchIcon } from '@patternfly/react-icons';
+import {
+  ApplicationsPage,
+  KubeflowDocs,
+  ProjectObjectType,
+  TitleWithIcon,
+  WhosMyAdministrator,
+} from 'mod-arch-shared';
+import { useThemeContext } from 'mod-arch-kubeflow';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
 import { hasAgentFiltersApplied } from '~/app/pages/agentsCatalog/utils/agentsCatalogUtils';
 import AgentsCatalogFilters from '~/app/pages/agentsCatalog/components/AgentsCatalogFilters';
@@ -24,6 +30,7 @@ const AgentsCatalog: React.FC = () => {
     emptyCategoryLabels,
     setCategoryCount,
   } = React.useContext(AgentsCatalogContext);
+  const { isMUITheme } = useThemeContext();
 
   const filtersApplied = hasAgentFiltersApplied(filters, searchQuery);
   const isAllAgentsView = selectedSourceLabel === undefined && !filtersApplied;
@@ -65,9 +72,14 @@ const AgentsCatalog: React.FC = () => {
         renderEmptyCategoriesState={() => (
           <EmptyCatalogState
             testid="empty-agents-catalog-no-categories"
-            title="No agents available"
-            headerIcon={SearchIcon}
-            description="There are no agent categories available. Configure sources in settings to get started."
+            title="Configure agent template sources"
+            headerIcon={null}
+            description={
+              isMUITheme
+                ? 'There are no agent templates to display. Follow the instructions in the docs below to add agent templates.'
+                : 'There are no agent templates to display. Use the Openshift console to add agent templates to the catalog.'
+            }
+            primaryAction={isMUITheme ? <KubeflowDocs /> : <WhosMyAdministrator />}
           />
         )}
         renderFilterSidebar={() => <AgentsCatalogFilters />}

--- a/clients/ui/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
@@ -77,7 +77,7 @@ const AgentsCatalog: React.FC = () => {
             description={
               isMUITheme
                 ? 'There are no agent templates to display. Follow the instructions in the docs below to add agent templates.'
-                : 'There are no agent templates to display. Use the Openshift console to add agent templates to the catalog.'
+                : 'There are no agent templates to display. Use the OpenShift console to add agent templates to the catalog.'
             }
             primaryAction={isMUITheme ? <KubeflowDocs /> : <WhosMyAdministrator />}
           />

--- a/clients/ui/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalogGalleryView.tsx
@@ -83,7 +83,7 @@ const AgentsCatalogGalleryView: React.FC<AgentsCatalogGalleryViewProps> = ({
           testid="empty-agents-catalog-state"
           title="No results found"
           headerIcon={SearchIcon}
-          description="Adjust your filters and try again."
+          description="No agent templates match your filters. Adjust your filters and try again."
           primaryAction={
             <Button variant="link" onClick={handleFilterReset}>
               Reset filters

--- a/clients/ui/frontend/src/app/shared/components/catalog/EmptyCatalogState.tsx
+++ b/clients/ui/frontend/src/app/shared/components/catalog/EmptyCatalogState.tsx
@@ -13,7 +13,7 @@ type EmptyCatalogStateProps = {
   className?: string;
   title: string;
   description: React.ReactNode;
-  headerIcon?: React.ComponentType;
+  headerIcon?: React.ComponentType | null;
   children?: React.ReactNode;
   primaryAction?: React.ReactNode;
   secondaryAction?: React.ReactNode;
@@ -33,7 +33,7 @@ const EmptyCatalogState: React.FC<EmptyCatalogStateProps> = ({
 }) => (
   <EmptyState
     className={className}
-    icon={headerIcon ?? PlusCircleIcon}
+    icon={headerIcon === null ? undefined : (headerIcon ?? PlusCircleIcon)}
     titleText={title}
     variant={variant}
     data-testid={testid}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix agents catalog texts for most of the pages.

non-PF mode:
- Agents Catalog
<img width="1914" height="791" alt="Screenshot 2026-07-22 at 10 36 24" src="https://github.com/user-attachments/assets/0d2cacba-f548-46d8-8ed5-51d26d87b70c" />

- Agents Catalog no-search result
<img width="1915" height="546" alt="Screenshot 2026-07-22 at 10 36 38" src="https://github.com/user-attachments/assets/b78db83c-c571-4d0a-a69e-b01063c7b7fa" />

- Agents Catalog no source
<img width="1915" height="530" alt="Screenshot 2026-07-22 at 10 43 18" src="https://github.com/user-attachments/assets/2c72c3fb-9dc8-4170-b328-be35e022f4ec" />

- Agents Catalog source without agents
<img width="1917" height="465" alt="Screenshot 2026-07-22 at 10 40 21" src="https://github.com/user-attachments/assets/b758f9d8-c9b3-44ed-9287-01e80a16f660" />

- Agents Detail page
<img width="1909" height="551" alt="Screenshot 2026-07-22 at 10 36 59" src="https://github.com/user-attachments/assets/76ed0e3f-c028-410e-afcf-0a78a9bd5ddc" />

PF mode:
- Agents Catalog
<img width="1894" height="807" alt="Screenshot 2026-07-22 at 10 34 27" src="https://github.com/user-attachments/assets/04a70b2b-af2d-4845-b82c-0ba1fe6353a5" />

- Agents Catalog no-search result
<img width="1908" height="655" alt="Screenshot 2026-07-22 at 10 34 40" src="https://github.com/user-attachments/assets/39eb4ca8-e71c-43b1-9851-520bd585ae3e" />

- Agents Catalog no source
<img width="1920" height="582" alt="Screenshot 2026-07-22 at 10 42 37" src="https://github.com/user-attachments/assets/adcf870d-f346-4527-a18b-763ea30b4f6a" />

- Agents Catalog source without agents
<img width="1918" height="530" alt="Screenshot 2026-07-22 at 10 40 46" src="https://github.com/user-attachments/assets/9f47a65d-9c80-4808-876b-9d0522cee336" />

- Agents Detail page
<img width="1910" height="667" alt="Screenshot 2026-07-22 at 10 35 08" src="https://github.com/user-attachments/assets/b4c5f69a-fe59-4710-a398-92dd565a75d8" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
