### PR TITLE
Fix MCP settings texts

### DIFF
--- a/catalog/internal/catalog/mcpcatalog/loader.go
+++ b/catalog/internal/catalog/mcpcatalog/loader.go
@@ -302,7 +302,7 @@ func (ml *MCPLoader) loadServersFromProvider(ctx context.Context, cancel context
 					(&MCPPartiallyAvailableError{FailedServers: failedServers}).Error())
 			} else {
 				basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusError,
-					fmt.Sprintf("all MCP servers failed to load from source %s (failed: %v)", sourceID, failedServers))
+					fmt.Sprintf("All MCP servers failed to load from source %s (failed: %v)", sourceID, failedServers))
 			}
 		} else {
 			basecatalog.SaveSourceStatus(ml.services.CatalogSourceRepository, sourceID, basecatalog.SourceStatusAvailable, "")

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/mcpCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/mcpCatalogSettings.ts
@@ -185,7 +185,7 @@ class McpManageSourcePage {
   }
 
   findPreviewPanelEmptyMessage() {
-    return cy.contains('To view the MCP servers from this source that will appear');
+    return cy.contains('Complete all required fields, then click');
   }
 
   findPreviewButtonHeader() {

--- a/clients/ui/frontend/src/app/pages/mcpCatalogSettings/components/McpPreviewPanel.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalogSettings/components/McpPreviewPanel.tsx
@@ -79,8 +79,8 @@ const McpPreviewPanel: React.FC<McpPreviewPanelProps> = ({ preview }) => {
     return (
       <EmptyState titleText={MCP_PAGE_TITLES.PREVIEW_SERVERS} variant={EmptyStateVariant.sm}>
         <EmptyStateBody>
-          To view the MCP servers from this source that will appear in the MCP catalog with your
-          current configuration, complete all required fields, then click <strong>Preview</strong>.
+          Complete all required fields, then click <strong>Preview</strong> to see which servers
+          will appear in the catalog.
         </EmptyStateBody>
         <EmptyStateFooter>
           <EmptyStateActions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Change the MCP settings texts.
- Fix the error from the backend text message to start with "All" instead "all" (typo fix)Before: 
<img width="952" height="73" alt="image" src="https://github.com/user-attachments/assets/16d7d638-c71a-4e6b-a258-5b93f7deb400" />
<img width="735" height="184" alt="image" src="https://github.com/user-attachments/assets/42c963ba-88f4-4d1d-be23-b82242b15b6b" />

After: 
<img width="943" height="74" alt="image" src="https://github.com/user-attachments/assets/33b862f0-4a90-4827-8321-89d299d42ca2" />
<img width="732" height="192" alt="image" src="https://github.com/user-attachments/assets/79d69fc2-2c6b-4692-955d-1b10db740baa" />

- Change the empty state preview text for MCP sources
Before:
<img width="804" height="390" alt="image" src="https://github.com/user-attachments/assets/d5f0c777-2109-4756-bdea-8537c1579a7c" />

After:
<img width="483" height="268" alt="image" src="https://github.com/user-attachments/assets/e580f374-0b64-4dd4-b609-6d948e1a8c4f" />



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
