### PR TITLE
Add skill source config and git-skills-plugin schema (SKC-102)

### DIFF
--- a/catalog/internal/catalog/basecatalog/config.go
+++ b/catalog/internal/catalog/basecatalog/config.go
@@ -57,6 +57,11 @@ type SourceConfig struct {
 	// AgentCatalogs contains agent catalog source definitions
 	AgentCatalogs []PluginSource `yaml:"agent_catalogs,omitempty" json:"agent_catalogs,omitempty"`
 
+	// SkillCatalogs contains skill catalog source definitions (type: git-skills-plugin).
+	// Skill-specific configuration (repositories, trustTier, syncIntervalMinutes,
+	// yamlCatalogPath) lives under each source's `properties`; see the skillcatalog package.
+	SkillCatalogs []PluginSource `yaml:"skill_catalogs,omitempty" json:"skill_catalogs,omitempty"`
+
 	// Labels contains label definitions for the catalogs
 	Labels []map[string]any `yaml:"labels,omitempty" json:"labels,omitempty"`
 
@@ -145,6 +150,9 @@ func (c *SourceConfig) Validate() error {
 	}
 
 	if err := validateSourceIDs("agent", c.AgentCatalogs, seen); err != nil {
+		return err
+	}
+	if err := validateSourceIDs("skill", c.SkillCatalogs, seen); err != nil {
 		return err
 	}
 	if err := ValidateNamedQueries(c.NamedQueries); err != nil {

--- a/catalog/internal/catalog/basecatalog/config_test.go
+++ b/catalog/internal/catalog/basecatalog/config_test.go
@@ -194,6 +194,49 @@ func TestSourceConfig_Validate(t *testing.T) {
 			expectErr: true,
 			errMsg:    `id "shared" used in multiple catalog types`,
 		},
+		{
+			name: "valid config with skill catalogs",
+			config: &SourceConfig{
+				SkillCatalogs: []PluginSource{
+					{ID: "skill1", Name: "Skill 1", Type: "git-skills-plugin"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "duplicate skill catalog IDs",
+			config: &SourceConfig{
+				SkillCatalogs: []PluginSource{
+					{ID: "dup", Name: "Skill 1", Type: "git-skills-plugin"},
+					{ID: "dup", Name: "Skill 2", Type: "git-skills-plugin"},
+				},
+			},
+			expectErr: true,
+			errMsg:    "duplicate skill catalog id: dup",
+		},
+		{
+			name: "missing skill catalog ID",
+			config: &SourceConfig{
+				SkillCatalogs: []PluginSource{
+					{Name: "Skill 1", Type: "git-skills-plugin"},
+				},
+			},
+			expectErr: true,
+			errMsg:    "skill catalog source missing id",
+		},
+		{
+			name: "cross-type ID collision between agent and skill catalogs",
+			config: &SourceConfig{
+				AgentCatalogs: []PluginSource{
+					{ID: "shared", Name: "Agent 1", Type: "yaml"},
+				},
+				SkillCatalogs: []PluginSource{
+					{ID: "shared", Name: "Skill 1", Type: "git-skills-plugin"},
+				},
+			},
+			expectErr: true,
+			errMsg:    `id "shared" used in multiple catalog types`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/catalog/internal/catalog/basecatalog/source_types.go
+++ b/catalog/internal/catalog/basecatalog/source_types.go
@@ -20,6 +20,7 @@ const (
 	AssetTypeModels     = "models"
 	AssetTypeMCPServers = "mcp_servers"
 	AssetTypeAgents     = "agents"
+	AssetTypeSkills     = "skills"
 )
 
 // CommonSourceFields holds the fields shared between ModelSource and MCPSource

--- a/catalog/internal/catalog/skillcatalog/sources.go
+++ b/catalog/internal/catalog/skillcatalog/sources.go
@@ -38,8 +38,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
 	apimodels "github.com/kubeflow/hub/catalog/pkg/openapi"
@@ -209,20 +211,41 @@ func validateTrustTier(tier string) error {
 }
 
 // validateRepositories checks the resolved repository list is non-empty, every
-// entry has a URL, and URLs are unique within the source.
+// entry has a URL, and URLs are unique within the source. Uniqueness is compared
+// on a normalized key (see normalizeRepoURL) so trivially-equivalent URLs are
+// rejected rather than indexed twice.
 func validateRepositories(repos []SkillRepository) error {
 	if len(repos) == 0 {
 		return fmt.Errorf("at least one repository is required")
 	}
-	seen := make(map[string]bool, len(repos))
+	seen := make(map[string]string, len(repos)) // normalized key -> original url
 	for i, r := range repos {
 		if r.URL == "" {
 			return fmt.Errorf("repository[%d]: url is required", i)
 		}
-		if seen[r.URL] {
-			return fmt.Errorf("duplicate repository url %q", r.URL)
+		key := normalizeRepoURL(r.URL)
+		if prev, dup := seen[key]; dup {
+			return fmt.Errorf("duplicate repository url %q (equivalent to %q)", r.URL, prev)
 		}
-		seen[r.URL] = true
+		seen[key] = r.URL
 	}
 	return nil
+}
+
+// normalizeRepoURL returns a comparison key for duplicate detection that treats
+// trivially-equivalent URLs as the same: the scheme and host are lowercased and a
+// trailing slash is trimmed. The path case is preserved (git paths can be
+// case-sensitive), and the original URL is kept verbatim as the canonical
+// identity — this key is used only for de-duplication.
+func normalizeRepoURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		// Non-standard form (e.g. scp-like git@github.com:org/repo.git); fall
+		// back to a trailing-slash-trimmed comparison of the raw value.
+		return strings.TrimRight(raw, "/")
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String()
 }

--- a/catalog/internal/catalog/skillcatalog/sources.go
+++ b/catalog/internal/catalog/skillcatalog/sources.go
@@ -233,19 +233,20 @@ func validateRepositories(repos []SkillRepository) error {
 }
 
 // normalizeRepoURL returns a comparison key for duplicate detection that treats
-// trivially-equivalent URLs as the same: the scheme and host are lowercased and a
-// trailing slash is trimmed. The path case is preserved (git paths can be
-// case-sensitive), and the original URL is kept verbatim as the canonical
-// identity — this key is used only for de-duplication.
+// trivially-equivalent URLs as the same: the scheme and host are lowercased, a
+// trailing slash is trimmed, and an optional ".git" suffix is dropped (clone URLs
+// resolve to the same repo with or without it). The path case is preserved (git
+// paths can be case-sensitive), and the original URL is kept verbatim as the
+// canonical identity — this key is used only for de-duplication.
 func normalizeRepoURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil || u.Host == "" {
 		// Non-standard form (e.g. scp-like git@github.com:org/repo.git); fall
-		// back to a trailing-slash-trimmed comparison of the raw value.
-		return strings.TrimRight(raw, "/")
+		// back to a trailing-slash- and ".git"-trimmed comparison of the raw value.
+		return strings.TrimSuffix(strings.TrimRight(raw, "/"), ".git")
 	}
 	u.Scheme = strings.ToLower(u.Scheme)
 	u.Host = strings.ToLower(u.Host)
-	u.Path = strings.TrimRight(u.Path, "/")
+	u.Path = strings.TrimSuffix(strings.TrimRight(u.Path, "/"), ".git")
 	return u.String()
 }

--- a/catalog/internal/catalog/skillcatalog/sources.go
+++ b/catalog/internal/catalog/skillcatalog/sources.go
@@ -1,0 +1,228 @@
+// Package skillcatalog implements the git-skills-plugin catalog source. This file
+// covers parsing and validating skill source configuration; repository resolution,
+// SKILL.md indexing, and the API service are added by later changes.
+//
+// Skill sources are configured as generic basecatalog.PluginSource entries under
+// the SourceConfig.SkillCatalogs (`skill_catalogs`) section. Because PluginSource
+// carries only a free-form `properties` map and configs are parsed with strict
+// unmarshalling, all skill-specific configuration lives under `properties`:
+//
+//	skill_catalogs:
+//	  - name: Community Skills
+//	    id: community-skills
+//	    type: git-skills-plugin
+//	    enabled: true
+//	    labels: [community]
+//	    properties:
+//	      trustTier: communityContributed       # optional provenance label
+//	      syncIntervalMinutes: 60               # optional
+//	      repositories:                         # inline form (UI-added sources)
+//	        - url: https://github.com/example/skills.git
+//	          refs: [main, v1.0]
+//	          scanPaths: [skills/]
+//	          authSecretName: git-creds
+//	          provider: Example Org
+//	          category: DevOps
+//	          labels: [community]
+//	          includedSkills: ["*"]
+//	          excludedSkills: ["*-draft"]
+//	          skillOverrides:
+//	            - name: deploy
+//	              category: SRE
+//
+// A shipped default instead points `properties.yamlCatalogPath` at a bundled file
+// holding the same `repositories:` list. Both forms are equivalent downstream.
+package skillcatalog
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
+	apimodels "github.com/kubeflow/hub/catalog/pkg/openapi"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// SourceTypeGitSkillsPlugin is the source `type` value for git-hosted skill catalogs.
+const SourceTypeGitSkillsPlugin = "git-skills-plugin"
+
+// Property keys understood under a skill source's `properties` map.
+const (
+	propYAMLCatalogPath = "yamlCatalogPath"
+	propRepositories    = "repositories"
+)
+
+// SkillOverride carries per-skill custom-metadata overrides for a repository entry.
+type SkillOverride struct {
+	Name     string   `json:"name"`
+	Category string   `json:"category,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
+}
+
+// SkillRepository is a single git repository listed by a skill source, together
+// with its custom metadata and include/exclude filters.
+type SkillRepository struct {
+	// URL is the git repository to resolve. Required.
+	URL string `json:"url"`
+	// CanonicalURL is the upstream identity when URL points at a mirror.
+	CanonicalURL string `json:"canonicalUrl,omitempty"`
+	// Refs are the tags, releases, branches, or commit SHAs to index. When empty
+	// the repository's default branch is used.
+	Refs []string `json:"refs,omitempty"`
+	// ScanPaths limits the SKILL.md scan to these subdirectories (default: whole repo).
+	ScanPaths []string `json:"scanPaths,omitempty"`
+	// AuthSecretName references a Secret providing credentials for private repos.
+	AuthSecretName string `json:"authSecretName,omitempty"`
+	// Provider, Category, Labels are custom metadata stamped onto the repo's skills.
+	Provider string   `json:"provider,omitempty"`
+	Category string   `json:"category,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
+	// IncludedSkills / ExcludedSkills are wildcard filters over skill names.
+	IncludedSkills []string `json:"includedSkills,omitempty"`
+	ExcludedSkills []string `json:"excludedSkills,omitempty"`
+	// SkillOverrides carry per-skill custom-metadata overrides.
+	SkillOverrides []SkillOverride `json:"skillOverrides,omitempty"`
+}
+
+// SkillSourceSpec is the validated skill-specific configuration extracted from a
+// PluginSource. Repositories are resolved to a single list regardless of whether
+// they were provided inline or via a file.
+type SkillSourceSpec struct {
+	TrustTier           string
+	SyncIntervalMinutes int
+	Repositories        []SkillRepository
+}
+
+// skillSourceProperties is the strict schema of a skill source's `properties` map.
+type skillSourceProperties struct {
+	TrustTier           string            `json:"trustTier,omitempty"`
+	SyncIntervalMinutes int               `json:"syncIntervalMinutes,omitempty"`
+	YAMLCatalogPath     string            `json:"yamlCatalogPath,omitempty"`
+	Repositories        []SkillRepository `json:"repositories,omitempty"`
+}
+
+// skillRepositoriesFile is the schema of the file referenced by yamlCatalogPath.
+type skillRepositoriesFile struct {
+	Repositories []SkillRepository `json:"repositories"`
+}
+
+// ParseSkillSource extracts and validates the skill-specific schema from a generic
+// PluginSource. Repositories come either inline (properties.repositories) or from a
+// file (properties.yamlCatalogPath); both forms yield an equivalent repository list.
+func ParseSkillSource(source basecatalog.PluginSource) (*SkillSourceSpec, error) {
+	if source.Type != SourceTypeGitSkillsPlugin {
+		return nil, fmt.Errorf("skill source %q has unexpected type %q (want %q)", source.GetId(), source.Type, SourceTypeGitSkillsPlugin)
+	}
+
+	props, err := decodeProperties(source.Properties)
+	if err != nil {
+		return nil, fmt.Errorf("skill source %q: %w", source.GetId(), err)
+	}
+
+	if err := validateTrustTier(props.TrustTier); err != nil {
+		return nil, fmt.Errorf("skill source %q: %w", source.GetId(), err)
+	}
+	if props.SyncIntervalMinutes < 0 {
+		return nil, fmt.Errorf("skill source %q: syncIntervalMinutes must not be negative", source.GetId())
+	}
+
+	repos, err := resolveRepositories(source, props)
+	if err != nil {
+		return nil, fmt.Errorf("skill source %q: %w", source.GetId(), err)
+	}
+	if err := validateRepositories(repos); err != nil {
+		return nil, fmt.Errorf("skill source %q: %w", source.GetId(), err)
+	}
+
+	return &SkillSourceSpec{
+		TrustTier:           props.TrustTier,
+		SyncIntervalMinutes: props.SyncIntervalMinutes,
+		Repositories:        repos,
+	}, nil
+}
+
+// decodeProperties strictly decodes the free-form properties map into the typed
+// skill schema, rejecting unknown keys so config typos surface as errors.
+func decodeProperties(props map[string]any) (*skillSourceProperties, error) {
+	raw, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("invalid properties: %w", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var out skillSourceProperties
+	if err := dec.Decode(&out); err != nil {
+		return nil, fmt.Errorf("invalid properties: %w", err)
+	}
+	return &out, nil
+}
+
+// resolveRepositories returns the repository list from exactly one of the inline
+// or file forms.
+func resolveRepositories(source basecatalog.PluginSource, props *skillSourceProperties) ([]SkillRepository, error) {
+	hasInline := len(props.Repositories) > 0
+	hasFile := props.YAMLCatalogPath != ""
+
+	switch {
+	case hasInline && hasFile:
+		return nil, fmt.Errorf("specify either %q (inline) or %q (file), not both", propRepositories, propYAMLCatalogPath)
+	case hasInline:
+		return props.Repositories, nil
+	case hasFile:
+		return loadRepositoriesFile(source, props.YAMLCatalogPath)
+	default:
+		return nil, fmt.Errorf("no repositories configured: set %q inline or %q", propRepositories, propYAMLCatalogPath)
+	}
+}
+
+// loadRepositoriesFile reads the repositories list from the file referenced by
+// yamlCatalogPath, resolving relative paths against the source's config file.
+func loadRepositoriesFile(source basecatalog.PluginSource, path string) ([]SkillRepository, error) {
+	resolved := path
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(filepath.Dir(source.Origin), resolved)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("reading repositories file %q: %w", resolved, err)
+	}
+	var file skillRepositoriesFile
+	if err := yaml.UnmarshalStrict(data, &file); err != nil {
+		return nil, fmt.Errorf("parsing repositories file %q: %w", resolved, err)
+	}
+	return file.Repositories, nil
+}
+
+// validateTrustTier accepts an empty tier (no label) or one of the vendor-neutral
+// SkillTrustTier enum values; anything else is rejected with a clear error.
+func validateTrustTier(tier string) error {
+	if tier == "" {
+		return nil
+	}
+	if !apimodels.SkillTrustTier(tier).IsValid() {
+		return fmt.Errorf("invalid trustTier %q: valid values are %v", tier, apimodels.AllowedSkillTrustTierEnumValues)
+	}
+	return nil
+}
+
+// validateRepositories checks the resolved repository list is non-empty, every
+// entry has a URL, and URLs are unique within the source.
+func validateRepositories(repos []SkillRepository) error {
+	if len(repos) == 0 {
+		return fmt.Errorf("at least one repository is required")
+	}
+	seen := make(map[string]bool, len(repos))
+	for i, r := range repos {
+		if r.URL == "" {
+			return fmt.Errorf("repository[%d]: url is required", i)
+		}
+		if seen[r.URL] {
+			return fmt.Errorf("duplicate repository url %q", r.URL)
+		}
+		seen[r.URL] = true
+	}
+	return nil
+}

--- a/catalog/internal/catalog/skillcatalog/sources_test.go
+++ b/catalog/internal/catalog/skillcatalog/sources_test.go
@@ -211,14 +211,39 @@ repositories:
 }
 
 func TestParseSkillSource_DuplicateRepoURL(t *testing.T) {
+	// Exact, host-case, and trailing-slash variants are all trivially equivalent
+	// and must be rejected as duplicates.
+	dupCases := map[string][2]string{
+		"exact":          {"https://github.com/example/skills.git", "https://github.com/example/skills.git"},
+		"host case":      {"https://github.com/example/skills.git", "https://GitHub.com/example/skills.git"},
+		"trailing slash": {"https://github.com/example/skills.git", "https://github.com/example/skills.git/"},
+		"scheme case":    {"https://github.com/example/skills.git", "HTTPS://github.com/example/skills.git"},
+	}
+	for name, urls := range dupCases {
+		t.Run(name, func(t *testing.T) {
+			src := skillSource(mustProps(t, `
+repositories:
+  - url: `+urls[0]+`
+  - url: `+urls[1]+`
+`))
+			_, err := ParseSkillSource(src)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "duplicate")
+		})
+	}
+}
+
+func TestParseSkillSource_DistinctPathCaseAllowed(t *testing.T) {
+	// Path case is preserved (git paths can be case-sensitive), so these are two
+	// distinct repositories, not duplicates.
 	src := skillSource(mustProps(t, `
 repositories:
-  - url: https://github.com/example/skills.git
+  - url: https://github.com/Example/skills.git
   - url: https://github.com/example/skills.git
 `))
-	_, err := ParseSkillSource(src)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate")
+	spec, err := ParseSkillSource(src)
+	require.NoError(t, err)
+	assert.Len(t, spec.Repositories, 2)
 }
 
 func TestParseSkillSource_UnknownPropertyRejected(t *testing.T) {

--- a/catalog/internal/catalog/skillcatalog/sources_test.go
+++ b/catalog/internal/catalog/skillcatalog/sources_test.go
@@ -1,0 +1,254 @@
+package skillcatalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
+)
+
+// mustProps parses a YAML snippet into a properties map the way source loading
+// produces it (YAML -> JSON-compatible map[string]any).
+func mustProps(t *testing.T, y string) map[string]any {
+	t.Helper()
+	props := map[string]any{}
+	require.NoError(t, yaml.Unmarshal([]byte(y), &props), "failed to parse test properties")
+	return props
+}
+
+func skillSource(props map[string]any) basecatalog.PluginSource {
+	return basecatalog.PluginSource{
+		Name:       "Community Skills",
+		ID:         "community-skills",
+		Type:       SourceTypeGitSkillsPlugin,
+		Properties: props,
+	}
+}
+
+func TestParseSkillSource_InlineRepositories(t *testing.T) {
+	src := skillSource(mustProps(t, `
+trustTier: communityContributed
+syncIntervalMinutes: 60
+repositories:
+  - url: https://github.com/example/skills.git
+    refs: [main, v1.0]
+    scanPaths: [skills/]
+    authSecretName: git-creds
+    provider: Example Org
+    category: DevOps
+    labels: [community]
+    includedSkills: ["*"]
+    excludedSkills: ["*-draft"]
+    skillOverrides:
+      - name: deploy
+        category: SRE
+        labels: [ops]
+`))
+
+	spec, err := ParseSkillSource(src)
+	require.NoError(t, err)
+	assert.Equal(t, "communityContributed", spec.TrustTier)
+	assert.Equal(t, 60, spec.SyncIntervalMinutes)
+	require.Len(t, spec.Repositories, 1)
+
+	r := spec.Repositories[0]
+	assert.Equal(t, "https://github.com/example/skills.git", r.URL)
+	assert.Equal(t, []string{"main", "v1.0"}, r.Refs)
+	assert.Equal(t, []string{"skills/"}, r.ScanPaths)
+	assert.Equal(t, "git-creds", r.AuthSecretName)
+	assert.Equal(t, []string{"*"}, r.IncludedSkills)
+	assert.Equal(t, []string{"*-draft"}, r.ExcludedSkills)
+	require.Len(t, r.SkillOverrides, 1)
+	assert.Equal(t, SkillOverride{Name: "deploy", Category: "SRE", Labels: []string{"ops"}}, r.SkillOverrides[0])
+}
+
+func TestParseSkillSource_FileFormEquivalentToInline(t *testing.T) {
+	repoYAML := `
+repositories:
+  - url: https://github.com/example/skills.git
+    refs: [main, v1.0]
+    provider: Example Org
+    category: DevOps
+    labels: [community]
+`
+	dir := t.TempDir()
+	repoFile := filepath.Join(dir, "example-skills.yaml")
+	require.NoError(t, os.WriteFile(repoFile, []byte(repoYAML), 0o600))
+
+	fileSrc := skillSource(mustProps(t, `
+trustTier: communityContributed
+yamlCatalogPath: example-skills.yaml
+`))
+	fileSrc.Origin = filepath.Join(dir, "catalog-sources.yaml")
+
+	inlineSrc := skillSource(mustProps(t, `
+trustTier: communityContributed
+repositories:
+  - url: https://github.com/example/skills.git
+    refs: [main, v1.0]
+    provider: Example Org
+    category: DevOps
+    labels: [community]
+`))
+
+	fileSpec, err := ParseSkillSource(fileSrc)
+	require.NoError(t, err, "file form")
+	inlineSpec, err := ParseSkillSource(inlineSrc)
+	require.NoError(t, err, "inline form")
+
+	assert.Equal(t, inlineSpec.Repositories, fileSpec.Repositories,
+		"file and inline forms should yield equivalent repositories")
+}
+
+func TestParseSkillSource_FileFormAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	repoFile := filepath.Join(dir, "abs-skills.yaml")
+	require.NoError(t, os.WriteFile(repoFile,
+		[]byte("repositories:\n  - url: https://github.com/example/skills.git\n"), 0o600))
+
+	src := skillSource(map[string]any{"yamlCatalogPath": repoFile})
+	spec, err := ParseSkillSource(src)
+	require.NoError(t, err)
+	require.Len(t, spec.Repositories, 1)
+}
+
+// TestParseSkillSource_ThroughReadSourceConfig exercises the full chain: a
+// skill_catalogs section parsed by basecatalog.ReadSourceConfig (strict) and then
+// handed to ParseSkillSource, for both the inline and file forms.
+func TestParseSkillSource_ThroughReadSourceConfig(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "redhat-skills.yaml"),
+		[]byte("repositories:\n  - url: https://github.com/redhat/skills.git\n    refs: [main]\n"), 0o600))
+
+	configPath := filepath.Join(dir, "catalog-sources.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+skill_catalogs:
+  - name: Community Skills
+    id: community-skills
+    type: git-skills-plugin
+    enabled: true
+    labels: [community]
+    properties:
+      trustTier: communityContributed
+      syncIntervalMinutes: 30
+      repositories:
+        - url: https://github.com/example/skills.git
+          refs: [main, v1.0]
+  - name: Red Hat Skills
+    id: redhat-skills
+    type: git-skills-plugin
+    enabled: true
+    properties:
+      trustTier: platformProvided
+      yamlCatalogPath: redhat-skills.yaml
+`), 0o600))
+
+	config, err := basecatalog.ReadSourceConfig(configPath)
+	require.NoError(t, err)
+	require.Len(t, config.SkillCatalogs, 2)
+
+	for _, src := range config.SkillCatalogs {
+		src.Origin = configPath // set by the loader in real use
+		spec, err := ParseSkillSource(src)
+		require.NoErrorf(t, err, "ParseSkillSource(%s)", src.GetId())
+		assert.Lenf(t, spec.Repositories, 1, "source %s", src.GetId())
+	}
+}
+
+func TestParseSkillSource_InvalidTrustTier(t *testing.T) {
+	src := skillSource(mustProps(t, `
+trustTier: superDuperTrusted
+repositories:
+  - url: https://github.com/example/skills.git
+`))
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trustTier")
+	assert.Contains(t, err.Error(), "superDuperTrusted")
+}
+
+func TestParseSkillSource_EmptyTrustTierAllowed(t *testing.T) {
+	src := skillSource(mustProps(t, `
+repositories:
+  - url: https://github.com/example/skills.git
+`))
+	spec, err := ParseSkillSource(src)
+	require.NoError(t, err)
+	assert.Empty(t, spec.TrustTier)
+}
+
+func TestParseSkillSource_BothFormsRejected(t *testing.T) {
+	src := skillSource(mustProps(t, `
+yamlCatalogPath: repos.yaml
+repositories:
+  - url: https://github.com/example/skills.git
+`))
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not both")
+}
+
+func TestParseSkillSource_NeitherFormRejected(t *testing.T) {
+	src := skillSource(mustProps(t, `trustTier: communityContributed`))
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+}
+
+func TestParseSkillSource_RepoMissingURL(t *testing.T) {
+	src := skillSource(mustProps(t, `
+repositories:
+  - provider: Example Org
+    refs: [main]
+`))
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "url is required")
+}
+
+func TestParseSkillSource_DuplicateRepoURL(t *testing.T) {
+	src := skillSource(mustProps(t, `
+repositories:
+  - url: https://github.com/example/skills.git
+  - url: https://github.com/example/skills.git
+`))
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+func TestParseSkillSource_UnknownPropertyRejected(t *testing.T) {
+	src := skillSource(mustProps(t, `
+trustTier: communityContributed
+bogusKey: nope
+repositories:
+  - url: https://github.com/example/skills.git
+`))
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+}
+
+func TestParseSkillSource_WrongSourceType(t *testing.T) {
+	src := skillSource(mustProps(t, `
+repositories:
+  - url: https://github.com/example/skills.git
+`))
+	src.Type = "hf"
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+}
+
+func TestParseSkillSource_NegativeSyncInterval(t *testing.T) {
+	src := skillSource(mustProps(t, `
+syncIntervalMinutes: -5
+repositories:
+  - url: https://github.com/example/skills.git
+`))
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "syncIntervalMinutes")
+}

--- a/catalog/internal/catalog/skillcatalog/sources_test.go
+++ b/catalog/internal/catalog/skillcatalog/sources_test.go
@@ -214,10 +214,12 @@ func TestParseSkillSource_DuplicateRepoURL(t *testing.T) {
 	// Exact, host-case, and trailing-slash variants are all trivially equivalent
 	// and must be rejected as duplicates.
 	dupCases := map[string][2]string{
-		"exact":          {"https://github.com/example/skills.git", "https://github.com/example/skills.git"},
-		"host case":      {"https://github.com/example/skills.git", "https://GitHub.com/example/skills.git"},
-		"trailing slash": {"https://github.com/example/skills.git", "https://github.com/example/skills.git/"},
-		"scheme case":    {"https://github.com/example/skills.git", "HTTPS://github.com/example/skills.git"},
+		"exact":              {"https://github.com/example/skills.git", "https://github.com/example/skills.git"},
+		"host case":          {"https://github.com/example/skills.git", "https://GitHub.com/example/skills.git"},
+		"trailing slash":     {"https://github.com/example/skills.git", "https://github.com/example/skills.git/"},
+		"scheme case":        {"https://github.com/example/skills.git", "HTTPS://github.com/example/skills.git"},
+		"git suffix":         {"https://github.com/example/skills.git", "https://github.com/example/skills"},
+		"git suffix + slash": {"https://github.com/example/skills.git", "https://github.com/example/skills/"},
 	}
 	for name, urls := range dupCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION

Assisted-by: Claude Code

## Description
Add SkillCatalogs to SourceConfig (skill_catalogs, type: git-skills-plugin) and the skillcatalog source schema/parser. Repositories load from either an inline properties.repositories list or a properties.yamlCatalogPath file, equivalent downstream;

## How Has This Been Tested?
Unit tests

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] The commits have meaningful messages
- [x ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ x] The developer has manually tested the changes and verified that the changes work.
- [x ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).