### PR TITLE
feat(api): create v1 OpenAPI specs for Model Catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ For additional context see the [Model Registry documentation](https://www.kubefl
 ## Repository Map
 
 ```
-api/openapi/                     # OpenAPI specs (model-registry.yaml, catalog.yaml)
+api/openapi/                     # OpenAPI specs (model-registry.yaml, model-registry-v1.yaml, catalog.yaml, catalog-v1.yaml)
 ├── src/                           # Source YAML files merged into final specs
 catalog/                         # Catalog service — federated model discovery
 ├── clients/python/                # Python client for catalog API (Poetry)
@@ -312,7 +312,9 @@ go mod tidy                       # Ensure module files are clean
 The following directories contain auto-generated code. Modify the sources and regenerate instead:
 
 - `api/openapi/model-registry.yaml` — **merged output**, do NOT edit. Edit source files in `api/openapi/src/model-registry.yaml` and `api/openapi/src/lib/*.yaml`, then run `make api/openapi/model-registry.yaml`
+- `api/openapi/model-registry-v1.yaml` — **merged output**, do NOT edit. Edit source files in `api/openapi/src/model-registry-v1.yaml` and `api/openapi/src/lib/*.yaml`, then run `make api/openapi/model-registry-v1.yaml`
 - `api/openapi/catalog.yaml` — **merged output**, do NOT edit. Edit source files in `api/openapi/src/catalog.yaml` and `api/openapi/src/lib/*.yaml`, then run `make api/openapi/catalog.yaml`
+- `api/openapi/catalog-v1.yaml` — **merged output**, do NOT edit. Edit source files in `api/openapi/src/catalog-v1.yaml` and `api/openapi/src/lib/*.yaml`, then run `make api/openapi/catalog-v1.yaml`
 - `pkg/openapi/` — generated from the merged `api/openapi/model-registry.yaml` via `make gen/openapi`
 - `catalog/pkg/openapi/` — generated from the merged `api/openapi/catalog.yaml` via `make -C catalog gen/openapi`
 - `internal/server/openapi/` — generated from OpenAPI specs via `make gen/openapi-server`

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,11 @@ api/openapi/model-registry.yaml: api/openapi/src/model-registry.yaml api/openapi
 api/openapi/model-registry-v1.yaml: api/openapi/src/model-registry-v1.yaml api/openapi/src/lib/*.yaml bin/yq
 	scripts/merge_openapi.sh model-registry-v1.yaml
 
-api/openapi/catalog.yaml: api/openapi/src/catalog.yaml api/openapi/src/lib/*.yaml $(wildcard api/openapi/src/plugins/*.yaml) bin/yq
+api/openapi/catalog.yaml: api/openapi/src/catalog.yaml api/openapi/src/lib/*.yaml $(filter-out %-v1.yaml,$(wildcard api/openapi/src/plugins/*.yaml)) bin/yq
 	scripts/merge_catalog_specs.sh catalog.yaml
+
+api/openapi/catalog-v1.yaml: api/openapi/src/catalog-v1.yaml api/openapi/src/lib/*.yaml $(wildcard api/openapi/src/plugins/*-v1.yaml) bin/yq
+	scripts/merge_catalog_specs.sh catalog-v1.yaml
 
 # validate the openapi schema
 .PHONY: openapi/validate
@@ -78,9 +81,11 @@ openapi/validate: bin/openapi-generator-cli bin/yq
 	@scripts/merge_openapi.sh --check model-registry.yaml || (echo "api/openapi/model-registry.yaml is incorrectly formatted. Run 'make api/openapi/model-registry.yaml' to fix it."; exit 1)
 	@scripts/merge_openapi.sh --check model-registry-v1.yaml || (echo "api/openapi/model-registry-v1.yaml is incorrectly formatted. Run 'make api/openapi/model-registry-v1.yaml' to fix it."; exit 1)
 	@scripts/merge_catalog_specs.sh --check catalog.yaml || (echo "api/openapi/catalog.yaml is incorrectly formatted. Run 'make api/openapi/catalog.yaml' to fix it."; exit 1)
+	@scripts/merge_catalog_specs.sh --check catalog-v1.yaml || (echo "api/openapi/catalog-v1.yaml is incorrectly formatted. Run 'make api/openapi/catalog-v1.yaml' to fix it."; exit 1)
 	$(OPENAPI_GENERATOR) validate -i api/openapi/model-registry.yaml
 	$(OPENAPI_GENERATOR) validate -i api/openapi/model-registry-v1.yaml
 	$(OPENAPI_GENERATOR) validate -i api/openapi/catalog.yaml
+	$(OPENAPI_GENERATOR) validate -i api/openapi/catalog-v1.yaml
 
 # generate the openapi server implementation
 .PHONY: gen/openapi-server

--- a/api/openapi/catalog-v1.yaml
+++ b/api/openapi/catalog-v1.yaml
@@ -1,0 +1,3136 @@
+openapi: 3.0.3
+info:
+  title: Catalog REST API
+  description: REST API for Kubeflow Hub Catalog
+  version: v1
+  license:
+    name: Apache 2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0"
+servers:
+  - url: "https://localhost:8080"
+  - url: "http://localhost:8080"
+paths:
+  /api/agent_catalog/v1/agents:
+    description: >-
+      The REST endpoint/path used to list zero or more `Agent` entities.
+    get:
+      summary: List agents.
+      tags:
+        - AgentCatalogService
+      parameters:
+        - name: name
+          description: Filter by name using SQL LIKE pattern matching.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: q
+          description: Free-form keyword search used to filter the response.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: source
+          description: Filter by source ID.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - name: sourceLabel
+          description: |-
+            Filter by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then entities from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/AgentListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findAgents
+  /api/agent_catalog/v1/agents/filter_options:
+    description: Lists options for `filterQuery` when listing agents.
+    get:
+      summary: Lists fields and values that can be used in `filterQuery` on the list agents endpoint.
+      tags:
+        - AgentCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/FilterOptionsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findAgentsFilterOptions
+  /api/agent_catalog/v1/agents/{id}:
+    description: >-
+      The REST endpoint/path used to get a single `Agent` entity.
+    get:
+      summary: Get an agent by ID.
+      tags:
+        - AgentCatalogService
+      parameters:
+        - name: id
+          description: The unique identifier of the entity.
+          schema:
+            type: string
+          in: path
+          required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/AgentResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getAgent
+  /api/agent_catalog/v1/agents/{id}/artifacts:
+    description: >-
+      The REST endpoint/path used to list artifacts for a specific agent.
+    get:
+      summary: List artifacts for an agent.
+      tags:
+        - AgentCatalogService
+      parameters:
+        - $ref: "#/components/parameters/agentArtifactType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/AgentArtifactListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getAgentArtifacts
+    parameters:
+      - name: id
+        description: The unique identifier of the agent.
+        schema:
+          type: string
+        in: path
+        required: true
+  /api/mcp_catalog/v1/mcp_servers:
+    description: >-
+      The REST endpoint/path used to list zero or more `MCPServer` entities.
+    get:
+      summary: List MCP servers.
+      tags:
+        - MCPCatalogService
+      parameters:
+        - name: name
+          description: Filter MCP servers by server name using SQL LIKE pattern matching.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: q
+          description: Free-form keyword search across name, description, and provider.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: sourceLabel
+          description: |-
+            Filter MCP servers by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then MCP servers from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - $ref: "#/components/parameters/mcpServerFilterQuery"
+        - $ref: "#/components/parameters/namedQuery"
+        - $ref: "#/components/parameters/includeTools"
+        - $ref: "#/components/parameters/toolLimit"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/MCPServerListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findMCPServers
+  /api/mcp_catalog/v1/mcp_servers/filter_options:
+    description: Lists options for `filterQuery` when listing MCP servers.
+    get:
+      summary: Lists fields, values, and named queries that can be used in `filterQuery` on the list MCP servers endpoint.
+      tags:
+        - MCPCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/FilterOptionsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findMCPServersFilterOptions
+  /api/mcp_catalog/v1/mcp_servers/{server_id}:
+    description: >-
+      The REST endpoint/path used to get an `MCPServer`.
+    get:
+      summary: Get an `MCPServer`.
+      tags:
+        - MCPCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/MCPServerResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getMCPServer
+    parameters:
+      - name: server_id
+        description: A unique identifier for an `MCPServer`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - $ref: "#/components/parameters/includeTools"
+      - $ref: "#/components/parameters/toolLimit"
+  /api/mcp_catalog/v1/mcp_servers/{server_id}/tools:
+    description: >-
+      The REST endpoint/path used to list zero or more `MCPTool` entities for an `MCPServer`.
+    get:
+      summary: List tools exposed by an `MCPServer`.
+      tags:
+        - MCPCatalogService
+      parameters:
+        - $ref: "#/components/parameters/mcpToolFilterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/MCPToolsListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findMCPServerTools
+    parameters:
+      - name: server_id
+        description: A unique identifier for an `MCPServer`.
+        schema:
+          type: string
+        in: path
+        required: true
+  /api/mcp_catalog/v1/mcp_servers/{server_id}/tools/{tool_name}:
+    description: >-
+      The REST endpoint/path used to get a specific `MCPTool` from an `MCPServer`.
+    get:
+      summary: Get an `MCPTool` from an `MCPServer`.
+      tags:
+        - MCPCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/MCPToolWithServerResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getMCPServerTool
+    parameters:
+      - name: server_id
+        description: A unique identifier for an `MCPServer`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: tool_name
+        description: A unique identifier for an `MCPTool` within the MCP server.
+        schema:
+          type: string
+        in: path
+        required: true
+  /api/model_catalog/v1/labels:
+    summary: Path used to get the list of catalog labels.
+    description: >-
+      The REST endpoint/path used to list zero or more `CatalogLabel` entities.
+    get:
+      summary: List All CatalogLabels
+      tags:
+        - ModelCatalogService
+      parameters:
+        - $ref: "#/components/parameters/assetType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/labelOrderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogLabelListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findLabels
+      description: Gets a list of all `CatalogLabel` entities.
+  /api/model_catalog/v1/models:
+    description: >-
+      The REST endpoint/path used to list zero or more `CatalogModel` entities from all `CatalogSources`.
+    get:
+      summary: Search catalog models across sources.
+      tags:
+        - ModelCatalogService
+      parameters:
+        - name: recommendations
+          in: query
+          deprecated: true
+          description: >-
+            Deprecated: use `orderBy=RECOMMENDED` instead. Sort models by lowest recommended latency using Pareto filtering.
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - name: targetRPS
+          in: query
+          description: Target requests per second for latency calculations
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: latencyProperty
+          in: query
+          description: Property name for latency metric
+          required: false
+          schema:
+            type: string
+            default: "ttft_p90"
+        - name: rpsProperty
+          in: query
+          description: Property name for RPS metric
+          required: false
+          schema:
+            type: string
+            default: "requests_per_second"
+        - name: hardwareCountProperty
+          in: query
+          description: Property name for hardware count
+          required: false
+          schema:
+            type: string
+            default: "hardware_count"
+        - name: hardwareTypeProperty
+          in: query
+          description: Property name for hardware type grouping
+          required: false
+          schema:
+            type: string
+            default: "hardware_type"
+        - name: source
+          description: |-
+            Filter models by source. Multiple values can be separated by commas
+            to filter by multiple sources (OR logic). For example:
+            ?source=huggingface,local will return models from either
+            huggingface OR local sources.
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+          in: query
+          required: false
+        - name: q
+          description: Free-form keyword search used to filter the response.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: sourceLabel
+          description: |-
+            Filter models by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then models from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - name: orderBy
+          style: form
+          explode: true
+          examples:
+            orderBy:
+              value: ID
+          description: |-
+            Specifies the order by criteria for listing entities.
+
+            Supported values are:
+            - CREATE_TIME
+            - LAST_UPDATE_TIME
+            - ID
+            - NAME
+            - ACCURACY
+            - RECOMMENDED
+
+            Defaults to `NAME`.
+
+            The `ACCURACY` sort will sort by the `overall_average` property in any linked metrics artifact.
+
+            The `RECOMMENDED` sort applies Pareto filtering and ranks models by recommended latency.
+            The Pareto-related parameters (`targetRPS`, `latencyProperty`, `rpsProperty`,
+            `hardwareCountProperty`, `hardwareTypeProperty`) are applied the same way as with the
+            deprecated `recommendations` parameter. With the default `sortOrder=ASC`, the most
+            recommended models (lowest latency) appear first. Use `sortOrder=DESC` to show the least
+            recommended configurations first.
+
+            In addition, models can be sorted by properties. For example:
+            - `provider.string_value` sorts by provider name
+            - `artifacts.ifeval.double_value` sorts by the min/max value a property called ifeval across all associated artifacts
+          schema:
+            $ref: "#/components/schemas/OrderByField"
+          in: query
+          required: false
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogModelListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findModels
+  /api/model_catalog/v1/models/filter_options:
+    description: Lists options for `filterQuery` when listing models.
+    get:
+      summary: Lists fields and available options that can be used in `filterQuery` on the list models endpoint.
+      tags:
+        - ModelCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/FilterOptionsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findModelsFilterOptions
+  /api/model_catalog/v1/sources:
+    summary: Path used to get the list of catalog sources.
+    description: >-
+      The REST endpoint/path used to list zero or more `CatalogSource` entities.
+    get:
+      summary: List All CatalogSources
+      tags:
+        - ModelCatalogService
+      parameters:
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/assetType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogSourceListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findSources
+      description: Gets a list of all `CatalogSource` entities.
+  /api/model_catalog/v1/sources/preview:
+    description: >-
+      The REST endpoint/path used to preview a catalog source configuration. This endpoint accepts a catalog source definition and returns a list of assets (models or MCP servers) with their inclusion/exclusion status based on the configured filters.
+    post:
+      summary: Preview catalog source configuration
+      description: |-
+        Accepts a catalog source configuration and returns a list of assets showing
+        which would be included or excluded based on the configured filters. This allows
+        users to test and validate their source configurations before applying them.
+
+        The response type varies based on the `assetType` field in the uploaded config:
+        - `models` (default): Returns a `CatalogSourcePreviewResponse` with `ModelPreviewResult` items
+          and model-specific summary fields (`totalModels`, `includedModels`, `excludedModels`).
+        - `mcp_servers`: Returns an `AssetSourcePreviewResponse` with `AssetPreviewResult` items
+          and generic summary fields (`totalAssets`, `includedAssets`, `excludedAssets`).
+
+        **Two modes of operation:**
+
+        1. **Stateless mode (recommended for new sources):** Upload both `config` and
+           `catalogData` files via multipart form. The assets are read directly from
+           the uploaded `catalogData`, enabling preview of new sources before saving
+           anything to the server. This is ideal for testing configurations.
+
+        2. **Path mode (for existing sources):** Upload only `config` with a `yamlCatalogPath`
+           property. The assets are read from the specified file path on the server.
+           Use this for previewing changes to existing saved sources.
+      tags:
+        - ModelCatalogService
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - config
+              properties:
+                config:
+                  type: string
+                  format: binary
+                  description: |-
+                    YAML file containing the catalog source configuration.
+                    The file should contain a source definition with `type` and `properties`
+                    fields, and an optional `assetType` field to specify the kind of assets
+                    being previewed (defaults to `models`).
+
+                    **For model sources** (`assetType: models` or omitted):
+                    Use `includedModels` and `excludedModels` filter patterns.
+
+                    **For MCP server sources** (`assetType: mcp_servers`):
+                    Use `includedServers` and `excludedServers` filter patterns.
+
+                    Filter patterns support the `*` wildcard only and are case-insensitive.
+                    Patterns match the entire asset name (e.g., `ibm-granite/*` matches all
+                    models starting with "ibm-granite/", `kubernetes*` matches all servers
+                    starting with "kubernetes").
+                catalogData:
+                  type: string
+                  format: binary
+                  description: |-
+                    Optional YAML file containing the catalog data.
+
+                    For model sources, the file should contain a `models:` key with a list
+                    of model entries. For MCP server sources, the file should contain an
+                    `mcp_servers:` key with a list of server entries.
+
+                    This field enables stateless preview of new sources before saving them.
+                    When provided, the catalog data is read directly from this file instead of
+                    from the `yamlCatalogPath` property in the config.
+
+                    **Two modes of operation:**
+                    1. **Stateless mode (recommended for new sources):** Upload both `config` and
+                       `catalogData` files. The assets are read from `catalogData`, allowing preview
+                       without saving anything to the server.
+                    2. **Path mode (for existing sources):** Upload only `config` with a `yamlCatalogPath`
+                       property pointing to a catalog file on the server filesystem.
+
+                    If both `catalogData` and `yamlCatalogPath` are provided, `catalogData` takes precedence.
+            examples:
+              statelessPreview:
+                summary: Stateless preview with uploaded catalog data
+                description: |-
+                  Upload both config and catalogData files to preview a new source
+                  before saving. This is the recommended approach for testing new configurations.
+                value: |
+                  # config file content:
+                  type: yaml
+                  includedModels:
+                    - "ibm-granite/*"
+                    - "meta-llama/*"
+                  excludedModels:
+                    - "*-draft"
+                    - "*-experimental"
+
+                  # catalogData file content (separate file):
+                  models:
+                    - name: ibm-granite/granite-3.0-8b-instruct
+                      description: Granite 8B Instruct model
+                    - name: ibm-granite/granite-3.0-2b-draft
+                      description: Draft version
+                    - name: meta-llama/Llama-2-7b-hf
+                      description: Llama 2 7B
+              pathBasedPreview:
+                summary: Path-based preview using server-side catalog
+                description: |-
+                  Upload only config file with yamlCatalogPath pointing to an
+                  existing catalog file on the server. Use this for previewing
+                  changes to existing saved sources.
+                value: |
+                  type: yaml
+                  includedModels:
+                    - "ibm-granite/*"
+                    - "meta-llama/*"
+                    - "mistralai/*"
+                  excludedModels:
+                    - "*-draft"
+                    - "*-experimental"
+                  properties:
+                    yamlCatalogPath: "models-catalog.yaml"
+              huggingfaceSource:
+                summary: HuggingFace catalog source
+                description: |-
+                  Upload configuration for HuggingFace source with API credentials.
+                  The API key is passed per-request and not persisted anywhere.
+                value: |
+                  type: hf
+                  includedModels:
+                    - "microsoft/*"
+                    - "google/*"
+                  excludedModels:
+                    - "*-gguf"
+                  properties:
+                    apiKey: "your-huggingface-api-key-here" # notsecret
+                    modelLimit: 100
+              mcpStatelessPreview:
+                summary: Stateless MCP server preview
+                description: |-
+                  Preview an MCP server source configuration with uploaded catalog data.
+                  Set assetType to mcp_servers and use includedServers/excludedServers filters.
+                  Upload this as the `config` field. The `catalogData` field should contain
+                  a separate YAML file with `mcp_servers:` entries.
+                value: |
+                  assetType: mcp_servers
+                  type: yaml
+                  includedServers:
+                    - "kubernetes*"
+                    - "prometheus*"
+                  excludedServers:
+                    - "*-internal"
+      parameters:
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/nextPageToken"
+        - name: filterStatus
+          description: |-
+            Filter the response to show specific asset statuses:
+            - `all` (default): Show all assets regardless of inclusion status
+            - `included`: Show only assets that pass the configured filters
+            - `excluded`: Show only assets that are filtered out
+          schema:
+            type: string
+            enum:
+              - all
+              - included
+              - excluded
+            default: all
+          in: query
+          required: false
+      responses:
+        "200":
+          description: Preview results for the catalog source configuration.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PreviewCatalogSourceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          description: Unprocessable Entity - Invalid source configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: previewCatalogSource
+  /api/model_catalog/v1/sources/{source_id}/models/{model_name+}:
+    description: >-
+      The REST endpoint/path used to get a `CatalogModel`.
+    get:
+      summary: Get a `CatalogModel`.
+      tags:
+        - ModelCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogModelResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getModel
+    parameters:
+      - name: source_id
+        description: A unique identifier for a `CatalogSource`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: model_name+
+        description: A unique identifier for the model.
+        schema:
+          type: string
+        in: path
+        required: true
+  /api/model_catalog/v1/sources/{source_id}/models/{model_name+}/artifacts:
+    description: >-
+      The REST endpoint/path used to list `CatalogArtifacts`.
+    get:
+      summary: List CatalogArtifacts.
+      tags:
+        - ModelCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getAllModelArtifacts
+    parameters:
+      - name: source_id
+        description: A unique identifier for a `CatalogSource`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: model_name+
+        description: A unique identifier for the model.
+        schema:
+          type: string
+        in: path
+        required: true
+      - $ref: "#/components/parameters/artifactType"
+      - $ref: "#/components/parameters/artifact_type"
+      - $ref: "#/components/parameters/artifactFilterQuery"
+      - $ref: "#/components/parameters/pageSize"
+      - $ref: "#/components/parameters/artifactOrderBy"
+      - $ref: "#/components/parameters/sortOrder"
+      - $ref: "#/components/parameters/nextPageToken"
+  /api/model_catalog/v1/sources/{source_id}/models/{model_name+}/artifacts/performance:
+    description: >-
+      Lists performance metrics artifacts (that is, artifacts of type `CatalogMetricsArtifact` where `metricsType` is `performance-metrics`).
+    get:
+      summary: List CatalogArtifacts.
+      tags:
+        - ModelCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogArtifactListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getAllModelPerformanceArtifacts
+    parameters:
+      - name: source_id
+        description: A unique identifier for a `CatalogSource`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: model_name+
+        description: A unique identifier for the model.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: targetRPS
+        description: |-
+          Target requests per second. If specified, values for `replicas` and
+          `total_requests_per_second` will be calculated and returned as custom
+          properties.
+        schema:
+          type: integer
+        in: query
+      - name: recommendations
+        description: Filter records that are less optimal based on approximate cost to run and latency.
+        schema:
+          type: boolean
+          default: false
+        in: query
+      - name: rpsProperty
+        description: Custom property name for requests per second metric.
+        schema:
+          type: string
+          default: "requests_per_second"
+        in: query
+      - name: latencyProperty
+        description: Custom property name for latency metric (e.g., ttft_p90, p90_latency).
+        schema:
+          type: string
+          default: "ttft_p90"
+        in: query
+      - name: hardwareCountProperty
+        description: Custom property name for hardware count metric.
+        schema:
+          type: string
+          default: "hardware_count"
+        in: query
+      - name: hardwareTypeProperty
+        description: Custom property name for hardware type grouping.
+        schema:
+          type: string
+          default: "hardware_type"
+        in: query
+      - $ref: "#/components/parameters/artifactFilterQuery"
+      - $ref: "#/components/parameters/pageSize"
+      - $ref: "#/components/parameters/artifactOrderBy"
+      - $ref: "#/components/parameters/sortOrder"
+      - $ref: "#/components/parameters/nextPageToken"
+  /api/skill_catalog/v1/skills:
+    description: >-
+      The REST endpoint/path used to list zero or more `Skill` entities.
+    get:
+      summary: List skills.
+      tags:
+        - SkillCatalogService
+      parameters:
+        - name: name
+          description: Filter by name using SQL LIKE pattern matching.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: q
+          description: Free-form keyword search used to filter the response.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: source
+          description: Filter by source ID.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - name: sourceLabel
+          description: |-
+            Filter by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then entities from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/SkillListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findSkills
+  /api/skill_catalog/v1/skills/filter_options:
+    description: Lists options for `filterQuery` when listing skills.
+    get:
+      summary: Lists fields and values that can be used in `filterQuery` on the list skills endpoint.
+      tags:
+        - SkillCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/FilterOptionsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findSkillsFilterOptions
+  /api/skill_catalog/v1/skills/{id}:
+    description: >-
+      The REST endpoint/path used to get a single `Skill` entity.
+    get:
+      summary: Get a skill by ID.
+      tags:
+        - SkillCatalogService
+      parameters:
+        - name: id
+          description: The unique identifier of the entity.
+          schema:
+            type: string
+          in: path
+          required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/SkillResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getSkill
+components:
+  schemas:
+    Agent:
+      description: An agent in the agent catalog.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              description: Agent identifier. Must be unique within a source.
+            sourceId:
+              type: string
+              description: Catalog source that provides this entity.
+            displayName:
+              type: string
+              description: Human-readable display name.
+            description:
+              type: string
+              description: Short description of the agent.
+            readme:
+              type: string
+              description: Full Markdown documentation.
+            framework:
+              type: string
+              description: Agent framework (e.g., langgraph, crewai, autogen).
+            labels:
+              type: array
+              items:
+                type: string
+              description: Labels for categorization and filtering.
+            logo:
+              type: string
+              description: URL or path to the agent logo image.
+            repositoryUrl:
+              type: string
+              format: uri
+              description: URL to the agent source code repository.
+            env:
+              type: array
+              items:
+                $ref: "#/components/schemas/AgentEnvVar"
+              description: Environment variables required for deployment.
+            artifacts:
+              type: array
+              items:
+                $ref: "#/components/schemas/AgentImageArtifact"
+              description: OCI image artifacts for agent deployment.
+    AgentArtifact:
+      description: A single artifact in the agent catalog API.
+      oneOf:
+        - $ref: "#/components/schemas/AgentTemplateArtifact"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          template-artifact: "#/components/schemas/AgentTemplateArtifact"
+    AgentArtifactList:
+      description: A list of agent artifact entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `AgentArtifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/AgentArtifact"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    AgentArtifactTypeQueryParam:
+      description: Supported artifact types for querying agent artifacts.
+      enum:
+        - template-artifact
+      type: string
+    AgentEnvVar:
+      description: An environment variable required by an agent.
+      type: object
+      required:
+        - name
+        - required
+      properties:
+        name:
+          type: string
+          description: Environment variable name.
+        required:
+          type: boolean
+          description: Whether this variable is required for deployment.
+    AgentImageArtifact:
+      description: OCI image artifact for agent deployment.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - artifactType
+            - uri
+          properties:
+            artifactType:
+              type: string
+              default: image-artifact
+            uri:
+              type: string
+              format: uri
+              description: URI of the artifact (e.g., OCI image reference).
+    AgentList:
+      description: A list of agent entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `Agent` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/Agent"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    AgentTemplateArtifact:
+      description: >-
+        Agent deployment template artifact. Contains the full agent.yaml specification as a JSON-encoded string.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - artifactType
+            - content
+          properties:
+            artifactType:
+              type: string
+              default: template-artifact
+            content:
+              type: string
+              description: >-
+                The agent.yaml specification as a JSON-encoded string. Describes the agent's deployment configuration including name, framework, environment variables, and other metadata.
+    ArtifactTypeQueryParam:
+      description: Supported artifact types for querying.
+      enum:
+        - model-artifact
+        - metrics-artifact
+      type: string
+    AssetPreviewResult:
+      description: |-
+        An asset (e.g., MCP server) with its inclusion/exclusion status based on the
+        configured catalog source filters.
+      type: object
+      required:
+        - name
+        - included
+      properties:
+        name:
+          type: string
+          description: Name of the asset
+          example: prometheus-mcp
+        included:
+          type: boolean
+          description: Whether this asset would be included based on the source configuration
+    AssetSourcePreviewResponse:
+      description: Response containing assets and their inclusion/exclusion status.
+      allOf:
+        - type: object
+          properties:
+            assetType:
+              $ref: "#/components/schemas/CatalogAssetType"
+            items:
+              description: Array of asset preview results.
+              type: array
+              items:
+                $ref: "#/components/schemas/AssetPreviewResult"
+            summary:
+              description: Summary of the preview results
+              type: object
+              properties:
+                totalAssets:
+                  type: integer
+                  description: Total number of assets evaluated
+                  example: 25
+                includedAssets:
+                  type: integer
+                  description: Number of assets that would be included
+                  example: 18
+                excludedAssets:
+                  type: integer
+                  description: Number of assets that would be excluded
+                  example: 7
+              required:
+                - totalAssets
+                - includedAssets
+                - excludedAssets
+          required:
+            - assetType
+            - items
+            - summary
+        - $ref: "#/components/schemas/BaseResourceList"
+    BaseModel:
+      type: object
+      properties:
+        description:
+          type: string
+          description: Human-readable description of the model.
+        readme:
+          type: string
+          description: Model documentation in Markdown.
+        maturity:
+          type: string
+          description: Maturity level of the model.
+          example: Generally Available
+        language:
+          type: array
+          description: List of supported languages (https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes).
+          items:
+            type: string
+          example:
+            - en
+            - es
+            - cz
+        tasks:
+          type: array
+          description: List of tasks the model is designed for.
+          items:
+            type: string
+          example:
+            - text-generation
+        provider:
+          type: string
+          description: Name of the organization or entity that provides the model.
+          example: IBM
+        logo:
+          type: string
+          format: uri
+          description: |-
+            URL to the model's logo. A [data
+            URL](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data)
+            is recommended.
+        license:
+          type: string
+          description: Short name of the model's license.
+          example: apache-2.0
+        licenseLink:
+          type: string
+          format: uri
+          description: URL to the license text.
+        libraryName:
+          type: string
+          example: transformers
+        customProperties:
+          description: User provided custom properties which are not defined by its type.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MetadataValue"
+    BaseResource:
+      allOf:
+        - type: object
+          properties:
+            customProperties:
+              description: User provided custom properties which are not defined by its type.
+              type: object
+              additionalProperties:
+                $ref: "#/components/schemas/MetadataValue"
+            description:
+              description: |-
+                An optional description about the resource.
+              type: string
+            externalId:
+              description: |-
+                The external id that come from the clients’ system. This field is optional.
+                If set, it must be unique among all resources within a database instance.
+              type: string
+            name:
+              description: |-
+                The client provided name of the artifact. This field is optional. If set,
+                it must be unique among all the artifacts of the same artifact type within
+                a database instance and cannot be changed once set.
+              type: string
+              minLength: 1
+            id:
+              format: int64
+              description: The unique server generated id of the resource.
+              type: string
+        - $ref: "#/components/schemas/BaseResourceDates"
+    BaseResourceDates:
+      description: Common timestamp fields for resources
+      type: object
+      properties:
+        createTimeSinceEpoch:
+          format: int64
+          description: Output only. Create time of the resource in millisecond since epoch.
+          type: string
+          readOnly: true
+        lastUpdateTimeSinceEpoch:
+          format: int64
+          description: Output only. Last update time of the resource since epoch in millisecond since epoch.
+          type: string
+          readOnly: true
+    BaseResourceList:
+      required:
+        - nextPageToken
+        - pageSize
+        - size
+      type: object
+      properties:
+        nextPageToken:
+          description: Token to use to retrieve next page of results.
+          type: string
+        pageSize:
+          format: int32
+          description: Maximum number of resources to return in the result.
+          type: integer
+        size:
+          format: int32
+          description: Number of items in result list.
+          type: integer
+    CatalogArtifact:
+      description: A single artifact in the catalog API.
+      oneOf:
+        - $ref: "#/components/schemas/CatalogModelArtifact"
+        - $ref: "#/components/schemas/CatalogMetricsArtifact"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          model-artifact: "#/components/schemas/CatalogModelArtifact"
+          metrics-artifact: "#/components/schemas/CatalogMetricsArtifact"
+    CatalogArtifactList:
+      description: List of CatalogModel entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `CatalogArtifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/CatalogArtifact"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    CatalogAssetType:
+      type: string
+      enum:
+        - models
+        - mcp_servers
+        - agents
+        - skills
+      default: models
+    CatalogLabel:
+      description: A catalog label. Labels are used to categorize catalog sources. Represented as a flexible map of string key-value pairs with a required 'name' field.
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          nullable: true
+          description: The unique name identifier for the label.
+        displayName:
+          type: string
+          description: An optional human-readable name to show in place of `name`.
+      additionalProperties:
+        type: string
+      example:
+        name: huggingface
+        displayName: HuggingFace Hub
+        description: HuggingFace models with full support and legal indemnification.
+    CatalogLabelList:
+      description: List of CatalogLabel entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `CatalogLabel` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/CatalogLabel"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    CatalogMetricsArtifact:
+      description: A metadata Artifact Entity.
+      allOf:
+        - type: object
+          required:
+            - artifactType
+            - metricsType
+          properties:
+            artifactType:
+              type: string
+              default: metrics-artifact
+            metricsType:
+              type: string
+              enum:
+                - performance-metrics
+                - accuracy-metrics
+                - security-metrics
+            customProperties:
+              description: User provided custom properties which are not defined by its type.
+              type: object
+              additionalProperties:
+                $ref: "#/components/schemas/MetadataValue"
+        - $ref: "#/components/schemas/BaseResource"
+    CatalogModel:
+      description: A model in the model catalog.
+      allOf:
+        - type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              description: Name of the model. Must be unique within a source.
+              example: ibm-granite/granite-3.1-8b-base
+            sourceId:
+              type: string
+              description: ID of the source this model belongs to.
+            validatedTasks:
+              type: array
+              items:
+                type: string
+              description: List of tasks for this model which have been validated by the catalog provider.
+            servingConfig:
+              $ref: "#/components/schemas/ServingConfig"
+            artifactCounts:
+              type: object
+              description: >-
+                Read-only counts of artifacts by category. Only populated on the single-model detail endpoint (GetModel). Keys with zero count are omitted. When no artifacts exist, the field is omitted entirely.
+              readOnly: true
+              additionalProperties:
+                type: integer
+                format: int32
+              example:
+                model-artifact: 3
+                performance-metrics: 12
+                accuracy-metrics: 2
+        - $ref: "#/components/schemas/BaseModel"
+        - $ref: "#/components/schemas/BaseResource"
+    CatalogModelArtifact:
+      description: A Catalog Model Artifact Entity.
+      allOf:
+        - type: object
+          required:
+            - artifactType
+            - uri
+          properties:
+            artifactType:
+              type: string
+              default: model-artifact
+            uri:
+              type: string
+              format: uri
+              description: URI where the model can be retrieved.
+            customProperties:
+              description: User provided custom properties which are not defined by its type.
+              type: object
+              additionalProperties:
+                $ref: "#/components/schemas/MetadataValue"
+        - $ref: "#/components/schemas/BaseResource"
+    CatalogModelList:
+      description: List of CatalogModel entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `CatalogModel` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/CatalogModel"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    CatalogSource:
+      description: A catalog source. A catalog source has CatalogModel children.
+      required:
+        - id
+        - name
+        - labels
+      type: object
+      properties:
+        id:
+          description: A unique identifier for a `CatalogSource`.
+          type: string
+        name:
+          description: The name of the catalog source.
+          type: string
+        enabled:
+          description: Whether the catalog source is enabled.
+          type: boolean
+          default: true
+        labels:
+          description: Labels for the catalog source.
+          type: array
+          items:
+            type: string
+        status:
+          $ref: "#/components/schemas/CatalogSourceStatus"
+          description: Current operational status of the catalog source.
+        error:
+          description: |-
+            Detailed error information when the status is "Error".
+            This field is null or empty when the source is functioning normally.
+          type: string
+          nullable: true
+        includedModels:
+          description: |-
+            Optional list of glob patterns for models to include. If specified, only models matching
+            at least one pattern will be included. If omitted, all models are considered for inclusion.
+
+            Pattern Syntax:
+            - Only the `*` wildcard is supported (matches zero or more characters)
+            - Patterns are case-insensitive (e.g., `Granite/*` matches `granite/model` and `GRANITE/model`)
+            - Patterns match the entire model name (anchored at start and end)
+            - Wildcards can appear anywhere: `Granite/*`, `*-beta`, `*deprecated*`, `*/old*`
+
+            Examples:
+            - `ibm-granite/*` - matches all models starting with "ibm-granite/"
+            - `meta-llama/*` - matches all models in the meta-llama namespace
+            - `*` - matches all models
+
+            Constraints:
+            - Patterns cannot be empty or whitespace-only
+            - A pattern cannot appear in both includedModels and excludedModels
+          type: array
+          items:
+            type: string
+        excludedModels:
+          description: |-
+            Optional list of glob patterns for models to exclude. Models matching any pattern
+            will be excluded even if they match an includedModels pattern. Exclusions take
+            precedence over inclusions.
+
+            Pattern Syntax:
+            - Only the `*` wildcard is supported (matches zero or more characters)
+            - Patterns are case-insensitive
+            - Patterns match the entire model name (anchored at start and end)
+            - Wildcards can appear anywhere in the pattern
+
+            Examples:
+            - `*-draft` - excludes all models ending with "-draft"
+            - `*-experimental` - excludes experimental models
+            - `*deprecated*` - excludes models with "deprecated" anywhere in the name
+            - `*/beta-*` - excludes models with "/beta-" in the path
+
+            Constraints:
+            - Patterns cannot be empty or whitespace-only
+            - A pattern cannot appear in both includedModels and excludedModels
+          type: array
+          items:
+            type: string
+        assetType:
+          $ref: "#/components/schemas/CatalogAssetType"
+          description: |-
+            The type of assets this source manages. Defaults to "models" if not specified.
+            This field determines which loader processes the source and which API endpoints
+            return the assets.
+    CatalogSourceList:
+      description: List of CatalogSource entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `CatalogSource` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/CatalogSource"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    CatalogSourcePreviewResponse:
+      description: Response containing models and their inclusion/exclusion status.
+      allOf:
+        - type: object
+          properties:
+            assetType:
+              $ref: "#/components/schemas/CatalogAssetType"
+            items:
+              description: Array of model preview results.
+              type: array
+              items:
+                $ref: "#/components/schemas/ModelPreviewResult"
+            summary:
+              description: Summary of the preview results
+              type: object
+              properties:
+                totalModels:
+                  type: integer
+                  description: Total number of models evaluated
+                  example: 1500
+                includedModels:
+                  type: integer
+                  description: Number of models that would be included
+                  example: 850
+                excludedModels:
+                  type: integer
+                  description: Number of models that would be excluded
+                  example: 650
+              required:
+                - totalModels
+                - includedModels
+                - excludedModels
+          required:
+            - assetType
+            - items
+            - summary
+        - $ref: "#/components/schemas/BaseResourceList"
+    CatalogSourceStatus:
+      description: |-
+        Operational status of a catalog source.
+        - `available`: The source is functioning correctly and models can be retrieved
+        - `partially-available`: The source loaded some models successfully but encountered errors with others
+        - `error`: The source is experiencing issues and cannot provide models
+        - `disabled`: The source has been intentionally disabled
+      enum:
+        - available
+        - partially-available
+        - error
+        - disabled
+      type: string
+    Error:
+      description: Error code and message.
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          description: Error code
+          type: string
+        message:
+          description: Error message
+          type: string
+    FieldFilter:
+      type: object
+      required:
+        - operator
+        - value
+      properties:
+        operator:
+          type: string
+          description: Filter operator (e.g., '<', '=', '>', 'IN')
+          example: '<'
+        value:
+          description: Filter value (can be number, string, or array)
+          example: 70
+    FilterOption:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: The data type of the filter option
+          enum:
+            - string
+            - number
+        values:
+          type: array
+          description: Known values of the property for string types with a small number of possible options.
+          items: {}
+        range:
+          $ref: "#/components/schemas/FilterOptionRange"
+    FilterOptionRange:
+      type: object
+      description: Min and max values for number types.
+      properties:
+        min:
+          type: number
+          format: double
+        max:
+          type: number
+          format: double
+    FilterOptionsList:
+      description: List of FilterOptions
+      type: object
+      properties:
+        filters:
+          type: object
+          description: A single filter option.
+          additionalProperties:
+            $ref: "#/components/schemas/FilterOption"
+        namedQueries:
+          type: object
+          description: Predefined named queries for common filtering scenarios
+          additionalProperties:
+            type: object
+            additionalProperties:
+              $ref: "#/components/schemas/FieldFilter"
+    MCPArtifact:
+      description: Artifact metadata for local MCP server deployment.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceDates"
+        - type: object
+          required:
+            - uri
+          properties:
+            uri:
+              type: string
+              format: uri
+              description: OCI image URI for local deployment.
+    MCPConfigMapKey:
+      type: object
+      required:
+        - key
+        - description
+      description: Individual key within a Kubernetes ConfigMap
+      properties:
+        key:
+          type: string
+          description: ConfigMap key name (often a filename)
+          maxLength: 253
+          example: config.toml
+        description:
+          type: string
+          description: What this key should contain
+          maxLength: 500
+          example: Main configuration file for MCP server
+        defaultContent:
+          type: string
+          description: |-
+            Default content users can copy and customize.
+            Limited to 10KB for performance. For larger configs, reference external documentation.
+          maxLength: 10000
+          example: |
+            log_level = "info"
+            port = 8080
+        envVarName:
+          type: string
+          description: Environment variable name if not mounted as file
+          maxLength: 253
+          example: MCP_CONFIG
+        required:
+          type: boolean
+          description: Whether this key is required
+          default: false
+    MCPConfigMapRequirement:
+      type: object
+      required:
+        - name
+        - description
+      description: Kubernetes ConfigMap requirement metadata
+      properties:
+        name:
+          type: string
+          description: Suggested ConfigMap name (must be valid Kubernetes name)
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
+          example: mcp-server-config
+        description:
+          type: string
+          description: Purpose of the ConfigMap
+          maxLength: 1000
+          example: Configuration files for MCP server runtime
+        keys:
+          type: array
+          description: Expected keys within the ConfigMap
+          items:
+            $ref: "#/components/schemas/MCPConfigMapKey"
+        mountAsFile:
+          type: boolean
+          description: Whether to mount ConfigMap as files
+          default: true
+        mountPath:
+          type: string
+          description: Mount path when mountAsFile is true (must be absolute path)
+          pattern: '^/[a-zA-Z0-9/_.-]*$'
+          maxLength: 4096
+          example: /etc/mcp-config
+    MCPEndpoints:
+      type: object
+      description: Remote endpoint metadata for MCP server access.
+      properties:
+        http:
+          type: string
+          format: uri
+          description: HTTP endpoint URL for the MCP server.
+        sse:
+          type: string
+          format: uri
+          description: SSE endpoint URL for the MCP server.
+    MCPEnvVarMetadata:
+      type: object
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+          description: Environment variable name
+          example: API_KEY
+        description:
+          type: string
+          description: Purpose and usage of this variable
+          example: API key for authenticating with external service
+        required:
+          type: boolean
+          description: Whether this variable must be set
+          default: false
+        defaultValue:
+          type: string
+          description: |-
+            Default value if not provided. Only for optional variables.
+            Secrets should NEVER have default values.
+          example: info
+        type:
+          type: string
+          enum: [string, int, boolean, secret, config]
+          description: Expected variable type
+          default: string
+        example:
+          type: string
+          description: Example value for documentation purposes
+          example: my-api-key-123
+    MCPPrerequisites:
+      type: object
+      description: |-
+        Aggregated Kubernetes prerequisites metadata for MCP server deployment.
+        All fields are discovery hints - not deployment configuration.
+      properties:
+        serviceAccount:
+          $ref: "#/components/schemas/MCPServiceAccountRequirement"
+          description: ServiceAccount requirements and RBAC hints
+        secrets:
+          type: array
+          description: Required Kubernetes Secrets
+          items:
+            $ref: "#/components/schemas/MCPSecretRequirement"
+        configMaps:
+          type: array
+          description: Required Kubernetes ConfigMaps
+          items:
+            $ref: "#/components/schemas/MCPConfigMapRequirement"
+        environmentVariables:
+          type: array
+          description: |-
+            Aggregated environment variables list.
+            Combines required and optional environment variables for convenience.
+          items:
+            $ref: "#/components/schemas/MCPEnvVarMetadata"
+        customResources:
+          type: array
+          description: |-
+            Other Kubernetes resources needed (e.g., PersistentVolumeClaims, NetworkPolicies).
+            Free-form hints for advanced deployment scenarios.
+          items:
+            type: string
+          example: ["PersistentVolumeClaim: mcp-data-storage"]
+      example:
+        serviceAccount:
+          required: true
+          hint: "Needs 'view' ClusterRole for read-only K8s access"
+          suggestedName: mcp-viewer
+        secrets:
+          - name: openai-credentials
+            description: "kubectl create secret generic openai-credentials --from-literal=api-key=YOUR_KEY"
+            keys:
+              - key: api-key
+                description: OpenAI API key
+                envVarName: OPENAI_API_KEY
+        configMaps:
+          - name: mcp-server-config
+            description: Configuration files
+            mountAsFile: true
+            mountPath: /etc/mcp-config
+            keys:
+              - key: config.toml
+                description: Main configuration
+                defaultContent: "log_level = \"info\"\nport = 8080\n"
+    MCPResourceRecommendation:
+      type: object
+      properties:
+        minimal:
+          type: object
+          description: Minimum viable resources for low-traffic scenarios
+          properties:
+            cpu:
+              type: string
+              description: CPU request (e.g., 50m, 0.1, 1)
+              example: 50m
+            memory:
+              type: string
+              description: Memory request (e.g., 64Mi, 128Mi, 1Gi)
+              example: 64Mi
+        recommended:
+          type: object
+          description: Recommended resources for typical production use
+          properties:
+            cpu:
+              type: string
+              example: 100m
+            memory:
+              type: string
+              example: 128Mi
+        high:
+          type: object
+          description: Resources for high-traffic or compute-intensive scenarios
+          properties:
+            cpu:
+              type: string
+              example: 500m
+            memory:
+              type: string
+              example: 512Mi
+    MCPRuntimeMetadata:
+      type: object
+      properties:
+        defaultPort:
+          type: integer
+          description: |-
+            Default port the MCP server listens on. Maps to MCPServer.spec.mcpPort.
+            Should align with the primary transport type.
+          example: 8080
+          minimum: 1
+          maximum: 65535
+        defaultArgs:
+          type: array
+          description: |-
+            Default command-line arguments for the MCP server.
+            Users can override or extend these in the MCPServer CRD.
+          items:
+            type: string
+          example: ["--log-level", "info", "--metrics-enabled"]
+        requiredEnvironmentVariables:
+          type: array
+          description: |-
+            Environment variables that MUST be set for the server to function.
+            Documents the names and purposes - values come from user's Secrets/ConfigMaps.
+          items:
+            $ref: "#/components/schemas/MCPEnvVarMetadata"
+        optionalEnvironmentVariables:
+          type: array
+          description: |-
+            Optional environment variables that configure server behavior.
+            Documents the names, purposes, and default values.
+          items:
+            $ref: "#/components/schemas/MCPEnvVarMetadata"
+        recommendedResources:
+          $ref: "#/components/schemas/MCPResourceRecommendation"
+          description: |-
+            Recommended CPU and memory resources based on typical workloads.
+            Users should adjust based on their specific usage patterns.
+        healthEndpoints:
+          type: object
+          description: Health check endpoint paths
+          properties:
+            liveness:
+              type: string
+              description: Liveness probe endpoint path
+              example: /health
+            readiness:
+              type: string
+              description: Readiness probe endpoint path
+              example: /ready
+        capabilities:
+          type: object
+          description: |-
+            Runtime capabilities and requirements for this MCP server.
+            Helps users understand what the server needs to run properly.
+          properties:
+            requiresNetwork:
+              type: boolean
+              description: Whether server requires network access
+              default: true
+            requiresFileSystem:
+              type: boolean
+              description: Whether server requires writable filesystem
+              default: false
+            requiresGPU:
+              type: boolean
+              description: Whether server requires GPU access
+              default: false
+        mcpPath:
+          type: string
+          description: |-
+            HTTP path where MCP server accepts requests.
+            Used for HTTP and SSE transports.
+            Aligns with MCP Lifecycle operator conventions.
+          pattern: '^/[a-zA-Z0-9/_.-]*$'
+          default: /mcp
+          example: /mcp
+        prerequisites:
+          $ref: "#/components/schemas/MCPPrerequisites"
+          description: |-
+            Kubernetes prerequisites discovery metadata.
+            Helps users understand what K8s resources to create before deployment.
+    MCPSecretKey:
+      type: object
+      required:
+        - key
+        - description
+      description: Individual key within a Kubernetes Secret
+      properties:
+        key:
+          type: string
+          description: Secret key name
+          maxLength: 253
+          example: api-key
+        description:
+          type: string
+          description: What this key should contain (never actual values)
+          maxLength: 500
+          example: OpenAI API key for authentication
+        envVarName:
+          type: string
+          description: Environment variable name to map this key to
+          maxLength: 253
+          example: OPENAI_API_KEY
+        required:
+          type: boolean
+          description: Whether this key must be present in the Secret
+          default: false
+    MCPSecretRequirement:
+      type: object
+      required:
+        - name
+        - description
+      description: |-
+        Kubernetes Secret requirement metadata.
+        Never stores actual secret values - provides discovery hints only.
+      properties:
+        name:
+          type: string
+          description: Suggested Secret name (must be valid Kubernetes name)
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
+          example: openai-credentials
+        description:
+          type: string
+          description: |-
+            Purpose of the Secret and kubectl creation hint.
+            Example: "kubectl create secret generic openai-credentials --from-literal=api-key=sk-..."
+          maxLength: 1000
+          example: Create with kubectl create secret generic openai-credentials --from-literal=api-key=YOUR_KEY
+        keys:
+          type: array
+          description: Expected keys within the Secret
+          items:
+            $ref: "#/components/schemas/MCPSecretKey"
+        mountAsFile:
+          type: boolean
+          description: Whether to mount Secret as files instead of environment variables
+          default: false
+        mountPath:
+          type: string
+          description: Mount path when mountAsFile is true (must be absolute path)
+          pattern: '^/[a-zA-Z0-9/_.-]*$'
+          maxLength: 4096
+          example: /etc/secrets
+    MCPSecurityIndicator:
+      type: object
+      description: Security posture metadata for an MCP server.
+      properties:
+        verifiedSource:
+          type: boolean
+          description: Whether the source of this server has been verified.
+        secureEndpoint:
+          type: boolean
+          description: Whether the server exposes secure communication endpoints.
+        sast:
+          type: boolean
+          description: Whether static analysis has been performed.
+        readOnlyTools:
+          type: boolean
+          description: Whether all exposed tools are read-only.
+    MCPServer:
+      description: An MCP server in the model catalog.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - name
+            - toolCount
+          properties:
+            name:
+              type: string
+              description: Human-readable MCP server name. Must be unique within a source.
+            displayName:
+              type: string
+              description: Optional human-friendly display label for this MCP server.
+              maxLength: 255
+            sourceId:
+              type: string
+              description: Catalog source that provides this server.
+            provider:
+              type: string
+              description: Organization providing the server.
+            logo:
+              type: string
+              description: MCP server logo.
+            version:
+              type: string
+              description: Semantic version string of the MCP server.
+            tags:
+              type: array
+              description: Categorization tags for this MCP server.
+              example:
+                - observability
+                - monitoring
+                - apm
+              items:
+                type: string
+            license:
+              type: string
+              description: SPDX identifier for the server license.
+            licenseLink:
+              type: string
+              format: uri
+              description: URL to the full license text.
+            toolCount:
+              type: integer
+              description: Number of tools exposed by this MCP server.
+              example: 15
+            tools:
+              type: array
+              description: Array of tools exposed by this MCP server.
+              items:
+                $ref: "#/components/schemas/MCPTool"
+            securityIndicators:
+              $ref: "#/components/schemas/MCPSecurityIndicator"
+            deploymentMode:
+              type: string
+              description: Deployment mode for the MCP server.
+              enum:
+                - local
+                - remote
+            transports:
+              type: array
+              description: Supported transport protocols.
+              items:
+                type: string
+                enum:
+                  - stdio
+                  - http
+                  - sse
+            artifacts:
+              type: array
+              description: OCI artifacts used for local deployment.
+              items:
+                $ref: "#/components/schemas/MCPArtifact"
+            endpoints:
+              $ref: "#/components/schemas/MCPEndpoints"
+            readme:
+              type: string
+              description: Full Markdown documentation for this MCP server.
+            documentationUrl:
+              type: string
+              format: uri
+              description: URL to external documentation.
+            repositoryUrl:
+              type: string
+              format: uri
+              description: URL to source repository.
+            sourceCode:
+              type: string
+              format: uri
+              description: URL to browsable source code.
+            publishedDate:
+              type: string
+              format: date-time
+              description: Initial publication timestamp for the server.
+            lastUpdated:
+              type: string
+              format: date-time
+              description: Last update timestamp for the server metadata.
+            runtimeMetadata:
+              $ref: "#/components/schemas/MCPRuntimeMetadata"
+              description: |-
+                Runtime metadata for deploying this MCP server via MCPServer CRDs.
+                Provides defaults, recommendations, and requirements for creating deployments.
+                This is discovery metadata, not actual deployment configuration.
+    MCPServerList:
+      description: List of MCP server entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `MCPServer` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/MCPServer"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    MCPServiceAccountRequirement:
+      type: object
+      description: |-
+        ServiceAccount requirements for Kubernetes deployment.
+        Provides discovery hints about RBAC permissions needed.
+      properties:
+        required:
+          type: boolean
+          description: Whether a ServiceAccount is required for this MCP server
+          default: false
+          example: true
+        hint:
+          type: string
+          description: |-
+            Human-readable description of required RBAC permissions.
+            Example: "Needs 'view' ClusterRole for read-only K8s access"
+          maxLength: 500
+          example: "Requires read-only access to pods and services in the namespace"
+        suggestedName:
+          type: string
+          description: Suggested ServiceAccount name (must be valid Kubernetes name)
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          maxLength: 253
+          example: mcp-server-viewer
+    MCPTool:
+      description: An MCP tool exposed by an MCP server.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - name
+            - accessType
+          properties:
+            name:
+              type: string
+              description: Tool identifier.
+            accessType:
+              type: string
+              description: Access mode supported by this tool.
+              enum:
+                - read_only
+                - read_write
+                - execute
+            parameters:
+              type: array
+              description: Input parameters accepted by this tool.
+              items:
+                $ref: "#/components/schemas/MCPToolParameter"
+    MCPToolParameter:
+      type: object
+      description: Metadata describing a single MCP tool parameter.
+      required:
+        - name
+        - type
+        - required
+      properties:
+        name:
+          type: string
+          description: Parameter name.
+        type:
+          type: string
+          description: Parameter type.
+        required:
+          type: boolean
+          description: Whether this parameter is required.
+        description:
+          type: string
+          description: Parameter purpose.
+    MCPToolWithServer:
+      type: object
+      required:
+        - serverId
+        - serverName
+        - tool
+      properties:
+        serverId:
+          type: string
+          description: ID of the MCP server that exposes this tool
+          example: prometheus-mcp
+        serverName:
+          type: string
+          description: Human-readable name of the MCP server
+          example: Prometheus MCP Server
+        tool:
+          $ref: "#/components/schemas/MCPTool"
+    MCPToolsList:
+      description: List of MCP tool entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `MCPTool` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/MCPTool"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    MetadataBoolValue:
+      description: A bool property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - bool_value
+      properties:
+        bool_value:
+          type: boolean
+        metadataType:
+          type: string
+          enum:
+            - MetadataBoolValue
+          default: MetadataBoolValue
+    MetadataDoubleValue:
+      description: A double property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - double_value
+      properties:
+        double_value:
+          format: double
+          type: number
+        metadataType:
+          type: string
+          enum:
+            - MetadataDoubleValue
+          default: MetadataDoubleValue
+    MetadataIntValue:
+      description: An integer (int32) property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - int_value
+      properties:
+        int_value:
+          format: int32
+          type: string
+          pattern: "^-?([1-9][0-9]{0,8}|0)$"
+        metadataType:
+          type: string
+          enum:
+            - MetadataIntValue
+          default: MetadataIntValue
+    MetadataProtoValue:
+      description: A proto property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - type
+        - proto_value
+      properties:
+        type:
+          description: url describing proto value
+          type: string
+        proto_value:
+          description: Base64 encoded bytes for proto value
+          type: string
+          format: byte
+        metadataType:
+          type: string
+          enum:
+            - MetadataProtoValue
+          default: MetadataProtoValue
+    MetadataStringValue:
+      description: A string property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - string_value
+      properties:
+        string_value:
+          type: string
+        metadataType:
+          type: string
+          enum:
+            - MetadataStringValue
+          default: MetadataStringValue
+    MetadataStructValue:
+      description: A struct property value.
+      type: object
+      additionalProperties: false
+      required:
+        - metadataType
+        - struct_value
+      properties:
+        struct_value:
+          description: Base64 encoded bytes for struct value
+          type: string
+          format: byte
+        metadataType:
+          type: string
+          enum:
+            - MetadataStructValue
+          default: MetadataStructValue
+    MetadataValue:
+      oneOf:
+        - $ref: "#/components/schemas/MetadataIntValue"
+        - $ref: "#/components/schemas/MetadataDoubleValue"
+        - $ref: "#/components/schemas/MetadataStringValue"
+        - $ref: "#/components/schemas/MetadataStructValue"
+        - $ref: "#/components/schemas/MetadataProtoValue"
+        - $ref: "#/components/schemas/MetadataBoolValue"
+      discriminator:
+        propertyName: metadataType
+        mapping:
+          MetadataBoolValue: "#/components/schemas/MetadataBoolValue"
+          MetadataDoubleValue: "#/components/schemas/MetadataDoubleValue"
+          MetadataIntValue: "#/components/schemas/MetadataIntValue"
+          MetadataProtoValue: "#/components/schemas/MetadataProtoValue"
+          MetadataStringValue: "#/components/schemas/MetadataStringValue"
+          MetadataStructValue: "#/components/schemas/MetadataStructValue"
+      description: A value in properties.
+      example:
+        string_value: my_value
+        metadataType: MetadataStringValue
+    ModelPreviewResult:
+      description: |-
+        A model with its inclusion/exclusion status based on the
+        configured catalog source filters.
+      type: object
+      required:
+        - name
+        - included
+      properties:
+        name:
+          type: string
+          description: Name of the model
+          example: microsoft/DialoGPT-medium
+        included:
+          type: boolean
+          description: Whether this model would be included based on the source configuration
+    OrderByField:
+      description: |-
+        Supported fields for ordering result entities.
+      enum:
+        - CREATE_TIME
+        - LAST_UPDATE_TIME
+        - ID
+        - NAME
+        - RECOMMENDED
+      type: string
+    PreviewCatalogSourceResponse:
+      description: >-
+        Polymorphic preview response. The `assetType` discriminator determines whether the payload is a model preview or an MCP server preview.
+      oneOf:
+        - $ref: "#/components/schemas/CatalogSourcePreviewResponse"
+        - $ref: "#/components/schemas/AssetSourcePreviewResponse"
+      discriminator:
+        propertyName: assetType
+        mapping:
+          models: "#/components/schemas/CatalogSourcePreviewResponse"
+          mcp_servers: "#/components/schemas/AssetSourcePreviewResponse"
+          agents: "#/components/schemas/AssetSourcePreviewResponse"
+          skills: "#/components/schemas/AssetSourcePreviewResponse"
+    ServingConfig:
+      description: >-
+        Serving and deployment configuration for the model. Each property represents a distinct configuration concern with its own typed schema. All properties are optional.
+      type: object
+      properties:
+        toolCalling:
+          $ref: "#/components/schemas/ToolCallingConfig"
+    Skill:
+      description: >-
+        An agent skill in the skill catalog. Indexed from a `SKILL.md` in a git repository per the Agent Skills specification (https://agentskills.io).
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - name
+          properties:
+            # --- Spec fields (from SKILL.md) ---
+            name:
+              type: string
+              description: Skill identifier from the SKILL.md frontmatter. Must be unique within a source and version.
+            description:
+              type: string
+              description: Short description of the skill from the SKILL.md frontmatter.
+            license:
+              type: string
+              description: Short name of the skill's license (e.g., apache-2.0).
+            compatibility:
+              type: string
+              description: Compatibility information declared in the SKILL.md frontmatter (e.g., supported clients or versions).
+            allowedTools:
+              type: array
+              items:
+                type: string
+              description: Tools the skill is permitted to use (`allowed-tools` in the SKILL.md frontmatter).
+            readme:
+              type: string
+              description: The SKILL.md body rendered as Markdown documentation.
+            # --- Canonical identity ---
+            repository:
+              type: string
+              description: >-
+                Canonical upstream git repository URL. Together with `path` this forms the skill's permanent identity, stable across index rebuilds and mirror deployments.
+            path:
+              type: string
+              description: Directory of the skill within the repository (the folder containing its SKILL.md).
+            version:
+              type: string
+              description: >-
+                The ref this entry was resolved at (tag, release, or commit). A branch ref is surfaced as `latest` rather than the raw branch name.
+            resolvedCommit:
+              type: string
+              description: The exact commit SHA the `version` ref resolved to at sync, used to pin reproducible installs.
+            # --- Catalog metadata (from the source configuration) ---
+            sourceId:
+              type: string
+              description: Catalog source that provides this entity.
+            trustTier:
+              $ref: "#/components/schemas/SkillTrustTier"
+            provider:
+              type: string
+              description: Name of the organization or entity that provides the skill.
+            category:
+              type: string
+              description: Category assigned to the skill in the source configuration.
+            labels:
+              type: array
+              items:
+                type: string
+              description: Labels for categorization and filtering.
+            supportingFiles:
+              type: array
+              items:
+                type: string
+              description: >-
+                Paths of files that accompany the SKILL.md in the skill directory. Contents are not stored; these link back to the repository.
+            bodyLineCount:
+              type: integer
+              format: int32
+              description: Number of lines in the SKILL.md body, surfaced for skills whose body exceeds recommended length.
+    SkillList:
+      description: A list of skill entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `Skill` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/Skill"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    SkillTrustTier:
+      description: >-
+        Provenance label applied to a skill from its source configuration. A plain label shown as a badge and usable for filtering; it carries no ordering or special semantics. Downstream products may map these to their own display names.
+      type: string
+      enum:
+        - platformProvided
+        - partnerVerified
+        - organizationApproved
+        - communityContributed
+    SortOrder:
+      description: Supported sort direction for ordering result entities.
+      enum:
+        - ASC
+        - DESC
+      type: string
+    ToolCallingConfig:
+      description: >-
+        Tool-calling arguments for this model.
+      type: object
+      properties:
+        toolCallParser:
+          type: string
+          description: >-
+            The tool-call parser identifier for the serving runtime.
+          example: granite
+        chatTemplate:
+          type: string
+          description: >-
+            Path to the chat template file packaged with the model.
+          example: opt/app-root/template/tool_chat_template_granite.jinja
+        enableAutoToolChoice:
+          type: boolean
+          description: >-
+            Whether to enable automatic tool choice in the serving runtime.
+          default: true
+        requiredArgs:
+          type: array
+          items:
+            type: string
+          description: >-
+            Additional CLI arguments required for tool calling beyond the parser, template, and auto-tool-choice flags. Each entry is a complete argument (e.g., "--config_format mistral").
+          example:
+            - "--config_format granite"
+  responses:
+    AgentArtifactListResponse:
+      description: A list of agent artifact entities.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AgentArtifactList"
+    AgentListResponse:
+      description: A list of agent entities.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AgentList"
+    AgentResponse:
+      description: A single agent entity.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Agent"
+    BadRequest:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Bad Request parameters
+    CatalogArtifactListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogArtifactList"
+      description: A response containing a list of CatalogArtifact entities.
+    CatalogLabelListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogLabelList"
+      description: A response containing a list of CatalogLabel entities.
+    CatalogModelListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogModelList"
+      description: A response containing a list of CatalogModel entities.
+    CatalogModelResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogModel"
+      description: A response containing a `CatalogModel` entity.
+    CatalogSourceListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogSourceList"
+      description: A response containing a list of CatalogSource entities.
+    Conflict:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Conflict with current state of target resource
+    FilterOptionsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FilterOptionsList"
+      description: A response containing options for a `filterQuery` parameter.
+    InternalServerError:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Unexpected internal server error
+    MCPServerListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MCPServerList"
+      description: A response containing a list of MCP server entities.
+    MCPServerResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MCPServer"
+      description: A response containing an `MCPServer` entity.
+    MCPToolWithServerResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MCPToolWithServer"
+      description: A response containing an `MCPToolWithServer` entity.
+    MCPToolsListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MCPToolsList"
+      description: A response containing a list of MCP tool entities.
+    NotFound:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: The specified resource was not found
+    PreviewCatalogSourceResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PreviewCatalogSourceResponse"
+          examples:
+            allModels:
+              summary: All models with inclusion status
+              description: Response showing all models when filterStatus=all
+              value:
+                assetType: models
+                nextPageToken: ""
+                pageSize: 10
+                size: 5
+                items:
+                  - name: "ibm-granite/granite-3.0-8b-instruct"
+                    included: true
+                  - name: "ibm-granite/granite-3.0-2b-instruct"
+                    included: true
+                  - name: "meta-llama/Llama-2-7b-hf"
+                    included: true
+                  - name: "mistralai/Mistral-7B-v0.1-draft"
+                    included: false
+                  - name: "microsoft/phi-2-experimental"
+                    included: false
+                summary:
+                  totalModels: 5
+                  includedModels: 3
+                  excludedModels: 2
+            includedOnly:
+              summary: Only included models
+              description: Response when filterStatus=included
+              value:
+                assetType: models
+                nextPageToken: ""
+                pageSize: 10
+                size: 3
+                items:
+                  - name: "ibm-granite/granite-3.0-8b-instruct"
+                    included: true
+                  - name: "ibm-granite/granite-3.0-2b-instruct"
+                    included: true
+                  - name: "meta-llama/Llama-2-7b-hf"
+                    included: true
+                summary:
+                  totalModels: 5
+                  includedModels: 3
+                  excludedModels: 2
+            excludedOnly:
+              summary: Only excluded models
+              description: Response when filterStatus=excluded
+              value:
+                assetType: models
+                nextPageToken: ""
+                pageSize: 10
+                size: 2
+                items:
+                  - name: "mistralai/Mistral-7B-v0.1-draft"
+                    included: false
+                  - name: "microsoft/phi-2-experimental"
+                    included: false
+                summary:
+                  totalModels: 5
+                  includedModels: 3
+                  excludedModels: 2
+            withPagination:
+              summary: Paginated response
+              description: Response with pagination when pageSize is smaller than total
+              value:
+                assetType: models
+                nextPageToken: "eyJvZmZzZXQiOjEwfQ==" # notsecret
+                pageSize: 10
+                size: 10
+                items:
+                  - name: "ibm-granite/granite-3.0-8b-instruct"
+                    included: true
+                  - name: "ibm-granite/granite-3.0-2b-instruct"
+                    included: true
+                  - name: "meta-llama/Llama-2-7b-hf"
+                    included: true
+                  - name: "meta-llama/Llama-2-13b-hf"
+                    included: true
+                  - name: "mistralai/Mistral-7B-Instruct-v0.3"
+                    included: true
+                  - name: "mistralai/Mistral-7B-v0.1"
+                    included: true
+                  - name: "microsoft/phi-2"
+                    included: true
+                  - name: "google/gemma-7b"
+                    included: true
+                  - name: "mistralai/Mistral-7B-v0.1-draft"
+                    included: false
+                  - name: "microsoft/phi-2-experimental"
+                    included: false
+                summary:
+                  totalModels: 150
+                  includedModels: 85
+                  excludedModels: 65
+            allMCPServers:
+              summary: All MCP servers with inclusion status
+              description: Response showing all MCP servers when assetType=mcp_servers
+              value:
+                assetType: mcp_servers
+                nextPageToken: ""
+                pageSize: 10
+                size: 3
+                items:
+                  - name: "kubernetes-mcp"
+                    included: true
+                  - name: "prometheus-mcp"
+                    included: true
+                  - name: "grafana-internal"
+                    included: false
+                summary:
+                  totalAssets: 3
+                  includedAssets: 2
+                  excludedAssets: 1
+      description: |-
+        A response containing preview results with inclusion/exclusion status.
+        The `assetType` discriminator determines whether the payload contains
+        model previews or MCP server previews.
+    ServiceUnavailable:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Service is unavailable
+    SkillListResponse:
+      description: A list of skill entities.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SkillList"
+    SkillResponse:
+      description: A single skill entity.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Skill"
+    Unauthorized:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Unauthorized
+    UnprocessableEntity:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      description: Unprocessable Entity error
+  parameters:
+    filterQuery:
+      examples:
+        filterQuery:
+          value: "name='my-model' AND state='LIVE'"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter the list of entities. The query supports rich filtering capabilities with automatic type inference.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Data Types:**
+        - Strings: `"value"` or `'value'`
+        - Numbers: `42`, `3.14`, `1e-5`
+        - Booleans: `true`, `false` (case-insensitive)
+
+        **Property Access:**
+        - Standard properties: `name`, `id`, `state`, `createTimeSinceEpoch`
+        - Custom properties: Any user-defined property name
+        - Escaped properties: Use backticks for special characters: `` `custom-property` ``
+        - Type-specific access: `property.string_value`, `property.double_value`, `property.int_value`, `property.bool_value`
+
+        **Examples:**
+        - Basic: `name = "my-model"`
+        - Comparison: `accuracy > 0.95`
+        - Pattern: `name LIKE "%tensorflow%"`
+        - Complex: `(name = "model-a" OR name = "model-b") AND state = "LIVE"`
+        - Custom property: `framework.string_value = "pytorch"`
+        - Escaped property: `` `mlflow.source.type` = "notebook" ``
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    orderBy:
+      style: form
+      explode: true
+      examples:
+        orderBy:
+          value: ID
+      name: orderBy
+      description: Specifies the order by criteria for listing entities.
+      schema:
+        $ref: "#/components/schemas/OrderByField"
+      in: query
+      required: false
+    labelOrderBy:
+      style: form
+      explode: true
+      examples:
+        labelOrderBy:
+          value: name
+      name: orderBy
+      description: |
+        Specifies the key to order catalog labels by. You can provide any string key
+        that may exist in the label maps. Labels that contain the specified key will
+        be sorted by that key's value. Labels that don't contain the key will maintain
+        their original order and appear after labels that do contain the key.
+      schema:
+        type: string
+      in: query
+      required: false
+    assetType:
+      name: assetType
+      description: Filter by asset type.
+      schema:
+        $ref: "#/components/schemas/CatalogAssetType"
+      in: query
+      required: false
+    agentArtifactType:
+      style: form
+      explode: true
+      examples:
+        agentArtifactType:
+          value: template-artifact
+      name: artifactType
+      description: Filter artifacts by type.
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/AgentArtifactTypeQueryParam"
+      in: query
+      required: false
+    mcpServerFilterQuery:
+      examples:
+        mcpServerFilterQuery:
+          value: "license='Apache 2.0' AND securityIndicators.verifiedSource=true"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter MCP servers.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Examples:**
+        - `license = "Apache 2.0"`
+        - `verifiedSource = true`
+        - `provider ILIKE "%local%"`
+        - `(license = "Apache 2.0" OR license = "MIT") AND verifiedSource = true`
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    mcpToolFilterQuery:
+      examples:
+        mcpToolFilterQuery:
+          value: "accessType='read_only' AND name ILIKE '%list%'"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter MCP tools for a specific MCP server.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Examples:**
+        - `name = "list_models"`
+        - `accessType = "read_only"`
+        - `name ILIKE "%search%"`
+        - `(accessType = "read_only" OR accessType = "execute") AND name LIKE "%model%"`
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    namedQuery:
+      examples:
+        namedQuery:
+          value: secure_servers
+      name: namedQuery
+      description: Predefined filter template name to apply when listing MCP servers.
+      schema:
+        type: string
+      in: query
+      required: false
+    includeTools:
+      examples:
+        includeTools:
+          value: true
+      name: includeTools
+      description: Whether to include the tools array in each MCP server result.
+      schema:
+        type: boolean
+        default: false
+      in: query
+      required: false
+    toolLimit:
+      examples:
+        toolLimit:
+          value: 10
+      name: toolLimit
+      description: Maximum number of tools to include when includeTools is true.
+      schema:
+        type: integer
+        format: int32
+        default: 10
+        minimum: 0
+        maximum: 100
+      in: query
+      required: false
+    artifactFilterQuery:
+      examples:
+        artifactFilterQuery:
+          value: "name='my-artifact' AND uri LIKE '%s3%'"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter catalog artifacts. The query supports rich filtering capabilities with automatic type inference.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Data Types:**
+        - Strings: `"value"` or `'value'`
+        - Numbers: `42`, `3.14`, `1e-5`
+        - Booleans: `true`, `false` (case-insensitive)
+
+        **Property Access (Artifacts):**
+        - Standard properties: `name`, `id`, `uri`, `artifactType`, `createTimeSinceEpoch`
+        - Custom properties: Any user-defined property name in `customProperties`
+        - Escaped properties: Use backticks for special characters: `` `custom-property` ``
+        - Type-specific access: `property.string_value`, `property.double_value`, `property.int_value`, `property.bool_value`
+
+        **Examples:**
+        - Basic: `name = "my-artifact"`
+        - Comparison: `ttft_mean > 90`
+        - Pattern: `uri LIKE "%s3.amazonaws.com%"`
+        - Complex: `(artifactType = "model-artifact" OR artifactType = "metrics-artifact") AND name LIKE "%pytorch%"`
+        - Custom property: `format.string_value = "pytorch"`
+        - Escaped property: `` `custom-key` = "value" ``
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    artifactOrderBy:
+      style: form
+      explode: true
+      examples:
+        standardField:
+          value: ID
+          summary: Order by standard field
+        customPropertyDouble:
+          value: mmlu.double_value
+          summary: Order by custom double property
+        customPropertyString:
+          value: framework_type.string_value
+          summary: Order by custom string property
+        customPropertyInt:
+          value: hardware_count.int_value
+          summary: Order by custom integer property
+      name: orderBy
+      description: |
+        Specifies the order by criteria for listing artifacts.
+
+        **Standard Fields:**
+        - `ID` - Order by artifact ID
+        - `NAME` - Order by artifact name
+        - `CREATE_TIME` - Order by creation timestamp
+        - `LAST_UPDATE_TIME` - Order by last update timestamp
+
+        **Custom Property Ordering:**
+
+        Artifacts can be ordered by custom properties using the format: `<property_name>.<value_type>`
+
+        Supported value types:
+        - `double_value` - For numeric (floating-point) properties
+        - `int_value` - For integer properties
+        - `string_value` - For string properties
+
+        Examples:
+        - `mmlu.double_value` - Order by the 'mmlu' benchmark score
+        - `accuracy.double_value` - Order by accuracy metric
+        - `framework_type.string_value` - Order by framework type
+        - `hardware_count.int_value` - Order by hardware count
+        - `ttft_mean.double_value` - Order by time-to-first-token mean
+
+        **Behavior:**
+        - If an invalid value type is specified (e.g., `accuracy.invalid_type`), an error is returned
+        - If an invalid format is used (e.g., `accuracy` without `.value_type`), it falls back to ID ordering
+        - If a property doesn't exist, it falls back to ID ordering
+        - Artifacts with the specified property are ordered first (by the property value), followed by artifacts without the property (ordered by ID)
+        - Empty property names (e.g., `.double_value`) return an error
+      schema:
+        type: string
+      in: query
+      required: false
+    artifactType:
+      style: form
+      explode: true
+      examples:
+        artifactType:
+          value: model-artifact
+      name: artifactType
+      description: "Specifies the artifact type for listing artifacts."
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/ArtifactTypeQueryParam"
+      in: query
+      required: false
+    artifact_type:
+      deprecated: true
+      style: form
+      explode: true
+      examples:
+        artifact_type:
+          value: model-artifact
+      name: artifact_type
+      description: "Specifies the artifact type for listing artifacts."
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/ArtifactTypeQueryParam"
+      in: query
+      required: false
+    id:
+      name: id
+      description: The ID of resource.
+      schema:
+        type: string
+        format: int64
+        pattern: "^[1-9][0-9]{0,8}$"
+      in: path
+      required: true
+    name:
+      examples:
+        name:
+          value: entity-name
+      name: name
+      description: Name of entity to search.
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]+$"
+      in: query
+      required: false
+    externalId:
+      examples:
+        externalId:
+          value: "10"
+      name: externalId
+      description: External ID of entity to search.
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]+$"
+      in: query
+      required: false
+    parentResourceId:
+      examples:
+        parentResourceId:
+          value: "10"
+      name: parentResourceId
+      description: ID of the parent resource to use for search.
+      schema:
+        type: string
+        format: int64
+        pattern: "^[1-9][0-9]{0,8}$"
+      in: query
+      required: false
+    pageSize:
+      examples:
+        pageSize:
+          value: 100
+      name: pageSize
+      description: Number of entities in each page.
+      schema:
+        type: string
+        format: int32
+        pattern: "^[1-9][0-9]{0,8}$"
+      in: query
+      required: false
+    nextPageToken:
+      name: nextPageToken
+      description: >-
+        Opaque pagination token returned by a previous list call. Do not construct manually; use the value from a prior response's nextPageToken field.
+      schema:
+        type: string
+      in: query
+      required: false
+    sortOrder:
+      style: form
+      explode: true
+      examples:
+        sortOrder:
+          value: DESC
+      name: sortOrder
+      description: "Specifies the sort order for listing entities, defaults to ASC."
+      schema:
+        $ref: "#/components/schemas/SortOrder"
+      in: query
+      required: false
+    stepIds:
+      style: form
+      explode: true
+      examples:
+        stepIds:
+          value: "1,2,3"
+      name: stepIds
+      description: "Comma-separated list of step IDs to filter metrics by."
+      schema:
+        type: string
+        pattern: "^[0-9]{1,9}(,[0-9]{1,9})*$"
+      in: query
+      required: false
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      bearerFormat: JWT
+      type: http
+      description: Bearer JWT scheme
+security:
+  - Bearer: []
+tags: []

--- a/api/openapi/src/catalog-v1.yaml
+++ b/api/openapi/src/catalog-v1.yaml
@@ -1,0 +1,816 @@
+openapi: 3.0.3
+info:
+  title: Catalog REST API
+  description: REST API for Kubeflow Hub Catalog
+  version: v1
+  license:
+    name: Apache 2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0"
+servers:
+  - url: "https://localhost:8080"
+  - url: "http://localhost:8080"
+paths:
+  /api/model_catalog/v1/labels:
+    summary: Path used to get the list of catalog labels.
+    description: >-
+      The REST endpoint/path used to list zero or more `CatalogLabel` entities.
+    get:
+      summary: List All CatalogLabels
+      tags:
+        - ModelCatalogService
+      parameters:
+        - $ref: "#/components/parameters/assetType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/labelOrderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogLabelListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findLabels
+      description: Gets a list of all `CatalogLabel` entities.
+  /api/model_catalog/v1/sources:
+    summary: Path used to get the list of catalog sources.
+    description: >-
+      The REST endpoint/path used to list zero or more `CatalogSource` entities.
+    get:
+      summary: List All CatalogSources
+      tags:
+        - ModelCatalogService
+      parameters:
+        - $ref: "#/components/parameters/name"
+        - $ref: "#/components/parameters/assetType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/CatalogSourceListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findSources
+      description: Gets a list of all `CatalogSource` entities.
+  /api/model_catalog/v1/sources/preview:
+    description: >-
+      The REST endpoint/path used to preview a catalog source configuration.
+      This endpoint accepts a catalog source definition and returns a list of
+      assets (models or MCP servers) with their inclusion/exclusion status based
+      on the configured filters.
+    post:
+      summary: Preview catalog source configuration
+      description: |-
+        Accepts a catalog source configuration and returns a list of assets showing
+        which would be included or excluded based on the configured filters. This allows
+        users to test and validate their source configurations before applying them.
+
+        The response type varies based on the `assetType` field in the uploaded config:
+        - `models` (default): Returns a `CatalogSourcePreviewResponse` with `ModelPreviewResult` items
+          and model-specific summary fields (`totalModels`, `includedModels`, `excludedModels`).
+        - `mcp_servers`: Returns an `AssetSourcePreviewResponse` with `AssetPreviewResult` items
+          and generic summary fields (`totalAssets`, `includedAssets`, `excludedAssets`).
+
+        **Two modes of operation:**
+
+        1. **Stateless mode (recommended for new sources):** Upload both `config` and
+           `catalogData` files via multipart form. The assets are read directly from
+           the uploaded `catalogData`, enabling preview of new sources before saving
+           anything to the server. This is ideal for testing configurations.
+
+        2. **Path mode (for existing sources):** Upload only `config` with a `yamlCatalogPath`
+           property. The assets are read from the specified file path on the server.
+           Use this for previewing changes to existing saved sources.
+      tags:
+        - ModelCatalogService
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - config
+              properties:
+                config:
+                  type: string
+                  format: binary
+                  description: |-
+                    YAML file containing the catalog source configuration.
+                    The file should contain a source definition with `type` and `properties`
+                    fields, and an optional `assetType` field to specify the kind of assets
+                    being previewed (defaults to `models`).
+
+                    **For model sources** (`assetType: models` or omitted):
+                    Use `includedModels` and `excludedModels` filter patterns.
+
+                    **For MCP server sources** (`assetType: mcp_servers`):
+                    Use `includedServers` and `excludedServers` filter patterns.
+
+                    Filter patterns support the `*` wildcard only and are case-insensitive.
+                    Patterns match the entire asset name (e.g., `ibm-granite/*` matches all
+                    models starting with "ibm-granite/", `kubernetes*` matches all servers
+                    starting with "kubernetes").
+                catalogData:
+                  type: string
+                  format: binary
+                  description: |-
+                    Optional YAML file containing the catalog data.
+
+                    For model sources, the file should contain a `models:` key with a list
+                    of model entries. For MCP server sources, the file should contain an
+                    `mcp_servers:` key with a list of server entries.
+
+                    This field enables stateless preview of new sources before saving them.
+                    When provided, the catalog data is read directly from this file instead of
+                    from the `yamlCatalogPath` property in the config.
+
+                    **Two modes of operation:**
+                    1. **Stateless mode (recommended for new sources):** Upload both `config` and
+                       `catalogData` files. The assets are read from `catalogData`, allowing preview
+                       without saving anything to the server.
+                    2. **Path mode (for existing sources):** Upload only `config` with a `yamlCatalogPath`
+                       property pointing to a catalog file on the server filesystem.
+
+                    If both `catalogData` and `yamlCatalogPath` are provided, `catalogData` takes precedence.
+            examples:
+              statelessPreview:
+                summary: Stateless preview with uploaded catalog data
+                description: |-
+                  Upload both config and catalogData files to preview a new source
+                  before saving. This is the recommended approach for testing new configurations.
+                value: |
+                  # config file content:
+                  type: yaml
+                  includedModels:
+                    - "ibm-granite/*"
+                    - "meta-llama/*"
+                  excludedModels:
+                    - "*-draft"
+                    - "*-experimental"
+
+                  # catalogData file content (separate file):
+                  models:
+                    - name: ibm-granite/granite-3.0-8b-instruct
+                      description: Granite 8B Instruct model
+                    - name: ibm-granite/granite-3.0-2b-draft
+                      description: Draft version
+                    - name: meta-llama/Llama-2-7b-hf
+                      description: Llama 2 7B
+              pathBasedPreview:
+                summary: Path-based preview using server-side catalog
+                description: |-
+                  Upload only config file with yamlCatalogPath pointing to an
+                  existing catalog file on the server. Use this for previewing
+                  changes to existing saved sources.
+                value: |
+                  type: yaml
+                  includedModels:
+                    - "ibm-granite/*"
+                    - "meta-llama/*"
+                    - "mistralai/*"
+                  excludedModels:
+                    - "*-draft"
+                    - "*-experimental"
+                  properties:
+                    yamlCatalogPath: "models-catalog.yaml"
+              huggingfaceSource:
+                summary: HuggingFace catalog source
+                description: |-
+                  Upload configuration for HuggingFace source with API credentials.
+                  The API key is passed per-request and not persisted anywhere.
+                value: |
+                  type: hf
+                  includedModels:
+                    - "microsoft/*"
+                    - "google/*"
+                  excludedModels:
+                    - "*-gguf"
+                  properties:
+                    apiKey: "your-huggingface-api-key-here" # notsecret
+                    modelLimit: 100
+              mcpStatelessPreview:
+                summary: Stateless MCP server preview
+                description: |-
+                  Preview an MCP server source configuration with uploaded catalog data.
+                  Set assetType to mcp_servers and use includedServers/excludedServers filters.
+                  Upload this as the `config` field. The `catalogData` field should contain
+                  a separate YAML file with `mcp_servers:` entries.
+                value: |
+                  assetType: mcp_servers
+                  type: yaml
+                  includedServers:
+                    - "kubernetes*"
+                    - "prometheus*"
+                  excludedServers:
+                    - "*-internal"
+      parameters:
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/nextPageToken"
+        - name: filterStatus
+          description: |-
+            Filter the response to show specific asset statuses:
+            - `all` (default): Show all assets regardless of inclusion status
+            - `included`: Show only assets that pass the configured filters
+            - `excluded`: Show only assets that are filtered out
+          schema:
+            type: string
+            enum:
+              - all
+              - included
+              - excluded
+            default: all
+          in: query
+          required: false
+      responses:
+        "200":
+          description: Preview results for the catalog source configuration.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PreviewCatalogSourceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          description: Unprocessable Entity - Invalid source configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: previewCatalogSource
+components:
+  schemas:
+    CatalogLabel:
+      description: A catalog label. Labels are used to categorize catalog sources. Represented as a flexible map of string key-value pairs with a required 'name' field.
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          nullable: true
+          description: The unique name identifier for the label.
+        displayName:
+          type: string
+          description: An optional human-readable name to show in place of `name`.
+      additionalProperties:
+        type: string
+      example:
+        name: huggingface
+        displayName: HuggingFace Hub
+        description: HuggingFace models with full support and legal indemnification.
+    CatalogLabelList:
+      description: List of CatalogLabel entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `CatalogLabel` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/CatalogLabel"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    CatalogSource:
+      description: A catalog source. A catalog source has CatalogModel children.
+      required:
+        - id
+        - name
+        - labels
+      type: object
+      properties:
+        id:
+          description: A unique identifier for a `CatalogSource`.
+          type: string
+        name:
+          description: The name of the catalog source.
+          type: string
+        enabled:
+          description: Whether the catalog source is enabled.
+          type: boolean
+          default: true
+        labels:
+          description: Labels for the catalog source.
+          type: array
+          items:
+            type: string
+        status:
+          $ref: "#/components/schemas/CatalogSourceStatus"
+          description: Current operational status of the catalog source.
+        error:
+          description: |-
+            Detailed error information when the status is "Error".
+            This field is null or empty when the source is functioning normally.
+          type: string
+          nullable: true
+        includedModels:
+          description: |-
+            Optional list of glob patterns for models to include. If specified, only models matching
+            at least one pattern will be included. If omitted, all models are considered for inclusion.
+
+            Pattern Syntax:
+            - Only the `*` wildcard is supported (matches zero or more characters)
+            - Patterns are case-insensitive (e.g., `Granite/*` matches `granite/model` and `GRANITE/model`)
+            - Patterns match the entire model name (anchored at start and end)
+            - Wildcards can appear anywhere: `Granite/*`, `*-beta`, `*deprecated*`, `*/old*`
+
+            Examples:
+            - `ibm-granite/*` - matches all models starting with "ibm-granite/"
+            - `meta-llama/*` - matches all models in the meta-llama namespace
+            - `*` - matches all models
+
+            Constraints:
+            - Patterns cannot be empty or whitespace-only
+            - A pattern cannot appear in both includedModels and excludedModels
+          type: array
+          items:
+            type: string
+        excludedModels:
+          description: |-
+            Optional list of glob patterns for models to exclude. Models matching any pattern
+            will be excluded even if they match an includedModels pattern. Exclusions take
+            precedence over inclusions.
+
+            Pattern Syntax:
+            - Only the `*` wildcard is supported (matches zero or more characters)
+            - Patterns are case-insensitive
+            - Patterns match the entire model name (anchored at start and end)
+            - Wildcards can appear anywhere in the pattern
+
+            Examples:
+            - `*-draft` - excludes all models ending with "-draft"
+            - `*-experimental` - excludes experimental models
+            - `*deprecated*` - excludes models with "deprecated" anywhere in the name
+            - `*/beta-*` - excludes models with "/beta-" in the path
+
+            Constraints:
+            - Patterns cannot be empty or whitespace-only
+            - A pattern cannot appear in both includedModels and excludedModels
+          type: array
+          items:
+            type: string
+        assetType:
+          $ref: "#/components/schemas/CatalogAssetType"
+          description: |-
+            The type of assets this source manages. Defaults to "models" if not specified.
+            This field determines which loader processes the source and which API endpoints
+            return the assets.
+    CatalogSourceStatus:
+      description: |-
+        Operational status of a catalog source.
+        - `available`: The source is functioning correctly and models can be retrieved
+        - `partially-available`: The source loaded some models successfully but encountered errors with others
+        - `error`: The source is experiencing issues and cannot provide models
+        - `disabled`: The source has been intentionally disabled
+      enum:
+        - available
+        - partially-available
+        - error
+        - disabled
+      type: string
+    CatalogSourceList:
+      description: List of CatalogSource entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `CatalogSource` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/CatalogSource"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    CatalogAssetType:
+      type: string
+      enum:
+        - models
+        - mcp_servers
+        - agents
+        - skills
+      default: models
+    CatalogSourcePreviewResponse:
+      description: Response containing models and their inclusion/exclusion status.
+      allOf:
+        - type: object
+          properties:
+            assetType:
+              $ref: "#/components/schemas/CatalogAssetType"
+            items:
+              description: Array of model preview results.
+              type: array
+              items:
+                $ref: "#/components/schemas/ModelPreviewResult"
+            summary:
+              description: Summary of the preview results
+              type: object
+              properties:
+                totalModels:
+                  type: integer
+                  description: Total number of models evaluated
+                  example: 1500
+                includedModels:
+                  type: integer
+                  description: Number of models that would be included
+                  example: 850
+                excludedModels:
+                  type: integer
+                  description: Number of models that would be excluded
+                  example: 650
+              required:
+                - totalModels
+                - includedModels
+                - excludedModels
+          required:
+            - assetType
+            - items
+            - summary
+        - $ref: "#/components/schemas/BaseResourceList"
+    ModelPreviewResult:
+      description: |-
+        A model with its inclusion/exclusion status based on the
+        configured catalog source filters.
+      type: object
+      required:
+        - name
+        - included
+      properties:
+        name:
+          type: string
+          description: Name of the model
+          example: microsoft/DialoGPT-medium
+        included:
+          type: boolean
+          description: Whether this model would be included based on the source configuration
+    AssetPreviewResult:
+      description: |-
+        An asset (e.g., MCP server) with its inclusion/exclusion status based on the
+        configured catalog source filters.
+      type: object
+      required:
+        - name
+        - included
+      properties:
+        name:
+          type: string
+          description: Name of the asset
+          example: prometheus-mcp
+        included:
+          type: boolean
+          description: Whether this asset would be included based on the source configuration
+    AssetSourcePreviewResponse:
+      description: Response containing assets and their inclusion/exclusion status.
+      allOf:
+        - type: object
+          properties:
+            assetType:
+              $ref: "#/components/schemas/CatalogAssetType"
+            items:
+              description: Array of asset preview results.
+              type: array
+              items:
+                $ref: "#/components/schemas/AssetPreviewResult"
+            summary:
+              description: Summary of the preview results
+              type: object
+              properties:
+                totalAssets:
+                  type: integer
+                  description: Total number of assets evaluated
+                  example: 25
+                includedAssets:
+                  type: integer
+                  description: Number of assets that would be included
+                  example: 18
+                excludedAssets:
+                  type: integer
+                  description: Number of assets that would be excluded
+                  example: 7
+              required:
+                - totalAssets
+                - includedAssets
+                - excludedAssets
+          required:
+            - assetType
+            - items
+            - summary
+        - $ref: "#/components/schemas/BaseResourceList"
+    PreviewCatalogSourceResponse:
+      description: >-
+        Polymorphic preview response. The `assetType` discriminator determines
+        whether the payload is a model preview or an MCP server preview.
+      oneOf:
+        - $ref: "#/components/schemas/CatalogSourcePreviewResponse"
+        - $ref: "#/components/schemas/AssetSourcePreviewResponse"
+      discriminator:
+        propertyName: assetType
+        mapping:
+          models: "#/components/schemas/CatalogSourcePreviewResponse"
+          mcp_servers: "#/components/schemas/AssetSourcePreviewResponse"
+          agents: "#/components/schemas/AssetSourcePreviewResponse"
+          skills: "#/components/schemas/AssetSourcePreviewResponse"
+    FilterOption:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: The data type of the filter option
+          enum:
+            - string
+            - number
+        values:
+          type: array
+          description: Known values of the property for string types with a small number of possible options.
+          items: {}
+        range:
+          $ref: "#/components/schemas/FilterOptionRange"
+    FilterOptionRange:
+      type: object
+      description: Min and max values for number types.
+      properties:
+        min:
+          type: number
+          format: double
+        max:
+          type: number
+          format: double
+    FieldFilter:
+      type: object
+      required:
+        - operator
+        - value
+      properties:
+        operator:
+          type: string
+          description: Filter operator (e.g., '<', '=', '>', 'IN')
+          example: '<'
+        value:
+          description: Filter value (can be number, string, or array)
+          example: 70
+    FilterOptionsList:
+      description: List of FilterOptions
+      type: object
+      properties:
+        filters:
+          type: object
+          description: A single filter option.
+          additionalProperties:
+            $ref: "#/components/schemas/FilterOption"
+        namedQueries:
+          type: object
+          description: Predefined named queries for common filtering scenarios
+          additionalProperties:
+            type: object
+            additionalProperties:
+              $ref: "#/components/schemas/FieldFilter"
+    OrderByField:
+      description: |-
+        Supported fields for ordering result entities.
+      enum:
+        - CREATE_TIME
+        - LAST_UPDATE_TIME
+        - ID
+        - NAME
+        - RECOMMENDED
+      type: string
+
+  responses:
+    CatalogLabelListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogLabelList"
+      description: A response containing a list of CatalogLabel entities.
+    CatalogSourceListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CatalogSourceList"
+      description: A response containing a list of CatalogSource entities.
+    FilterOptionsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FilterOptionsList"
+      description: A response containing options for a `filterQuery` parameter.
+    PreviewCatalogSourceResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PreviewCatalogSourceResponse"
+          examples:
+            allModels:
+              summary: All models with inclusion status
+              description: Response showing all models when filterStatus=all
+              value:
+                assetType: models
+                nextPageToken: ""
+                pageSize: 10
+                size: 5
+                items:
+                  - name: "ibm-granite/granite-3.0-8b-instruct"
+                    included: true
+                  - name: "ibm-granite/granite-3.0-2b-instruct"
+                    included: true
+                  - name: "meta-llama/Llama-2-7b-hf"
+                    included: true
+                  - name: "mistralai/Mistral-7B-v0.1-draft"
+                    included: false
+                  - name: "microsoft/phi-2-experimental"
+                    included: false
+                summary:
+                  totalModels: 5
+                  includedModels: 3
+                  excludedModels: 2
+            includedOnly:
+              summary: Only included models
+              description: Response when filterStatus=included
+              value:
+                assetType: models
+                nextPageToken: ""
+                pageSize: 10
+                size: 3
+                items:
+                  - name: "ibm-granite/granite-3.0-8b-instruct"
+                    included: true
+                  - name: "ibm-granite/granite-3.0-2b-instruct"
+                    included: true
+                  - name: "meta-llama/Llama-2-7b-hf"
+                    included: true
+                summary:
+                  totalModels: 5
+                  includedModels: 3
+                  excludedModels: 2
+            excludedOnly:
+              summary: Only excluded models
+              description: Response when filterStatus=excluded
+              value:
+                assetType: models
+                nextPageToken: ""
+                pageSize: 10
+                size: 2
+                items:
+                  - name: "mistralai/Mistral-7B-v0.1-draft"
+                    included: false
+                  - name: "microsoft/phi-2-experimental"
+                    included: false
+                summary:
+                  totalModels: 5
+                  includedModels: 3
+                  excludedModels: 2
+            withPagination:
+              summary: Paginated response
+              description: Response with pagination when pageSize is smaller than total
+              value:
+                assetType: models
+                nextPageToken: "eyJvZmZzZXQiOjEwfQ==" # notsecret
+                pageSize: 10
+                size: 10
+                items:
+                  - name: "ibm-granite/granite-3.0-8b-instruct"
+                    included: true
+                  - name: "ibm-granite/granite-3.0-2b-instruct"
+                    included: true
+                  - name: "meta-llama/Llama-2-7b-hf"
+                    included: true
+                  - name: "meta-llama/Llama-2-13b-hf"
+                    included: true
+                  - name: "mistralai/Mistral-7B-Instruct-v0.3"
+                    included: true
+                  - name: "mistralai/Mistral-7B-v0.1"
+                    included: true
+                  - name: "microsoft/phi-2"
+                    included: true
+                  - name: "google/gemma-7b"
+                    included: true
+                  - name: "mistralai/Mistral-7B-v0.1-draft"
+                    included: false
+                  - name: "microsoft/phi-2-experimental"
+                    included: false
+                summary:
+                  totalModels: 150
+                  includedModels: 85
+                  excludedModels: 65
+            allMCPServers:
+              summary: All MCP servers with inclusion status
+              description: Response showing all MCP servers when assetType=mcp_servers
+              value:
+                assetType: mcp_servers
+                nextPageToken: ""
+                pageSize: 10
+                size: 3
+                items:
+                  - name: "kubernetes-mcp"
+                    included: true
+                  - name: "prometheus-mcp"
+                    included: true
+                  - name: "grafana-internal"
+                    included: false
+                summary:
+                  totalAssets: 3
+                  includedAssets: 2
+                  excludedAssets: 1
+      description: |-
+        A response containing preview results with inclusion/exclusion status.
+        The `assetType` discriminator determines whether the payload contains
+        model previews or MCP server previews.
+
+  parameters:
+    filterQuery:
+      examples:
+        filterQuery:
+          value: "name='my-model' AND state='LIVE'"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter catalog models. The query supports rich filtering capabilities with automatic type inference.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Data Types:**
+        - Strings: `"value"` or `'value'`
+        - Numbers: `42`, `3.14`, `1e-5`
+        - Booleans: `true`, `false` (case-insensitive)
+
+        **Property Access:**
+        - Standard properties: `name`, `id`, `state`, `createTimeSinceEpoch`
+        - Custom properties: Any user-defined property name
+        - Escaped properties: Use backticks for special characters: `` `custom-property` ``
+        - Type-specific access: `property.string_value`, `property.double_value`, `property.int_value`, `property.bool_value`
+        - **Related artifact properties**: `artifacts.<propertyName>` to filter models by their artifact properties
+
+        **Examples:**
+        - Basic: `name = "my-model"`
+        - Comparison: `accuracy > 0.95`
+        - Pattern: `name LIKE "%tensorflow%"`
+        - Complex: `(name = "model-a" OR name = "model-b") AND state = "LIVE"`
+        - Custom property: `framework.string_value = "pytorch"`
+        - Escaped property: `` `mlflow.source.type` = "notebook" ``
+        - **Artifact filtering**: `artifacts.ttft_mean >= 90` - filter models that have artifacts with ttft_mean >= 90
+        - **Artifact custom property**: `artifacts.format = "pytorch"` - filter models by artifact custom properties
+        - **Combined filtering**: `name = "llm-model" AND artifacts.performance_score > 0.95` - combine model and artifact filters
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    orderBy:
+      style: form
+      explode: true
+      examples:
+        orderBy:
+          value: ID
+      name: orderBy
+      description: Specifies the order by criteria for listing entities.
+      schema:
+        $ref: "#/components/schemas/OrderByField"
+      in: query
+      required: false
+    labelOrderBy:
+      style: form
+      explode: true
+      examples:
+        labelOrderBy:
+          value: name
+      name: orderBy
+      description: |
+        Specifies the key to order catalog labels by. You can provide any string key
+        that may exist in the label maps. Labels that contain the specified key will
+        be sorted by that key's value. Labels that don't contain the key will maintain
+        their original order and appear after labels that do contain the key.
+      schema:
+        type: string
+      in: query
+      required: false
+    assetType:
+      name: assetType
+      description: Filter by asset type.
+      schema:
+        $ref: "#/components/schemas/CatalogAssetType"
+      in: query
+      required: false
+tags: []

--- a/api/openapi/src/plugins/agent-v1.yaml
+++ b/api/openapi/src/plugins/agent-v1.yaml
@@ -1,0 +1,314 @@
+paths:
+  /api/agent_catalog/v1/agents:
+    description: >-
+      The REST endpoint/path used to list zero or more `Agent` entities.
+    get:
+      summary: List agents.
+      tags:
+        - AgentCatalogService
+      parameters:
+        - name: name
+          description: Filter by name using SQL LIKE pattern matching.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: q
+          description: Free-form keyword search used to filter the response.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: source
+          description: Filter by source ID.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - name: sourceLabel
+          description: |-
+            Filter by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then entities from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/AgentListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findAgents
+
+  /api/agent_catalog/v1/agents/filter_options:
+    description: Lists options for `filterQuery` when listing agents.
+    get:
+      summary: Lists fields and values that can be used in `filterQuery` on the list agents endpoint.
+      tags:
+        - AgentCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/FilterOptionsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findAgentsFilterOptions
+
+  /api/agent_catalog/v1/agents/{id}:
+    description: >-
+      The REST endpoint/path used to get a single `Agent` entity.
+    get:
+      summary: Get an agent by ID.
+      tags:
+        - AgentCatalogService
+      parameters:
+        - name: id
+          description: The unique identifier of the entity.
+          schema:
+            type: string
+          in: path
+          required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/AgentResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getAgent
+
+  /api/agent_catalog/v1/agents/{id}/artifacts:
+    description: >-
+      The REST endpoint/path used to list artifacts for a specific agent.
+    get:
+      summary: List artifacts for an agent.
+      tags:
+        - AgentCatalogService
+      parameters:
+        - $ref: "#/components/parameters/agentArtifactType"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/AgentArtifactListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getAgentArtifacts
+    parameters:
+      - name: id
+        description: The unique identifier of the agent.
+        schema:
+          type: string
+        in: path
+        required: true
+
+# Parameters (pageSize, orderBy, filterQuery, sortOrder, nextPageToken) and shared
+# responses (BadRequest, FilterOptionsResponse, etc.) are provided by lib/common.yaml
+# and catalog.yaml during spec assembly. Only plugin-specific schemas and responses
+# are defined here.
+components:
+  schemas:
+    Agent:
+      description: An agent in the agent catalog.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              description: Agent identifier. Must be unique within a source.
+            sourceId:
+              type: string
+              description: Catalog source that provides this entity.
+            displayName:
+              type: string
+              description: Human-readable display name.
+            description:
+              type: string
+              description: Short description of the agent.
+            readme:
+              type: string
+              description: Full Markdown documentation.
+            framework:
+              type: string
+              description: Agent framework (e.g., langgraph, crewai, autogen).
+            labels:
+              type: array
+              items:
+                type: string
+              description: Labels for categorization and filtering.
+            logo:
+              type: string
+              description: URL or path to the agent logo image.
+            repositoryUrl:
+              type: string
+              format: uri
+              description: URL to the agent source code repository.
+            env:
+              type: array
+              items:
+                $ref: "#/components/schemas/AgentEnvVar"
+              description: Environment variables required for deployment.
+            artifacts:
+              type: array
+              items:
+                $ref: "#/components/schemas/AgentImageArtifact"
+              description: OCI image artifacts for agent deployment.
+
+    AgentEnvVar:
+      description: An environment variable required by an agent.
+      type: object
+      required:
+        - name
+        - required
+      properties:
+        name:
+          type: string
+          description: Environment variable name.
+        required:
+          type: boolean
+          description: Whether this variable is required for deployment.
+
+    AgentArtifact:
+      description: A single artifact in the agent catalog API.
+      oneOf:
+        - $ref: "#/components/schemas/AgentTemplateArtifact"
+      discriminator:
+        propertyName: artifactType
+        mapping:
+          template-artifact: "#/components/schemas/AgentTemplateArtifact"
+
+    AgentImageArtifact:
+      description: OCI image artifact for agent deployment.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - artifactType
+            - uri
+          properties:
+            artifactType:
+              type: string
+              default: image-artifact
+            uri:
+              type: string
+              format: uri
+              description: URI of the artifact (e.g., OCI image reference).
+
+    AgentTemplateArtifact:
+      description: >-
+        Agent deployment template artifact. Contains the full agent.yaml
+        specification as a JSON-encoded string.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - artifactType
+            - content
+          properties:
+            artifactType:
+              type: string
+              default: template-artifact
+            content:
+              type: string
+              description: >-
+                The agent.yaml specification as a JSON-encoded string.
+                Describes the agent's deployment configuration including
+                name, framework, environment variables, and other metadata.
+
+    AgentArtifactTypeQueryParam:
+      description: Supported artifact types for querying agent artifacts.
+      enum:
+        - template-artifact
+      type: string
+
+    AgentArtifactList:
+      description: A list of agent artifact entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `AgentArtifact` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/AgentArtifact"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+
+    AgentList:
+      description: A list of agent entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `Agent` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/Agent"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+
+  responses:
+    AgentArtifactListResponse:
+      description: A list of agent artifact entities.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AgentArtifactList"
+    AgentListResponse:
+      description: A list of agent entities.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AgentList"
+    AgentResponse:
+      description: A single agent entity.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Agent"
+  parameters:
+    agentArtifactType:
+      style: form
+      explode: true
+      examples:
+        agentArtifactType:
+          value: template-artifact
+      name: artifactType
+      description: Filter artifacts by type.
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/AgentArtifactTypeQueryParam"
+      in: query
+      required: false

--- a/api/openapi/src/plugins/mcp-v1.yaml
+++ b/api/openapi/src/plugins/mcp-v1.yaml
@@ -1,0 +1,859 @@
+paths:
+  /api/mcp_catalog/v1/mcp_servers:
+    description: >-
+      The REST endpoint/path used to list zero or more `MCPServer` entities.
+    get:
+      summary: List MCP servers.
+      tags:
+        - MCPCatalogService
+      parameters:
+        - name: name
+          description: Filter MCP servers by server name using SQL LIKE pattern matching.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: q
+          description: Free-form keyword search across name, description, and provider.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: sourceLabel
+          description: |-
+            Filter MCP servers by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then MCP servers from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - $ref: "#/components/parameters/mcpServerFilterQuery"
+        - $ref: "#/components/parameters/namedQuery"
+        - $ref: "#/components/parameters/includeTools"
+        - $ref: "#/components/parameters/toolLimit"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/MCPServerListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findMCPServers
+  /api/mcp_catalog/v1/mcp_servers/filter_options:
+    description: Lists options for `filterQuery` when listing MCP servers.
+    get:
+      summary: Lists fields, values, and named queries that can be used in `filterQuery` on the list MCP servers endpoint.
+      tags:
+        - MCPCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/FilterOptionsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findMCPServersFilterOptions
+  /api/mcp_catalog/v1/mcp_servers/{server_id}:
+    description: >-
+      The REST endpoint/path used to get an `MCPServer`.
+    get:
+      summary: Get an `MCPServer`.
+      tags:
+        - MCPCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/MCPServerResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getMCPServer
+    parameters:
+      - name: server_id
+        description: A unique identifier for an `MCPServer`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - $ref: "#/components/parameters/includeTools"
+      - $ref: "#/components/parameters/toolLimit"
+  /api/mcp_catalog/v1/mcp_servers/{server_id}/tools:
+    description: >-
+      The REST endpoint/path used to list zero or more `MCPTool` entities for an `MCPServer`.
+    get:
+      summary: List tools exposed by an `MCPServer`.
+      tags:
+        - MCPCatalogService
+      parameters:
+        - $ref: "#/components/parameters/mcpToolFilterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/MCPToolsListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findMCPServerTools
+    parameters:
+      - name: server_id
+        description: A unique identifier for an `MCPServer`.
+        schema:
+          type: string
+        in: path
+        required: true
+  /api/mcp_catalog/v1/mcp_servers/{server_id}/tools/{tool_name}:
+    description: >-
+      The REST endpoint/path used to get a specific `MCPTool` from an `MCPServer`.
+    get:
+      summary: Get an `MCPTool` from an `MCPServer`.
+      tags:
+        - MCPCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/MCPToolWithServerResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getMCPServerTool
+    parameters:
+      - name: server_id
+        description: A unique identifier for an `MCPServer`.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: tool_name
+        description: A unique identifier for an `MCPTool` within the MCP server.
+        schema:
+          type: string
+        in: path
+        required: true
+components:
+  schemas:
+    MCPServer:
+      description: An MCP server in the model catalog.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - name
+            - toolCount
+          properties:
+            name:
+              type: string
+              description: Human-readable MCP server name. Must be unique within a source.
+            displayName:
+              type: string
+              description: Optional human-friendly display label for this MCP server.
+              maxLength: 255
+            sourceId:
+              type: string
+              description: Catalog source that provides this server.
+            provider:
+              type: string
+              description: Organization providing the server.
+            logo:
+              type: string
+              description: MCP server logo.
+            version:
+              type: string
+              description: Semantic version string of the MCP server.
+            tags:
+              type: array
+              description: Categorization tags for this MCP server.
+              example:
+                - observability
+                - monitoring
+                - apm
+              items:
+                type: string
+            license:
+              type: string
+              description: SPDX identifier for the server license.
+            licenseLink:
+              type: string
+              format: uri
+              description: URL to the full license text.
+            toolCount:
+              type: integer
+              description: Number of tools exposed by this MCP server.
+              example: 15
+            tools:
+              type: array
+              description: Array of tools exposed by this MCP server.
+              items:
+                $ref: "#/components/schemas/MCPTool"
+            securityIndicators:
+              $ref: "#/components/schemas/MCPSecurityIndicator"
+            deploymentMode:
+              type: string
+              description: Deployment mode for the MCP server.
+              enum:
+                - local
+                - remote
+            transports:
+              type: array
+              description: Supported transport protocols.
+              items:
+                type: string
+                enum:
+                  - stdio
+                  - http
+                  - sse
+            artifacts:
+              type: array
+              description: OCI artifacts used for local deployment.
+              items:
+                $ref: "#/components/schemas/MCPArtifact"
+            endpoints:
+              $ref: "#/components/schemas/MCPEndpoints"
+            readme:
+              type: string
+              description: Full Markdown documentation for this MCP server.
+            documentationUrl:
+              type: string
+              format: uri
+              description: URL to external documentation.
+            repositoryUrl:
+              type: string
+              format: uri
+              description: URL to source repository.
+            sourceCode:
+              type: string
+              format: uri
+              description: URL to browsable source code.
+            publishedDate:
+              type: string
+              format: date-time
+              description: Initial publication timestamp for the server.
+            lastUpdated:
+              type: string
+              format: date-time
+              description: Last update timestamp for the server metadata.
+            runtimeMetadata:
+              $ref: "#/components/schemas/MCPRuntimeMetadata"
+              description: |-
+                Runtime metadata for deploying this MCP server via MCPServer CRDs.
+                Provides defaults, recommendations, and requirements for creating deployments.
+                This is discovery metadata, not actual deployment configuration.
+    MCPServerList:
+      description: List of MCP server entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `MCPServer` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/MCPServer"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    MCPSecurityIndicator:
+      type: object
+      description: Security posture metadata for an MCP server.
+      properties:
+        verifiedSource:
+          type: boolean
+          description: Whether the source of this server has been verified.
+        secureEndpoint:
+          type: boolean
+          description: Whether the server exposes secure communication endpoints.
+        sast:
+          type: boolean
+          description: Whether static analysis has been performed.
+        readOnlyTools:
+          type: boolean
+          description: Whether all exposed tools are read-only.
+    MCPArtifact:
+      description: Artifact metadata for local MCP server deployment.
+      allOf:
+        - $ref: "#/components/schemas/BaseResourceDates"
+        - type: object
+          required:
+            - uri
+          properties:
+            uri:
+              type: string
+              format: uri
+              description: OCI image URI for local deployment.
+    MCPEndpoints:
+      type: object
+      description: Remote endpoint metadata for MCP server access.
+      properties:
+        http:
+          type: string
+          format: uri
+          description: HTTP endpoint URL for the MCP server.
+        sse:
+          type: string
+          format: uri
+          description: SSE endpoint URL for the MCP server.
+    MCPTool:
+      description: An MCP tool exposed by an MCP server.
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - name
+            - accessType
+          properties:
+            name:
+              type: string
+              description: Tool identifier.
+            accessType:
+              type: string
+              description: Access mode supported by this tool.
+              enum:
+                - read_only
+                - read_write
+                - execute
+            parameters:
+              type: array
+              description: Input parameters accepted by this tool.
+              items:
+                $ref: "#/components/schemas/MCPToolParameter"
+    MCPToolWithServer:
+      type: object
+      required:
+        - serverId
+        - serverName
+        - tool
+      properties:
+        serverId:
+          type: string
+          description: ID of the MCP server that exposes this tool
+          example: prometheus-mcp
+        serverName:
+          type: string
+          description: Human-readable name of the MCP server
+          example: Prometheus MCP Server
+        tool:
+          $ref: "#/components/schemas/MCPTool"
+    MCPToolParameter:
+      type: object
+      description: Metadata describing a single MCP tool parameter.
+      required:
+        - name
+        - type
+        - required
+      properties:
+        name:
+          type: string
+          description: Parameter name.
+        type:
+          type: string
+          description: Parameter type.
+        required:
+          type: boolean
+          description: Whether this parameter is required.
+        description:
+          type: string
+          description: Parameter purpose.
+    MCPToolsList:
+      description: List of MCP tool entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `MCPTool` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/MCPTool"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+    MCPRuntimeMetadata:
+      type: object
+      properties:
+        defaultPort:
+          type: integer
+          description: |-
+            Default port the MCP server listens on. Maps to MCPServer.spec.mcpPort.
+            Should align with the primary transport type.
+          example: 8080
+          minimum: 1
+          maximum: 65535
+        defaultArgs:
+          type: array
+          description: |-
+            Default command-line arguments for the MCP server.
+            Users can override or extend these in the MCPServer CRD.
+          items:
+            type: string
+          example: ["--log-level", "info", "--metrics-enabled"]
+        requiredEnvironmentVariables:
+          type: array
+          description: |-
+            Environment variables that MUST be set for the server to function.
+            Documents the names and purposes - values come from user's Secrets/ConfigMaps.
+          items:
+            $ref: "#/components/schemas/MCPEnvVarMetadata"
+        optionalEnvironmentVariables:
+          type: array
+          description: |-
+            Optional environment variables that configure server behavior.
+            Documents the names, purposes, and default values.
+          items:
+            $ref: "#/components/schemas/MCPEnvVarMetadata"
+        recommendedResources:
+          $ref: "#/components/schemas/MCPResourceRecommendation"
+          description: |-
+            Recommended CPU and memory resources based on typical workloads.
+            Users should adjust based on their specific usage patterns.
+        healthEndpoints:
+          type: object
+          description: Health check endpoint paths
+          properties:
+            liveness:
+              type: string
+              description: Liveness probe endpoint path
+              example: /health
+            readiness:
+              type: string
+              description: Readiness probe endpoint path
+              example: /ready
+        capabilities:
+          type: object
+          description: |-
+            Runtime capabilities and requirements for this MCP server.
+            Helps users understand what the server needs to run properly.
+          properties:
+            requiresNetwork:
+              type: boolean
+              description: Whether server requires network access
+              default: true
+            requiresFileSystem:
+              type: boolean
+              description: Whether server requires writable filesystem
+              default: false
+            requiresGPU:
+              type: boolean
+              description: Whether server requires GPU access
+              default: false
+        mcpPath:
+          type: string
+          description: |-
+            HTTP path where MCP server accepts requests.
+            Used for HTTP and SSE transports.
+            Aligns with MCP Lifecycle operator conventions.
+          pattern: '^/[a-zA-Z0-9/_.-]*$'
+          default: /mcp
+          example: /mcp
+        prerequisites:
+          $ref: "#/components/schemas/MCPPrerequisites"
+          description: |-
+            Kubernetes prerequisites discovery metadata.
+            Helps users understand what K8s resources to create before deployment.
+    MCPEnvVarMetadata:
+      type: object
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+          description: Environment variable name
+          example: API_KEY
+        description:
+          type: string
+          description: Purpose and usage of this variable
+          example: API key for authenticating with external service
+        required:
+          type: boolean
+          description: Whether this variable must be set
+          default: false
+        defaultValue:
+          type: string
+          description: |-
+            Default value if not provided. Only for optional variables.
+            Secrets should NEVER have default values.
+          example: info
+        type:
+          type: string
+          enum: [string, int, boolean, secret, config]
+          description: Expected variable type
+          default: string
+        example:
+          type: string
+          description: Example value for documentation purposes
+          example: my-api-key-123
+    MCPResourceRecommendation:
+      type: object
+      properties:
+        minimal:
+          type: object
+          description: Minimum viable resources for low-traffic scenarios
+          properties:
+            cpu:
+              type: string
+              description: CPU request (e.g., 50m, 0.1, 1)
+              example: 50m
+            memory:
+              type: string
+              description: Memory request (e.g., 64Mi, 128Mi, 1Gi)
+              example: 64Mi
+        recommended:
+          type: object
+          description: Recommended resources for typical production use
+          properties:
+            cpu:
+              type: string
+              example: 100m
+            memory:
+              type: string
+              example: 128Mi
+        high:
+          type: object
+          description: Resources for high-traffic or compute-intensive scenarios
+          properties:
+            cpu:
+              type: string
+              example: 500m
+            memory:
+              type: string
+              example: 512Mi
+    MCPServiceAccountRequirement:
+      type: object
+      description: |-
+        ServiceAccount requirements for Kubernetes deployment.
+        Provides discovery hints about RBAC permissions needed.
+      properties:
+        required:
+          type: boolean
+          description: Whether a ServiceAccount is required for this MCP server
+          default: false
+          example: true
+        hint:
+          type: string
+          description: |-
+            Human-readable description of required RBAC permissions.
+            Example: "Needs 'view' ClusterRole for read-only K8s access"
+          maxLength: 500
+          example: "Requires read-only access to pods and services in the namespace"
+        suggestedName:
+          type: string
+          description: Suggested ServiceAccount name (must be valid Kubernetes name)
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          maxLength: 253
+          example: mcp-server-viewer
+    MCPSecretKey:
+      type: object
+      required:
+        - key
+        - description
+      description: Individual key within a Kubernetes Secret
+      properties:
+        key:
+          type: string
+          description: Secret key name
+          maxLength: 253
+          example: api-key
+        description:
+          type: string
+          description: What this key should contain (never actual values)
+          maxLength: 500
+          example: OpenAI API key for authentication
+        envVarName:
+          type: string
+          description: Environment variable name to map this key to
+          maxLength: 253
+          example: OPENAI_API_KEY
+        required:
+          type: boolean
+          description: Whether this key must be present in the Secret
+          default: false
+    MCPSecretRequirement:
+      type: object
+      required:
+        - name
+        - description
+      description: |-
+        Kubernetes Secret requirement metadata.
+        Never stores actual secret values - provides discovery hints only.
+      properties:
+        name:
+          type: string
+          description: Suggested Secret name (must be valid Kubernetes name)
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
+          example: openai-credentials
+        description:
+          type: string
+          description: |-
+            Purpose of the Secret and kubectl creation hint.
+            Example: "kubectl create secret generic openai-credentials --from-literal=api-key=sk-..."
+          maxLength: 1000
+          example: Create with kubectl create secret generic openai-credentials --from-literal=api-key=YOUR_KEY
+        keys:
+          type: array
+          description: Expected keys within the Secret
+          items:
+            $ref: "#/components/schemas/MCPSecretKey"
+        mountAsFile:
+          type: boolean
+          description: Whether to mount Secret as files instead of environment variables
+          default: false
+        mountPath:
+          type: string
+          description: Mount path when mountAsFile is true (must be absolute path)
+          pattern: '^/[a-zA-Z0-9/_.-]*$'
+          maxLength: 4096
+          example: /etc/secrets
+    MCPConfigMapKey:
+      type: object
+      required:
+        - key
+        - description
+      description: Individual key within a Kubernetes ConfigMap
+      properties:
+        key:
+          type: string
+          description: ConfigMap key name (often a filename)
+          maxLength: 253
+          example: config.toml
+        description:
+          type: string
+          description: What this key should contain
+          maxLength: 500
+          example: Main configuration file for MCP server
+        defaultContent:
+          type: string
+          description: |-
+            Default content users can copy and customize.
+            Limited to 10KB for performance. For larger configs, reference external documentation.
+          maxLength: 10000
+          example: |
+            log_level = "info"
+            port = 8080
+        envVarName:
+          type: string
+          description: Environment variable name if not mounted as file
+          maxLength: 253
+          example: MCP_CONFIG
+        required:
+          type: boolean
+          description: Whether this key is required
+          default: false
+    MCPConfigMapRequirement:
+      type: object
+      required:
+        - name
+        - description
+      description: Kubernetes ConfigMap requirement metadata
+      properties:
+        name:
+          type: string
+          description: Suggested ConfigMap name (must be valid Kubernetes name)
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
+          example: mcp-server-config
+        description:
+          type: string
+          description: Purpose of the ConfigMap
+          maxLength: 1000
+          example: Configuration files for MCP server runtime
+        keys:
+          type: array
+          description: Expected keys within the ConfigMap
+          items:
+            $ref: "#/components/schemas/MCPConfigMapKey"
+        mountAsFile:
+          type: boolean
+          description: Whether to mount ConfigMap as files
+          default: true
+        mountPath:
+          type: string
+          description: Mount path when mountAsFile is true (must be absolute path)
+          pattern: '^/[a-zA-Z0-9/_.-]*$'
+          maxLength: 4096
+          example: /etc/mcp-config
+    MCPPrerequisites:
+      type: object
+      description: |-
+        Aggregated Kubernetes prerequisites metadata for MCP server deployment.
+        All fields are discovery hints - not deployment configuration.
+      properties:
+        serviceAccount:
+          $ref: "#/components/schemas/MCPServiceAccountRequirement"
+          description: ServiceAccount requirements and RBAC hints
+        secrets:
+          type: array
+          description: Required Kubernetes Secrets
+          items:
+            $ref: "#/components/schemas/MCPSecretRequirement"
+        configMaps:
+          type: array
+          description: Required Kubernetes ConfigMaps
+          items:
+            $ref: "#/components/schemas/MCPConfigMapRequirement"
+        environmentVariables:
+          type: array
+          description: |-
+            Aggregated environment variables list.
+            Combines required and optional environment variables for convenience.
+          items:
+            $ref: "#/components/schemas/MCPEnvVarMetadata"
+        customResources:
+          type: array
+          description: |-
+            Other Kubernetes resources needed (e.g., PersistentVolumeClaims, NetworkPolicies).
+            Free-form hints for advanced deployment scenarios.
+          items:
+            type: string
+          example: ["PersistentVolumeClaim: mcp-data-storage"]
+      example:
+        serviceAccount:
+          required: true
+          hint: "Needs 'view' ClusterRole for read-only K8s access"
+          suggestedName: mcp-viewer
+        secrets:
+          - name: openai-credentials
+            description: "kubectl create secret generic openai-credentials --from-literal=api-key=YOUR_KEY"
+            keys:
+              - key: api-key
+                description: OpenAI API key
+                envVarName: OPENAI_API_KEY
+        configMaps:
+          - name: mcp-server-config
+            description: Configuration files
+            mountAsFile: true
+            mountPath: /etc/mcp-config
+            keys:
+              - key: config.toml
+                description: Main configuration
+                defaultContent: "log_level = \"info\"\nport = 8080\n"
+  responses:
+    MCPServerListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MCPServerList"
+      description: A response containing a list of MCP server entities.
+    MCPServerResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MCPServer"
+      description: A response containing an `MCPServer` entity.
+    MCPToolsListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MCPToolsList"
+      description: A response containing a list of MCP tool entities.
+    MCPToolWithServerResponse:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MCPToolWithServer"
+      description: A response containing an `MCPToolWithServer` entity.
+  parameters:
+    mcpServerFilterQuery:
+      examples:
+        mcpServerFilterQuery:
+          value: "license='Apache 2.0' AND securityIndicators.verifiedSource=true"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter MCP servers.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Examples:**
+        - `license = "Apache 2.0"`
+        - `verifiedSource = true`
+        - `provider ILIKE "%local%"`
+        - `(license = "Apache 2.0" OR license = "MIT") AND verifiedSource = true`
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    mcpToolFilterQuery:
+      examples:
+        mcpToolFilterQuery:
+          value: "accessType='read_only' AND name ILIKE '%list%'"
+      name: filterQuery
+      description: |
+        A SQL-like query string to filter MCP tools for a specific MCP server.
+
+        **Supported Operators:**
+        - Comparison: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`
+        - Pattern matching: `LIKE`, `ILIKE` (case-insensitive)
+        - Set membership: `IN`
+        - Logical: `AND`, `OR`
+        - Grouping: `()` for complex expressions
+
+        **Examples:**
+        - `name = "list_models"`
+        - `accessType = "read_only"`
+        - `name ILIKE "%search%"`
+        - `(accessType = "read_only" OR accessType = "execute") AND name LIKE "%model%"`
+      schema:
+        type: string
+        pattern: "^[\\x20-\\x7E]*$"
+      in: query
+      required: false
+    namedQuery:
+      examples:
+        namedQuery:
+          value: secure_servers
+      name: namedQuery
+      description: Predefined filter template name to apply when listing MCP servers.
+      schema:
+        type: string
+      in: query
+      required: false
+    includeTools:
+      examples:
+        includeTools:
+          value: true
+      name: includeTools
+      description: Whether to include the tools array in each MCP server result.
+      schema:
+        type: boolean
+        default: false
+      in: query
+      required: false
+    toolLimit:
+      examples:
+        toolLimit:
+          value: 10
+      name: toolLimit
+      description: Maximum number of tools to include when includeTools is true.
+      schema:
+        type: integer
+        format: int32
+        default: 10
+        minimum: 0
+        maximum: 100
+      in: query
+      required: false

--- a/api/openapi/src/plugins/model-v1.yaml
+++ b/api/openapi/src/plugins/model-v1.yaml
@@ -181,7 +181,7 @@ paths:
           type: string
         in: path
         required: true
-  /api/model_catalog/v1/sources/{source_id}/models/{model_name}/artifacts:
+  /api/model_catalog/v1/sources/{source_id}/models/{model_name+}/artifacts:
     description: >-
       The REST endpoint/path used to list `CatalogArtifacts`.
     get:
@@ -207,7 +207,7 @@ paths:
           type: string
         in: path
         required: true
-      - name: model_name
+      - name: model_name+
         description: A unique identifier for the model.
         schema:
           type: string
@@ -220,7 +220,7 @@ paths:
       - $ref: "#/components/parameters/artifactOrderBy"
       - $ref: "#/components/parameters/sortOrder"
       - $ref: "#/components/parameters/nextPageToken"
-  /api/model_catalog/v1/sources/{source_id}/models/{model_name}/artifacts/performance:
+  /api/model_catalog/v1/sources/{source_id}/models/{model_name+}/artifacts/performance:
     description: >-
       Lists performance metrics artifacts (that is, artifacts of type `CatalogMetricsArtifact` where `metricsType` is `performance-metrics`).
     get:
@@ -246,7 +246,7 @@ paths:
           type: string
         in: path
         required: true
-      - name: model_name
+      - name: model_name+
         description: A unique identifier for the model.
         schema:
           type: string

--- a/api/openapi/src/plugins/skill-v1.yaml
+++ b/api/openapi/src/plugins/skill-v1.yaml
@@ -1,0 +1,223 @@
+paths:
+  /api/skill_catalog/v1/skills:
+    description: >-
+      The REST endpoint/path used to list zero or more `Skill` entities.
+    get:
+      summary: List skills.
+      tags:
+        - SkillCatalogService
+      parameters:
+        - name: name
+          description: Filter by name using SQL LIKE pattern matching.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: q
+          description: Free-form keyword search used to filter the response.
+          schema:
+            type: string
+          in: query
+          required: false
+        - name: source
+          description: Filter by source ID.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - name: sourceLabel
+          description: |-
+            Filter by the label associated with the source. Multiple
+            values can be separated by commas. If one of the values is the
+            string `null`, then entities from every source without a label will
+            be returned.
+          schema:
+            type: array
+            items:
+              type: string
+          in: query
+          required: false
+        - $ref: "#/components/parameters/filterQuery"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/orderBy"
+        - $ref: "#/components/parameters/sortOrder"
+        - $ref: "#/components/parameters/nextPageToken"
+      responses:
+        "200":
+          $ref: "#/components/responses/SkillListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findSkills
+
+  /api/skill_catalog/v1/skills/filter_options:
+    description: Lists options for `filterQuery` when listing skills.
+    get:
+      summary: Lists fields and values that can be used in `filterQuery` on the list skills endpoint.
+      tags:
+        - SkillCatalogService
+      responses:
+        "200":
+          $ref: "#/components/responses/FilterOptionsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: findSkillsFilterOptions
+
+  /api/skill_catalog/v1/skills/{id}:
+    description: >-
+      The REST endpoint/path used to get a single `Skill` entity.
+    get:
+      summary: Get a skill by ID.
+      tags:
+        - SkillCatalogService
+      parameters:
+        - name: id
+          description: The unique identifier of the entity.
+          schema:
+            type: string
+          in: path
+          required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/SkillResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getSkill
+
+# Parameters (pageSize, orderBy, filterQuery, sortOrder, nextPageToken) and shared
+# responses (BadRequest, FilterOptionsResponse, etc.) are provided by lib/common.yaml
+# and catalog.yaml during spec assembly. Only plugin-specific schemas and responses
+# are defined here.
+components:
+  schemas:
+    SkillTrustTier:
+      description: >-
+        Provenance label applied to a skill from its source configuration. A
+        plain label shown as a badge and usable for filtering; it carries no
+        ordering or special semantics. Downstream products may map these to
+        their own display names.
+      type: string
+      enum:
+        - platformProvided
+        - partnerVerified
+        - organizationApproved
+        - communityContributed
+
+    Skill:
+      description: >-
+        An agent skill in the skill catalog. Indexed from a `SKILL.md` in a git
+        repository per the Agent Skills specification (https://agentskills.io).
+      allOf:
+        - $ref: "#/components/schemas/BaseResource"
+        - type: object
+          required:
+            - name
+          properties:
+            # --- Spec fields (from SKILL.md) ---
+            name:
+              type: string
+              description: Skill identifier from the SKILL.md frontmatter. Must be unique within a source and version.
+            description:
+              type: string
+              description: Short description of the skill from the SKILL.md frontmatter.
+            license:
+              type: string
+              description: Short name of the skill's license (e.g., apache-2.0).
+            compatibility:
+              type: string
+              description: Compatibility information declared in the SKILL.md frontmatter (e.g., supported clients or versions).
+            allowedTools:
+              type: array
+              items:
+                type: string
+              description: Tools the skill is permitted to use (`allowed-tools` in the SKILL.md frontmatter).
+            readme:
+              type: string
+              description: The SKILL.md body rendered as Markdown documentation.
+            # --- Canonical identity ---
+            repository:
+              type: string
+              description: >-
+                Canonical upstream git repository URL. Together with `path` this
+                forms the skill's permanent identity, stable across index
+                rebuilds and mirror deployments.
+            path:
+              type: string
+              description: Directory of the skill within the repository (the folder containing its SKILL.md).
+            version:
+              type: string
+              description: >-
+                The ref this entry was resolved at (tag, release, or commit). A
+                branch ref is surfaced as `latest` rather than the raw branch name.
+            resolvedCommit:
+              type: string
+              description: The exact commit SHA the `version` ref resolved to at sync, used to pin reproducible installs.
+            # --- Catalog metadata (from the source configuration) ---
+            sourceId:
+              type: string
+              description: Catalog source that provides this entity.
+            trustTier:
+              $ref: "#/components/schemas/SkillTrustTier"
+            provider:
+              type: string
+              description: Name of the organization or entity that provides the skill.
+            category:
+              type: string
+              description: Category assigned to the skill in the source configuration.
+            labels:
+              type: array
+              items:
+                type: string
+              description: Labels for categorization and filtering.
+            supportingFiles:
+              type: array
+              items:
+                type: string
+              description: >-
+                Paths of files that accompany the SKILL.md in the skill
+                directory. Contents are not stored; these link back to the repository.
+            bodyLineCount:
+              type: integer
+              format: int32
+              description: Number of lines in the SKILL.md body, surfaced for skills whose body exceeds recommended length.
+
+    SkillList:
+      description: A list of skill entities.
+      allOf:
+        - type: object
+          properties:
+            items:
+              description: Array of `Skill` entities.
+              type: array
+              items:
+                $ref: "#/components/schemas/Skill"
+          required:
+            - items
+        - $ref: "#/components/schemas/BaseResourceList"
+
+  responses:
+    SkillListResponse:
+      description: A list of skill entities.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SkillList"
+    SkillResponse:
+      description: A single skill entity.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Skill"

--- a/scripts/merge_catalog_specs.sh
+++ b/scripts/merge_catalog_specs.sh
@@ -84,10 +84,18 @@ cp "$SOURCE_FILE" "$OUT_FILE"
 # Step 2: Discover and merge plugin specs (before shared libraries,
 # so catalog-specific parameters appear before common.yaml parameters
 # in the final output — preserving the original key order)
+NAME="${BASENAME%.yaml}"
+VARIANT="${NAME#catalog}"
+if [[ -n "$VARIANT" ]]; then
+    FIND_ARGS=(-name "*${VARIANT}.yaml")
+else
+    FIND_ARGS=(-name '*.yaml' -not -name '*-v1.yaml')
+fi
+
 PLUGIN_FILES=()
 while IFS= read -r f; do
     PLUGIN_FILES+=("$f")
-done < <(find api/openapi/src/plugins -maxdepth 1 -name '*.yaml' -not -name '*-v1.yaml' -type f 2>/dev/null | sort || true)
+done < <(find api/openapi/src/plugins -maxdepth 1 "${FIND_ARGS[@]}" -type f 2>/dev/null | sort || true)
 
 for plugin_file in "${PLUGIN_FILES[@]}"; do
     temp_merged="$(mktemp -t merged_tempXXXXXX).yaml"
@@ -103,7 +111,7 @@ register_temp "$temp_with_libs"
 $YQ eval-all '. as $item ireduce ({}; . * $item)' "$OUT_FILE" api/openapi/src/lib/*.yaml >"$temp_with_libs"
 mv "$temp_with_libs" "$OUT_FILE"
 
-# Step 3: Re-order keys and sort for deterministic output
+# Step 4: Re-order keys and sort for deterministic output
 $YQ eval -i '
     {
         "openapi": .openapi,


### PR DESCRIPTION
## Description

Define v1 OpenAPI specs for the model, agent, MCP, and skill catalogs. Part of the implementation for KEP-0004.

Alpha specs are unchanged. This is spec-only: no Go server or client is generated from the v1 spec yet.

Fixes #2993

## How Has This Been Tested?
Specs only, so there are no functional changes to test, but the files were regenerated.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
