### PR TITLE
feat(mcp): add serverJson field to MCP server API

### DIFF
--- a/api/openapi/catalog-v1.yaml
+++ b/api/openapi/catalog-v1.yaml
@@ -2084,6 +2084,13 @@ components:
                 Runtime metadata for deploying this MCP server via MCPServer CRDs.
                 Provides defaults, recommendations, and requirements for creating deployments.
                 This is discovery metadata, not actual deployment configuration.
+            serverJson:
+              type: object
+              description: |-
+                MCP server.json conformant structure. Opaque to this API; the
+                schema is defined by the MCP specification and may evolve independently.
+                See https://registry.modelcontextprotocol.io/docs#/schemas/ServerJSON for details.
+              additionalProperties: true
     MCPServerList:
       description: List of MCP server entities.
       allOf:

--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -2080,6 +2080,13 @@ components:
                 Runtime metadata for deploying this MCP server via MCPServer CRDs.
                 Provides defaults, recommendations, and requirements for creating deployments.
                 This is discovery metadata, not actual deployment configuration.
+            serverJson:
+              type: object
+              description: |-
+                MCP server.json conformant structure. Opaque to this API; the
+                schema is defined by the MCP specification and may evolve independently.
+                See https://registry.modelcontextprotocol.io/docs#/schemas/ServerJSON for details.
+              additionalProperties: true
     MCPServerList:
       description: List of MCP server entities.
       allOf:

--- a/api/openapi/src/plugins/mcp-v1.yaml
+++ b/api/openapi/src/plugins/mcp-v1.yaml
@@ -259,6 +259,13 @@ components:
                 Runtime metadata for deploying this MCP server via MCPServer CRDs.
                 Provides defaults, recommendations, and requirements for creating deployments.
                 This is discovery metadata, not actual deployment configuration.
+            serverJson:
+              type: object
+              description: |-
+                MCP server.json conformant structure. Opaque to this API; the
+                schema is defined by the MCP specification and may evolve independently.
+                See https://registry.modelcontextprotocol.io/docs#/schemas/ServerJSON for details.
+              additionalProperties: true
     MCPServerList:
       description: List of MCP server entities.
       allOf:

--- a/api/openapi/src/plugins/mcp.yaml
+++ b/api/openapi/src/plugins/mcp.yaml
@@ -259,6 +259,13 @@ components:
                 Runtime metadata for deploying this MCP server via MCPServer CRDs.
                 Provides defaults, recommendations, and requirements for creating deployments.
                 This is discovery metadata, not actual deployment configuration.
+            serverJson:
+              type: object
+              description: |-
+                MCP server.json conformant structure. Opaque to this API; the
+                schema is defined by the MCP specification and may evolve independently.
+                See https://registry.modelcontextprotocol.io/docs#/schemas/ServerJSON for details.
+              additionalProperties: true
     MCPServerList:
       description: List of MCP server entities.
       allOf:

--- a/catalog/internal/catalog/mcpcatalog/db_mcp.go
+++ b/catalog/internal/catalog/mcpcatalog/db_mcp.go
@@ -48,7 +48,7 @@ func (d *dbMCPCatalogImpl) GetFilterOptions(ctx context.Context) (*openapi.Filte
 
 	for _, prop := range contextProperties {
 		switch prop.Name {
-		case "artifacts", "base_name", "documentationUrl", "logo", "repositoryUrl", "sourceCode", "source_id", "tools", "version":
+		case "artifacts", "base_name", "documentationUrl", "logo", "repositoryUrl", "serverJson", "sourceCode", "source_id", "tools", "version":
 			continue
 		}
 

--- a/catalog/internal/catalog/mcpcatalog/providers.go
+++ b/catalog/internal/catalog/mcpcatalog/providers.go
@@ -129,6 +129,7 @@ type yamlMCPServer struct {
 	CustomProperties         *map[string]apimodels.MetadataValue `yaml:"customProperties,omitempty"`
 	CreateTimeSinceEpoch     *string                             `yaml:"createTimeSinceEpoch,omitempty"`
 	LastUpdateTimeSinceEpoch *string                             `yaml:"lastUpdateTimeSinceEpoch,omitempty"`
+	ServerJSON               map[string]any                      `yaml:"server_json,omitempty" json:"server_json,omitempty"`
 }
 
 // yamlMCPTool represents an MCP tool definition
@@ -461,6 +462,15 @@ func (ys *yamlMCPServer) ToMCPServerProviderRecord() MCPServerProviderRecord {
 			properties = append(properties, mrmodels.NewStringProperty("runtimeMetadata", string(jsonBytes), false))
 		} else {
 			glog.Warningf("failed to marshal runtimeMetadata for server %q: %v", ys.Name, err)
+		}
+	}
+
+	// Convert server_json to JSON
+	if len(ys.ServerJSON) > 0 {
+		if jsonBytes, err := json.Marshal(ys.ServerJSON); err == nil {
+			properties = append(properties, mrmodels.NewStringProperty("serverJson", string(jsonBytes), false))
+		} else {
+			glog.Warningf("failed to marshal server_json for server %q: %v", ys.Name, err)
 		}
 	}
 

--- a/catalog/internal/catalog/mcpcatalog/providers_test.go
+++ b/catalog/internal/catalog/mcpcatalog/providers_test.go
@@ -1118,3 +1118,87 @@ func TestYamlMCPServerSecurityIndicatorsPartial(t *testing.T) {
 	_, hasReadOnlyTools := boolProps["readOnlyTools"]
 	assert.False(t, hasReadOnlyTools, "readOnlyTools should not be present when unset")
 }
+
+func TestYamlMCPServerServerJSONConversion(t *testing.T) {
+	yamlServer := &yamlMCPServer{
+		Name: "server-json-test",
+		ServerJSON: map[string]any{
+			"$schema":     "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			"name":        "com.example/test-server",
+			"description": "A test MCP server",
+			"version":     "1.0.0",
+			"repository": map[string]any{
+				"url":    "https://github.com/example/test-server",
+				"source": "github",
+			},
+			"packages": []any{
+				map[string]any{
+					"registryType": "oci",
+					"identifier":   "registry.example.com/test-server:1.0",
+					"transport": map[string]any{
+						"type": "streamable-http",
+						"url":  "http://localhost:8080/mcp",
+					},
+				},
+			},
+			"_meta": map[string]any{
+				"org.kubeflow.hub/mcp-runtime": map[string]any{
+					"defaultPort": 8080,
+				},
+			},
+		},
+	}
+
+	record := yamlServer.ToMCPServerProviderRecord()
+	assert.Nil(t, record.Error)
+	assert.NotNil(t, record.Server)
+
+	props := record.Server.GetProperties()
+	require.NotNil(t, props)
+
+	var serverJsonStr *string
+	for _, prop := range *props {
+		if prop.Name == "serverJson" && prop.StringValue != nil {
+			serverJsonStr = prop.StringValue
+			break
+		}
+	}
+	require.NotNil(t, serverJsonStr, "serverJson property should be set")
+
+	var parsed map[string]any
+	err := json.Unmarshal([]byte(*serverJsonStr), &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, "com.example/test-server", parsed["name"])
+	assert.Equal(t, "1.0.0", parsed["version"])
+
+	repo, ok := parsed["repository"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "github", repo["source"])
+
+	packages, ok := parsed["packages"].([]any)
+	require.True(t, ok)
+	require.Len(t, packages, 1)
+
+	meta, ok := parsed["_meta"].(map[string]any)
+	require.True(t, ok)
+	_, ok = meta["org.kubeflow.hub/mcp-runtime"]
+	assert.True(t, ok, "_meta should contain mcp-runtime key")
+}
+
+func TestYamlMCPServerServerJSONNil(t *testing.T) {
+	yamlServer := &yamlMCPServer{
+		Name: "no-server-json",
+	}
+
+	record := yamlServer.ToMCPServerProviderRecord()
+	assert.Nil(t, record.Error)
+
+	props := record.Server.GetProperties()
+	require.NotNil(t, props)
+
+	for _, prop := range *props {
+		assert.NotEqual(t, "serverJson", prop.Name,
+			"serverJson property should not be set when ServerJSON is nil")
+	}
+}

--- a/catalog/internal/catalog/mcpcatalog/service/entity_mappings_mcp_server.go
+++ b/catalog/internal/catalog/mcpcatalog/service/entity_mappings_mcp_server.go
@@ -58,4 +58,5 @@ var mcpServerProperties = map[string]filter.PropertyDefinition{
 	"endpoints":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "endpoints"},
 	"artifacts":                {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "artifacts"},
 	"runtimeMetadata":          {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "runtimeMetadata"},
+	"serverJson":               {Location: filter.PropertyTable, ValueType: filter.StringValueType, Column: "serverJson"},
 }

--- a/catalog/internal/converter/mcp_converter.go
+++ b/catalog/internal/converter/mcp_converter.go
@@ -78,6 +78,9 @@ func ConvertOpenapiMCPServerToDb(openapiServer *openapi.MCPServer) models.MCPSer
 	if runtimeMetadata, ok := openapiServer.GetRuntimeMetadataOk(); ok && runtimeMetadata != nil {
 		addJSONProperty(&properties, "runtimeMetadata", runtimeMetadata)
 	}
+	if len(openapiServer.ServerJson) > 0 {
+		addJSONProperty(&properties, "serverJson", openapiServer.ServerJson)
+	}
 
 	// Set properties on the server
 	dbServer.Properties = &properties
@@ -220,6 +223,12 @@ func convertDbMCPServerToOpenapiInternal(dbServer models.MCPServer, tools []open
 		var runtimeMetadata openapi.MCPRuntimeMetadata
 		if err := json.Unmarshal([]byte(runtimeJSON), &runtimeMetadata); err == nil {
 			openapiServer.RuntimeMetadata = &runtimeMetadata
+		}
+	}
+	if serverJsonStr := pa.GetString("serverJson"); serverJsonStr != "" {
+		var serverJson map[string]interface{}
+		if err := json.Unmarshal([]byte(serverJsonStr), &serverJson); err == nil {
+			openapiServer.ServerJson = serverJson
 		}
 	}
 

--- a/catalog/internal/converter/mcp_converter_test.go
+++ b/catalog/internal/converter/mcp_converter_test.go
@@ -1,6 +1,7 @@
 package converter_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/kubeflow/hub/catalog/internal/catalog/mcpcatalog/models"
@@ -70,4 +71,57 @@ func TestConvertDbMCPToolToOpenapi_StripsQualifiedPrefix(t *testing.T) {
 			assert.Equal(t, tc.expectedName, result.Name)
 		})
 	}
+}
+
+func TestConvertDbMCPServerToOpenapi_IncludesServerJson(t *testing.T) {
+	baseName := "server-json-server"
+	version := "1.0.0"
+	serverJsonMap := map[string]any{
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+		"name":    "com.example/test",
+		"version": "1.0.0",
+		"packages": []any{
+			map[string]any{"registryType": "oci", "identifier": "registry.example.com/test:1.0"},
+		},
+	}
+	jsonBytes, err := json.Marshal(serverJsonMap)
+	require.NoError(t, err)
+	serverJsonStr := string(jsonBytes)
+
+	server := &models.MCPServerImpl{
+		Attributes: &models.MCPServerAttributes{
+			Name: &baseName,
+		},
+		Properties: &[]dbmodels.Properties{
+			{Name: "version", StringValue: &version},
+			{Name: "serverJson", StringValue: &serverJsonStr},
+		},
+	}
+
+	result := converter.ConvertDbMCPServerToOpenapi(server)
+	require.NotNil(t, result)
+	require.NotNil(t, result.ServerJson)
+	assert.Equal(t, "com.example/test", result.ServerJson["name"])
+	assert.Equal(t, "1.0.0", result.ServerJson["version"])
+
+	packages, ok := result.ServerJson["packages"].([]any)
+	require.True(t, ok)
+	require.Len(t, packages, 1)
+}
+
+func TestConvertDbMCPServerToOpenapi_NoServerJson(t *testing.T) {
+	baseName := "no-server-json"
+	version := "1.0.0"
+	server := &models.MCPServerImpl{
+		Attributes: &models.MCPServerAttributes{
+			Name: &baseName,
+		},
+		Properties: &[]dbmodels.Properties{
+			{Name: "version", StringValue: &version},
+		},
+	}
+
+	result := converter.ConvertDbMCPServerToOpenapi(server)
+	require.NotNil(t, result)
+	assert.Nil(t, result.ServerJson)
 }

--- a/catalog/internal/plugins/mcp/plugin.go
+++ b/catalog/internal/plugins/mcp/plugin.go
@@ -53,6 +53,7 @@ func (p *Plugin) DatastoreEntries() []plugin.DatastoreEntry {
 				AddStruct("tags").
 				AddStruct("transports").
 				AddString("deploymentMode").
+				AddString("serverJson").
 				AddBoolean("verifiedSource").
 				AddBoolean("secureEndpoint").
 				AddBoolean("sast").

--- a/catalog/pkg/openapi/model_mcp_server.go
+++ b/catalog/pkg/openapi/model_mcp_server.go
@@ -75,6 +75,8 @@ type MCPServer struct {
 	// Last update timestamp for the server metadata.
 	LastUpdated     *time.Time          `json:"lastUpdated,omitempty"`
 	RuntimeMetadata *MCPRuntimeMetadata `json:"runtimeMetadata,omitempty"`
+	// MCP server.json conformant structure. Opaque to this API; the schema is defined by the MCP specification and may evolve independently. See https://registry.modelcontextprotocol.io/docs#/schemas/ServerJSON for details.
+	ServerJson map[string]interface{} `json:"serverJson,omitempty"`
 }
 
 type _MCPServer MCPServer
@@ -1010,6 +1012,38 @@ func (o *MCPServer) SetRuntimeMetadata(v MCPRuntimeMetadata) {
 	o.RuntimeMetadata = &v
 }
 
+// GetServerJson returns the ServerJson field value if set, zero value otherwise.
+func (o *MCPServer) GetServerJson() map[string]interface{} {
+	if o == nil || IsNil(o.ServerJson) {
+		var ret map[string]interface{}
+		return ret
+	}
+	return o.ServerJson
+}
+
+// GetServerJsonOk returns a tuple with the ServerJson field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *MCPServer) GetServerJsonOk() (map[string]interface{}, bool) {
+	if o == nil || IsNil(o.ServerJson) {
+		return map[string]interface{}{}, false
+	}
+	return o.ServerJson, true
+}
+
+// HasServerJson returns a boolean if a field has been set.
+func (o *MCPServer) HasServerJson() bool {
+	if o != nil && !IsNil(o.ServerJson) {
+		return true
+	}
+
+	return false
+}
+
+// SetServerJson gets a reference to the given map[string]interface{} and assigns it to the ServerJson field.
+func (o *MCPServer) SetServerJson(v map[string]interface{}) {
+	o.ServerJson = v
+}
+
 func (o MCPServer) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -1102,6 +1136,9 @@ func (o MCPServer) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.RuntimeMetadata) {
 		toSerialize["runtimeMetadata"] = o.RuntimeMetadata
+	}
+	if !IsNil(o.ServerJson) {
+		toSerialize["serverJson"] = o.ServerJson
 	}
 	return toSerialize, nil
 }


### PR DESCRIPTION

## Summary
- Add a freeform `serverJson` field (`type: object, additionalProperties: true`) to the `MCPServer` schema so the catalog can pass through [MCP server.json](https://registry.modelcontextprotocol.io/docs#/schemas/ServerJSON) conformant metadata without coupling the API to a specific spec version
- Parse `server_json` from catalog YAML, store as a JSON string property in the database, and serve it in the REST API response
- Register the property in the datastore spec, entity mappings, and filter options exclusion list
## Why
We want to make the server json available so that it can be displayed and people can copy and paste it into the registry of their choice.  
## Test plan
- [x] Unit tests for YAML→property conversion (`TestYamlMCPServerServerJSONConversion`, `TestYamlMCPServerServerJSONNil`)
- [x] Unit tests for DB↔OpenAPI round-trip (`TestConvertDbMCPServerToOpenapi_IncludesServerJson`, `TestConvertDbMCPServerToOpenapi_NoServerJson`)
- [x] Full `catalog/internal/catalog/mcpcatalog/` and `catalog/internal/converter/` test suites pass
- [x] Manual testing: loaded production Red Hat MCP catalog data, verified `serverJson` appears correctly in `GET /api/mcp_catalog/v1alpha1/mcp_servers` response
- [x] Backwards compatible — field is optional; absent `server_json` in YAML produces no property; API omits the field when not present

🤖 Generated with [Claude Code](https://claude.com/claude-code)