### PR TITLE
fix(catalog): reclaim stale leader lock from crashed pod

### DIFF
--- a/catalog/internal/leader/election.go
+++ b/catalog/internal/leader/election.go
@@ -3,7 +3,6 @@ package leader
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
@@ -16,11 +15,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const (
-	defaultUnhealthyThreshold int32 = 3
-	lockTableName                   = "locks"
-	staleLockMultiplier             = 2
-)
+const defaultUnhealthyThreshold int32 = 3
 
 // isFatalError reports whether err indicates a lost pglock schema (SQLSTATE 42P01,
 // "undefined table/sequence"). When resetFunc is available, the run loop attempts
@@ -43,55 +38,16 @@ type lockClient interface {
 }
 
 // pglockAdapter wraps *pglock.Client to satisfy lockClient.
-// It tracks the last-seen record version number (RVN) to detect stale locks
-// left by crashed pods that never released cleanly. FailIfLocked() prevents
-// pglock's built-in two-phase takeover, so this adapter reimplements the
-// staleness check externally.
 type pglockAdapter struct {
-	client        *pglock.Client
-	db            *sql.DB
-	leaseDuration time.Duration
-	lastSeenRVN   int64
-	lastSeenAt    time.Time
+	client *pglock.Client
 }
 
 func (a *pglockAdapter) acquireContext(ctx context.Context, name string) (lockHandle, error) {
-	lock, err := a.client.AcquireContext(ctx, name, pglock.FailIfLocked())
+	lock, err := a.client.AcquireContext(ctx, name)
 	if err != nil {
-		if errors.Is(err, pglock.ErrNotAcquired) {
-			a.reclaimStaleIfNeeded(ctx, name)
-		}
 		return nil, err
 	}
-	a.lastSeenAt = time.Time{}
 	return &pglockHandle{client: a.client, lock: lock}, nil
-}
-
-func (a *pglockAdapter) reclaimStaleIfNeeded(ctx context.Context, name string) {
-	var currentRVN int64
-	err := a.db.QueryRowContext(ctx,
-		`SELECT record_version_number FROM `+lockTableName+` WHERE name = $1`, name).Scan(&currentRVN)
-	if err != nil {
-		return
-	}
-
-	if !a.lastSeenAt.IsZero() && currentRVN == a.lastSeenRVN && time.Since(a.lastSeenAt) > staleLockMultiplier*a.leaseDuration {
-		result, err := a.db.ExecContext(ctx,
-			`DELETE FROM `+lockTableName+` WHERE name = $1 AND record_version_number = $2`,
-			name, currentRVN)
-		if err != nil {
-			glog.Warningf("Failed to delete stale lock %q: %v", name, err)
-		} else if rows, _ := result.RowsAffected(); rows > 0 {
-			glog.Infof("Reclaimed stale lock %q (RVN %d unchanged for >%v)", name, currentRVN, staleLockMultiplier*a.leaseDuration)
-		}
-		a.lastSeenAt = time.Time{}
-		return
-	}
-
-	if a.lastSeenAt.IsZero() || currentRVN != a.lastSeenRVN {
-		a.lastSeenRVN = currentRVN
-		a.lastSeenAt = time.Now()
-	}
 }
 
 // pglockHandle wraps a held *pglock.Lock to satisfy lockHandle.
@@ -157,8 +113,8 @@ type LeaderElector struct {
 	activeCallbacks sync.WaitGroup
 
 	// Health tracking.
-	// dbReachable flips to true on first successful DB contact (acquisition
-	// or ErrNotAcquired). Pods that have never contacted the DB are not ready.
+	// dbReachable is set after TryCreateTable succeeds in the constructor,
+	// proving DB connectivity before the election loop starts.
 	// consecutiveFailures counts consecutive infrastructure errors (DB
 	// unreachable, lost heartbeat). Healthy() returns false when the DB has
 	// never been reached OR failures exceed the threshold.
@@ -223,7 +179,7 @@ func NewLeaderElector(
 		lockName:           lockName,
 		lockDuration:       lockDuration,
 		heartbeatFreq:      heartbeatFreq,
-		locker:             &pglockAdapter{client: client, db: db, leaseDuration: lockDuration},
+		locker:             &pglockAdapter{client: client},
 		done:               make(chan struct{}),
 		unhealthyThreshold: defaultUnhealthyThreshold,
 		resetFunc: func() (lockClient, error) {
@@ -238,13 +194,14 @@ func NewLeaderElector(
 			if err := c.TryCreateTable(); err != nil {
 				return nil, fmt.Errorf("failed to recreate pglock schema: %w", err)
 			}
-			return &pglockAdapter{client: c, db: db, leaseDuration: lockDuration}, nil
+			return &pglockAdapter{client: c}, nil
 		},
 	}
-	// dbReachable starts false (zero value) — pod is not ready until first
-	// successful DB contact. No need to hack the failure counter.
+	// TryCreateTable succeeded — DB is reachable. Setting this before the
+	// election loop starts lets the readiness probe pass while AcquireContext
+	// blocks waiting for an existing leader to release the lock.
+	e.dbReachable.Store(true)
 
-	// Start the background goroutine immediately
 	go e.run()
 
 	return e, nil
@@ -339,8 +296,8 @@ func (e *LeaderElector) run() {
 		}
 
 		if err != nil {
-			// pglock returns ErrNotAcquired (not context.Canceled) when the
-			// context is cancelled during acquisition — check context first.
+			// pglock may return a wrapped error instead of context.Canceled
+			// when the context is cancelled during acquisition.
 			if ctx.Err() != nil {
 				glog.Info("Leader election canceled, shutting down")
 				e.err = ctx.Err()
@@ -348,16 +305,7 @@ func (e *LeaderElector) run() {
 			}
 
 			var delay time.Duration
-			if errors.Is(err, pglock.ErrNotAcquired) {
-				// Lock held by another pod — DB is reachable, pod is healthy.
-				// Keep retry interval short so we acquire quickly when the
-				// lease is released (e.g., during rolling updates).
-				e.dbReachable.Store(true)
-				e.consecutiveFailures.Store(0)
-				backoff.reset()
-				delay = backoff.next()
-				glog.Infof("Lock held by another instance, retrying in %v", delay)
-			} else if isFatalError(err) {
+			if isFatalError(err) {
 				if e.resetFunc == nil {
 					// No recovery path — exit so the pod restarts and recreates the schema.
 					glog.Errorf("Fatal leader election error (schema lost): %v — exiting for pod restart", err)

--- a/catalog/internal/leader/election.go
+++ b/catalog/internal/leader/election.go
@@ -3,6 +3,7 @@ package leader
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
@@ -15,7 +16,11 @@ import (
 	"gorm.io/gorm"
 )
 
-const defaultUnhealthyThreshold int32 = 3
+const (
+	defaultUnhealthyThreshold int32 = 3
+	lockTableName                   = "locks"
+	staleLockMultiplier             = 2
+)
 
 // isFatalError reports whether err indicates a lost pglock schema (SQLSTATE 42P01,
 // "undefined table/sequence"). When resetFunc is available, the run loop attempts
@@ -38,16 +43,55 @@ type lockClient interface {
 }
 
 // pglockAdapter wraps *pglock.Client to satisfy lockClient.
+// It tracks the last-seen record version number (RVN) to detect stale locks
+// left by crashed pods that never released cleanly. FailIfLocked() prevents
+// pglock's built-in two-phase takeover, so this adapter reimplements the
+// staleness check externally.
 type pglockAdapter struct {
-	client *pglock.Client
+	client        *pglock.Client
+	db            *sql.DB
+	leaseDuration time.Duration
+	lastSeenRVN   int64
+	lastSeenAt    time.Time
 }
 
 func (a *pglockAdapter) acquireContext(ctx context.Context, name string) (lockHandle, error) {
 	lock, err := a.client.AcquireContext(ctx, name, pglock.FailIfLocked())
 	if err != nil {
+		if errors.Is(err, pglock.ErrNotAcquired) {
+			a.reclaimStaleIfNeeded(ctx, name)
+		}
 		return nil, err
 	}
+	a.lastSeenAt = time.Time{}
 	return &pglockHandle{client: a.client, lock: lock}, nil
+}
+
+func (a *pglockAdapter) reclaimStaleIfNeeded(ctx context.Context, name string) {
+	var currentRVN int64
+	err := a.db.QueryRowContext(ctx,
+		`SELECT record_version_number FROM `+lockTableName+` WHERE name = $1`, name).Scan(&currentRVN)
+	if err != nil {
+		return
+	}
+
+	if !a.lastSeenAt.IsZero() && currentRVN == a.lastSeenRVN && time.Since(a.lastSeenAt) > staleLockMultiplier*a.leaseDuration {
+		result, err := a.db.ExecContext(ctx,
+			`DELETE FROM `+lockTableName+` WHERE name = $1 AND record_version_number = $2`,
+			name, currentRVN)
+		if err != nil {
+			glog.Warningf("Failed to delete stale lock %q: %v", name, err)
+		} else if rows, _ := result.RowsAffected(); rows > 0 {
+			glog.Infof("Reclaimed stale lock %q (RVN %d unchanged for >%v)", name, currentRVN, staleLockMultiplier*a.leaseDuration)
+		}
+		a.lastSeenAt = time.Time{}
+		return
+	}
+
+	if a.lastSeenAt.IsZero() || currentRVN != a.lastSeenRVN {
+		a.lastSeenRVN = currentRVN
+		a.lastSeenAt = time.Now()
+	}
 }
 
 // pglockHandle wraps a held *pglock.Lock to satisfy lockHandle.
@@ -179,7 +223,7 @@ func NewLeaderElector(
 		lockName:           lockName,
 		lockDuration:       lockDuration,
 		heartbeatFreq:      heartbeatFreq,
-		locker:             &pglockAdapter{client: client},
+		locker:             &pglockAdapter{client: client, db: db, leaseDuration: lockDuration},
 		done:               make(chan struct{}),
 		unhealthyThreshold: defaultUnhealthyThreshold,
 		resetFunc: func() (lockClient, error) {
@@ -194,7 +238,7 @@ func NewLeaderElector(
 			if err := c.TryCreateTable(); err != nil {
 				return nil, fmt.Errorf("failed to recreate pglock schema: %w", err)
 			}
-			return &pglockAdapter{client: c}, nil
+			return &pglockAdapter{client: c, db: db, leaseDuration: lockDuration}, nil
 		},
 	}
 	// dbReachable starts false (zero value) — pod is not ready until first

--- a/catalog/internal/leader/election_health_internal_test.go
+++ b/catalog/internal/leader/election_health_internal_test.go
@@ -81,13 +81,14 @@ func newTestElector(ctx context.Context, locker lockClient, threshold int32) *Le
 		unhealthyThreshold: threshold,
 		retryBackoff:       &backoff{current: time.Millisecond, max: time.Millisecond},
 	}
-	// dbReachable starts false (zero value) — Healthy() returns false until
-	// first successful DB contact, matching NewLeaderElector behavior.
+	// In production, dbReachable is set after TryCreateTable succeeds.
+	// Match that behavior here.
+	e.dbReachable.Store(true)
 	go e.run()
 	return e
 }
 
-func TestHealthyStartsUnhealthy(t *testing.T) {
+func TestHealthyBecomesUnhealthyAfterThreshold(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -98,13 +99,11 @@ func TestHealthyStartsUnhealthy(t *testing.T) {
 
 	e := newTestElector(ctx, locker, 3)
 
-	assert.False(t, e.Healthy(), "should start unhealthy before first acquisition")
+	assert.True(t, e.Healthy(), "should start healthy (DB was reachable at construction)")
 
 	require.Eventually(t, func() bool {
-		return locker.calls.Load() >= 3
-	}, 2*time.Second, 5*time.Millisecond, "should have attempted acquisition at least 3 times")
-
-	assert.False(t, e.Healthy(), "should remain unhealthy with sustained failures")
+		return !e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should become unhealthy after threshold consecutive failures")
 
 	cancel()
 	_ = e.Wait()
@@ -116,41 +115,20 @@ func TestHealthyRecoveryAfterAcquisitionSucceeds(t *testing.T) {
 
 	locker := &failingLocker{
 		err:       errors.New("connection refused"),
-		failCount: 4,
+		failCount: 10,
 	}
 
 	e := newTestElector(ctx, locker, 3)
 
-	assert.False(t, e.Healthy(), "should start unhealthy")
+	require.Eventually(t, func() bool {
+		return !e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should become unhealthy after threshold failures")
 
 	require.Eventually(t, func() bool {
 		return e.Healthy()
 	}, 2*time.Second, 5*time.Millisecond, "should recover to healthy after successful acquisition")
 
 	assert.Equal(t, int32(0), e.consecutiveFailures.Load(), "consecutive failures should be reset")
-
-	cancel()
-	_ = e.Wait()
-}
-
-func TestHealthyBecomesHealthyOnFirstSuccess(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	locker := &failingLocker{
-		err:       errors.New("connection refused"),
-		failCount: 0, // succeeds on first call
-	}
-
-	e := newTestElector(ctx, locker, 3)
-
-	assert.False(t, e.Healthy(), "should start unhealthy")
-
-	require.Eventually(t, func() bool {
-		return e.Healthy()
-	}, 2*time.Second, 5*time.Millisecond, "should become healthy after first successful acquisition")
-
-	assert.Equal(t, int32(0), e.consecutiveFailures.Load())
 
 	cancel()
 	_ = e.Wait()
@@ -167,14 +145,11 @@ func TestHealthyThresholdBoundary(t *testing.T) {
 
 	e := newTestElector(ctx, locker, 2)
 
-	assert.False(t, e.Healthy(), "should start unhealthy (threshold=2)")
+	assert.True(t, e.Healthy(), "should start healthy (threshold=2)")
 
-	// Continued failures keep it unhealthy
 	require.Eventually(t, func() bool {
-		return locker.calls.Load() >= 2
-	}, 2*time.Second, 5*time.Millisecond, "should have attempted acquisition")
-
-	assert.False(t, e.Healthy(), "should remain unhealthy with sustained failures")
+		return !e.Healthy()
+	}, 2*time.Second, 5*time.Millisecond, "should become unhealthy after threshold failures")
 
 	cancel()
 	_ = e.Wait()
@@ -200,55 +175,6 @@ func (s *switchableLocker) setErr(err error) {
 	s.mu.Lock()
 	s.err = err
 	s.mu.Unlock()
-}
-
-func TestHealthyWhenLockHeldByAnother(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	locker := &failingLocker{
-		err:       pglock.ErrNotAcquired,
-		failCount: -1,
-	}
-
-	e := newTestElector(ctx, locker, 3)
-
-	assert.False(t, e.Healthy(), "should start unhealthy")
-
-	// ErrNotAcquired proves DB is reachable → should become healthy
-	require.Eventually(t, func() bool {
-		return e.Healthy()
-	}, 2*time.Second, 5*time.Millisecond, "should become healthy when lock is held by another pod")
-
-	assert.Equal(t, int32(0), e.consecutiveFailures.Load())
-
-	cancel()
-	_ = e.Wait()
-}
-
-func TestHealthyContentionThenInfraFailure(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	locker := &switchableLocker{err: pglock.ErrNotAcquired}
-
-	e := newTestElector(ctx, locker, 3)
-
-	// Contention → healthy
-	require.Eventually(t, func() bool {
-		return e.Healthy()
-	}, 2*time.Second, 5*time.Millisecond, "should become healthy during contention")
-
-	// Switch to infra failure
-	locker.setErr(errors.New("connection refused"))
-
-	// Should become unhealthy after threshold failures
-	require.Eventually(t, func() bool {
-		return !e.Healthy()
-	}, 2*time.Second, 5*time.Millisecond, "should become unhealthy after infra failure")
-
-	cancel()
-	_ = e.Wait()
 }
 
 func TestHealthyLoseLockBecomesUnhealthy(t *testing.T) {

--- a/catalog/internal/leader/election_test.go
+++ b/catalog/internal/leader/election_test.go
@@ -481,6 +481,61 @@ func TestRollingUpdateDoesNotDeadlock(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+// TestCrashedPodStaleLockReclaim verifies that when a pod crashes without
+// releasing the lock, a new pod detects the stale lock (RVN unchanged for
+// longer than leaseDuration) and reclaims it.
+func TestCrashedPodStaleLockReclaim(t *testing.T) {
+	gormDB, cleanup := testutils.SetupPostgresWithMigrations(t, testhelpers.MustDatastoreSpec(t))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lockDuration := 3 * time.Second
+	heartbeat := 1 * time.Second
+	lockName := "test_crash_reclaim"
+
+	// Bootstrap the schema by creating and immediately canceling a throwaway elector.
+	// This lets pglock create its table and sequence with the correct schema.
+	bootstrapCtx, bootstrapCancel := context.WithCancel(ctx)
+	bootstrapCancel()
+	bootstrap, err := leader.NewLeaderElector(gormDB, bootstrapCtx, lockName, lockDuration, heartbeat)
+	require.NoError(t, err)
+	_ = bootstrap.Wait()
+
+	// Simulate a crashed pod by inserting a stale lock row.
+	sqlDB, err := gormDB.DB()
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx,
+		`INSERT INTO locks (name, record_version_number, owner) VALUES ($1, $2, $3)
+		 ON CONFLICT (name) DO UPDATE SET record_version_number = $2, owner = $3`,
+		lockName, 9999, "pglock-dead-pod-123456")
+	require.NoError(t, err)
+
+	var becameLeader atomic.Bool
+	elector, err := leader.NewLeaderElector(gormDB, ctx, lockName, lockDuration, heartbeat)
+	require.NoError(t, err)
+	elector.OnBecomeLeader(func(ctx context.Context) {
+		becameLeader.Store(true)
+		<-ctx.Done()
+	})
+
+	require.Eventually(t, func() bool {
+		return elector.Healthy()
+	}, 3*time.Second, 100*time.Millisecond, "pod should report healthy (DB reachable via ErrNotAcquired)")
+
+	// staleLockMultiplier (2x) means reclaim takes ~2*lockDuration
+	require.Eventually(t, func() bool {
+		return becameLeader.Load()
+	}, 2*lockDuration+5*time.Second, 200*time.Millisecond,
+		"pod should reclaim stale lock and become leader within 2x leaseDuration")
+
+	cancel()
+	err = elector.Wait()
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 // TestLeaderElector_GoroutineStartsImmediately verifies that the background
 // goroutine starts immediately from the constructor.
 func TestLeaderElector_GoroutineStartsImmediately(t *testing.T) {

--- a/catalog/internal/leader/election_test.go
+++ b/catalog/internal/leader/election_test.go
@@ -408,15 +408,10 @@ func TestLeaderElector_WaitReturnsCorrectError(t *testing.T) {
 // TestRollingUpdateDoesNotDeadlock simulates a rolling update with replicas=1:
 //
 //  1. Old pod holds the leader lease and is healthy.
-//  2. New pod starts and attempts to acquire the lease.
-//  3. New pod cannot become leader (old pod holds the lease).
-//  4. New pod's Healthy() must return true (ErrNotAcquired proves DB is reachable).
-//  5. Kubernetes sees the new pod as ready, terminates the old pod.
-//  6. Old pod releases the lease on shutdown.
-//  7. New pod acquires the lease and becomes leader.
-//
-// Without the ErrNotAcquired fix, step 4 would return false → readiness probe
-// fails → Kubernetes never kills the old pod → deadlock.
+//  2. New pod starts — Healthy() returns true immediately (TryCreateTable proved DB reachable).
+//  3. Kubernetes sees the new pod as ready, terminates the old pod.
+//  4. Old pod releases the lease on shutdown.
+//  5. New pod acquires the lease and becomes leader.
 func TestRollingUpdateDoesNotDeadlock(t *testing.T) {
 	db, cleanup := testutils.SetupPostgresWithMigrations(t, testhelpers.MustDatastoreSpec(t))
 	defer cleanup()
@@ -424,7 +419,6 @@ func TestRollingUpdateDoesNotDeadlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// --- Step 1: Old pod acquires the lease ---
 	oldCtx, oldCancel := context.WithCancel(ctx)
 	defer oldCancel()
 
@@ -439,51 +433,39 @@ func TestRollingUpdateDoesNotDeadlock(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return oldBecameLeader.Load()
 	}, 3*time.Second, 100*time.Millisecond, "old pod should acquire leadership")
-	assert.True(t, oldPod.Healthy(), "old pod should be healthy")
 
-	// --- Step 2-3: New pod starts, cannot acquire (old pod holds lease) ---
 	newCtx, newCancel := context.WithCancel(ctx)
 	defer newCancel()
 
+	var newBecameLeader atomic.Bool
 	newPod, err := leader.NewLeaderElector(db, newCtx, "rolling-update-lock", 5*time.Second, 1*time.Second)
 	require.NoError(t, err)
-
-	// New pod starts unhealthy (cold start)
-	assert.False(t, newPod.Healthy(), "new pod should start unhealthy")
-
-	// --- Step 4: New pod gets ErrNotAcquired → becomes healthy ---
-	require.Eventually(t, func() bool {
-		return newPod.Healthy()
-	}, 5*time.Second, 100*time.Millisecond,
-		"new pod should become healthy while waiting for lease (ErrNotAcquired proves DB connectivity)")
-
-	// --- Step 5-6: Kubernetes terminates old pod (simulate with cancel) ---
-	t.Log("Simulating Kubernetes terminating old pod")
-	oldCancel()
-	err = oldPod.Wait()
-	assert.ErrorIs(t, err, context.Canceled)
-
-	// --- Step 7: New pod acquires leadership ---
-	var newBecameLeader atomic.Bool
 	newPod.OnBecomeLeader(func(ctx context.Context) {
 		newBecameLeader.Store(true)
 		<-ctx.Done()
 	})
 
+	// New pod is healthy immediately — no deadlock
+	assert.True(t, newPod.Healthy(), "new pod should be healthy immediately (DB reachable from TryCreateTable)")
+	assert.False(t, newBecameLeader.Load(), "new pod should not be leader yet")
+
+	// Simulate Kubernetes terminating old pod
+	t.Log("Simulating Kubernetes terminating old pod")
+	oldCancel()
+	assert.ErrorIs(t, oldPod.Wait(), context.Canceled)
+
+	// New pod acquires leadership after old pod releases
 	require.Eventually(t, func() bool {
 		return newBecameLeader.Load()
 	}, 10*time.Second, 200*time.Millisecond, "new pod should acquire leadership after old pod is terminated")
 
-	assert.True(t, newPod.Healthy(), "new pod should remain healthy as leader")
-
 	newCancel()
-	err = newPod.Wait()
-	assert.ErrorIs(t, err, context.Canceled)
+	assert.ErrorIs(t, newPod.Wait(), context.Canceled)
 }
 
 // TestCrashedPodStaleLockReclaim verifies that when a pod crashes without
-// releasing the lock, a new pod detects the stale lock (RVN unchanged for
-// longer than leaseDuration) and reclaims it.
+// releasing the lock, a new pod takes over via pglock's built-in two-phase
+// CAS takeover within leaseDuration.
 func TestCrashedPodStaleLockReclaim(t *testing.T) {
 	gormDB, cleanup := testutils.SetupPostgresWithMigrations(t, testhelpers.MustDatastoreSpec(t))
 	defer cleanup()
@@ -496,14 +478,13 @@ func TestCrashedPodStaleLockReclaim(t *testing.T) {
 	lockName := "test_crash_reclaim"
 
 	// Bootstrap the schema by creating and immediately canceling a throwaway elector.
-	// This lets pglock create its table and sequence with the correct schema.
 	bootstrapCtx, bootstrapCancel := context.WithCancel(ctx)
 	bootstrapCancel()
 	bootstrap, err := leader.NewLeaderElector(gormDB, bootstrapCtx, lockName, lockDuration, heartbeat)
 	require.NoError(t, err)
 	_ = bootstrap.Wait()
 
-	// Simulate a crashed pod by inserting a stale lock row.
+	// Simulate a crashed pod by inserting a stale lock row directly.
 	sqlDB, err := gormDB.DB()
 	require.NoError(t, err)
 
@@ -521,15 +502,14 @@ func TestCrashedPodStaleLockReclaim(t *testing.T) {
 		<-ctx.Done()
 	})
 
-	require.Eventually(t, func() bool {
-		return elector.Healthy()
-	}, 3*time.Second, 100*time.Millisecond, "pod should report healthy (DB reachable via ErrNotAcquired)")
+	// dbReachable is set after TryCreateTable in constructor
+	assert.True(t, elector.Healthy(), "pod should be healthy immediately after construction")
 
-	// staleLockMultiplier (2x) means reclaim takes ~2*lockDuration
+	// pglock takes over stale lock within leaseDuration (two-phase CAS)
 	require.Eventually(t, func() bool {
 		return becameLeader.Load()
-	}, 2*lockDuration+5*time.Second, 200*time.Millisecond,
-		"pod should reclaim stale lock and become leader within 2x leaseDuration")
+	}, lockDuration+5*time.Second, 200*time.Millisecond,
+		"pod should take over stale lock and become leader within leaseDuration")
 
 	cancel()
 	err = elector.Wait()


### PR DESCRIPTION
Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a pod crashes without releasing the leader lock, the replacement pod can never acquire it and runs in read-only mode indefinitely.
Track the lock row's version number across retries. If it hasn't changed for 2x leaseDuration (no heartbeats from the dead pod), delete the stale row so the next acquisition attempt succeeds.
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
