### PR TITLE
feat(api): create v1 OpenAPI specs for Model Registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ gen/converter: internal/converter/generated/converter.go
 api/openapi/model-registry.yaml: api/openapi/src/model-registry.yaml api/openapi/src/lib/*.yaml bin/yq
 	scripts/merge_openapi.sh model-registry.yaml
 
+api/openapi/model-registry-v1.yaml: api/openapi/src/model-registry-v1.yaml api/openapi/src/lib/*.yaml bin/yq
+	scripts/merge_openapi.sh model-registry-v1.yaml
+
 api/openapi/catalog.yaml: api/openapi/src/catalog.yaml api/openapi/src/lib/*.yaml $(wildcard api/openapi/src/plugins/*.yaml) bin/yq
 	scripts/merge_catalog_specs.sh catalog.yaml
 
@@ -73,8 +76,10 @@ api/openapi/catalog.yaml: api/openapi/src/catalog.yaml api/openapi/src/lib/*.yam
 .PHONY: openapi/validate
 openapi/validate: bin/openapi-generator-cli bin/yq
 	@scripts/merge_openapi.sh --check model-registry.yaml || (echo "api/openapi/model-registry.yaml is incorrectly formatted. Run 'make api/openapi/model-registry.yaml' to fix it."; exit 1)
+	@scripts/merge_openapi.sh --check model-registry-v1.yaml || (echo "api/openapi/model-registry-v1.yaml is incorrectly formatted. Run 'make api/openapi/model-registry-v1.yaml' to fix it."; exit 1)
 	@scripts/merge_catalog_specs.sh --check catalog.yaml || (echo "api/openapi/catalog.yaml is incorrectly formatted. Run 'make api/openapi/catalog.yaml' to fix it."; exit 1)
 	$(OPENAPI_GENERATOR) validate -i api/openapi/model-registry.yaml
+	$(OPENAPI_GENERATOR) validate -i api/openapi/model-registry-v1.yaml
 	$(OPENAPI_GENERATOR) validate -i api/openapi/catalog.yaml
 
 # generate the openapi server implementation

--- a/api/openapi/model-registry-v1.yaml
+++ b/api/openapi/model-registry-v1.yaml
@@ -1,0 +1,2733 @@
+openapi: 3.0.3
+info:
+  title: Model Registry REST API
+  version: v1
+  description: REST API for Model Registry to create and manage ML model metadata
+  license:
+    name: Apache 2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0"
+servers:
+  - url: "https://localhost:8080"
+  - url: "http://localhost:8080"
+paths:
+  /api/model_registry/v1/artifact:
+    summary: Path used to search for an artifact.
+    description: >-
+      The REST endpoint/path used to search for an `Artifact` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findArtifact
+      summary: Get an Artifact that matches search parameters.
+      description: Gets the details of a single instance of an `Artifact` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+      - $ref: "#/components/parameters/parentResourceId"
+  /api/model_registry/v1/artifacts:
+    summary: Path used to manage the list of artifacts.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `Artifact` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/artifactType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getArtifacts
+      summary: List All Artifacts
+      description: Gets a list of all `Artifact` entities.
+    post:
+      requestBody:
+        description: A new `Artifact` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ArtifactCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createArtifact
+      summary: Create an Artifact
+      description: Creates a new instance of an `Artifact`.
+  /api/model_registry/v1/artifacts/{id}:
+    summary: Path used to manage a single Artifact.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `Artifact`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getArtifact
+      summary: Get an Artifact
+      description: Gets the details of a single instance of an `Artifact`.
+    patch:
+      requestBody:
+        description: Updated `Artifact` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ArtifactUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateArtifact
+      summary: Update an Artifact
+      description: Updates an existing `Artifact`.
+    parameters:
+      - name: id
+        description: A unique identifier for an `Artifact`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/inference_service:
+    summary: Path used to manage an instance of inferenceservice.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `InferenceService` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findInferenceService
+      summary: Get an InferenceServices that matches search parameters.
+      description: Gets the details of a single instance of `InferenceService` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+      - $ref: "#/components/parameters/parentResourceId"
+  /api/model_registry/v1/inference_services:
+    summary: Path used to manage the list of inferenceservices.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `InferenceService` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceServices
+      summary: List All InferenceServices
+      description: Gets a list of all `InferenceService` entities.
+    post:
+      requestBody:
+        description: A new `InferenceService` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InferenceServiceCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createInferenceService
+      summary: Create a InferenceService
+      description: Creates a new instance of a `InferenceService`.
+  "/api/model_registry/v1/inference_services/{inference_service_id}":
+    summary: Path used to manage a single InferenceService.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `InferenceService`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceService
+      summary: Get a InferenceService
+      description: Gets the details of a single instance of a `InferenceService`.
+    patch:
+      requestBody:
+        description: Updated `InferenceService` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InferenceServiceUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateInferenceService
+      summary: Update a InferenceService
+      description: Updates an existing `InferenceService`.
+    parameters:
+      - name: inference_service_id
+        description: A unique identifier for a `InferenceService`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/inference_services/{inference_service_id}/model":
+    summary: Path used to manage a `RegisteredModel` associated with an `InferenceService`.
+    description: >-
+      The REST endpoint/path used to list the `RegisteredModel` entity for an `InferenceService`.  This path contains a `GET` operation to perform the get task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceServiceModel
+      summary: Get InferenceService's RegisteredModel
+      description: Gets the `RegisteredModel` entity for the `InferenceService`.
+    parameters:
+      - name: inference_service_id
+        description: A unique identifier for a `InferenceService`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/inference_services/{inference_service_id}/serves":
+    summary: Path used to manage the list of `ServeModels` for a `InferenceService`.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ServeModel` entities for a `InferenceService`.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/externalId"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ServeModelListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceServiceServes
+      summary: List All InferenceService's ServeModel actions
+      description: Gets a list of all `ServeModel` entities for the `InferenceService`.
+    post:
+      requestBody:
+        description: A new `ServeModel` to be associated with the `InferenceService`.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServeModelCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ServeModelResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createInferenceServiceServe
+      summary: Create a ServeModel action in a InferenceService
+      description: Creates a new instance of a `ServeModel` associated with `InferenceService`.
+    parameters:
+      - name: inference_service_id
+        description: A unique identifier for a `InferenceService`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/inference_services/{inference_service_id}/version":
+    summary: Path used to get the current `ModelVersion` associated with an `InferenceService`.
+    description: >-
+      The REST endpoint/path used to get the current `ModelVersion` entity for a `InferenceService`. This path contains a `GET` operation to perform the get task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceServiceVersion
+      summary: Get InferenceService's ModelVersion
+      description: Gets the `ModelVersion` entity for the `InferenceService`.
+    parameters:
+      - name: inference_service_id
+        description: A unique identifier for a `InferenceService`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/model_artifact:
+    summary: Path used to search for a modelartifact.
+    description: >-
+      The REST endpoint/path used to search for a `ModelArtifact` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findModelArtifact
+      summary: Get a ModelArtifact that matches search parameters.
+      description: Gets the details of a single instance of a `ModelArtifact` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+      - $ref: "#/components/parameters/parentResourceId"
+  /api/model_registry/v1/model_artifacts:
+    summary: Path used to manage the list of modelartifacts.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ModelArtifact` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelArtifacts
+      summary: List All ModelArtifacts
+      description: Gets a list of all `ModelArtifact` entities.
+    post:
+      requestBody:
+        description: A new `ModelArtifact` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelArtifactCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ModelArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createModelArtifact
+      summary: Create a ModelArtifact
+      description: Creates a new instance of a `ModelArtifact`.
+  "/api/model_registry/v1/model_artifacts/{model_artifact_id}":
+    summary: Path used to manage a single ModelArtifact.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `ModelArtifact`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelArtifactResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelArtifact
+      summary: Get a ModelArtifact
+      description: Gets the details of a single instance of a `ModelArtifact`.
+    patch:
+      requestBody:
+        description: Updated `ModelArtifact` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelArtifactUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateModelArtifact
+      summary: Update a ModelArtifact
+      description: Updates an existing `ModelArtifact`.
+    parameters:
+      - name: model_artifact_id
+        description: A unique identifier for a `ModelArtifact`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/model_version:
+    summary: Path used to search for a modelversion.
+    description: >-
+      The REST endpoint/path used to search for a `ModelVersion` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findModelVersion
+      summary: Get a ModelVersion that matches search parameters.
+      description: Gets the details of a single instance of a `ModelVersion` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+      - $ref: "#/components/parameters/parentResourceId"
+  /api/model_registry/v1/model_versions:
+    summary: Path used to manage the list of modelversions.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ModelVersion` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelVersions
+      summary: List All ModelVersions
+      description: Gets a list of all `ModelVersion` entities.
+    post:
+      requestBody:
+        description: A new `ModelVersion` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelVersionCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createModelVersion
+      summary: Create a ModelVersion
+      description: Creates a new instance of a `ModelVersion`.
+  "/api/model_registry/v1/model_versions/{model_version_id}":
+    summary: Path used to manage a single ModelVersion.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `ModelVersion`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelVersion
+      summary: Get a ModelVersion
+      description: Gets the details of a single instance of a `ModelVersion`.
+    patch:
+      requestBody:
+        description: Updated `ModelVersion` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelVersionUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateModelVersion
+      summary: Update a ModelVersion
+      description: Updates an existing `ModelVersion`.
+    parameters:
+      - name: model_version_id
+        description: A unique identifier for a `ModelVersion`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/model_versions/{model_version_id}/artifacts":
+    summary: Path used to manage the list of artifacts for a modelversion.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `Artifact` entities for a `ModelVersion`.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/externalId"
+        - $ref: "#/components/parameters/artifactType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelVersionArtifacts
+      summary: List all artifacts associated with the `ModelVersion`
+    post:
+      requestBody:
+        description: A new or existing `Artifact` to be associated with the `ModelVersion`.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Artifact"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactResponse"
+        "201":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: upsertModelVersionArtifact
+      summary: Upsert an Artifact in a ModelVersion
+      description: Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
+    parameters:
+      - name: model_version_id
+        description: A unique identifier for a `ModelVersion`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/registered_model:
+    summary: Path used to search for a registeredmodel.
+    description: >-
+      The REST endpoint/path used to search for a `RegisteredModel` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findRegisteredModel
+      summary: Get a RegisteredModel that matches search parameters.
+      description: Gets the details of a single instance of a `RegisteredModel` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+  /api/model_registry/v1/registered_models:
+    summary: Path used to manage the list of registeredmodels.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `RegisteredModel` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getRegisteredModels
+      summary: List All RegisteredModels
+      description: Gets a list of all `RegisteredModel` entities.
+    post:
+      requestBody:
+        description: A new `RegisteredModel` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisteredModelCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createRegisteredModel
+      summary: Create a RegisteredModel
+      description: Creates a new instance of a `RegisteredModel`.
+  "/api/model_registry/v1/registered_models/{registered_model_id}":
+    summary: Path used to manage a single RegisteredModel.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `RegisteredModel`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getRegisteredModel
+      summary: Get a RegisteredModel
+      description: Gets the details of a single instance of a `RegisteredModel`.
+    patch:
+      requestBody:
+        description: Updated `RegisteredModel` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisteredModelUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateRegisteredModel
+      summary: Update a RegisteredModel
+      description: Updates an existing `RegisteredModel`.
+    parameters:
+      - name: registered_model_id
+        description: A unique identifier for a `RegisteredModel`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/registered_models/{registered_model_id}/versions":
+    summary: Path used to manage the list of modelversions for a registeredmodel.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ModelVersion` entities for a `RegisteredModel`.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/externalId"
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getRegisteredModelVersions
+      summary: List All RegisteredModel's ModelVersions
+      description: Gets a list of all `ModelVersion` entities for the `RegisteredModel`.
+    post:
+      requestBody:
+        description: A new `ModelVersion` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelVersion"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createRegisteredModelVersion
+      summary: Create a ModelVersion in RegisteredModel
+      description: Creates a new instance of a `ModelVersion`.
+    parameters:
+      - name: registered_model_id
+        description: A unique identifier for a `RegisteredModel`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/serving_environment:
+    summary: Path used to find a servingenvironment.
+    description: >-
+      The REST endpoint/path used to search for a `ServingEnvironment` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ServingEnvironmentResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findServingEnvironment
+      summary: Find ServingEnvironment
+      description: Finds a `ServingEnvironment` entity that matches query parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+  /api/model_registry/v1/serving_environments:
+    summary: Path used to manage the list of servingenvironments.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ServingEnvironment` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ServingEnvironmentListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getServingEnvironments
+      summary: List All ServingEnvironments
+      description: Gets a list of all `ServingEnvironment` entities.
+    post:
+      requestBody:
+        description: A new `ServingEnvironment` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServingEnvironmentCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ServingEnvironmentResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createServingEnvironment
+      summary: Create a ServingEnvironment
+      description: Creates a new instance of a `ServingEnvironment`.
+  "/api/model_registry/v1/serving_environments/{serving_environment_id}":
+    summary: Path used to manage a single ServingEnvironment.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `ServingEnvironment`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ServingEnvironmentResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getServingEnvironment
+      summary: Get a ServingEnvironment
+      description: Gets the details of a single instance of a `ServingEnvironment`.
+    patch:
+      requestBody:
+        description: Updated `ServingEnvironment` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServingEnvironmentUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ServingEnvironmentResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateServingEnvironment
+      summary: Update a ServingEnvironment
+      description: Updates an existing `ServingEnvironment`.
+    parameters:
+      - name: serving_environment_id
+        description: A unique identifier for a `ServingEnvironment`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/serving_environments/{serving_environment_id}/inference_services":
+    summary: Path used to manage the list of `InferenceServices` for a `ServingEnvironment`.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `InferenceService` entities for a `ServingEnvironment`.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/externalId"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getEnvironmentInferenceServices
+      summary: List All ServingEnvironment's InferenceServices
+      description: Gets a list of all `InferenceService` entities for the `ServingEnvironment`.
+    post:
+      requestBody:
+        description: A new `InferenceService` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InferenceServiceCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createEnvironmentInferenceService
+      summary: Create a InferenceService in ServingEnvironment
+      description: Creates a new instance of a `InferenceService`.
+    parameters:
+      - name: serving_environment_id
+        description: A unique identifier for a `ServingEnvironment`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+components:
+  schemas:
+    Artifact:
+      oneOf:
+        - $ref: "#/components/schemas/ModelArtifact"
+        - $ref: "#/components/schemas/DocArtifact"
+        - $ref: "#/components/schemas/DataSet"
+        - $ref: "#/components/schemas/Metric"
+        - $ref: "#/components/schemas/Parameter"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          model-artifact: "#/components/schemas/ModelArtifact"
+          doc-artifact: "#/components/schemas/DocArtifact"
+          dataset-artifact: "#/components/schemas/DataSet"
+          metric: "#/components/schemas/Metric"
+          parameter: "#/components/schemas/Parameter"
+      description: A metadata Artifact Entity.
+    ArtifactCreate:
+      description: An Artifact to be created.
+      oneOf:
+        - $ref: "#/components/schemas/ModelArtifactCreate"
+        - $ref: "#/components/schemas/DocArtifactCreate"
+        - $ref: "#/components/schemas/DataSetCreate"
+        - $ref: "#/components/schemas/MetricCreate"
+        - $ref: "#/components/schemas/ParameterCreate"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          model-artifact: "#/components/schemas/ModelArtifactCreate"
+          doc-artifact: "#/components/schemas/DocArtifactCreate"
+          dataset-artifact: "#/components/schemas/DataSetCreate"
+          metric: "#/components/schemas/MetricCreate"
+          parameter: "#/components/schemas/ParameterCreate"
+    ArtifactList:
+      description: A list of Artifact entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `Artifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/Artifact"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ArtifactState:
+      description: |2-
+         - PENDING: A state indicating that the artifact may exist.
+         - LIVE: A state indicating that the artifact should exist, unless something
+        external to the system deletes it.
+         - MARKED_FOR_DELETION: A state indicating that the artifact should be deleted.
+         - DELETED: A state indicating that the artifact has been deleted.
+         - ABANDONED: A state indicating that the artifact has been abandoned, which may be
+        due to a failed or cancelled execution.
+         - REFERENCE: A state indicating that the artifact is a reference artifact. At
+        execution start time, the orchestrator produces an output artifact for
+        each output key with state PENDING. However, for an intermediate
+        artifact, this first artifact's state will be REFERENCE. Intermediate
+        artifacts emitted during a component's execution will copy the REFERENCE
+        artifact's attributes. At the end of an execution, the artifact state
+        should remain REFERENCE instead of being changed to LIVE.
+
+        See also: ml-metadata Artifact.State
+      default: UNKNOWN
+      enum:
+        - UNKNOWN
+        - PENDING
+        - LIVE
+        - MARKED_FOR_DELETION
+        - DELETED
+        - ABANDONED
+        - REFERENCE
+      type: string
+    ArtifactTypeQueryParam:
+      description: Supported artifact types for querying.
+      enum:
+        - model-artifact
+        - doc-artifact
+        - dataset-artifact
+        - metric
+        - parameter
+      type: string
+    ArtifactUpdate:
+      description: An Artifact to be updated.
+      oneOf:
+        - $ref: "#/components/schemas/ModelArtifactUpdate"
+        - $ref: "#/components/schemas/DocArtifactUpdate"
+        - $ref: "#/components/schemas/DataSetUpdate"
+        - $ref: "#/components/schemas/MetricUpdate"
+        - $ref: "#/components/schemas/ParameterUpdate"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          model-artifact: "#/components/schemas/ModelArtifactUpdate"
+          doc-artifact: "#/components/schemas/DocArtifactUpdate"
+          dataset-artifact: "#/components/schemas/DataSetUpdate"
+          metric: "#/components/schemas/MetricUpdate"
+          parameter: "#/components/schemas/ParameterUpdate"
+    BaseArtifact:
+      description: Base schema for all artifact types with common server generated properties.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+    BaseModel:
+      type: object
+      properties:
+        description:
+          type: string
+          description: Human-readable description of the model.
+        readme:
+          type: string
+          description: Model documentation in Markdown.
+        maturity:
+          type: string
+          description: Maturity level of the model.
+          example: Generally Available
+        language:
+          type: array
+          description: List of supported languages (https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes).
+          items:
+            type: string
+          example:
+            - en
+            - es
+            - cz
+        tasks:
+          type: array
+          description: List of tasks the model is designed for.
+          items:
+            type: string
+          example:
+            - text-generation
+        provider:
+          type: string
+          description: Name of the organization or entity that provides the model.
+          example: IBM
+        logo:
+          type: string
+          format: uri
+          description: |-
+            URL to the model's logo. A [data
+            URL](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data)
+            is recommended.
+        license:
+          type: string
+          description: Short name of the model's license.
+          example: apache-2.0
+        licenseLink:
+          type: string
+          format: uri
+          description: URL to the license text.
+        libraryName:
+          type: string
+          example: transformers
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+    BaseResource:
+      allOf:
+        - type: object
+          properties:
+            customProperties:
+              description: User provided custom properties which are not defined by its type.
+              type: object
+              additionalProperties:
+                $ref: "#/components/schemas/MetadataValue"
+            description:
+              description: |-
+                An optional description about the resource.
+              type: string
+            externalId:
+              description: |-
+                The external id that come from the clients’ system. This field is optional.
+                If set, it must be unique among all resources within a database instance.
+              type: string
+            name:
+              description: |-
+                The client provided name of the artifact. This field is optional. If set,
+                it must be unique among all the artifacts of the same artifact type within
+                a database instance and cannot be changed once set.
+              type: string
+              minLength: 1
+            id:
+              format: int64
+              description: The unique server generated id of the resource.
+              type: string
+        - $ref: "#/components/schemas/BaseResourceDates"
+    BaseResourceCreate:
+      type: object
+      properties:
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
+        name:
+          description: |-
+            The client provided name of the artifact. This field is optional. If set,
+            it must be unique among all the artifacts of the same artifact type within
+            a database instance and cannot be changed once set.
+          type: string
+    BaseResourceDates:
+      description: Common timestamp fields for resources
+      type: object
+      properties:
+        createTimeSinceEpoch:
+          format: int64
+          description: Output only. Create time of the resource in millisecond since epoch.
+          type: string
+          readOnly: true
+        lastUpdateTimeSinceEpoch:
+          format: int64
+          description: Output only. Last update time of the resource since epoch in millisecond since epoch.
+          type: string
+          readOnly: true
+    BaseResourceList:
+      required:
+        - nextPageToken
+        - pageSize
+        - size
+      type: object
+      properties:
+        nextPageToken:
+          description: Token to use to retrieve next page of results.
+          type: string
+        pageSize:
+          format: int32
+          description: Maximum number of resources to return in the result.
+          type: integer
+        size:
+          format: int32
+          description: Number of items in result list.
+          type: integer
+    BaseResourceUpdate:
+      type: object
+      properties:
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
+    DataSet:
+      description: A dataset artifact representing training or test data.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/DataSetCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "dataset-artifact"
+    DataSetCreate:
+      description: A dataset artifact to be created.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/DataSetUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "dataset-artifact"
+    DataSetUpdate:
+      description: A dataset artifact to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "dataset-artifact"
+            digest:
+              description: A unique hash or identifier for the dataset content.
+              type: string
+            sourceType:
+              description: The type of data source (e.g., "s3", "hdfs", "local", "database").
+              type: string
+            source:
+              description: The location or connection string for the dataset source.
+              type: string
+            schema:
+              description: JSON schema or description of the dataset structure.
+              type: string
+            profile:
+              description: Statistical profile or summary of the dataset.
+              type: string
+            uri:
+              description: |-
+                The uniform resource identifier of the physical dataset.
+                May be empty if there is no physical dataset.
+              type: string
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    DocArtifact:
+      description: A document.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/DocArtifactCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
+    DocArtifactCreate:
+      description: A document artifact to be created.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/DocArtifactUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
+    DocArtifactUpdate:
+      description: A document artifact to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
+            uri:
+              description: |-
+                The uniform resource identifier of the physical artifact.
+                May be empty if there is no physical artifact.
+              type: string
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    Error:
+      description: Error code and message.
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          description: Error code
+          type: string
+        message:
+          description: Error message
+          type: string
+    ExecutionState:
+      description: |-
+        The state of the Execution. The state transitions are
+          NEW -> RUNNING -> COMPLETE | CACHED | FAILED | CANCELED
+        CACHED means the execution is skipped due to cached results.
+        CANCELED means the execution is skipped due to precondition not met. It is
+        different from CACHED in that a CANCELED execution will not have any event
+        associated with it. It is different from FAILED in that there is no
+        unexpected error happened and it is regarded as a normal state.
+
+        See also: ml-metadata Execution.State
+      default: UNKNOWN
+      enum:
+        - UNKNOWN
+        - NEW
+        - RUNNING
+        - COMPLETE
+        - FAILED
+        - CACHED
+        - CANCELED
+      type: string
+    InferenceService:
+      description: >-
+        An `InferenceService` entity in a `ServingEnvironment` represents a deployed `ModelVersion` from a `RegisteredModel` created by Model Serving.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - $ref: "#/components/schemas/InferenceServiceCreate"
+    InferenceServiceCreate:
+      description: >-
+        An `InferenceService` entity in a `ServingEnvironment` represents a deployed `ModelVersion` from a `RegisteredModel` created by Model Serving.
+      required:
+        - registeredModelId
+        - servingEnvironmentId
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/InferenceServiceUpdate"
+        - type: object
+          properties:
+            registeredModelId:
+              description: ID of the `RegisteredModel` to serve.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+              minLength: 1
+            servingEnvironmentId:
+              description: ID of the parent `ServingEnvironment` for this `InferenceService` entity.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+              minLength: 1
+    InferenceServiceList:
+      description: List of InferenceServices.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: ""
+              type: array
+              items:
+                $ref: "#/components/schemas/InferenceService"
+              readOnly: false
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    InferenceServiceState:
+      description: |-
+        - DEPLOYED: A state indicating that the `InferenceService` should be deployed.
+        - UNDEPLOYED: A state indicating that the `InferenceService` should be un-deployed.
+        The state indicates the desired state of inference service.
+        See the associated `ServeModel` for the actual status of service deployment action.
+      default: DEPLOYED
+      enum:
+        - DEPLOYED
+        - UNDEPLOYED
+      type: string
+    InferenceServiceUpdate:
+      description: >-
+        An `InferenceService` entity in a `ServingEnvironment` represents a deployed `ModelVersion` from a `RegisteredModel` created by Model Serving.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            modelVersionId:
+              description: >-
+                ID of the `ModelVersion` to serve. If it's unspecified, then the latest `ModelVersion` by creation order will be served.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+            runtime:
+              description: Model runtime.
+              type: string
+            desiredState:
+              $ref: "#/components/schemas/InferenceServiceState"
+    MetadataBoolValue:
+      description: A bool property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - bool_value
+      properties:
+        bool_value:
+          type: boolean
+        metadataType:
+          type: string
+          enum:
+            - MetadataBoolValue
+          default: MetadataBoolValue
+    MetadataDoubleValue:
+      description: A double property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - double_value
+      properties:
+        double_value:
+          format: double
+          type: number
+        metadataType:
+          type: string
+          enum:
+            - MetadataDoubleValue
+          default: MetadataDoubleValue
+    MetadataIntValue:
+      description: An integer (int32) property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - int_value
+      properties:
+        int_value:
+          format: int32
+          type: string
+          pattern: "^-?([1-9][0-9]{0,8}|0)$"
+        metadataType:
+          type: string
+          enum:
+            - MetadataIntValue
+          default: MetadataIntValue
+    MetadataProtoValue:
+      description: A proto property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - type
+        - proto_value
+      properties:
+        type:
+          description: url describing proto value
+          type: string
+        proto_value:
+          description: Base64 encoded bytes for proto value
+          type: string
+          format: byte
+        metadataType:
+          type: string
+          enum:
+            - MetadataProtoValue
+          default: MetadataProtoValue
+    MetadataStringValue:
+      description: A string property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - string_value
+      properties:
+        string_value:
+          type: string
+        metadataType:
+          type: string
+          enum:
+            - MetadataStringValue
+          default: MetadataStringValue
+    MetadataStructValue:
+      description: A struct property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - struct_value
+      properties:
+        struct_value:
+          description: Base64 encoded bytes for struct value
+          type: string
+          format: byte
+        metadataType:
+          type: string
+          enum:
+            - MetadataStructValue
+          default: MetadataStructValue
+    MetadataValue:
+      oneOf:
+        - $ref: "#/components/schemas/MetadataIntValue"
+        - $ref: "#/components/schemas/MetadataDoubleValue"
+        - $ref: "#/components/schemas/MetadataStringValue"
+        - $ref: "#/components/schemas/MetadataStructValue"
+        - $ref: "#/components/schemas/MetadataProtoValue"
+        - $ref: "#/components/schemas/MetadataBoolValue"
+      discriminator:
+        propertyName: metadataType
+        mapping:
+          MetadataBoolValue: "#/components/schemas/MetadataBoolValue"
+          MetadataDoubleValue: "#/components/schemas/MetadataDoubleValue"
+          MetadataIntValue: "#/components/schemas/MetadataIntValue"
+          MetadataProtoValue: "#/components/schemas/MetadataProtoValue"
+          MetadataStringValue: "#/components/schemas/MetadataStringValue"
+          MetadataStructValue: "#/components/schemas/MetadataStructValue"
+      description: A value in properties.
+      example:
+        string_value: my_value
+        metadataType: MetadataStringValue
+    Metric:
+      description: A metric representing a numerical measurement from model training or evaluation.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/MetricCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "metric"
+    MetricCreate:
+      description: A metric to be created.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/MetricUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "metric"
+            name:
+              description: The name/key of the metric (e.g., "accuracy", "loss", "f1_score").
+              type: string
+    MetricUpdate:
+      description: A metric to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "metric"
+            value:
+              description: The numeric value of the metric.
+              type: number
+              format: double
+            timestamp:
+              description: Unix timestamp in milliseconds when the metric was recorded.
+              type: string
+              format: int64
+            step:
+              description: The step number for multi-step metrics (e.g., training epochs).
+              type: string
+              format: int64
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    ModelArtifact:
+      description: An ML model artifact.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/ModelArtifactCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "model-artifact"
+    ModelArtifactCreate:
+      description: An ML model artifact.
+      properties:
+        artifactType:
+          type: string
+          default: "model-artifact"
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ModelArtifactUpdate"
+    ModelArtifactList:
+      description: List of ModelArtifact entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `ModelArtifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/ModelArtifact"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ModelArtifactUpdate:
+      description: An ML model artifact to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "model-artifact"
+            modelFormatName:
+              description: Name of the model format.
+              type: string
+            storageKey:
+              description: Storage secret name.
+              type: string
+            storagePath:
+              description: Path for model in storage provided by `storageKey`.
+              type: string
+            modelFormatVersion:
+              description: Version of the model format.
+              type: string
+            serviceAccountName:
+              description: Name of the service account with storage secret.
+              type: string
+            modelSourceKind:
+              type: string
+              description: "A string identifier describing the source kind. It differentiates various sources of model artifacts.\nThis identifier should be agreed upon by producers and consumers of source model metadata.\nIt is not an enumeration to keep the source of model metadata open ended. \nE.g. Kubeflow pipelines could use `pipelines` to identify models it produces."
+            modelSourceClass:
+              type: string
+              description: |-
+                A subgroup within the source kind. It is a specific sub-component or instance within the source kind.
+                E.g. `pipelinerun` for a Kubeflow pipeline run.
+            modelSourceGroup:
+              type: string
+              description: "Unique identifier for a source group for models from source class. \nIt maps to a physical group of source models. \nE.g. a Kubernetes namespace where the pipeline run was executed."
+            modelSourceId:
+              type: string
+              description: |-
+                A unique identifier for a source model within kind, class, and group.
+                It should be a url friendly string if source supports using URLs to locate source models.
+                E.g. a pipeline run ID.
+            modelSourceName:
+              type: string
+              description: "A human-readable name for the source model. \nE.g. `my-project/1`, `ibm-granite/granite-3.1-8b-base:2.1.2`."
+            uri:
+              description: |-
+                The uniform resource identifier of the physical artifact.
+                May be empty if there is no physical artifact.
+              type: string
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    ModelVersion:
+      description: Represents a ModelVersion belonging to a RegisteredModel.
+      allOf:
+        - $ref: "#/components/schemas/ModelVersionCreate"
+        - $ref: "#/components/schemas/BaseResource"
+    ModelVersionCreate:
+      description: Represents a ModelVersion belonging to a RegisteredModel.
+      required:
+        - name
+        - registeredModelId
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ModelVersionUpdate"
+        - type: object
+          properties:
+            registeredModelId:
+              description: ID of the `RegisteredModel` to which this version belongs.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+              minLength: 1
+            name:
+              description: |-
+                The client provided name of the model's version. It must be unique among all the ModelVersions of the same
+                type within a Model Registry instance and cannot be changed once set.
+              type: string
+              minLength: 1
+    ModelVersionList:
+      description: List of ModelVersion entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `ModelVersion` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/ModelVersion"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ModelVersionState:
+      description: |-
+        - LIVE: A state indicating that the `ModelVersion` exists
+        - ARCHIVED: A state indicating that the `ModelVersion` has been archived.
+      default: LIVE
+      enum:
+        - LIVE
+        - ARCHIVED
+      type: string
+    ModelVersionUpdate:
+      description: Represents a ModelVersion belonging to a RegisteredModel.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            state:
+              $ref: "#/components/schemas/ModelVersionState"
+            author:
+              description: Name of the author.
+              type: string
+    OrderByField:
+      description: Supported fields for ordering result entities.
+      enum:
+        - CREATE_TIME
+        - LAST_UPDATE_TIME
+        - ID
+      type: string
+    Parameter:
+      description: A parameter representing a configuration parameter used in model training or execution.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/ParameterCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "parameter"
+    ParameterCreate:
+      description: A parameter to be created.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ParameterUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "parameter"
+            name:
+              description: The name/key of the parameter (e.g., "learning_rate", "batch_size", "epochs").
+              type: string
+    ParameterType:
+      description: The data type of the parameter (e.g., "string", "number", "boolean", "object").
+      enum:
+        - string
+        - number
+        - boolean
+        - object
+    ParameterUpdate:
+      description: A parameter to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "parameter"
+            value:
+              description: The value of the parameter.
+              type: string
+            parameterType:
+              allOf:
+                - $ref: "#/components/schemas/ParameterType"
+              default: "string"
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    RegisteredModel:
+      description: A registered model in model registry. A registered model has ModelVersion children.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - $ref: "#/components/schemas/RegisteredModelCreate"
+    RegisteredModelCreate:
+      description: A registered model in model registry. A registered model has ModelVersion children.
+      required:
+        - name
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/RegisteredModelUpdate"
+        - type: object
+          properties:
+            name:
+              description: |-
+                The client provided name of the model. It must be unique among all the RegisteredModels of the same
+                type within a Model Registry instance and cannot be changed once set.
+              type: string
+              minLength: 1
+    RegisteredModelList:
+      description: List of RegisteredModels.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: ""
+              type: array
+              items:
+                $ref: "#/components/schemas/RegisteredModel"
+              readOnly: false
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    RegisteredModelState:
+      description: |-
+        - LIVE: A state indicating that the `RegisteredModel` exists
+        - ARCHIVED: A state indicating that the `RegisteredModel` has been archived.
+      default: LIVE
+      enum:
+        - LIVE
+        - ARCHIVED
+      type: string
+    RegisteredModelUpdate:
+      description: A registered model in model registry. A registered model has ModelVersion children.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - $ref: "#/components/schemas/BaseModel"
+        - type: object
+          properties:
+            owner:
+              type: string
+            state:
+              $ref: "#/components/schemas/RegisteredModelState"
+    ServeModel:
+      description: An ML model serving action.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - $ref: "#/components/schemas/ServeModelCreate"
+    ServeModelCreate:
+      description: An ML model serving action.
+      required:
+        - modelVersionId
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ServeModelUpdate"
+        - type: object
+          properties:
+            modelVersionId:
+              description: ID of the `ModelVersion` that was served in `InferenceService`.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+              minLength: 1
+    ServeModelList:
+      description: List of ServeModel entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `ModelArtifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/ServeModel"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ServeModelUpdate:
+      description: An ML model serving action.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            lastKnownState:
+              $ref: "#/components/schemas/ExecutionState"
+    ServingEnvironment:
+      description: A Model Serving environment for serving `RegisteredModels`.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - $ref: "#/components/schemas/ServingEnvironmentCreate"
+    ServingEnvironmentCreate:
+      description: A Model Serving environment for serving `RegisteredModels`.
+      required:
+        - name
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ServingEnvironmentUpdate"
+        - type: object
+          properties:
+            name:
+              description: The name of the ServingEnvironment.
+              type: string
+              minLength: 1
+    ServingEnvironmentList:
+      description: List of ServingEnvironments.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: ""
+              type: array
+              items:
+                $ref: "#/components/schemas/ServingEnvironment"
+              readOnly: false
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ServingEnvironmentUpdate:
+      description: A Model Serving environment for serving `RegisteredModels`.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+    SortOrder:
+      description: Supported sort direction for ordering result entities.
+      enum:
+        - ASC
+        - DESC
+      type: string
+  responses:
+    ArtifactListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ArtifactList"
+      description: A response containing a list of `Artifact` entities.
+      links:
+        GetArtifactById:
+          $ref: '#/components/links/GetArtifactById'
+        PatchArtifactById:
+          $ref: '#/components/links/PatchArtifactById'
+        SearchArtifactByExternalId:
+          $ref: '#/components/links/SearchArtifactByExternalId'
+        SearchArtifactByName:
+          $ref: '#/components/links/SearchArtifactByName'
+        SearchArtifactByParentResourceId:
+          $ref: '#/components/links/SearchArtifactByParentResourceId'
+    ArtifactResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Artifact"
+      description: A response containing an `Artifact` entity.
+      links:
+        GetArtifactById:
+          $ref: '#/components/links/GetArtifactById'
+        PatchArtifactById:
+          $ref: '#/components/links/PatchArtifactById'
+        SearchArtifactByExternalId:
+          $ref: '#/components/links/SearchArtifactByExternalId'
+        SearchArtifactByName:
+          $ref: '#/components/links/SearchArtifactByName'
+        SearchArtifactByParentResourceId:
+          $ref: '#/components/links/SearchArtifactByParentResourceId'
+    BadRequest:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Bad Request parameters
+    Conflict:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Conflict with current state of target resource
+    InferenceServiceListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/InferenceServiceList"
+      description: A response containing a list of `InferenceService` entities.
+      links:
+        GetISById:
+          $ref: '#/components/links/GetISById'
+        PatchISById:
+          $ref: '#/components/links/PatchISById'
+        SearchISByExternalId:
+          $ref: '#/components/links/SearchISByExternalId'
+        SearchISByName:
+          $ref: '#/components/links/SearchISByName'
+        SearchISByParentResourceId:
+          $ref: '#/components/links/SearchISByParentResourceId'
+    InferenceServiceResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/InferenceService"
+      description: A response containing a `InferenceService` entity.
+      links:
+        GetISById:
+          $ref: '#/components/links/GetISById'
+        PatchISById:
+          $ref: '#/components/links/PatchISById'
+        SearchISByExternalId:
+          $ref: '#/components/links/SearchISByExternalId'
+        SearchISByName:
+          $ref: '#/components/links/SearchISByName'
+        SearchISByParentResourceId:
+          $ref: '#/components/links/SearchISByParentResourceId'
+    InternalServerError:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Unexpected internal server error
+    ModelArtifactListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelArtifactList"
+      description: A response containing a list of ModelArtifact entities.
+      links:
+        GetModelArtifactById:
+          $ref: '#/components/links/GetModelArtifactById'
+        PatchModelArtifactById:
+          $ref: '#/components/links/PatchModelArtifactById'
+        SearchModelArtifactByExternalId:
+          $ref: '#/components/links/SearchModelArtifactByExternalId'
+        SearchModelArtifactByName:
+          $ref: '#/components/links/SearchModelArtifactByName'
+        SearchModelArtifactByParentResourceId:
+          $ref: '#/components/links/SearchModelArtifactByParentResourceId'
+    ModelArtifactResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelArtifact"
+      description: A response containing a `ModelArtifact` entity.
+      links:
+        GetModelArtifactById:
+          $ref: '#/components/links/GetModelArtifactById'
+        PatchModelArtifactById:
+          $ref: '#/components/links/PatchModelArtifactById'
+        SearchModelArtifactByExternalId:
+          $ref: '#/components/links/SearchModelArtifactByExternalId'
+        SearchModelArtifactByName:
+          $ref: '#/components/links/SearchModelArtifactByName'
+        SearchModelArtifactByParentResourceId:
+          $ref: '#/components/links/SearchModelArtifactByParentResourceId'
+    ModelVersionListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelVersionList"
+      description: A response containing a list of `ModelVersion` entities.
+      links:
+        GetModelVersionById:
+          $ref: '#/components/links/GetModelVersionById'
+        PatchModelVersionById:
+          $ref: '#/components/links/PatchModelVersionById'
+        SearchModelVersionByExternalId:
+          $ref: '#/components/links/SearchModelVersionByExternalId'
+        SearchModelVersionByName:
+          $ref: '#/components/links/SearchModelVersionByName'
+    ModelVersionResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelVersion"
+      description: A response containing a `ModelVersion` entity.
+      links:
+        GetModelVersionById:
+          $ref: '#/components/links/GetModelVersionById'
+        PatchModelVersionById:
+          $ref: '#/components/links/PatchModelVersionById'
+        SearchModelVersionByExternalId:
+          $ref: '#/components/links/SearchModelVersionByExternalId'
+        SearchModelVersionByName:
+          $ref: '#/components/links/SearchModelVersionByName'
+    NotFound:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: The specified resource was not found
+    RegisteredModelListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RegisteredModelList"
+      description: A response containing a list of `RegisteredModel` entities.
+      links:
+        GetRegisteredModelById:
+          $ref: '#/components/links/GetRegisteredModelById'
+        PatchRegisteredModelById:
+          $ref: '#/components/links/PatchRegisteredModelById'
+        SearchRegisteredModelByExternalId:
+          $ref: '#/components/links/SearchRegisteredModelByExternalId'
+        SearchRegisteredModelByName:
+          $ref: '#/components/links/SearchRegisteredModelByName'
+    RegisteredModelResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RegisteredModel"
+      description: A response containing a `RegisteredModel` entity.
+      links:
+        GetRegisteredModelById:
+          $ref: '#/components/links/GetRegisteredModelById'
+        PatchRegisteredModelById:
+          $ref: '#/components/links/PatchRegisteredModelById'
+        SearchRegisteredModelByExternalId:
+          $ref: '#/components/links/SearchRegisteredModelByExternalId'
+        SearchRegisteredModelByName:
+          $ref: '#/components/links/SearchRegisteredModelByName'
+    ServeModelListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServeModelList"
+      description: A response containing a list of `ServeModel` entities.
+    ServeModelResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServeModel"
+      description: A response containing a `ServeModel` entity.
+    ServiceUnavailable:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Service is unavailable
+    ServingEnvironmentListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServingEnvironmentList"
+      description: A response containing a list of `ServingEnvironment` entities.
+      links:
+        GetServingEnvironmentById:
+          $ref: '#/components/links/GetServingEnvironmentById'
+        PatchServingEnvironmentById:
+          $ref: '#/components/links/PatchServingEnvironmentById'
+        SearchServingEnvironmentByExternalId:
+          $ref: '#/components/links/SearchServingEnvironmentByExternalId'
+        SearchServingEnvironmentByName:
+          $ref: '#/components/links/SearchServingEnvironmentByName'
+    ServingEnvironmentResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServingEnvironment"
+      description: A response containing a `ServingEnvironment` entity.
+      links:
+        GetServingEnvironmentById:
+          $ref: '#/components/links/GetServingEnvironmentById'
+        PatchServingEnvironmentById:
+          $ref: '#/components/links/PatchServingEnvironmentById'
+        SearchServingEnvironmentByExternalId:
+          $ref: '#/components/links/SearchServingEnvironmentByExternalId'
+        SearchServingEnvironmentByName:
+          $ref: '#/components/links/SearchServingEnvironmentByName'
+    Unauthorized:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Unauthorized
+    UnprocessableEntity:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Unprocessable Entity error
+  parameters:
+    orderBy:
+      style: form
+      explode: true
+      examples:
+        orderBy:
+          value: ID
+      name: orderBy
+      description: Specifies the order by criteria for listing entities.
+      schema:
+        $ref: "#/components/schemas/OrderByField"
+      in: query
+      required: false
+    artifactType:
+      style: form
+      explode: true
+      examples:
+        artifactType:
+          value: model-artifact
+      name: artifactType
+      description: "Specifies the artifact type for listing artifacts."
+      schema:
+        $ref: "#/components/schemas/ArtifactTypeQueryParam"
+      in: query
+      required: false
+    id:
+      name: id
+      description: The ID of resource.
+      schema:
+        type: string
+        format: int64
+        pattern: "^[1-9][0-9]{0,8}$"
+      in: path
+      required: true
+    name:
+      examples:
+        name:
+          value: entity-name
+      name: name
+      description: Name of entity to search.
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]+$"
+      in: query
+      required: false
+    externalId:
+      examples:
+        externalId:
+          value: "10"
+      name: externalId
+      description: External ID of entity to search.
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]+$"
+      in: query
+      required: false
+    parentResourceId:
+      examples:
+        parentResourceId:
+          value: "10"
+      name: parentResourceId
+      description: ID of the parent resource to use for search.
+      schema:
+        type: string
+        format: int64
+        pattern: "^[1-9][0-9]{0,8}$"
+      in: query
+      required: false
+    filterQuery:
+      examples:
+        filterQuery:
+          value: "name='my-model' AND state='LIVE'"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter the list of entities. The query supports rich filtering capabilities with automatic type inference.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Data Types:**
+        - Strings: `"value"` or `'value'`
+        - Numbers: `42`, `3.14`, `1e-5`
+        - Booleans: `true`, `false` (case-insensitive)
+
+        **Property Access:**
+        - Standard properties: `name`, `id`, `state`, `createTimeSinceEpoch`
+        - Custom properties: Any user-defined property name
+        - Escaped properties: Use backticks for special characters: `` `custom-property` ``
+        - Type-specific access: `property.string_value`, `property.double_value`, `property.int_value`, `property.bool_value`
+
+        **Examples:**
+        - Basic: `name = "my-model"`
+        - Comparison: `accuracy > 0.95`
+        - Pattern: `name LIKE "%tensorflow%"`
+        - Complex: `(name = "model-a" OR name = "model-b") AND state = "LIVE"`
+        - Custom property: `framework.string_value = "pytorch"`
+        - Escaped property: `` `mlflow.source.type` = "notebook" ``
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    pageSize:
+      examples:
+        pageSize:
+          value: 100
+      name: pageSize
+      description: Number of entities in each page.
+      schema:
+        type: string
+        format: int32
+        pattern: "^[1-9][0-9]{0,8}$"
+      in: query
+      required: false
+    nextPageToken:
+      name: nextPageToken
+      description: >-
+        Opaque pagination token returned by a previous list call. Do not construct manually; use the value from a prior response's nextPageToken field.
+      schema:
+        type: string
+      in: query
+      required: false
+    sortOrder:
+      style: form
+      explode: true
+      examples:
+        sortOrder:
+          value: DESC
+      name: sortOrder
+      description: "Specifies the sort order for listing entities, defaults to ASC."
+      schema:
+        $ref: "#/components/schemas/SortOrder"
+      in: query
+      required: false
+    stepIds:
+      style: form
+      explode: true
+      examples:
+        stepIds:
+          value: "1,2,3"
+      name: stepIds
+      description: "Comma-separated list of step IDs to filter metrics by."
+      schema:
+        type: string
+        pattern: "^[0-9]{1,9}(,[0-9]{1,9})*$"
+      in: query
+      required: false
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      bearerFormat: JWT
+      type: http
+      description: Bearer JWT scheme
+  links:
+    # Artifact
+    GetArtifactById:
+      operationId: getArtifact
+      parameters:
+        id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `GET /api/model_registry/v1/artifacts/{id}`.
+
+    PatchArtifactById:
+      operationId: updateArtifact
+      parameters:
+        id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `PATCH /api/model_registry/v1/artifacts/{id}`.
+
+    SearchArtifactByExternalId:
+      operationId: findArtifact
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/artifact`.
+
+    SearchArtifactByName:
+      operationId: findArtifact
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/artifact`.
+
+    # Unsure about this one
+    SearchArtifactByParentResourceId:
+      operationId: findArtifact
+      parameters:
+        parentResourceId: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `parentResourceId` parameter in `GET /api/model_registry/v1/artifact`, assuming that the 'Artifact' entity is a parent to another 'Artifact' entity.
+
+    # InferenceService
+    GetISById:
+      operationId: getInferenceService
+      parameters:
+        inference_service_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `GET /api/model_registry/v1/inference_services/{inference_service_id}`.
+
+    PatchISById:
+      operationId: updateInferenceService
+      parameters:
+        inference_service_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `PATCH /api/model_registry/v1/inference_services/{inference_service_id}`.
+
+    SearchISByExternalId:
+      operationId: findInferenceService
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/inference_service`.
+
+    SearchISByName:
+      operationId: findInferenceService
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/inference_service`.
+
+    # Unsure about this one
+    SearchISByParentResourceId:
+      operationId: findInferenceService
+      parameters:
+        parentResourceId: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `parentResourceId` parameter in GET /api/model_registry/v1/inference_service`, assuming that the 'InferenceService' entity is a parent to another 'InferenceService' entity.
+
+    # ModelArtifact
+    GetModelArtifactById:
+      operationId: getModelArtifact
+      parameters:
+        model_artifact_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `GET "/api/model_registry/v1/model_artifacts/{model_artifact_id}`.
+
+    PatchModelArtifactById:
+      operationId: updateModelArtifact
+      parameters:
+        model_artifact_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `PATCH "/api/model_registry/v1/model_artifacts/{model_artifact_id}`.
+
+    SearchModelArtifactByExternalId:
+      operationId: findModelArtifact
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/model_artifact`.
+
+    SearchModelArtifactByName:
+      operationId: findModelArtifact
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/model_artifact`.
+
+    # Unsure about this one
+    SearchModelArtifactByParentResourceId:
+      operationId: findModelArtifact
+      parameters:
+        parentResourceId: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `parentResourceId` parameter in `GET /api/model_registry/v1/model_artifact`, assuming that the 'ModelArtifact' entity is a parent to another 'ModelArtifact' entity.
+
+    # RegisteredModel
+    GetRegisteredModelById:
+      operationId: getRegisteredModel
+      parameters:
+        registered_model_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `registered_model_id` parameter in `GET /api/model_registry/v1/registered_models/{registered_model_id}`.
+
+    PatchRegisteredModelById:
+      operationId: updateRegisteredModel
+      parameters:
+        registered_model_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `registered_model_id` parameter in `PATCH /api/model_registry/v1/registered_models/{registered_model_id}`.
+
+    SearchRegisteredModelByExternalId:
+      operationId: findRegisteredModel
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/registered_model`.
+
+    SearchRegisteredModelByName:
+      operationId: findRegisteredModel
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/registered_model`.
+
+    # ModelVersion
+    GetModelVersionById:
+      operationId: getModelVersion
+      parameters:
+        model_version_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `model_version_id` parameter in `GET /api/model_registry/v1/model_versions/{model_version_id}`.
+
+    PatchModelVersionById:
+      operationId: updateModelVersion
+      parameters:
+        model_version_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `model_version_id` parameter in `PATCH /api/model_registry/v1/model_versions/{model_version_id}`.
+
+    SearchModelVersionByExternalId:
+      operationId: findModelVersion
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/model_version`.
+
+    SearchModelVersionByName:
+      operationId: findModelVersion
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/model_version`.
+
+    # ServingEnvironment
+    GetServingEnvironmentById:
+      operationId: getServingEnvironment
+      parameters:
+        serving_environment_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `serving_environment_id` parameter in `GET /api/model_registry/v1/serving_environments/{serving_environment_id}`.
+
+    PatchServingEnvironmentById:
+      operationId: updateServingEnvironment
+      parameters:
+        serving_environment_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `serving_environment_id` parameter in `PATCH /api/model_registry/v1/serving_environments/{serving_environment_id}`.
+
+    SearchServingEnvironmentByExternalId:
+      operationId: findServingEnvironment
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/serving_environment`.
+
+    SearchServingEnvironmentByName:
+      operationId: findServingEnvironment
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/serving_environment`.
+
+security:
+  - Bearer: []
+tags:
+  - name: ModelRegistryService
+    description: Model Registry Service REST API

--- a/api/openapi/src/model-registry-v1.yaml
+++ b/api/openapi/src/model-registry-v1.yaml
@@ -1,0 +1,2299 @@
+openapi: 3.0.3
+info:
+  title: Model Registry REST API
+  version: v1
+  description: REST API for Model Registry to create and manage ML model metadata
+  license:
+    name: Apache 2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0"
+servers:
+  - url: "https://localhost:8080"
+  - url: "http://localhost:8080"
+paths:
+  /api/model_registry/v1/artifact:
+    summary: Path used to search for an artifact.
+    description: >-
+      The REST endpoint/path used to search for an `Artifact` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findArtifact
+      summary: Get an Artifact that matches search parameters.
+      description: Gets the details of a single instance of an `Artifact` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+      - $ref: "#/components/parameters/parentResourceId"
+  /api/model_registry/v1/artifacts:
+    summary: Path used to manage the list of artifacts.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `Artifact` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/artifactType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getArtifacts
+      summary: List All Artifacts
+      description: Gets a list of all `Artifact` entities.
+    post:
+      requestBody:
+        description: A new `Artifact` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ArtifactCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createArtifact
+      summary: Create an Artifact
+      description: Creates a new instance of an `Artifact`.
+  /api/model_registry/v1/artifacts/{id}:
+    summary: Path used to manage a single Artifact.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `Artifact`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getArtifact
+      summary: Get an Artifact
+      description: Gets the details of a single instance of an `Artifact`.
+    patch:
+      requestBody:
+        description: Updated `Artifact` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ArtifactUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateArtifact
+      summary: Update an Artifact
+      description: Updates an existing `Artifact`.
+    parameters:
+      - name: id
+        description: A unique identifier for an `Artifact`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/inference_service:
+    summary: Path used to manage an instance of inferenceservice.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `InferenceService` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findInferenceService
+      summary: Get an InferenceServices that matches search parameters.
+      description: Gets the details of a single instance of `InferenceService` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+      - $ref: "#/components/parameters/parentResourceId"
+  /api/model_registry/v1/inference_services:
+    summary: Path used to manage the list of inferenceservices.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `InferenceService` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceServices
+      summary: List All InferenceServices
+      description: Gets a list of all `InferenceService` entities.
+    post:
+      requestBody:
+        description: A new `InferenceService` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InferenceServiceCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createInferenceService
+      summary: Create a InferenceService
+      description: Creates a new instance of a `InferenceService`.
+  "/api/model_registry/v1/inference_services/{inference_service_id}":
+    summary: Path used to manage a single InferenceService.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `InferenceService`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceService
+      summary: Get a InferenceService
+      description: Gets the details of a single instance of a `InferenceService`.
+    patch:
+      requestBody:
+        description: Updated `InferenceService` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InferenceServiceUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateInferenceService
+      summary: Update a InferenceService
+      description: Updates an existing `InferenceService`.
+    parameters:
+      - name: inference_service_id
+        description: A unique identifier for a `InferenceService`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/inference_services/{inference_service_id}/model":
+    summary: Path used to manage a `RegisteredModel` associated with an `InferenceService`.
+    description: >-
+      The REST endpoint/path used to list the `RegisteredModel` entity for an `InferenceService`.  This path contains a `GET` operation to perform the get task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceServiceModel
+      summary: Get InferenceService's RegisteredModel
+      description: Gets the `RegisteredModel` entity for the `InferenceService`.
+    parameters:
+      - name: inference_service_id
+        description: A unique identifier for a `InferenceService`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/inference_services/{inference_service_id}/serves":
+    summary: Path used to manage the list of `ServeModels` for a `InferenceService`.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ServeModel` entities for a `InferenceService`.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/externalId"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ServeModelListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceServiceServes
+      summary: List All InferenceService's ServeModel actions
+      description: Gets a list of all `ServeModel` entities for the `InferenceService`.
+    post:
+      requestBody:
+        description: A new `ServeModel` to be associated with the `InferenceService`.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServeModelCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ServeModelResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createInferenceServiceServe
+      summary: Create a ServeModel action in a InferenceService
+      description: Creates a new instance of a `ServeModel` associated with `InferenceService`.
+    parameters:
+      - name: inference_service_id
+        description: A unique identifier for a `InferenceService`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/inference_services/{inference_service_id}/version":
+    summary: Path used to get the current `ModelVersion` associated with an `InferenceService`.
+    description: >-
+      The REST endpoint/path used to get the current `ModelVersion` entity for a `InferenceService`. This path contains a `GET` operation to perform the get task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getInferenceServiceVersion
+      summary: Get InferenceService's ModelVersion
+      description: Gets the `ModelVersion` entity for the `InferenceService`.
+    parameters:
+      - name: inference_service_id
+        description: A unique identifier for a `InferenceService`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/model_artifact:
+    summary: Path used to search for a modelartifact.
+    description: >-
+      The REST endpoint/path used to search for a `ModelArtifact` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findModelArtifact
+      summary: Get a ModelArtifact that matches search parameters.
+      description: Gets the details of a single instance of a `ModelArtifact` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+      - $ref: "#/components/parameters/parentResourceId"
+  /api/model_registry/v1/model_artifacts:
+    summary: Path used to manage the list of modelartifacts.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ModelArtifact` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelArtifacts
+      summary: List All ModelArtifacts
+      description: Gets a list of all `ModelArtifact` entities.
+    post:
+      requestBody:
+        description: A new `ModelArtifact` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelArtifactCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ModelArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createModelArtifact
+      summary: Create a ModelArtifact
+      description: Creates a new instance of a `ModelArtifact`.
+  "/api/model_registry/v1/model_artifacts/{model_artifact_id}":
+    summary: Path used to manage a single ModelArtifact.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `ModelArtifact`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelArtifactResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelArtifact
+      summary: Get a ModelArtifact
+      description: Gets the details of a single instance of a `ModelArtifact`.
+    patch:
+      requestBody:
+        description: Updated `ModelArtifact` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelArtifactUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateModelArtifact
+      summary: Update a ModelArtifact
+      description: Updates an existing `ModelArtifact`.
+    parameters:
+      - name: model_artifact_id
+        description: A unique identifier for a `ModelArtifact`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/model_version:
+    summary: Path used to search for a modelversion.
+    description: >-
+      The REST endpoint/path used to search for a `ModelVersion` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findModelVersion
+      summary: Get a ModelVersion that matches search parameters.
+      description: Gets the details of a single instance of a `ModelVersion` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+      - $ref: "#/components/parameters/parentResourceId"
+  /api/model_registry/v1/model_versions:
+    summary: Path used to manage the list of modelversions.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ModelVersion` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelVersions
+      summary: List All ModelVersions
+      description: Gets a list of all `ModelVersion` entities.
+    post:
+      requestBody:
+        description: A new `ModelVersion` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelVersionCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createModelVersion
+      summary: Create a ModelVersion
+      description: Creates a new instance of a `ModelVersion`.
+  "/api/model_registry/v1/model_versions/{model_version_id}":
+    summary: Path used to manage a single ModelVersion.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `ModelVersion`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelVersion
+      summary: Get a ModelVersion
+      description: Gets the details of a single instance of a `ModelVersion`.
+    patch:
+      requestBody:
+        description: Updated `ModelVersion` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelVersionUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateModelVersion
+      summary: Update a ModelVersion
+      description: Updates an existing `ModelVersion`.
+    parameters:
+      - name: model_version_id
+        description: A unique identifier for a `ModelVersion`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/model_versions/{model_version_id}/artifacts":
+    summary: Path used to manage the list of artifacts for a modelversion.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `Artifact` entities for a `ModelVersion`.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/externalId"
+        - $ref: "#/components/parameters/artifactType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getModelVersionArtifacts
+      summary: List all artifacts associated with the `ModelVersion`
+    post:
+      requestBody:
+        description: A new or existing `Artifact` to be associated with the `ModelVersion`.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Artifact"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ArtifactResponse"
+        "201":
+          $ref: "#/components/responses/ArtifactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: upsertModelVersionArtifact
+      summary: Upsert an Artifact in a ModelVersion
+      description: Creates a new instance of an Artifact if needed and associates it with `ModelVersion`.
+    parameters:
+      - name: model_version_id
+        description: A unique identifier for a `ModelVersion`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/registered_model:
+    summary: Path used to search for a registeredmodel.
+    description: >-
+      The REST endpoint/path used to search for a `RegisteredModel` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findRegisteredModel
+      summary: Get a RegisteredModel that matches search parameters.
+      description: Gets the details of a single instance of a `RegisteredModel` that matches search parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+  /api/model_registry/v1/registered_models:
+    summary: Path used to manage the list of registeredmodels.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `RegisteredModel` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getRegisteredModels
+      summary: List All RegisteredModels
+      description: Gets a list of all `RegisteredModel` entities.
+    post:
+      requestBody:
+        description: A new `RegisteredModel` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisteredModelCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createRegisteredModel
+      summary: Create a RegisteredModel
+      description: Creates a new instance of a `RegisteredModel`.
+  "/api/model_registry/v1/registered_models/{registered_model_id}":
+    summary: Path used to manage a single RegisteredModel.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `RegisteredModel`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getRegisteredModel
+      summary: Get a RegisteredModel
+      description: Gets the details of a single instance of a `RegisteredModel`.
+    patch:
+      requestBody:
+        description: Updated `RegisteredModel` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisteredModelUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/RegisteredModelResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateRegisteredModel
+      summary: Update a RegisteredModel
+      description: Updates an existing `RegisteredModel`.
+    parameters:
+      - name: registered_model_id
+        description: A unique identifier for a `RegisteredModel`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/registered_models/{registered_model_id}/versions":
+    summary: Path used to manage the list of modelversions for a registeredmodel.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ModelVersion` entities for a `RegisteredModel`.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/externalId"
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ModelVersionListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getRegisteredModelVersions
+      summary: List All RegisteredModel's ModelVersions
+      description: Gets a list of all `ModelVersion` entities for the `RegisteredModel`.
+    post:
+      requestBody:
+        description: A new `ModelVersion` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelVersion"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ModelVersionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createRegisteredModelVersion
+      summary: Create a ModelVersion in RegisteredModel
+      description: Creates a new instance of a `ModelVersion`.
+    parameters:
+      - name: registered_model_id
+        description: A unique identifier for a `RegisteredModel`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  /api/model_registry/v1/serving_environment:
+    summary: Path used to find a servingenvironment.
+    description: >-
+      The REST endpoint/path used to search for a `ServingEnvironment` entity.  This path contains a `GET` operation to perform the find task.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ServingEnvironmentResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: findServingEnvironment
+      summary: Find ServingEnvironment
+      description: Finds a `ServingEnvironment` entity that matches query parameters.
+    parameters:
+      - $ref: "#/components/parameters/name"
+      - $ref: "#/components/parameters/externalId"
+  /api/model_registry/v1/serving_environments:
+    summary: Path used to manage the list of servingenvironments.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `ServingEnvironment` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/ServingEnvironmentListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getServingEnvironments
+      summary: List All ServingEnvironments
+      description: Gets a list of all `ServingEnvironment` entities.
+    post:
+      requestBody:
+        description: A new `ServingEnvironment` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServingEnvironmentCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/ServingEnvironmentResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createServingEnvironment
+      summary: Create a ServingEnvironment
+      description: Creates a new instance of a `ServingEnvironment`.
+  "/api/model_registry/v1/serving_environments/{serving_environment_id}":
+    summary: Path used to manage a single ServingEnvironment.
+    description: >-
+      The REST endpoint/path used to get and update single instances of an `ServingEnvironment`. This path contains `GET` and `PATCH` operations used to perform the get and update tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ServingEnvironmentResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getServingEnvironment
+      summary: Get a ServingEnvironment
+      description: Gets the details of a single instance of a `ServingEnvironment`.
+    patch:
+      requestBody:
+        description: Updated `ServingEnvironment` information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServingEnvironmentUpdate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "200":
+          $ref: "#/components/responses/ServingEnvironmentResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: updateServingEnvironment
+      summary: Update a ServingEnvironment
+      description: Updates an existing `ServingEnvironment`.
+    parameters:
+      - name: serving_environment_id
+        description: A unique identifier for a `ServingEnvironment`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+  "/api/model_registry/v1/serving_environments/{serving_environment_id}/inference_services":
+    summary: Path used to manage the list of `InferenceServices` for a `ServingEnvironment`.
+    description: >-
+      The REST endpoint/path used to list and create zero or more `InferenceService` entities for a `ServingEnvironment`.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.
+    get:
+      tags:
+        - ModelRegistryService
+      parameters:
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/externalId"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/InferenceServiceListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: getEnvironmentInferenceServices
+      summary: List All ServingEnvironment's InferenceServices
+      description: Gets a list of all `InferenceService` entities for the `ServingEnvironment`.
+    post:
+      requestBody:
+        description: A new `InferenceService` to be created.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InferenceServiceCreate"
+        required: true
+      tags:
+        - ModelRegistryService
+      responses:
+        "201":
+          $ref: "#/components/responses/InferenceServiceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: createEnvironmentInferenceService
+      summary: Create a InferenceService in ServingEnvironment
+      description: Creates a new instance of a `InferenceService`.
+    parameters:
+      - name: serving_environment_id
+        description: A unique identifier for a `ServingEnvironment`.
+        schema:
+          type: string
+          format: int64
+          pattern: "^[1-9][0-9]{0,8}$"
+        in: path
+        required: true
+components:
+  schemas:
+    Artifact:
+      oneOf:
+        - $ref: "#/components/schemas/ModelArtifact"
+        - $ref: "#/components/schemas/DocArtifact"
+        - $ref: "#/components/schemas/DataSet"
+        - $ref: "#/components/schemas/Metric"
+        - $ref: "#/components/schemas/Parameter"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          model-artifact: "#/components/schemas/ModelArtifact"
+          doc-artifact: "#/components/schemas/DocArtifact"
+          dataset-artifact: "#/components/schemas/DataSet"
+          metric: "#/components/schemas/Metric"
+          parameter: "#/components/schemas/Parameter"
+      description: A metadata Artifact Entity.
+    ArtifactCreate:
+      description: An Artifact to be created.
+      oneOf:
+        - $ref: "#/components/schemas/ModelArtifactCreate"
+        - $ref: "#/components/schemas/DocArtifactCreate"
+        - $ref: "#/components/schemas/DataSetCreate"
+        - $ref: "#/components/schemas/MetricCreate"
+        - $ref: "#/components/schemas/ParameterCreate"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          model-artifact: "#/components/schemas/ModelArtifactCreate"
+          doc-artifact: "#/components/schemas/DocArtifactCreate"
+          dataset-artifact: "#/components/schemas/DataSetCreate"
+          metric: "#/components/schemas/MetricCreate"
+          parameter: "#/components/schemas/ParameterCreate"
+    ArtifactList:
+      description: A list of Artifact entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `Artifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/Artifact"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ArtifactState:
+      description: |2-
+         - PENDING: A state indicating that the artifact may exist.
+         - LIVE: A state indicating that the artifact should exist, unless something
+        external to the system deletes it.
+         - MARKED_FOR_DELETION: A state indicating that the artifact should be deleted.
+         - DELETED: A state indicating that the artifact has been deleted.
+         - ABANDONED: A state indicating that the artifact has been abandoned, which may be
+        due to a failed or cancelled execution.
+         - REFERENCE: A state indicating that the artifact is a reference artifact. At
+        execution start time, the orchestrator produces an output artifact for
+        each output key with state PENDING. However, for an intermediate
+        artifact, this first artifact's state will be REFERENCE. Intermediate
+        artifacts emitted during a component's execution will copy the REFERENCE
+        artifact's attributes. At the end of an execution, the artifact state
+        should remain REFERENCE instead of being changed to LIVE.
+
+        See also: ml-metadata Artifact.State
+      default: UNKNOWN
+      enum:
+        - UNKNOWN
+        - PENDING
+        - LIVE
+        - MARKED_FOR_DELETION
+        - DELETED
+        - ABANDONED
+        - REFERENCE
+      type: string
+    ArtifactTypeQueryParam:
+      description: Supported artifact types for querying.
+      enum:
+        - model-artifact
+        - doc-artifact
+        - dataset-artifact
+        - metric
+        - parameter
+      type: string
+    ArtifactUpdate:
+      description: An Artifact to be updated.
+      oneOf:
+        - $ref: "#/components/schemas/ModelArtifactUpdate"
+        - $ref: "#/components/schemas/DocArtifactUpdate"
+        - $ref: "#/components/schemas/DataSetUpdate"
+        - $ref: "#/components/schemas/MetricUpdate"
+        - $ref: "#/components/schemas/ParameterUpdate"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          model-artifact: "#/components/schemas/ModelArtifactUpdate"
+          doc-artifact: "#/components/schemas/DocArtifactUpdate"
+          dataset-artifact: "#/components/schemas/DataSetUpdate"
+          metric: "#/components/schemas/MetricUpdate"
+          parameter: "#/components/schemas/ParameterUpdate"
+    BaseResourceCreate:
+      type: object
+      properties:
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
+        name:
+          description: |-
+            The client provided name of the artifact. This field is optional. If set,
+            it must be unique among all the artifacts of the same artifact type within
+            a database instance and cannot be changed once set.
+          type: string
+    BaseResourceUpdate:
+      type: object
+      properties:
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+        description:
+          description: |-
+            An optional description about the resource.
+          type: string
+        externalId:
+          description: |-
+            The external id that come from the clients’ system. This field is optional.
+            If set, it must be unique among all resources within a database instance.
+          type: string
+    BaseArtifact:
+      description: Base schema for all artifact types with common server generated properties.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+    DocArtifact:
+      description: A document.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/DocArtifactCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
+    DocArtifactCreate:
+      description: A document artifact to be created.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/DocArtifactUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
+    DocArtifactUpdate:
+      description: A document artifact to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "doc-artifact"
+            uri:
+              description: |-
+                The uniform resource identifier of the physical artifact.
+                May be empty if there is no physical artifact.
+              type: string
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    DataSet:
+      description: A dataset artifact representing training or test data.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/DataSetCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "dataset-artifact"
+    DataSetCreate:
+      description: A dataset artifact to be created.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/DataSetUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "dataset-artifact"
+    DataSetUpdate:
+      description: A dataset artifact to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "dataset-artifact"
+            digest:
+              description: A unique hash or identifier for the dataset content.
+              type: string
+            sourceType:
+              description: The type of data source (e.g., "s3", "hdfs", "local", "database").
+              type: string
+            source:
+              description: The location or connection string for the dataset source.
+              type: string
+            schema:
+              description: JSON schema or description of the dataset structure.
+              type: string
+            profile:
+              description: Statistical profile or summary of the dataset.
+              type: string
+            uri:
+              description: |-
+                The uniform resource identifier of the physical dataset.
+                May be empty if there is no physical dataset.
+              type: string
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    Metric:
+      description: A metric representing a numerical measurement from model training or evaluation.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/MetricCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "metric"
+    MetricCreate:
+      description: A metric to be created.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/MetricUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "metric"
+            name:
+              description: The name/key of the metric (e.g., "accuracy", "loss", "f1_score").
+              type: string
+    MetricUpdate:
+      description: A metric to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "metric"
+            value:
+              description: The numeric value of the metric.
+              type: number
+              format: double
+            timestamp:
+              description: Unix timestamp in milliseconds when the metric was recorded.
+              type: string
+              format: int64
+            step:
+              description: The step number for multi-step metrics (e.g., training epochs).
+              type: string
+              format: int64
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    Parameter:
+      description: A parameter representing a configuration parameter used in model training or execution.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/ParameterCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "parameter"
+    ParameterCreate:
+      description: A parameter to be created.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ParameterUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "parameter"
+            name:
+              description: The name/key of the parameter (e.g., "learning_rate", "batch_size", "epochs").
+              type: string
+    ParameterType:
+      description: The data type of the parameter (e.g., "string", "number", "boolean", "object").
+      enum:
+        - string
+        - number
+        - boolean
+        - object
+    ParameterUpdate:
+      description: A parameter to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "parameter"
+            value:
+              description: The value of the parameter.
+              type: string
+            parameterType:
+              allOf:
+                - $ref: "#/components/schemas/ParameterType"
+              default: "string"
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    ExecutionState:
+      description: |-
+        The state of the Execution. The state transitions are
+          NEW -> RUNNING -> COMPLETE | CACHED | FAILED | CANCELED
+        CACHED means the execution is skipped due to cached results.
+        CANCELED means the execution is skipped due to precondition not met. It is
+        different from CACHED in that a CANCELED execution will not have any event
+        associated with it. It is different from FAILED in that there is no
+        unexpected error happened and it is regarded as a normal state.
+
+        See also: ml-metadata Execution.State
+      default: UNKNOWN
+      enum:
+        - UNKNOWN
+        - NEW
+        - RUNNING
+        - COMPLETE
+        - FAILED
+        - CACHED
+        - CANCELED
+      type: string
+    InferenceService:
+      description: >-
+        An `InferenceService` entity in a `ServingEnvironment` represents a deployed `ModelVersion` from a `RegisteredModel` created by Model Serving.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - $ref: "#/components/schemas/InferenceServiceCreate"
+    InferenceServiceCreate:
+      description: >-
+        An `InferenceService` entity in a `ServingEnvironment` represents a deployed `ModelVersion` from a `RegisteredModel` created by Model Serving.
+      required:
+        - registeredModelId
+        - servingEnvironmentId
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/InferenceServiceUpdate"
+        - type: object
+          properties:
+            registeredModelId:
+              description: ID of the `RegisteredModel` to serve.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+              minLength: 1
+            servingEnvironmentId:
+              description: ID of the parent `ServingEnvironment` for this `InferenceService` entity.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+              minLength: 1
+    InferenceServiceList:
+      description: List of InferenceServices.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: ""
+              type: array
+              items:
+                $ref: "#/components/schemas/InferenceService"
+              readOnly: false
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    InferenceServiceState:
+      description: |-
+        - DEPLOYED: A state indicating that the `InferenceService` should be deployed.
+        - UNDEPLOYED: A state indicating that the `InferenceService` should be un-deployed.
+        The state indicates the desired state of inference service.
+        See the associated `ServeModel` for the actual status of service deployment action.
+      default: DEPLOYED
+      enum:
+        - DEPLOYED
+        - UNDEPLOYED
+      type: string
+    InferenceServiceUpdate:
+      description: >-
+        An `InferenceService` entity in a `ServingEnvironment` represents a deployed `ModelVersion` from a `RegisteredModel` created by Model Serving.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            modelVersionId:
+              description: >-
+                ID of the `ModelVersion` to serve. If it's unspecified, then the latest `ModelVersion` by creation order will be served.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+            runtime:
+              description: Model runtime.
+              type: string
+            desiredState:
+              $ref: "#/components/schemas/InferenceServiceState"
+    ModelArtifact:
+      description: An ML model artifact.
+      allOf:
+        - $ref: "#/components/schemas/BaseArtifact"
+        - $ref: "#/components/schemas/ModelArtifactCreate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "model-artifact"
+    ModelArtifactCreate:
+      description: An ML model artifact.
+      properties:
+        artifactType:
+          type: string
+          default: "model-artifact"
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ModelArtifactUpdate"
+    ModelArtifactList:
+      description: List of ModelArtifact entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `ModelArtifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/ModelArtifact"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ModelArtifactUpdate:
+      description: An ML model artifact to be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            artifactType:
+              type: string
+              default: "model-artifact"
+            modelFormatName:
+              description: Name of the model format.
+              type: string
+            storageKey:
+              description: Storage secret name.
+              type: string
+            storagePath:
+              description: Path for model in storage provided by `storageKey`.
+              type: string
+            modelFormatVersion:
+              description: Version of the model format.
+              type: string
+            serviceAccountName:
+              description: Name of the service account with storage secret.
+              type: string
+            modelSourceKind:
+              type: string
+              description: "A string identifier describing the source kind. It differentiates various sources of model artifacts.\nThis identifier should be agreed upon by producers and consumers of source model metadata.\nIt is not an enumeration to keep the source of model metadata open ended. \nE.g. Kubeflow pipelines could use `pipelines` to identify models it produces."
+            modelSourceClass:
+              type: string
+              description: |-
+                A subgroup within the source kind. It is a specific sub-component or instance within the source kind.
+                E.g. `pipelinerun` for a Kubeflow pipeline run.
+            modelSourceGroup:
+              type: string
+              description: "Unique identifier for a source group for models from source class. \nIt maps to a physical group of source models. \nE.g. a Kubernetes namespace where the pipeline run was executed."
+            modelSourceId:
+              type: string
+              description: |-
+                A unique identifier for a source model within kind, class, and group.
+                It should be a url friendly string if source supports using URLs to locate source models.
+                E.g. a pipeline run ID.
+            modelSourceName:
+              type: string
+              description: "A human-readable name for the source model. \nE.g. `my-project/1`, `ibm-granite/granite-3.1-8b-base:2.1.2`."
+            uri:
+              description: |-
+                The uniform resource identifier of the physical artifact.
+                May be empty if there is no physical artifact.
+              type: string
+            state:
+              $ref: "#/components/schemas/ArtifactState"
+    ModelVersion:
+      description: Represents a ModelVersion belonging to a RegisteredModel.
+      allOf:
+        - $ref: "#/components/schemas/ModelVersionCreate"
+        - $ref: "#/components/schemas/BaseResource"
+    ModelVersionCreate:
+      description: Represents a ModelVersion belonging to a RegisteredModel.
+      required:
+        - name
+        - registeredModelId
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ModelVersionUpdate"
+        - type: object
+          properties:
+            registeredModelId:
+              description: ID of the `RegisteredModel` to which this version belongs.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+              minLength: 1
+            name:
+              description: |-
+                The client provided name of the model's version. It must be unique among all the ModelVersions of the same
+                type within a Model Registry instance and cannot be changed once set.
+              type: string
+              minLength: 1
+    ModelVersionList:
+      description: List of ModelVersion entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `ModelVersion` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/ModelVersion"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ModelVersionState:
+      description: |-
+        - LIVE: A state indicating that the `ModelVersion` exists
+        - ARCHIVED: A state indicating that the `ModelVersion` has been archived.
+      default: LIVE
+      enum:
+        - LIVE
+        - ARCHIVED
+      type: string
+    ModelVersionUpdate:
+      description: Represents a ModelVersion belonging to a RegisteredModel.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            state:
+              $ref: "#/components/schemas/ModelVersionState"
+            author:
+              description: Name of the author.
+              type: string
+    RegisteredModel:
+      description: A registered model in model registry. A registered model has ModelVersion children.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - $ref: "#/components/schemas/RegisteredModelCreate"
+    RegisteredModelCreate:
+      description: A registered model in model registry. A registered model has ModelVersion children.
+      required:
+        - name
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/RegisteredModelUpdate"
+        - type: object
+          properties:
+            name:
+              description: |-
+                The client provided name of the model. It must be unique among all the RegisteredModels of the same
+                type within a Model Registry instance and cannot be changed once set.
+              type: string
+              minLength: 1
+    RegisteredModelList:
+      description: List of RegisteredModels.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: ""
+              type: array
+              items:
+                $ref: "#/components/schemas/RegisteredModel"
+              readOnly: false
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    RegisteredModelState:
+      description: |-
+        - LIVE: A state indicating that the `RegisteredModel` exists
+        - ARCHIVED: A state indicating that the `RegisteredModel` has been archived.
+      default: LIVE
+      enum:
+        - LIVE
+        - ARCHIVED
+      type: string
+    RegisteredModelUpdate:
+      description: A registered model in model registry. A registered model has ModelVersion children.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - $ref: "#/components/schemas/BaseModel"
+        - type: object
+          properties:
+            owner:
+              type: string
+            state:
+              $ref: "#/components/schemas/RegisteredModelState"
+    ServeModel:
+      description: An ML model serving action.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - $ref: "#/components/schemas/ServeModelCreate"
+    ServeModelCreate:
+      description: An ML model serving action.
+      required:
+        - modelVersionId
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ServeModelUpdate"
+        - type: object
+          properties:
+            modelVersionId:
+              description: ID of the `ModelVersion` that was served in `InferenceService`.
+              type: string
+              format: int64
+              pattern: "^[1-9][0-9]{0,8}$"
+              minLength: 1
+    ServeModelList:
+      description: List of ServeModel entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `ModelArtifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/ServeModel"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ServeModelUpdate:
+      description: An ML model serving action.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+        - type: object
+          properties:
+            lastKnownState:
+              $ref: "#/components/schemas/ExecutionState"
+    ServingEnvironment:
+      description: A Model Serving environment for serving `RegisteredModels`.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - $ref: "#/components/schemas/ServingEnvironmentCreate"
+    ServingEnvironmentCreate:
+      description: A Model Serving environment for serving `RegisteredModels`.
+      required:
+        - name
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceCreate"
+        - $ref: "#/components/schemas/ServingEnvironmentUpdate"
+        - type: object
+          properties:
+            name:
+              description: The name of the ServingEnvironment.
+              type: string
+              minLength: 1
+    ServingEnvironmentList:
+      description: List of ServingEnvironments.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: ""
+              type: array
+              items:
+                $ref: "#/components/schemas/ServingEnvironment"
+              readOnly: false
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ServingEnvironmentUpdate:
+      description: A Model Serving environment for serving `RegisteredModels`.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceUpdate"
+    OrderByField:
+      description: Supported fields for ordering result entities.
+      enum:
+        - CREATE_TIME
+        - LAST_UPDATE_TIME
+        - ID
+      type: string
+  responses:
+    ArtifactListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ArtifactList"
+      description: A response containing a list of `Artifact` entities.
+      links:
+        GetArtifactById:
+          $ref: '#/components/links/GetArtifactById'
+        PatchArtifactById:
+          $ref: '#/components/links/PatchArtifactById'
+        SearchArtifactByExternalId:
+          $ref: '#/components/links/SearchArtifactByExternalId'
+        SearchArtifactByName:
+          $ref: '#/components/links/SearchArtifactByName'
+        SearchArtifactByParentResourceId:
+          $ref: '#/components/links/SearchArtifactByParentResourceId'
+    ArtifactResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Artifact"
+      description: A response containing an `Artifact` entity.
+      links:
+        GetArtifactById:
+          $ref: '#/components/links/GetArtifactById'
+        PatchArtifactById:
+          $ref: '#/components/links/PatchArtifactById'
+        SearchArtifactByExternalId:
+          $ref: '#/components/links/SearchArtifactByExternalId'
+        SearchArtifactByName:
+          $ref: '#/components/links/SearchArtifactByName'
+        SearchArtifactByParentResourceId:
+          $ref: '#/components/links/SearchArtifactByParentResourceId'
+    InferenceServiceListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/InferenceServiceList"
+      description: A response containing a list of `InferenceService` entities.
+      links:
+        GetISById:
+          $ref: '#/components/links/GetISById'
+        PatchISById:
+          $ref: '#/components/links/PatchISById'
+        SearchISByExternalId:
+          $ref: '#/components/links/SearchISByExternalId'
+        SearchISByName:
+          $ref: '#/components/links/SearchISByName'
+        SearchISByParentResourceId:
+          $ref: '#/components/links/SearchISByParentResourceId'
+    InferenceServiceResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/InferenceService"
+      description: A response containing a `InferenceService` entity.
+      links:
+        GetISById:
+          $ref: '#/components/links/GetISById'
+        PatchISById:
+          $ref: '#/components/links/PatchISById'
+        SearchISByExternalId:
+          $ref: '#/components/links/SearchISByExternalId'
+        SearchISByName:
+          $ref: '#/components/links/SearchISByName'
+        SearchISByParentResourceId:
+          $ref: '#/components/links/SearchISByParentResourceId'
+    ModelArtifactListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelArtifactList"
+      description: A response containing a list of ModelArtifact entities.
+      links:
+        GetModelArtifactById:
+          $ref: '#/components/links/GetModelArtifactById'
+        PatchModelArtifactById:
+          $ref: '#/components/links/PatchModelArtifactById'
+        SearchModelArtifactByExternalId:
+          $ref: '#/components/links/SearchModelArtifactByExternalId'
+        SearchModelArtifactByName:
+          $ref: '#/components/links/SearchModelArtifactByName'
+        SearchModelArtifactByParentResourceId:
+          $ref: '#/components/links/SearchModelArtifactByParentResourceId'
+    ModelArtifactResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelArtifact"
+      description: A response containing a `ModelArtifact` entity.
+      links:
+        GetModelArtifactById:
+          $ref: '#/components/links/GetModelArtifactById'
+        PatchModelArtifactById:
+          $ref: '#/components/links/PatchModelArtifactById'
+        SearchModelArtifactByExternalId:
+          $ref: '#/components/links/SearchModelArtifactByExternalId'
+        SearchModelArtifactByName:
+          $ref: '#/components/links/SearchModelArtifactByName'
+        SearchModelArtifactByParentResourceId:
+          $ref: '#/components/links/SearchModelArtifactByParentResourceId'
+    ModelVersionListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelVersionList"
+      description: A response containing a list of `ModelVersion` entities.
+      links:
+        GetModelVersionById:
+          $ref: '#/components/links/GetModelVersionById'
+        PatchModelVersionById:
+          $ref: '#/components/links/PatchModelVersionById'
+        SearchModelVersionByExternalId:
+          $ref: '#/components/links/SearchModelVersionByExternalId'
+        SearchModelVersionByName:
+          $ref: '#/components/links/SearchModelVersionByName'
+    ModelVersionResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelVersion"
+      description: A response containing a `ModelVersion` entity.
+      links:
+        GetModelVersionById:
+          $ref: '#/components/links/GetModelVersionById'
+        PatchModelVersionById:
+          $ref: '#/components/links/PatchModelVersionById'
+        SearchModelVersionByExternalId:
+          $ref: '#/components/links/SearchModelVersionByExternalId'
+        SearchModelVersionByName:
+          $ref: '#/components/links/SearchModelVersionByName'
+    RegisteredModelListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RegisteredModelList"
+      description: A response containing a list of `RegisteredModel` entities.
+      links:
+        GetRegisteredModelById:
+          $ref: '#/components/links/GetRegisteredModelById'
+        PatchRegisteredModelById:
+          $ref: '#/components/links/PatchRegisteredModelById'
+        SearchRegisteredModelByExternalId:
+          $ref: '#/components/links/SearchRegisteredModelByExternalId'
+        SearchRegisteredModelByName:
+          $ref: '#/components/links/SearchRegisteredModelByName'
+    RegisteredModelResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RegisteredModel"
+      description: A response containing a `RegisteredModel` entity.
+      links:
+        GetRegisteredModelById:
+          $ref: '#/components/links/GetRegisteredModelById'
+        PatchRegisteredModelById:
+          $ref: '#/components/links/PatchRegisteredModelById'
+        SearchRegisteredModelByExternalId:
+          $ref: '#/components/links/SearchRegisteredModelByExternalId'
+        SearchRegisteredModelByName:
+          $ref: '#/components/links/SearchRegisteredModelByName'
+    ServeModelListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServeModelList"
+      description: A response containing a list of `ServeModel` entities.
+    ServeModelResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServeModel"
+      description: A response containing a `ServeModel` entity.
+    ServingEnvironmentListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServingEnvironmentList"
+      description: A response containing a list of `ServingEnvironment` entities.
+      links:
+        GetServingEnvironmentById:
+          $ref: '#/components/links/GetServingEnvironmentById'
+        PatchServingEnvironmentById:
+          $ref: '#/components/links/PatchServingEnvironmentById'
+        SearchServingEnvironmentByExternalId:
+          $ref: '#/components/links/SearchServingEnvironmentByExternalId'
+        SearchServingEnvironmentByName:
+          $ref: '#/components/links/SearchServingEnvironmentByName'
+    ServingEnvironmentResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServingEnvironment"
+      description: A response containing a `ServingEnvironment` entity.
+      links:
+        GetServingEnvironmentById:
+          $ref: '#/components/links/GetServingEnvironmentById'
+        PatchServingEnvironmentById:
+          $ref: '#/components/links/PatchServingEnvironmentById'
+        SearchServingEnvironmentByExternalId:
+          $ref: '#/components/links/SearchServingEnvironmentByExternalId'
+        SearchServingEnvironmentByName:
+          $ref: '#/components/links/SearchServingEnvironmentByName'
+  parameters:
+    orderBy:
+      style: form
+      explode: true
+      examples:
+        orderBy:
+          value: ID
+      name: orderBy
+      description: Specifies the order by criteria for listing entities.
+      schema:
+        $ref: "#/components/schemas/OrderByField"
+      in: query
+      required: false
+    artifactType:
+      style: form
+      explode: true
+      examples:
+        artifactType:
+          value: model-artifact
+      name: artifactType
+      description: "Specifies the artifact type for listing artifacts."
+      schema:
+        $ref: "#/components/schemas/ArtifactTypeQueryParam"
+      in: query
+      required: false
+  securitySchemes: {}
+  links:
+    # Artifact
+    GetArtifactById:
+      operationId: getArtifact
+      parameters:
+        id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `GET /api/model_registry/v1/artifacts/{id}`.
+
+    PatchArtifactById:
+      operationId: updateArtifact
+      parameters:
+        id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `PATCH /api/model_registry/v1/artifacts/{id}`.
+
+    SearchArtifactByExternalId:
+      operationId: findArtifact
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/artifact`.
+
+    SearchArtifactByName:
+      operationId: findArtifact
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/artifact`.
+
+    # Unsure about this one
+    SearchArtifactByParentResourceId:
+      operationId: findArtifact
+      parameters:
+        parentResourceId: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `parentResourceId` parameter in `GET /api/model_registry/v1/artifact`, assuming that the 'Artifact' entity is a parent to another 'Artifact' entity.
+
+    # InferenceService
+    GetISById:
+      operationId: getInferenceService
+      parameters:
+        inference_service_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `GET /api/model_registry/v1/inference_services/{inference_service_id}`.
+
+    PatchISById:
+      operationId: updateInferenceService
+      parameters:
+        inference_service_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `PATCH /api/model_registry/v1/inference_services/{inference_service_id}`.
+
+    SearchISByExternalId:
+      operationId: findInferenceService
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/inference_service`.
+
+    SearchISByName:
+      operationId: findInferenceService
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/inference_service`.
+
+    # Unsure about this one
+    SearchISByParentResourceId:
+      operationId: findInferenceService
+      parameters:
+        parentResourceId: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `parentResourceId` parameter in GET /api/model_registry/v1/inference_service`, assuming that the 'InferenceService' entity is a parent to another 'InferenceService' entity.
+
+    # ModelArtifact
+    GetModelArtifactById:
+      operationId: getModelArtifact
+      parameters:
+        model_artifact_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `GET "/api/model_registry/v1/model_artifacts/{model_artifact_id}`.
+
+    PatchModelArtifactById:
+      operationId: updateModelArtifact
+      parameters:
+        model_artifact_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `id` parameter in `PATCH "/api/model_registry/v1/model_artifacts/{model_artifact_id}`.
+
+    SearchModelArtifactByExternalId:
+      operationId: findModelArtifact
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/model_artifact`.
+
+    SearchModelArtifactByName:
+      operationId: findModelArtifact
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/model_artifact`.
+
+    # Unsure about this one
+    SearchModelArtifactByParentResourceId:
+      operationId: findModelArtifact
+      parameters:
+        parentResourceId: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `parentResourceId` parameter in `GET /api/model_registry/v1/model_artifact`, assuming that the 'ModelArtifact' entity is a parent to another 'ModelArtifact' entity.
+
+    # RegisteredModel
+    GetRegisteredModelById:
+      operationId: getRegisteredModel
+      parameters:
+        registered_model_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `registered_model_id` parameter in `GET /api/model_registry/v1/registered_models/{registered_model_id}`.
+
+    PatchRegisteredModelById:
+      operationId: updateRegisteredModel
+      parameters:
+        registered_model_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `registered_model_id` parameter in `PATCH /api/model_registry/v1/registered_models/{registered_model_id}`.
+
+    SearchRegisteredModelByExternalId:
+      operationId: findRegisteredModel
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/registered_model`.
+
+    SearchRegisteredModelByName:
+      operationId: findRegisteredModel
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/registered_model`.
+
+    # ModelVersion
+    GetModelVersionById:
+      operationId: getModelVersion
+      parameters:
+        model_version_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `model_version_id` parameter in `GET /api/model_registry/v1/model_versions/{model_version_id}`.
+
+    PatchModelVersionById:
+      operationId: updateModelVersion
+      parameters:
+        model_version_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `model_version_id` parameter in `PATCH /api/model_registry/v1/model_versions/{model_version_id}`.
+
+    SearchModelVersionByExternalId:
+      operationId: findModelVersion
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/model_version`.
+
+    SearchModelVersionByName:
+      operationId: findModelVersion
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/model_version`.
+
+    # ServingEnvironment
+    GetServingEnvironmentById:
+      operationId: getServingEnvironment
+      parameters:
+        serving_environment_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `serving_environment_id` parameter in `GET /api/model_registry/v1/serving_environments/{serving_environment_id}`.
+
+    PatchServingEnvironmentById:
+      operationId: updateServingEnvironment
+      parameters:
+        serving_environment_id: "$response.body#/id"
+      description: >
+        The `id` value returned in the response can be used as the `serving_environment_id` parameter in `PATCH /api/model_registry/v1/serving_environments/{serving_environment_id}`.
+
+    SearchServingEnvironmentByExternalId:
+      operationId: findServingEnvironment
+      parameters:
+        externalId: "$response.body#/externalId"
+      description: >
+        The `externalId` value returned in the response can be used as the `externalId` parameter in `GET /api/model_registry/v1/serving_environment`.
+
+    SearchServingEnvironmentByName:
+      operationId: findServingEnvironment
+      parameters:
+        name: "$response.body#/name"
+      description: >
+        The `name` value returned in the response can be used as the `name` parameter in `GET /api/model_registry/v1/serving_environment`.
+
+tags:
+  - name: ModelRegistryService
+    description: Model Registry Service REST API

--- a/api/openapi/src/plugins/model-v1.yaml
+++ b/api/openapi/src/plugins/model-v1.yaml
@@ -1,0 +1,596 @@
+paths:
+  /api/model_catalog/v1/models:
+    description: >-
+      The REST endpoint/path used to list zero or more `CatalogModel` entities from all `CatalogSources`.
+    get:
+      summary: Search catalog models across sources.
+      tags:
+        - ModelCatalogService
+      parameters:
+        - name: recommendations
+          in: query
+          deprecated: true
+          description: >-
+            Deprecated: use `orderBy=RECOMMENDED` instead.
+            Sort models by lowest recommended latency using Pareto filtering.
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - name: targetRPS
+          in: query
+          description: Target requests per second for latency calculations
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: latencyProperty
+          in: query
+          description: Property name for latency metric
+          required: false
+          schema:
+            type: string
+            default: "ttft_p90"
+        - name: rpsProperty
+          in: query
+          description: Property name for RPS metric
+          required: false
+          schema:
+            type: string
+            default: "requests_per_second"
+        - name: hardwareCountProperty
+          in: query
+          description: Property name for hardware count
+          required: false
+          schema:
+            type: string
+            default: "hardware_count"
+        - name: hardwareTypeProperty
+          in: query
+          description: Property name for hardware type grouping
+          required: false
+          schema:
+            type: string
+            default: "hardware_type"
+        - name: source
+          description: |-
+            Filter models by source. Multiple values can be separated by commas
+            to filter by multiple sources (OR logic). For example:
+            ?source=huggingface,local will return models from either
+            huggingface OR local sources.
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+          in: query
+          required: false
+        - name: q
+          description: Free-form keyword search used to filter the response.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: sourceLabel
+          description: |-
+            Filter models by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then models from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - name: orderBy
+          style: form
+          explode: true
+          examples:
+            orderBy:
+              value: ID
+          description: |-
+            Specifies the order by criteria for listing entities.
+
+            Supported values are:
+            - CREATE_TIME
+            - LAST_UPDATE_TIME
+            - ID
+            - NAME
+            - ACCURACY
+            - RECOMMENDED
+
+            Defaults to `NAME`.
+
+            The `ACCURACY` sort will sort by the `overall_average` property in any linked metrics artifact.
+
+            The `RECOMMENDED` sort applies Pareto filtering and ranks models by recommended latency.
+            The Pareto-related parameters (`targetRPS`, `latencyProperty`, `rpsProperty`,
+            `hardwareCountProperty`, `hardwareTypeProperty`) are applied the same way as with the
+            deprecated `recommendations` parameter. With the default `sortOrder=ASC`, the most
+            recommended models (lowest latency) appear first. Use `sortOrder=DESC` to show the least
+            recommended configurations first.
+
+            In addition, models can be sorted by properties. For example:
+            - `provider.string_value` sorts by provider name
+            - `artifacts.ifeval.double_value` sorts by the min/max value a property called ifeval across all associated artifacts
+          schema:
+            $ref: "#/components/schemas/OrderByField"
+          in: query
+          required: false
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogModelListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findModels
+  /api/model_catalog/v1/models/filter_options:
+    description: Lists options for `filterQuery` when listing models.
+    get:
+      summary: Lists fields and available options that can be used in `filterQuery` on the list models endpoint.
+      tags:
+        - ModelCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/FilterOptionsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findModelsFilterOptions
+  /api/model_catalog/v1/sources/{source_id}/models/{model_name+}:
+    description: >-
+      The REST endpoint/path used to get a `CatalogModel`.
+    get:
+      summary: Get a `CatalogModel`.
+      tags:
+        - ModelCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogModelResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getModel
+    parameters:
+      - name: source_id
+        description: A unique identifier for a `CatalogSource`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: model_name+
+        description: A unique identifier for the model.
+        schema:
+          type: string
+        in: path
+        required: true
+  /api/model_catalog/v1/sources/{source_id}/models/{model_name}/artifacts:
+    description: >-
+      The REST endpoint/path used to list `CatalogArtifacts`.
+    get:
+      summary: List CatalogArtifacts.
+      tags:
+        - ModelCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getAllModelArtifacts
+    parameters:
+      - name: source_id
+        description: A unique identifier for a `CatalogSource`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: model_name
+        description: A unique identifier for the model.
+        schema:
+          type: string
+        in: path
+        required: true
+      - $ref: "#/components/parameters/artifactType"
+      - $ref: "#/components/parameters/artifact_type"
+      - $ref: "#/components/parameters/artifactFilterQuery"
+      - $ref: "#/components/parameters/pageSize"
+      - $ref: "#/components/parameters/artifactOrderBy"
+      - $ref: "#/components/parameters/sortOrder"
+      - $ref: "#/components/parameters/nextPageToken"
+  /api/model_catalog/v1/sources/{source_id}/models/{model_name}/artifacts/performance:
+    description: >-
+      Lists performance metrics artifacts (that is, artifacts of type `CatalogMetricsArtifact` where `metricsType` is `performance-metrics`).
+    get:
+      summary: List CatalogArtifacts.
+      tags:
+        - ModelCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getAllModelPerformanceArtifacts
+    parameters:
+      - name: source_id
+        description: A unique identifier for a `CatalogSource`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: model_name
+        description: A unique identifier for the model.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: targetRPS
+        description: |-
+          Target requests per second. If specified, values for `replicas` and
+          `total_requests_per_second` will be calculated and returned as custom
+          properties.
+        schema:
+          type: integer
+        in: query
+      - name: recommendations
+        description: Filter records that are less optimal based on approximate cost to run and latency.
+        schema:
+          type: boolean
+          default: false
+        in: query
+      - name: rpsProperty
+        description: Custom property name for requests per second metric.
+        schema:
+          type: string
+          default: "requests_per_second"
+        in: query
+      - name: latencyProperty
+        description: Custom property name for latency metric (e.g., ttft_p90, p90_latency).
+        schema:
+          type: string
+          default: "ttft_p90"
+        in: query
+      - name: hardwareCountProperty
+        description: Custom property name for hardware count metric.
+        schema:
+          type: string
+          default: "hardware_count"
+        in: query
+      - name: hardwareTypeProperty
+        description: Custom property name for hardware type grouping.
+        schema:
+          type: string
+          default: "hardware_type"
+        in: query
+      - $ref: "#/components/parameters/artifactFilterQuery"
+      - $ref: "#/components/parameters/pageSize"
+      - $ref: "#/components/parameters/artifactOrderBy"
+      - $ref: "#/components/parameters/sortOrder"
+      - $ref: "#/components/parameters/nextPageToken"
+components:
+  schemas:
+    CatalogArtifact:
+      description: A single artifact in the catalog API.
+      oneOf:
+        - $ref: "#/components/schemas/CatalogModelArtifact"
+        - $ref: "#/components/schemas/CatalogMetricsArtifact"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          model-artifact: "#/components/schemas/CatalogModelArtifact"
+          metrics-artifact: "#/components/schemas/CatalogMetricsArtifact"
+    CatalogArtifactList:
+      description: List of CatalogModel entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `CatalogArtifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/CatalogArtifact"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    ArtifactTypeQueryParam:
+      description: Supported artifact types for querying.
+      enum:
+        - model-artifact
+        - metrics-artifact
+      type: string
+    CatalogMetricsArtifact:
+      description: A metadata Artifact Entity.
+      allOf:
+        - type: object
+          required:
+            - artifactType
+            - metricsType
+          properties:
+            artifactType:
+              type: string
+              default: metrics-artifact
+            metricsType:
+              type: string
+              enum:
+                - performance-metrics
+                - accuracy-metrics
+                - security-metrics
+            customProperties:
+              description: User provided custom properties which are not defined by its type.
+              type: object
+              additionalProperties:
+                $ref: "#/components/schemas/MetadataValue"
+        - $ref: "#/components/schemas/BaseResource"
+    CatalogModel:
+      description: A model in the model catalog.
+      allOf:
+        - type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              description: Name of the model. Must be unique within a source.
+              example: ibm-granite/granite-3.1-8b-base
+            sourceId:
+              type: string
+              description: ID of the source this model belongs to.
+            validatedTasks:
+              type: array
+              items:
+                type: string
+              description: List of tasks for this model which have been validated by the catalog provider.
+            servingConfig:
+              $ref: "#/components/schemas/ServingConfig"
+            artifactCounts:
+              type: object
+              description: >-
+                Read-only counts of artifacts by category. Only populated on the
+                single-model detail endpoint (GetModel). Keys with zero count are omitted.
+                When no artifacts exist, the field is omitted entirely.
+              readOnly: true
+              additionalProperties:
+                type: integer
+                format: int32
+              example:
+                model-artifact: 3
+                performance-metrics: 12
+                accuracy-metrics: 2
+        - $ref: "#/components/schemas/BaseModel"
+        - $ref: "#/components/schemas/BaseResource"
+    ServingConfig:
+      description: >-
+        Serving and deployment configuration for the model. Each property represents a distinct configuration concern with its own typed schema. All properties are optional.
+      type: object
+      properties:
+        toolCalling:
+          $ref: "#/components/schemas/ToolCallingConfig"
+    ToolCallingConfig:
+      description: >-
+        Tool-calling arguments for this model.
+      type: object
+      properties:
+        toolCallParser:
+          type: string
+          description: >-
+            The tool-call parser identifier for the serving runtime.
+          example: granite
+        chatTemplate:
+          type: string
+          description: >-
+            Path to the chat template file packaged with the model.
+          example: opt/app-root/template/tool_chat_template_granite.jinja
+        enableAutoToolChoice:
+          type: boolean
+          description: >-
+            Whether to enable automatic tool choice in the serving runtime.
+          default: true
+        requiredArgs:
+          type: array
+          items:
+            type: string
+          description: >-
+            Additional CLI arguments required for tool calling beyond the parser, template, and auto-tool-choice flags. Each entry is a complete argument (e.g., "--config_format mistral").
+          example:
+            - "--config_format granite"
+    CatalogModelArtifact:
+      description: A Catalog Model Artifact Entity.
+      allOf:
+        - type: object
+          required:
+            - artifactType
+            - uri
+          properties:
+            artifactType:
+              type: string
+              default: model-artifact
+            uri:
+              type: string
+              format: uri
+              description: URI where the model can be retrieved.
+            customProperties:
+              description: User provided custom properties which are not defined by its type.
+              type: object
+              additionalProperties:
+                $ref: "#/components/schemas/MetadataValue"
+        - $ref: "#/components/schemas/BaseResource"
+    CatalogModelList:
+      description: List of CatalogModel entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `CatalogModel` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/CatalogModel"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+  responses:
+    CatalogArtifactListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogArtifactList"
+      description: A response containing a list of CatalogArtifact entities.
+    CatalogModelListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogModelList"
+      description: A response containing a list of CatalogModel entities.
+    CatalogModelResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogModel"
+      description: A response containing a `CatalogModel` entity.
+  parameters:
+    artifactFilterQuery:
+      examples:
+        artifactFilterQuery:
+          value: "name='my-artifact' AND uri LIKE '%s3%'"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter catalog artifacts. The query supports rich filtering capabilities with automatic type inference.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Data Types:**
+        - Strings: `"value"` or `'value'`
+        - Numbers: `42`, `3.14`, `1e-5`
+        - Booleans: `true`, `false` (case-insensitive)
+
+        **Property Access (Artifacts):**
+        - Standard properties: `name`, `id`, `uri`, `artifactType`, `createTimeSinceEpoch`
+        - Custom properties: Any user-defined property name in `customProperties`
+        - Escaped properties: Use backticks for special characters: `` `custom-property` ``
+        - Type-specific access: `property.string_value`, `property.double_value`, `property.int_value`, `property.bool_value`
+
+        **Examples:**
+        - Basic: `name = "my-artifact"`
+        - Comparison: `ttft_mean > 90`
+        - Pattern: `uri LIKE "%s3.amazonaws.com%"`
+        - Complex: `(artifactType = "model-artifact" OR artifactType = "metrics-artifact") AND name LIKE "%pytorch%"`
+        - Custom property: `format.string_value = "pytorch"`
+        - Escaped property: `` `custom-key` = "value" ``
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    artifactOrderBy:
+      style: form
+      explode: true
+      examples:
+        standardField:
+          value: ID
+          summary: Order by standard field
+        customPropertyDouble:
+          value: mmlu.double_value
+          summary: Order by custom double property
+        customPropertyString:
+          value: framework_type.string_value
+          summary: Order by custom string property
+        customPropertyInt:
+          value: hardware_count.int_value
+          summary: Order by custom integer property
+      name: orderBy
+      description: |
+        Specifies the order by criteria for listing artifacts.
+
+        **Standard Fields:**
+        - `ID` - Order by artifact ID
+        - `NAME` - Order by artifact name
+        - `CREATE_TIME` - Order by creation timestamp
+        - `LAST_UPDATE_TIME` - Order by last update timestamp
+
+        **Custom Property Ordering:**
+
+        Artifacts can be ordered by custom properties using the format: `<property_name>.<value_type>`
+
+        Supported value types:
+        - `double_value` - For numeric (floating-point) properties
+        - `int_value` - For integer properties
+        - `string_value` - For string properties
+
+        Examples:
+        - `mmlu.double_value` - Order by the 'mmlu' benchmark score
+        - `accuracy.double_value` - Order by accuracy metric
+        - `framework_type.string_value` - Order by framework type
+        - `hardware_count.int_value` - Order by hardware count
+        - `ttft_mean.double_value` - Order by time-to-first-token mean
+
+        **Behavior:**
+        - If an invalid value type is specified (e.g., `accuracy.invalid_type`), an error is returned
+        - If an invalid format is used (e.g., `accuracy` without `.value_type`), it falls back to ID ordering
+        - If a property doesn't exist, it falls back to ID ordering
+        - Artifacts with the specified property are ordered first (by the property value), followed by artifacts without the property (ordered by ID)
+        - Empty property names (e.g., `.double_value`) return an error
+      schema:
+        type: string
+      in: query
+      required: false
+    artifactType:
+      style: form
+      explode: true
+      examples:
+        artifactType:
+          value: model-artifact
+      name: artifactType
+      description: "Specifies the artifact type for listing artifacts."
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/ArtifactTypeQueryParam"
+      in: query
+      required: false
+    artifact_type:
+      deprecated: true
+      style: form
+      explode: true
+      examples:
+        artifact_type:
+          value: model-artifact
+      name: artifact_type
+      description: "Specifies the artifact type for listing artifacts."
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/ArtifactTypeQueryParam"
+      in: query
+      required: false

--- a/scripts/merge_catalog_specs.sh
+++ b/scripts/merge_catalog_specs.sh
@@ -87,7 +87,7 @@ cp "$SOURCE_FILE" "$OUT_FILE"
 PLUGIN_FILES=()
 while IFS= read -r f; do
     PLUGIN_FILES+=("$f")
-done < <(find api/openapi/src/plugins -maxdepth 1 -name '*.yaml' -type f 2>/dev/null | sort || true)
+done < <(find api/openapi/src/plugins -maxdepth 1 -name '*.yaml' -not -name '*-v1.yaml' -type f 2>/dev/null | sort || true)
 
 for plugin_file in "${PLUGIN_FILES[@]}"; do
     temp_merged="$(mktemp -t merged_tempXXXXXX).yaml"


### PR DESCRIPTION
## Description

Define v1 OpenAPI spec for Model Registry. Part of the implementation
for KEP-0004.

`v1alpha3` specs are unchanged.

Fixes #2992

## How Has This Been Tested?
Regenerated the openapi spec file and checked the report. This is only a spec change, so there's no code to check (outside of the generator script).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
