### PR TITLE
feat(catalog): add SKILL.md parser (SKC-104)

### DIFF
--- a/catalog/internal/catalog/skillcatalog/skillmd_parser.go
+++ b/catalog/internal/catalog/skillcatalog/skillmd_parser.go
@@ -49,20 +49,6 @@ type ParsedSkill struct {
 	Warnings []string
 }
 
-// skillFrontmatter is the YAML frontmatter schema. Parsing is lenient: unknown
-// keys are ignored (not strict) so authors can carry extra fields.
-type skillFrontmatter struct {
-	Name          string `json:"name,omitempty"`
-	Description   string `json:"description,omitempty"`
-	License       string `json:"license,omitempty"`
-	Compatibility string `json:"compatibility,omitempty"`
-	// AllowedTools is a space-separated string per the spec, e.g.
-	// "Bash(git:*) Read". A YAML list is also accepted for leniency, so this is
-	// decoded as `any` and normalized by parseAllowedTools.
-	AllowedTools any            `json:"allowed-tools,omitempty"`
-	Metadata     map[string]any `json:"metadata,omitempty"`
-}
-
 // ParseSkillMD parses SKILL.md content leniently per the Agent Skills spec.
 // expectedName is the skill's directory name, used for the name-match warning.
 //
@@ -74,33 +60,39 @@ func ParseSkillMD(content []byte, expectedName string) (*ParsedSkill, error) {
 		return nil, err
 	}
 
-	var fm skillFrontmatter
-	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
+	// Decode into a generic map rather than a typed struct so that a single
+	// field with the wrong type (e.g. metadata written as a string) is tolerated
+	// — warned and ignored — instead of failing the whole frontmatter. Only YAML
+	// that is malformed or not a mapping is fatal.
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(fmText), &raw); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidFrontmatter, err)
 	}
 
-	if strings.TrimSpace(fm.Description) == "" {
-		return nil, ErrMissingDescription
-	}
-
 	skill := &ParsedSkill{
-		Name:          fm.Name,
-		Description:   fm.Description,
-		License:       fm.License,
-		Compatibility: fm.Compatibility,
-		AllowedTools:  parseAllowedTools(fm.AllowedTools),
-		Metadata:      fm.Metadata,
 		Body:          body,
 		BodyLineCount: countLines(body),
 	}
 
+	// description is required; missing, empty, or non-string skips the skill.
+	skill.Description = skill.stringField(raw, "description")
+	if strings.TrimSpace(skill.Description) == "" {
+		return nil, ErrMissingDescription
+	}
+
+	skill.Name = skill.stringField(raw, "name")
+	skill.License = skill.stringField(raw, "license")
+	skill.Compatibility = skill.stringField(raw, "compatibility")
+	skill.AllowedTools = parseAllowedTools(raw["allowed-tools"])
+	skill.Metadata = skill.mapField(raw, "metadata")
+
 	// Name (lenient: warn, never skip).
 	switch {
-	case fm.Name == "":
+	case skill.Name == "":
 		skill.Name = expectedName
 		skill.warnf("frontmatter is missing 'name'; using directory name %q", expectedName)
-	case fm.Name != expectedName:
-		skill.warnf("frontmatter name %q does not match directory %q", fm.Name, expectedName)
+	case skill.Name != expectedName:
+		skill.warnf("frontmatter name %q does not match directory %q", skill.Name, expectedName)
 	}
 
 	// Length limits from the spec (lenient: warn, never skip).
@@ -123,6 +115,38 @@ func ParseSkillMD(content []byte, expectedName string) (*ParsedSkill, error) {
 // warnf appends a formatted non-fatal warning.
 func (s *ParsedSkill) warnf(format string, args ...any) {
 	s.Warnings = append(s.Warnings, fmt.Sprintf(format, args...))
+}
+
+// stringField reads a string frontmatter field. An absent field yields ""; a
+// present field of the wrong type is warned and ignored (returns "") rather than
+// failing the whole parse.
+func (s *ParsedSkill) stringField(raw map[string]any, key string) string {
+	v, ok := raw[key]
+	if !ok || v == nil {
+		return ""
+	}
+	str, ok := v.(string)
+	if !ok {
+		s.warnf("frontmatter field %q is not a string and was ignored", key)
+		return ""
+	}
+	return str
+}
+
+// mapField reads a map frontmatter field. An absent field yields nil; a present
+// field of the wrong type is warned and ignored (returns nil) rather than
+// failing the whole parse.
+func (s *ParsedSkill) mapField(raw map[string]any, key string) map[string]any {
+	v, ok := raw[key]
+	if !ok || v == nil {
+		return nil
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		s.warnf("frontmatter field %q is not a map and was ignored", key)
+		return nil
+	}
+	return m
 }
 
 // parseAllowedTools normalizes the frontmatter allowed-tools value into a slice.

--- a/catalog/internal/catalog/skillcatalog/skillmd_parser.go
+++ b/catalog/internal/catalog/skillcatalog/skillmd_parser.go
@@ -10,10 +10,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-// maxSkillNameLength is the maximum name length recommended by the Agent Skills
-// specification (https://agentskills.io/specification). Longer names warn rather
-// than skip, per the lenient validation policy.
-const maxSkillNameLength = 64
+// Length limits from the Agent Skills specification
+// (https://agentskills.io/specification). Violations warn rather than skip, per
+// the lenient validation policy.
+const (
+	maxSkillNameLength          = 64
+	maxSkillDescriptionLength   = 1024
+	maxSkillCompatibilityLength = 500
+	maxSkillBodyLines           = 500
+)
 
 // utf8BOM is the UTF-8 byte-order mark, stripped from the start of a file if present.
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
@@ -47,12 +52,15 @@ type ParsedSkill struct {
 // skillFrontmatter is the YAML frontmatter schema. Parsing is lenient: unknown
 // keys are ignored (not strict) so authors can carry extra fields.
 type skillFrontmatter struct {
-	Name          string         `json:"name,omitempty"`
-	Description   string         `json:"description,omitempty"`
-	License       string         `json:"license,omitempty"`
-	Compatibility string         `json:"compatibility,omitempty"`
-	AllowedTools  []string       `json:"allowed-tools,omitempty"`
-	Metadata      map[string]any `json:"metadata,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Description   string `json:"description,omitempty"`
+	License       string `json:"license,omitempty"`
+	Compatibility string `json:"compatibility,omitempty"`
+	// AllowedTools is a space-separated string per the spec, e.g.
+	// "Bash(git:*) Read". A YAML list is also accepted for leniency, so this is
+	// decoded as `any` and normalized by parseAllowedTools.
+	AllowedTools any            `json:"allowed-tools,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
 }
 
 // ParseSkillMD parses SKILL.md content leniently per the Agent Skills spec.
@@ -80,33 +88,64 @@ func ParseSkillMD(content []byte, expectedName string) (*ParsedSkill, error) {
 		Description:   fm.Description,
 		License:       fm.License,
 		Compatibility: fm.Compatibility,
-		AllowedTools:  fm.AllowedTools,
+		AllowedTools:  parseAllowedTools(fm.AllowedTools),
 		Metadata:      fm.Metadata,
 		Body:          body,
 		BodyLineCount: countLines(body),
 	}
 
-	// Name validation (lenient: warn, never skip).
+	// Name (lenient: warn, never skip).
 	switch {
 	case fm.Name == "":
 		skill.Name = expectedName
-		skill.Warnings = append(skill.Warnings,
-			fmt.Sprintf("frontmatter is missing 'name'; using directory name %q", expectedName))
+		skill.warnf("frontmatter is missing 'name'; using directory name %q", expectedName)
 	case fm.Name != expectedName:
-		skill.Warnings = append(skill.Warnings,
-			fmt.Sprintf("frontmatter name %q does not match directory %q", fm.Name, expectedName))
-	}
-	if utf8.RuneCountInString(skill.Name) > maxSkillNameLength {
-		skill.Warnings = append(skill.Warnings,
-			fmt.Sprintf("name %q exceeds the recommended maximum of %d characters", skill.Name, maxSkillNameLength))
+		skill.warnf("frontmatter name %q does not match directory %q", fm.Name, expectedName)
 	}
 
-	if skill.BodyLineCount > 500 {
-		skill.Warnings = append(skill.Warnings,
-			fmt.Sprintf("body is %d lines, exceeding the recommended maximum of 500", skill.BodyLineCount))
+	// Length limits from the spec (lenient: warn, never skip).
+	if n := utf8.RuneCountInString(skill.Name); n > maxSkillNameLength {
+		skill.warnf("name is %d characters, which exceeds the maximum of %d", n, maxSkillNameLength)
+	}
+	if n := utf8.RuneCountInString(skill.Description); n > maxSkillDescriptionLength {
+		skill.warnf("description is %d characters, which exceeds the maximum of %d", n, maxSkillDescriptionLength)
+	}
+	if n := utf8.RuneCountInString(skill.Compatibility); n > maxSkillCompatibilityLength {
+		skill.warnf("compatibility is %d characters, which exceeds the maximum of %d", n, maxSkillCompatibilityLength)
+	}
+	if skill.BodyLineCount > maxSkillBodyLines {
+		skill.warnf("body is %d lines, which exceeds the recommended maximum of %d", skill.BodyLineCount, maxSkillBodyLines)
 	}
 
 	return skill, nil
+}
+
+// warnf appends a formatted non-fatal warning.
+func (s *ParsedSkill) warnf(format string, args ...any) {
+	s.Warnings = append(s.Warnings, fmt.Sprintf(format, args...))
+}
+
+// parseAllowedTools normalizes the frontmatter allowed-tools value into a slice.
+// The spec defines it as a space-separated string (e.g. "Bash(git:*) Read"); a
+// YAML list of strings is also accepted for leniency. Anything else yields nil.
+func parseAllowedTools(v any) []string {
+	switch t := v.(type) {
+	case string:
+		return strings.Fields(t)
+	case []any:
+		tools := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok && strings.TrimSpace(s) != "" {
+				tools = append(tools, s)
+			}
+		}
+		if len(tools) == 0 {
+			return nil
+		}
+		return tools
+	default:
+		return nil
+	}
 }
 
 // splitFrontmatter separates the `---`-delimited YAML frontmatter from the body.
@@ -115,13 +154,13 @@ func splitFrontmatter(content []byte) (frontmatter string, body string, err erro
 	s := strings.ReplaceAll(string(bytes.TrimPrefix(content, utf8BOM)), "\r\n", "\n")
 
 	lines := strings.Split(s, "\n")
-	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+	if len(lines) == 0 || !isFrontmatterFence(lines[0]) {
 		return "", "", ErrNoFrontmatter
 	}
 
 	closing := -1
 	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) == "---" {
+		if isFrontmatterFence(lines[i]) {
 			closing = i
 			break
 		}
@@ -133,6 +172,14 @@ func splitFrontmatter(content []byte) (frontmatter string, body string, err erro
 	frontmatter = strings.Join(lines[1:closing], "\n")
 	body = strings.Trim(strings.Join(lines[closing+1:], "\n"), "\n")
 	return frontmatter, body, nil
+}
+
+// isFrontmatterFence reports whether a line is a `---` frontmatter delimiter.
+// The dashes must start at column 0: leading whitespace is significant, so an
+// indented `---` inside a YAML block scalar is not mistaken for the fence.
+// Trailing whitespace (and a stray CR) is tolerated.
+func isFrontmatterFence(line string) bool {
+	return strings.TrimRight(line, " \t\r") == "---"
 }
 
 // countLines returns the number of lines in the body, ignoring surrounding blank

--- a/catalog/internal/catalog/skillcatalog/skillmd_parser.go
+++ b/catalog/internal/catalog/skillcatalog/skillmd_parser.go
@@ -1,0 +1,146 @@
+package skillcatalog
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// maxSkillNameLength is the maximum name length recommended by the Agent Skills
+// specification (https://agentskills.io/specification). Longer names warn rather
+// than skip, per the lenient validation policy.
+const maxSkillNameLength = 64
+
+// utf8BOM is the UTF-8 byte-order mark, stripped from the start of a file if present.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// Skip errors: a SKILL.md that returns one of these is logged and not indexed.
+var (
+	// ErrNoFrontmatter indicates the file has no `---`-delimited YAML frontmatter.
+	ErrNoFrontmatter = errors.New("SKILL.md has no YAML frontmatter")
+	// ErrInvalidFrontmatter indicates the frontmatter block is not valid YAML.
+	ErrInvalidFrontmatter = errors.New("SKILL.md frontmatter is not valid YAML")
+	// ErrMissingDescription indicates the required `description` field is absent.
+	ErrMissingDescription = errors.New("SKILL.md frontmatter is missing required 'description'")
+)
+
+// ParsedSkill is the result of parsing a SKILL.md file per the Agent Skills
+// specification. Metadata is surfaced downstream as customProperties.
+type ParsedSkill struct {
+	Name          string
+	Description   string
+	License       string
+	Compatibility string
+	AllowedTools  []string
+	Metadata      map[string]any
+	Body          string
+	BodyLineCount int
+	// Warnings are non-fatal issues; a skill with warnings is still indexed but
+	// its source is marked partially-available.
+	Warnings []string
+}
+
+// skillFrontmatter is the YAML frontmatter schema. Parsing is lenient: unknown
+// keys are ignored (not strict) so authors can carry extra fields.
+type skillFrontmatter struct {
+	Name          string         `json:"name,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	License       string         `json:"license,omitempty"`
+	Compatibility string         `json:"compatibility,omitempty"`
+	AllowedTools  []string       `json:"allowed-tools,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+}
+
+// ParseSkillMD parses SKILL.md content leniently per the Agent Skills spec.
+// expectedName is the skill's directory name, used for the name-match warning.
+//
+// It returns a non-nil error only for the skip cases (no/invalid frontmatter,
+// missing description); a successful parse may still carry Warnings.
+func ParseSkillMD(content []byte, expectedName string) (*ParsedSkill, error) {
+	fmText, body, err := splitFrontmatter(content)
+	if err != nil {
+		return nil, err
+	}
+
+	var fm skillFrontmatter
+	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidFrontmatter, err)
+	}
+
+	if strings.TrimSpace(fm.Description) == "" {
+		return nil, ErrMissingDescription
+	}
+
+	skill := &ParsedSkill{
+		Name:          fm.Name,
+		Description:   fm.Description,
+		License:       fm.License,
+		Compatibility: fm.Compatibility,
+		AllowedTools:  fm.AllowedTools,
+		Metadata:      fm.Metadata,
+		Body:          body,
+		BodyLineCount: countLines(body),
+	}
+
+	// Name validation (lenient: warn, never skip).
+	switch {
+	case fm.Name == "":
+		skill.Name = expectedName
+		skill.Warnings = append(skill.Warnings,
+			fmt.Sprintf("frontmatter is missing 'name'; using directory name %q", expectedName))
+	case fm.Name != expectedName:
+		skill.Warnings = append(skill.Warnings,
+			fmt.Sprintf("frontmatter name %q does not match directory %q", fm.Name, expectedName))
+	}
+	if utf8.RuneCountInString(skill.Name) > maxSkillNameLength {
+		skill.Warnings = append(skill.Warnings,
+			fmt.Sprintf("name %q exceeds the recommended maximum of %d characters", skill.Name, maxSkillNameLength))
+	}
+
+	if skill.BodyLineCount > 500 {
+		skill.Warnings = append(skill.Warnings,
+			fmt.Sprintf("body is %d lines, exceeding the recommended maximum of 500", skill.BodyLineCount))
+	}
+
+	return skill, nil
+}
+
+// splitFrontmatter separates the `---`-delimited YAML frontmatter from the body.
+// Line endings are normalized to LF and a leading UTF-8 BOM is stripped.
+func splitFrontmatter(content []byte) (frontmatter string, body string, err error) {
+	s := strings.ReplaceAll(string(bytes.TrimPrefix(content, utf8BOM)), "\r\n", "\n")
+
+	lines := strings.Split(s, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", ErrNoFrontmatter
+	}
+
+	closing := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			closing = i
+			break
+		}
+	}
+	if closing == -1 {
+		return "", "", fmt.Errorf("%w: frontmatter opened with '---' but has no closing delimiter", ErrInvalidFrontmatter)
+	}
+
+	frontmatter = strings.Join(lines[1:closing], "\n")
+	body = strings.Trim(strings.Join(lines[closing+1:], "\n"), "\n")
+	return frontmatter, body, nil
+}
+
+// countLines returns the number of lines in the body, ignoring surrounding blank
+// lines. An empty body counts as zero.
+func countLines(body string) int {
+	trimmed := strings.Trim(body, "\n")
+	if trimmed == "" {
+		return 0
+	}
+	return strings.Count(trimmed, "\n") + 1
+}

--- a/catalog/internal/catalog/skillcatalog/skillmd_parser_test.go
+++ b/catalog/internal/catalog/skillcatalog/skillmd_parser_test.go
@@ -182,6 +182,63 @@ func TestParseSkillMD_NoClosingDelimiterSkipped(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidFrontmatter, "an opened-but-unclosed frontmatter is invalid, not absent")
 }
 
+func TestParseSkillMD_IndentedDashesInsideBlockScalarNotAFence(t *testing.T) {
+	// The `---` inside the `description` block scalar is indented, so it must not
+	// be treated as the closing fence — only the column-0 `---` closes frontmatter.
+	content := `---
+foo: bar
+description: |
+   blah
+   ---
+   blah
+baz: qux
+---
+Body
+`
+	skill, err := ParseSkillMD([]byte(content), "x")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Contains(t, skill.Description, "---", "the indented --- belongs to the description")
+	assert.Contains(t, skill.Description, "blah")
+	assert.Equal(t, "Body", strings.TrimSpace(skill.Body), "frontmatter must not leak into the body")
+}
+
+func TestParseSkillMD_StripsLeadingBOM(t *testing.T) {
+	// Some editors save UTF-8 files with a leading BOM; it must not defeat
+	// frontmatter detection (Go's TrimSpace does not treat U+FEFF as whitespace).
+	content := append([]byte{0xEF, 0xBB, 0xBF}, []byte(validSkillMD)...)
+	skill, err := ParseSkillMD(content, "deploy")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, "deploy", skill.Name)
+	assert.Equal(t, "Deploy an application to the cluster.", skill.Description)
+}
+
+func TestParseSkillMD_AllowedToolsSpaceSeparatedString(t *testing.T) {
+	// The spec defines allowed-tools as a space-separated string.
+	content := "---\nname: t\ndescription: d\nallowed-tools: Bash(git:*) Bash(jq:*) Read\n---\nbody\n"
+	skill, err := ParseSkillMD([]byte(content), "t")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, []string{"Bash(git:*)", "Bash(jq:*)", "Read"}, skill.AllowedTools)
+}
+
+func TestParseSkillMD_DescriptionTooLongWarns(t *testing.T) {
+	content := "---\nname: d\ndescription: " + strings.Repeat("x", 1025) + "\n---\nbody\n"
+	skill, err := ParseSkillMD([]byte(content), "d")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.True(t, hasWarning(skill.Warnings, "description"), "expected a description-length warning, got %v", skill.Warnings)
+}
+
+func TestParseSkillMD_CompatibilityTooLongWarns(t *testing.T) {
+	content := "---\nname: c\ndescription: d\ncompatibility: " + strings.Repeat("y", 501) + "\n---\nbody\n"
+	skill, err := ParseSkillMD([]byte(content), "c")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.True(t, hasWarning(skill.Warnings, "compatibility"), "expected a compatibility-length warning, got %v", skill.Warnings)
+}
+
 func hasWarning(warnings []string, substr string) bool {
 	for _, w := range warnings {
 		if strings.Contains(w, substr) {

--- a/catalog/internal/catalog/skillcatalog/skillmd_parser_test.go
+++ b/catalog/internal/catalog/skillcatalog/skillmd_parser_test.go
@@ -1,0 +1,192 @@
+package skillcatalog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validSkillMD = `---
+name: deploy
+description: Deploy an application to the cluster.
+license: apache-2.0
+compatibility: claude-code >= 1.0
+allowed-tools:
+  - Bash
+  - Read
+metadata:
+  author: Example Org
+  tier: internal
+---
+# Deploy
+
+This skill deploys an application.
+
+## Usage
+
+Run the deploy command.
+`
+
+func TestParseSkillMD_Valid(t *testing.T) {
+	skill, err := ParseSkillMD([]byte(validSkillMD), "deploy")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+
+	assert.Equal(t, "deploy", skill.Name)
+	assert.Equal(t, "Deploy an application to the cluster.", skill.Description)
+	assert.Equal(t, "apache-2.0", skill.License)
+	assert.Equal(t, "claude-code >= 1.0", skill.Compatibility)
+	assert.Equal(t, []string{"Bash", "Read"}, skill.AllowedTools)
+	assert.Equal(t, "Example Org", skill.Metadata["author"])
+	assert.Equal(t, "internal", skill.Metadata["tier"])
+	assert.Empty(t, skill.Warnings)
+
+	assert.Contains(t, skill.Body, "# Deploy")
+	assert.Contains(t, skill.Body, "Run the deploy command.")
+	assert.NotContains(t, skill.Body, "name: deploy", "body must not include frontmatter")
+	assert.Positive(t, skill.BodyLineCount)
+}
+
+func TestParseSkillMD_NameMismatchWarns(t *testing.T) {
+	skill, err := ParseSkillMD([]byte(validSkillMD), "deployment")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, "deploy", skill.Name, "frontmatter name is kept")
+	assert.True(t, hasWarning(skill.Warnings, "does not match"),
+		"expected a name-mismatch warning, got %v", skill.Warnings)
+}
+
+func TestParseSkillMD_MissingNameUsesDirectory(t *testing.T) {
+	content := `---
+description: A skill with no name.
+---
+Body.
+`
+	skill, err := ParseSkillMD([]byte(content), "fallback-name")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, "fallback-name", skill.Name)
+	assert.True(t, hasWarning(skill.Warnings, "name"), "expected a missing-name warning, got %v", skill.Warnings)
+}
+
+func TestParseSkillMD_NameTooLongWarns(t *testing.T) {
+	longName := strings.Repeat("a", 65)
+	content := "---\nname: " + longName + "\ndescription: x\n---\nbody\n"
+	skill, err := ParseSkillMD([]byte(content), longName)
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.True(t, hasWarning(skill.Warnings, "exceeds"), "expected a length warning, got %v", skill.Warnings)
+}
+
+func TestParseSkillMD_MissingDescriptionSkipped(t *testing.T) {
+	content := `---
+name: deploy
+license: apache-2.0
+---
+Body without a description.
+`
+	skill, err := ParseSkillMD([]byte(content), "deploy")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingDescription)
+	assert.Nil(t, skill)
+}
+
+func TestParseSkillMD_MalformedYAMLSkipped(t *testing.T) {
+	content := `---
+name: deploy
+description: "unterminated
+  : : bad
+---
+Body.
+`
+	skill, err := ParseSkillMD([]byte(content), "deploy")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidFrontmatter)
+	assert.Nil(t, skill)
+}
+
+func TestParseSkillMD_NoFrontmatterSkipped(t *testing.T) {
+	content := "# Just a markdown file\n\nNo frontmatter here.\n"
+	skill, err := ParseSkillMD([]byte(content), "deploy")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoFrontmatter)
+	assert.Nil(t, skill)
+}
+
+func TestParseSkillMD_LongBodyWarns(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("---\nname: big\ndescription: A big skill.\n---\n")
+	for i := 0; i < 600; i++ {
+		b.WriteString("line\n")
+	}
+	skill, err := ParseSkillMD([]byte(b.String()), "big")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, 600, skill.BodyLineCount)
+	assert.True(t, hasWarning(skill.Warnings, "500"), "expected a body-length warning, got %v", skill.Warnings)
+}
+
+func TestParseSkillMD_MetadataMap(t *testing.T) {
+	content := `---
+name: m
+description: d
+metadata:
+  author: Jane
+  count: 3
+  nested:
+    a: b
+---
+body
+`
+	skill, err := ParseSkillMD([]byte(content), "m")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, "Jane", skill.Metadata["author"])
+	assert.EqualValues(t, 3, skill.Metadata["count"])
+	assert.NotNil(t, skill.Metadata["nested"])
+}
+
+func TestParseSkillMD_Unicode(t *testing.T) {
+	content := `---
+name: 日本語スキル
+description: スキルの説明 — with émojis 🚀
+---
+# 見出し
+
+本文です。
+`
+	skill, err := ParseSkillMD([]byte(content), "日本語スキル")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, "日本語スキル", skill.Name)
+	assert.Contains(t, skill.Description, "🚀")
+	assert.Contains(t, skill.Body, "本文です。")
+}
+
+func TestParseSkillMD_CRLFLineEndings(t *testing.T) {
+	content := "---\r\nname: crlf\r\ndescription: Windows line endings.\r\n---\r\n# Body\r\n\r\nText.\r\n"
+	skill, err := ParseSkillMD([]byte(content), "crlf")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, "crlf", skill.Name)
+	assert.Equal(t, "Windows line endings.", skill.Description)
+	assert.Contains(t, skill.Body, "# Body")
+}
+
+func TestParseSkillMD_NoClosingDelimiterSkipped(t *testing.T) {
+	content := "---\nname: x\ndescription: y\nbody without closing fence\n"
+	_, err := ParseSkillMD([]byte(content), "x")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidFrontmatter, "an opened-but-unclosed frontmatter is invalid, not absent")
+}
+
+func hasWarning(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/catalog/internal/catalog/skillcatalog/skillmd_parser_test.go
+++ b/catalog/internal/catalog/skillcatalog/skillmd_parser_test.go
@@ -239,6 +239,37 @@ func TestParseSkillMD_CompatibilityTooLongWarns(t *testing.T) {
 	assert.True(t, hasWarning(skill.Warnings, "compatibility"), "expected a compatibility-length warning, got %v", skill.Warnings)
 }
 
+func TestParseSkillMD_WrongTypeMetadataDoesNotSkipSkill(t *testing.T) {
+	// metadata written as a string (not a map) must be ignored with a warning —
+	// the rest of the frontmatter still parses. (The whole skill must not be lost.)
+	content := `---
+name: deploy
+description: Deploy the app.
+metadata: not-a-map
+---
+Body.
+`
+	skill, err := ParseSkillMD([]byte(content), "deploy")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, "deploy", skill.Name)
+	assert.Equal(t, "Deploy the app.", skill.Description)
+	assert.Nil(t, skill.Metadata)
+	assert.True(t, hasWarning(skill.Warnings, "metadata"), "expected a metadata type warning, got %v", skill.Warnings)
+}
+
+func TestParseSkillMD_NonStringNameWarnsAndFallsBack(t *testing.T) {
+	// name written as a number is not a string; ignore it, fall back to the
+	// directory name, and still parse rather than failing.
+	content := "---\nname: 123\ndescription: Valid description.\nlicense: apache-2.0\n---\nbody\n"
+	skill, err := ParseSkillMD([]byte(content), "expected-dir")
+	require.NoError(t, err)
+	require.NotNil(t, skill)
+	assert.Equal(t, "expected-dir", skill.Name)
+	assert.Equal(t, "apache-2.0", skill.License, "other fields still parse")
+	assert.True(t, hasWarning(skill.Warnings, "name"), "expected a name type/fallback warning, got %v", skill.Warnings)
+}
+
 func hasWarning(warnings []string, substr string) bool {
 	for _, w := range warnings {
 		if strings.Contains(w, substr) {


### PR DESCRIPTION
## Description

Add a lenient parser for SKILL.md files per the Agent Skills spec. It splits the `---`-delimited YAML frontmatter (CRLF- and BOM-tolerant) from the body and parses name, description, license, compatibility, allowed-tools, and the metadata map, plus body extraction and line count.

Lenient validation matches the spec table: name mismatch and over-length warn (and still load); missing description and invalid or unclosed frontmatter skip; a body over 500 lines warns and surfaces the line count. Skip cases use sentinel errors; non-fatal issues are collected as warnings.

Includes a fixture suite: valid, name mismatch, missing name, name too long, missing description, malformed YAML, no/unclosed frontmatter, long body, metadata map, unicode, and CRLF.

Tracking: #3014
Assisted-by: Claude Code

## How Has This Been Tested?
unit tests

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] The commits have meaningful messages
- [x ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ x] The developer has manually tested the changes and verified that the changes work.
- [ x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).